### PR TITLE
fix(signals): a thread spanning two projects is not read

### DIFF
--- a/backend/internal/compose/integration/signalextract_integration_test.go
+++ b/backend/internal/compose/integration/signalextract_integration_test.go
@@ -843,3 +843,89 @@ func TestALongThreadIsWalkedToItsStartOnePassAtATime(t *testing.T) {
 			brain.calls)
 	}
 }
+
+// linkToProject files one activity under a project, the way the attribution
+// ladder does — through the owner, because the ladder is what a capture runs
+// and this test is about the READ that follows it.
+func linkToProject(t *testing.T, owner *pgx.Conn, activity, project ids.UUID) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO activity_link (activity_id, entity_type, project_id)
+		 VALUES ($1, 'project', $2)`, activity, project); err != nil {
+		t.Fatalf("filing the activity under its project: %v", err)
+	}
+}
+
+func seedProjectFor(t *testing.T, owner *pgx.Conn, org ids.UUID, name, key string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO project (id, organization_id, name, key, source, captured_by)
+		 VALUES ($1, $2, $3, $4, 'ui', 'human:probe')`, id, org, name, key); err != nil {
+		t.Fatalf("seeding project %s: %v", name, err)
+	}
+	return id
+}
+
+// A conversation spanning two PROJECTS at one account is skipped, for the
+// reason the two-account refusal above gives one level up.
+//
+// The account is unambiguous here — one client, one org — so this thread passes
+// every rule the extractor had. What it has no single answer to is WHICH BODY
+// OF WORK its findings belong to, and the model is shown the whole conversation,
+// so a finding drawn from the migration half would be filed against the rollout
+// half half the time (#2287).
+func TestAThreadSpanningTwoProjectsIsNotRead(t *testing.T) {
+	e := Setup(t)
+	acme := e.SeedOrg(t, "Acme", &e.Rep1)
+	owner := OwnerConn(t)
+	rollout := seedProjectFor(t, owner, acme, "Rollout", "roll")
+	migration := seedProjectFor(t, owner, acme, "Migration", "migr")
+
+	at := extractClock.Add(-48 * time.Hour)
+	contact := employeeOf(t, e, acme, "Ada at Acme")
+	first := seedMessage(t, e, contact, "thread-two-projects", "Both workstreams",
+		"We are ending our side of the arrangement.", "inbound", at)
+	second := seedMessage(t, e, contact, "thread-two-projects", "Both workstreams",
+		"Same for the other one.", "inbound", at.Add(time.Minute))
+	linkToProject(t, owner, first, rollout)
+	linkToProject(t, owner, second, migration)
+
+	brain := &scriptedBrain{reply: `{"events": []}`}
+	if pass := extractPassStats(t, e, brain); pass.Due != 0 {
+		t.Fatalf("the queue offered %d conversation(s), want none spanning two projects", pass.Due)
+	}
+	if brain.calls != 0 {
+		t.Errorf("the model was called %d time(s) on a conversation with no single body of work", brain.calls)
+	}
+}
+
+// ONE project is not ambiguity, and neither is none. Refusing either would take
+// most mail out of the pass — the great majority carries no project link at all
+// — so this is the arm that keeps the rule a refusal rather than a filter.
+func TestAThreadOnOneProjectOrNoneIsStillRead(t *testing.T) {
+	for name, linked := range map[string]bool{"one project": true, "no project": false} {
+		t.Run(name, func(t *testing.T) {
+			e := Setup(t)
+			acme := e.SeedOrg(t, "Acme", &e.Rep1)
+			owner := OwnerConn(t)
+			at := extractClock.Add(-48 * time.Hour)
+			contact := employeeOf(t, e, acme, "Ada at Acme")
+			first := seedMessage(t, e, contact, "thread-one-project", "The workstream",
+				"We are ending our side of the arrangement.", "inbound", at)
+			second := seedMessage(t, e, contact, "thread-one-project", "The workstream",
+				"Confirming.", "inbound", at.Add(time.Minute))
+			if linked {
+				rollout := seedProjectFor(t, owner, acme, "Rollout", "roll")
+				// BOTH messages, which is what one body of work looks like.
+				linkToProject(t, owner, first, rollout)
+				linkToProject(t, owner, second, rollout)
+			}
+
+			brain := &scriptedBrain{reply: `{"events": []}`}
+			if pass := extractPassStats(t, e, brain); pass.Due != 1 {
+				t.Fatalf("the queue offered %d conversation(s) with %s, want 1", pass.Due, name)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/signalextractread.go
+++ b/backend/internal/compose/signalextractread.go
@@ -152,6 +152,17 @@ var dueThreadsQuery = `
 			       count(DISTINCT a.id) AS message_count,
 			       min(ro.organization_id::text) AS one_org,
 			       count(DISTINCT ro.organization_id) AS org_count,
+			       -- The same question one level down. A thread is read as one
+			       -- conversation about one thing, and the model is shown all of
+			       -- it — so a thread spanning two projects at one client has no
+			       -- single body of work its findings belong to, and whichever
+			       -- project the extractor happened to file them against would be
+			       -- wrong for half the messages (#2287).
+			       --
+			       -- Counted from the link directly rather than through a reach
+			       -- set: a project is named on the activity or it is not, where
+			       -- an organization is also reached through the people on it.
+			       count(DISTINCT pl.project_id) AS project_count,
 			       -- Shared only when EVERY message is: the model is shown the
 			       -- whole conversation, so what it writes is as private as the
 			       -- most private thing it read.
@@ -212,6 +223,11 @@ var dueThreadsQuery = `
 			                      AND t.audience <> 'workspace') AS every_message_open
 			  FROM activity a
 			  LEFT JOIN (` + activities.OrgReachSet() + `) ro ON ro.activity_id = a.id
+			  -- Safe to widen the row set: every aggregate above is DISTINCT,
+			  -- bool_and or min, so a message repeated once per project link
+			  -- contributes the same value it did.
+			  LEFT JOIN activity_link pl
+			    ON pl.activity_id = a.id AND pl.entity_type = 'project'
 			  -- Who may read this message, asked of the records it is filed
 			  -- against. A message is discoverable when ANY of its links is
 			  -- (auth.ActivityDiscoverClause), so one workspace-visible link
@@ -245,6 +261,10 @@ var dueThreadsQuery = `
 		  FROM conversation c
 		  LEFT JOIN signal_thread_scan s ON s.thread_key = c.thread_key
 		 WHERE c.org_count = 1
+		   -- At MOST one, where the organization must be exactly one: most mail
+		   -- carries no project at all, and a thread about no particular body of
+		   -- work is still a thread worth reading. Two is the refusal.
+		   AND c.project_count <= 1
 		   AND c.every_message_open
 		   -- A conversation nobody else may read, whose reader cannot be named,
 		   -- is not offered at all. Reading it would produce a finding with no


### PR DESCRIPTION
Closes #2287

`dueThreads` reads a thread only once it resolves to exactly one organization. The same argument applies one level down and was not made: a thread spanning two projects at one client **passed every rule the extractor had** — the account is unambiguous — while having no single body of work its findings belong to. The model is shown the whole conversation, so a finding drawn from one project's half was filed against the other's half the time.

## At most one, where the org must be exactly one

Most mail carries no project link at all, and a thread about no particular body of work is still a thread worth reading. **Two is the refusal.** Both arms are tested, because a rule that refused the zero case would take the great majority of mail out of the pass.

Counted from the link **directly** rather than through a reach set: a project is named on the activity or it is not, where an organization is also reached through the people on it.

The extra join widens the row set, and that is safe here — every aggregate in the CTE is `DISTINCT`, `bool_and` or `min`, so a message repeated once per project link contributes the value it already did. The existing two-account and two-employer refusals still pass unchanged, which is the check on that.

## The stamp is deliberately not here

The issue also asks that the resulting signal be stamped with the thread's project. **Not done, and not an oversight:** `signal` has no project column and no read is project-scoped, so adding one would be structure nothing consumes — the tree's own rule against speculative abstraction.

The refusal is what stops the mis-filing the issue title names. The stamp is a capability, and it belongs with the reader that wants it — `#2219`'s project-narrowed context reads are the plausible caller, and it can carry the column when it needs it.

## Verification

- Two projects on one thread: not offered, model not called.
- One project, and none: both offered.
- Removing the rule: *"the queue offered 1 conversation(s), want none spanning two projects"*.
- `make check-backend` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC
