### PR TITLE
fix: three tests still expect what production stopped doing (main red, #4904 follow-up)

### DIFF
--- a/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
@@ -95,9 +95,10 @@ func TestStrengthFoldLeavesTheInboundAnchorEmptyWhenNobodyWroteIn(t *testing.T) 
 // The two are answering different questions. "They last wrote eighteen months
 // ago" is history and stays true however old it gets. The anchor is an action —
 // it is what a Follow up button opens a reply against — and it has to agree
-// with the state the counts report. This contact reads untried, because nothing
-// inside the window says otherwise; offering to answer a thread from last year
-// would contradict the same page's own summary.
+// with the state the counts report. This contact reads lapsed: an exchange
+// that is real, just older than the window, ranks warmer than a cold approach
+// and colder than an unanswered follow-up — offering to answer a thread from
+// last year would still contradict the same page's own summary.
 func TestStrengthFoldDropsAnInboundAnchorOlderThanTheWindow(t *testing.T) {
 	e := integration.Setup(t)
 	owner := integration.OwnerConn(t)
@@ -109,6 +110,7 @@ func TestStrengthFoldDropsAnInboundAnchorOlderThanTheWindow(t *testing.T) {
 	longAgo := org360Clock.AddDate(0, 0, -400)
 	stale := integration.AccountMailDirectedAt(t, owner, e.WS, "Re: 2025 tender", "inbound", longAgo)
 	integration.LinkActivity(t, owner, stale, "person", person)
+	integration.LinkActivitySender(t, owner, stale, person)
 
 	got := foldOneContact(t, e, org, person)
 
@@ -119,8 +121,8 @@ func TestStrengthFoldDropsAnInboundAnchorOlderThanTheWindow(t *testing.T) {
 		t.Fatalf("a reply from %s is outside the 90-day window and must not be offered as a reply anchor, got %s",
 			longAgo.Format("2006-01-02"), got.LastInboundActivity)
 	}
-	if people.EngagementOf(got) != people.EngagementUntried {
-		t.Fatalf("a contact whose only message predates the window reads as %q, want untried",
+	if people.EngagementOf(got) != people.EngagementLapsed {
+		t.Fatalf("a contact whose only message predates the window reads as %q, want lapsed",
 			people.EngagementOf(got))
 	}
 }

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -598,6 +598,7 @@ func TestPerson360AssemblesEverySectionFromRealRows(t *testing.T) {
 		VALUES ($1, 'email', 'Re: pricing', 'body', '2026-08-01T09:00:00Z',
 		        'inbound', 'manual', 'human:x')`)
 	LinkActivity(t, owner, inbound, "person", mine)
+	LinkActivitySender(t, owner, inbound, mine)
 	task := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, is_done, source, captured_by)
 		VALUES ($1, 'task', 'Send the quote', '2026-07-28T09:00:00Z', '2026-07-30T09:00:00Z',
 		        false, 'manual', 'human:x')`)
@@ -700,6 +701,7 @@ func TestADismissalHoldsUntilTheEvidenceMoves(t *testing.T) {
 		VALUES ($1, 'email', 'Re: Following up', 'body', $2,
 		        'inbound', 'manual', 'human:x')`, roomAgo(time.Hour))
 	LinkActivity(t, owner, inbound, "person", mine)
+	LinkActivitySender(t, owner, inbound, mine)
 
 	reArmed, err := svc.Assemble(rep, personID)
 	if err != nil {

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -101,6 +101,20 @@ func LinkActivity(t *testing.T, owner *pgx.Conn, activity ids.UUID, entityType s
 	}
 }
 
+// LinkActivitySender names WHO sent an activity — distinct from LinkActivity,
+// which only says the activity CONCERNS somebody. sender.go's SenderPredicate
+// (backend/internal/modules/people/sender.go) reads this row for "they wrote
+// last" answers, and a thread linked to everybody it concerns says nothing
+// about which of them is its author.
+func LinkActivitySender(t *testing.T, owner *pgx.Conn, activity, person ids.UUID) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO activity_participant (activity_id, person_id, role) VALUES ($1, $2, 'from')`,
+		activity, person); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // SeedExtraWorkspace mints an additional tenant. archived names a workspace
 // nobody looks at any more, which still holds everything it held the day it was
 // archived — some passes are owed on it and some deliberately skip it, so a

--- a/backend/internal/platform/jobs/pass_integration_test.go
+++ b/backend/internal/platform/jobs/pass_integration_test.go
@@ -22,9 +22,11 @@ import (
 	"github.com/margince/margince/backend/internal/platform/jobs"
 )
 
-// aScheduledKind is a kind api/jobs.yaml declares with a fixed cadence, so the
-// spec lookup answers a real number rather than a zero this test invented.
-const aScheduledKind = "capture_counterparty_verdict"
+// aScheduledKind is a kind api/jobs.yaml declares with a fixed, hourly
+// cadence, so the spec lookup answers a real number rather than a zero this
+// test invented — every arithmetic assertion below is in units of this
+// cadence, so a kind picked here must keep one for as long as this file does.
+const aScheduledKind = "capture_classify"
 
 func TestAScheduledRunIsWhenThePassRuns(t *testing.T) {
 	_, pool := migratedAppPool(t)


### PR DESCRIPTION
## Summary

`main` is currently red: `main-health` (run 34185948837, tip `edb9949764`)
and every PR's `integration` shards fail on three unrelated tests, all stale
against `8c1cd8a39` (#4904, "The webinar defect list: nine fixes") — a real,
correct production change this morning that a few existing tests weren't
updated to match. Found while investigating why an unrelated PR's CI (#4926)
was red on packages it never touches.

### `activity_participant` authorship, now required for "last touch"

#4904 fixed Person360/org360's last-inbound fold to require
`SenderPredicate` authorship (`backend/internal/modules/people/sender.go`)
rather than mere `activity_link` reachability — a thread is linked to
everybody it concerns, so "they wrote last" was reading as whoever's page
was open. Two existing integration tests seed an inbound activity via
`LinkActivity` with no `activity_participant` "from" row naming the sender,
so the (correct, new) authorship check finds nobody and the last-inbound
date comes back empty:

- `person_relationship_room_integration_test.go` — two call sites
  (`TestPerson360AssemblesEverySectionFromRealRows`,
  `TestADismissalHoldsUntilTheEvidenceMoves`)
- `org360_lasttouch_integration_test.go` — one call site
  (`TestStrengthFoldDropsAnInboundAnchorOlderThanTheWindow`)

Added `LinkActivitySender` (`backend/internal/compose/integration/seed.go`)
alongside `LinkActivity` at each, rather than hand-rolling the raw
`activity_participant` INSERT three more times — two other tests already do
that inline.

### A genuinely new engagement state, old expectation

Same commit's last bullet: `lapsed` is an intentional new engagement state
— "an exchange that is real and older than the window" — ranking between
`untried` and `no-reply`. `TestStrengthFoldDropsAnInboundAnchorOlderThanTheWindow`
still asserted the pre-`lapsed` answer (`EngagementUntried`) for a contact
whose only message predates the window; the correct answer once authorship
is restored is `EngagementLapsed`. Updated the assertion and its doc comment.

### A cadence the test's own fixture kind no longer holds

`TestAScheduledRunIsWhenThePassRuns` (`backend/internal/platform/jobs`) uses
`capture_counterparty_verdict` as its "a kind with a fixed cadence" stand-in
and asserts `time.Hour`. The same commit moved that specific kind's cadence
to 10 minutes ("a new sender becomes a record in minutes, not most of an
hour"), and every time-arithmetic assertion in the file is written in units
of the fixture kind's cadence. Repointed the constant at `capture_classify`,
a sibling kind that still holds an hourly cadence, rather than rewriting
every assertion's arithmetic.

## Test plan

- [x] `make test-integration` — **0 skips, 51 packages, all green** (was
      failing before this fix, confirmed via `main-health` run 34185948837
      on the current main tip reproducing the identical three failures)
- [x] `make check-go` — clean (0 lint, 0 craft findings); the one local
      `backend/gates` failure (`TestPublicTreeCitesNoDocumentGitIgnores`) is
      the same pre-existing, machine-local `.git/info/exclude` artifact
      documented on prior PRs — unrelated to this diff
- [x] `make craft-static --strict` — 0 blocker/major/minor
- [x] No `crm.yaml` contract change, no AI prompt touched → no aicert
      re-run needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvvZzihBBSeaLc3WcZ6Xh1


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three stale tests that broke `main`'s integration suite after production stopped matching their expectations.

- Last-touch now requires an `activity_participant` "from" row; two tests seed inbound activity without one, so their last-inbound date comes back empty. Added `LinkActivitySender` to seed authorship at each call site.
- `lapsed` is now the correct engagement state for a contact whose only message predates the window; the test still asserted `untried`.
- `capture_counterparty_verdict`'s cadence moved to 10 minutes, so the hourly-cadence fixture kind switched to `capture_classify` instead of rewriting each time-arithmetic assertion.

<sup>Written for commit ae2fe7c91b713f2fc1ee05cd7ce5d839c010df85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved integration test coverage for contact engagement states, activity attribution, relationship views, dismissal behavior, and scheduled processing.
  - Updated test scenarios to more accurately represent inbound activity senders and engagement that has lapsed beyond the relevant time window.
  - Refined test fixtures and expectations to better validate current behavior across these workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->