### PR TITLE
fix(consent): a purpose that names nothing is not an archived one

### DIFF
--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -382,46 +382,6 @@ func (c *consentEnv) grantMarketingByConfirmLink(t *testing.T) string {
 	return token
 }
 
-// Issuance mints nothing, and says so.
-//
-// This replaces a test of the issuance round trip — non-DOI purposes refused,
-// a fresh token superseding a stale one, both mints audited. None of that
-// exists now: the endpoint returns a conflict for every caller, nothing writes
-// consent_doi_token, and the redemption arm is gone. A double-opt-in purpose
-// confirms through a spent confirm-details link instead, which
-// TestConsentDoubleOptInNorm exercises.
-//
-// What is worth holding is that the refusal is a refusal: the same answer
-// whatever purpose is named, and no row behind it. An endpoint in the public
-// contract that quietly minted again would hand an operator both halves of a
-// round trip whose only value is that the subject completed one of them.
-func TestDOIIssuanceMintsNothingWhicheverPurposeIsNamed(t *testing.T) {
-	c := setupConsent(t)
-
-	// A purpose that requires double opt-in, and one that does not, get the
-	// same answer. The endpoint resolves no id, so it can tell a caller nothing
-	// about which purposes exist.
-	for _, purpose := range []string{"marketing_email", "transactional"} {
-		if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
-			"purpose_id": c.purposes[purpose],
-		}, nil, nil); status != http.StatusConflict {
-			t.Errorf("issuance under %s → %d, want 409", purpose, status)
-		}
-	}
-
-	// And nothing was written. The table keeps its history and takes no new
-	// rows, so an unredeemed invitation cannot outlive the change.
-	var audit struct {
-		Data []AnyMap `json:"data"`
-	}
-	if status := c.Call(t, "GET", "/v1/audit-log?entity_type=consent_doi_token", nil, nil, &audit); status != http.StatusOK {
-		t.Fatalf("audit read → %d", status)
-	}
-	if len(audit.Data) != 0 {
-		t.Fatalf("a refused issuance audited %d row(s), want none", len(audit.Data))
-	}
-}
-
 func TestConsentProofLogIsAppendOnlyAndIdempotent(t *testing.T) {
 	c := setupConsent(t)
 	grant := func() int {

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -181,14 +181,10 @@ func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDC
 		"IssueDoubleOptInJSONBody.purpose_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/consent/double-opt-in",
 			omitted: AnyMap{}, supplied: AnyMap{"purpose_id": absent}, field: "purpose_id",
-			// This endpoint mints nothing and resolves nothing: it refuses every
-			// caller with a conflict, whatever purpose they name. So it has no row
-			// to hide and no 404 to give — and equally no way to enumerate, since
-			// a visible purpose, an invisible one and one that never existed all
-			// get the identical answer. The omitted half above is still held: a
-			// body-id probe runs ahead of the refusal precisely so this endpoint
-			// does not become the one place a missing id goes unnamed.
-			suppliedStatus: http.StatusConflict,
+			// No exception any more. This endpoint used to refuse every caller
+			// with a conflict, so it had no row to hide; it resolves the purpose
+			// and mints a link now, which puts it back under the rule every other
+			// required body id follows.
 		},
 		"ApplyTagRequest.entity_id": {
 			method: "POST", path: "/v1/tags/" + f.tag + "/apply",

--- a/backend/internal/modules/consent/confirmtoken.go
+++ b/backend/internal/modules/consent/confirmtoken.go
@@ -171,29 +171,47 @@ func deliveryAddressTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID) (s
 // cannot honestly ask about. A record-confirmation link names no purpose and is
 // exempt.
 //
-// TWO refusals, because they fail differently for the reader. An ARCHIVED
-// purpose would mint and mail and then dead-end: consentCardFor resolves only a
-// live purpose, so the subject opens a 404 sent in the installation's name. A
-// purpose that does not REQUIRE double opt-in is a different mistake — the mail
-// would ask somebody to confirm a subscription whose grant never needed
+// THREE answers, because they fail differently for the reader.
+//
+// A purpose that RESOLVES TO NOTHING — never existed, or belongs to a workspace
+// this caller cannot see — is not found. It is deliberately not a 422 naming
+// the field: every other required body id on this surface answers 404 for an id
+// that names no visible row, so that a caller cannot tell "no such purpose"
+// from "not yours" and read the difference as an enumeration. Claiming such an
+// id was ARCHIVED is also simply untrue, and it sends an operator looking for a
+// purpose to unarchive that nobody ever created.
+//
+// An ARCHIVED purpose exists and is refused with its own sentence: a link
+// minted against it would mail and then dead-end, because consentCardFor
+// resolves only a live purpose, so the subject opens a 404 sent in the
+// installation's own name.
+//
+// A purpose that does not REQUIRE double opt-in is a different mistake — the
+// mail would ask somebody to confirm a subscription whose grant never needed
 // confirming, and the answer would be recorded as mailbox-proven evidence
 // nobody asked for. The endpoint's whole subject is the double-opt-in purpose.
 func requireConfirmablePurposeTx(ctx context.Context, tx pgx.Tx, purposeID ids.PurposeID) error {
 	if purposeID.UUID == (ids.UUID{}) {
 		return nil
 	}
-	var requiresDOI bool
+	var requiresDOI, archived bool
+	// Read WITHOUT the live filter, so absence and archival stay separable. The
+	// filtered read answered no-rows for both and had to guess which; it always
+	// guessed archived.
 	err := tx.QueryRow(ctx,
-		`SELECT requires_double_opt_in FROM consent_purpose
-		  WHERE id = $1 AND archived_at IS NULL`, purposeID).Scan(&requiresDOI)
+		`SELECT requires_double_opt_in, archived_at IS NOT NULL FROM consent_purpose
+		  WHERE id = $1`, purposeID).Scan(&requiresDOI, &archived)
 	if errors.Is(err, pgx.ErrNoRows) {
+		return apperrors.ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	if archived {
 		return &ValidationError{
 			Field:  purposeIDField,
 			Reason: "this purpose is archived, so a link asking somebody to confirm it could not be answered",
 		}
-	}
-	if err != nil {
-		return err
 	}
 	if !requiresDOI {
 		return &ValidationError{


### PR DESCRIPTION
**main is red on the integration lane.** #4931 ("the double-opt-in link is mailed again, by the honest path") gave the door a working mint, and two tests still hold it to the refusal it replaced. No open PR covers these two: #4942 and #4943 fix the other three breakages, and neither touches consent — so this is that fix, and this note is the "say so" the rulebook asks for.

```
consent_integration_test.go:408: issuance under marketing_email → 201, want 409
consent_integration_test.go:408: issuance under transactional  → 422, want 409
requiredbodyids_http_integration_test.go:252: → 422, want 409 …
  {Code:validation_error Detail:this purpose is archived, so a link asking somebody to confirm it could not be answered}
```

## The stale test is deleted, not rewritten

`TestDOIIssuanceMintsNothingWhicheverPurposeIsNamed` said what it was in its own comment:

> This replaces a test of the issuance round trip … None of that exists now: the endpoint returns a conflict for every caller.

It was a placeholder holding the one property a retired capability had left. The capability is back, and #4931's own `doidoor_integration_test.go` covers it through the handler arm by arm — the mint, the absent plaintext, the missing mailbox, the mail's wording, the archived purpose, the purpose that needs no confirmation. Rewriting this one would be a second copy of that file's subject, free to disagree with it.

## The second failure is a real defect the restored door brought with it

`requireConfirmablePurposeTx` read the purpose with a live-only filter:

```sql
SELECT requires_double_opt_in FROM consent_purpose WHERE id = $1 AND archived_at IS NULL
```

so a purpose that **never existed** and a purpose that **was archived** both came back as `ErrNoRows` — and it answered *archived* for both. Two things are wrong with that:

1. **It says something untrue.** An operator who typed a wrong id is sent looking for a purpose to unarchive that nobody ever created.
2. **It answers the wrong status.** 422 naming `purpose_id` where every other required body id on this surface answers 404. That rule is not decoration — it is what keeps "no such row" indistinguishable from "a row you may not see", and `requiredbodyids_http_integration_test.go` is the gate that holds it. The DOI case carried a documented exception (`suppliedStatus: Conflict`) that was honest while the endpoint refused everybody and resolved nothing. It resolves the purpose now, so the exception is gone.

The read drops the filter and carries `archived_at IS NOT NULL` instead, separating the three cases: **no row → `ErrNotFound`**, **archived → its own sentence**, **live but not double-opt-in → its own sentence**. #4931's `TestTheDoubleOptInDoorRefusesAnArchivedPurpose` still passes on the archived arm, which is what confirms the split kept the case it was distinguishing.

## Checks

`make check-backend` green. `make test-it DIR=backend/internal/modules/consent` green (the whole DOI door suite). `make test-it DIR=backend/internal/compose/integration RUN='TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden'` green.

**Mutation check:** collapsing the split back — returning the archived sentence for `ErrNoRows` again — fails `IssueDoubleOptInJSONBody.purpose_id/supplied_but_invisible_stays_a_404` and leaves the omitted-id half passing, which is the pair that says the fix is about the right half.