### PR TITLE
main is red: a test cites a migration that never existed

### DIFF
--- a/frontend/src/screens/settings-grants.test.tsx
+++ b/frontend/src/screens/settings-grants.test.tsx
@@ -87,9 +87,9 @@ describe("the grant that opens one settings page", () => {
 
   it("opens Seats & license for a lone license read", async () => {
     // `LicenseCard` calls `/installation/license` and nothing else, so this is
-    // the grant that actually reaches content. Core migration 0261 grants
-    // `license` to admin and ops and to nobody else, so it is still a grant an
-    // edited role can hold rather than a role name.
+    // the grant that actually reaches content. The role defaults give `license`
+    // read to admin and ops and to nobody else (identity's policy defaults), so
+    // it is still a grant an edited role can hold rather than a role name.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("license") }),


### PR DESCRIPTION
`main` fails `TestEveryCitedMigrationExists` on the tip (`d407de3a4`), reproduced locally against plain `origin/main`:

```
frontend/src/screens/settings-grants.test.tsx:89 cites migration 0261
A citation written now against a version that never existed is a dead end from birth.
```

Landed with https://github.com/margince/margince/pull/4938. The four-digit sequence closed at the `0001` baseline, and this grant was never a migration to begin with — it lives in identity's role defaults, in Go.

**This is not one branch's problem.** The gate is in the `gates` package, so it takes `deterministic-gates`, `extension-reference` and the integration lane's coverage job red on *every* open pull request. https://github.com/margince/margince/pull/4945 is currently showing two of those three for this reason and nothing of its own.

The claim in the comment is true and worth keeping — admin and ops hold `license` read and nobody else does (`identity/internal/policy/defaults.go`, `objLicense: readOnly` under `admin` and `ops`) — so the comment now points at where that is actually decided instead of at a version number. No behaviour change; a comment is the whole diff.

Verified: `TestEveryCitedMigrationExists` passes, the file's own 22 tests pass, biome clean.

One of several causes collected under https://github.com/margince/margince/issues/4852.