### PR TITLE
fix(tests): the license grant is stated, not cited

### DIFF
--- a/backend/danglingcitations.txt
+++ b/backend/danglingcitations.txt
@@ -243,7 +243,6 @@ frontend/src/screens/embedreindex.test.tsx migration 0115
 frontend/src/screens/embedreindex.tsx migration 0115
 frontend/src/screens/relationships.test.tsx migration 0007
 frontend/src/screens/relationships.tsx migration 0007
-frontend/src/screens/settings-nav.test.tsx migration 0261
 scripts/deploy/db-bootstrap.sql migration 0015
 scripts/lib-testdb.sh migration 0015
 scripts/test-migration-versions.sh core 0002

--- a/frontend/src/screens/settings-grants.test.tsx
+++ b/frontend/src/screens/settings-grants.test.tsx
@@ -87,9 +87,9 @@ describe("the grant that opens one settings page", () => {
 
   it("opens Seats & license for a lone license read", async () => {
     // `LicenseCard` calls `/installation/license` and nothing else, so this is
-    // the grant that actually reaches content. Core migration 0261 grants
+    // the grant that actually reaches content. The seeded matrix gives
     // `license` to admin and ops and to nobody else, so it is still a grant an
-    // edited role can hold rather than a role name.
+    // edited role can hold rather than a role name in disguise.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("license") }),

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -196,8 +196,8 @@ const SEEDED_READS: GrantSpec = {
 };
 
 // What the matrix adds for ops: the objects it shares with admin alone.
-// `embedding_reindex` is what opens System health, and `license` — which core
-// migration 0261 grants to admin and ops and to nobody else — is what opens
+// `embedding_reindex` is what opens System health, and `license` — which the
+// seeded matrix grants to admin and ops and to nobody else — is what opens
 // Seats & license.
 //
 // `ai_model_rate` opens AI usage and NOT Model calls, which is the two entries


### PR DESCRIPTION
**main is red on `TestEveryCitedMigrationExists`, and #4938 is why** — my own merge. It blocks every open PR, so this is the fix.

```
frontend/src/screens/settings-grants.test.tsx:89 cites migration 0261
  A citation written now against a version that never existed is a dead end from birth.
```

## What happened

The register is keyed by **path**. `settings-nav.test.tsx` had a ratified line for its 0261 citation; splitting the suite copied that sentence into `settings-grants.test.tsx`, where the same citation is *new*. A rename or a split turns a ratified dead end into an unratified one, and the gate is right to say so.

## Why the line was not simply re-added

Adding the copy would have left **two** register lines where there was one, and the register's own note is exactly about that:

> a file acquires no citation of a version it does not ALREADY cite … Per FILE rather than a total, because a total lets a deletion anywhere fund a new dead citation elsewhere.

So both sentences state the invariant instead. Neither claim needed the version: what they say is that `license` is a **grant** the seeded role matrix gives admin and ops and nobody else — which is why a role an installation has edited can hold it, and why the case is not a role name in disguise. Which migration first wrote that row is not part of it, and a reader who wanted it has `git log` for the matrix.

The old register line goes with the citation it recorded, so the backlog is one shorter than before rather than one longer.

## Checks

`go test -count=1 -run TestEveryCitedMigrationExists ./gates` green. Both suites still pass — 40 tests, unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated test comments to clarify the source and meaning of the `license` grant.
  - Removed an outdated entry from the dangling-citation register.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->