### PR TITLE
feat(frontend): an admin turns a transition on from the screen

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -2886,3 +2886,139 @@ test.describe("filters and views", () => {
     ).toBeVisible();
   });
 });
+
+test.describe("stage automation, in German", () => {
+  // The rule and the report the page draws. Routed rather than seeded, because
+  // what is under test is the German surface over a KNOWN state — a suspension
+  // with a reason, and a transition nobody has decided about — and neither is a
+  // state the seed happens to produce.
+  const SUSPENDED_REASON =
+    "ein Zug hat einen Datensatz außerhalb des eigenen Workspace erreicht";
+
+  async function stubStageAutomation(
+    page: Page,
+    options: { suspended?: boolean } = {},
+  ) {
+    const suspended = options.suspended ?? true;
+    await page.route("**/stage-automation/report**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          window_days: 30,
+          data: [
+            {
+              pipeline_id: "p1",
+              from_stage_id: "s1",
+              to_stage_id: "s2",
+              from_stage_name: "Erstkontakt",
+              to_stage_name: "Angebot",
+              reviewed: 240,
+              proposed: 0,
+              expired: 0,
+              superseded: 0,
+              accepted_clean: 236,
+              accepted_edited: 2,
+              rejected: 2,
+              auto_applied: 0,
+              unsafe: 1,
+              observation_days: 34,
+              clean_acceptance_rate: 0.98,
+              edit_rate: 0.01,
+              rejection_rate: 0.01,
+              // UNDER the 1% ceiling. The rule below is suspended for a SAFETY
+              // defect, which needs no volume — so the record has to be good,
+              // or the page would rightly draw "not earned yet" instead of the
+              // undo window this test is about.
+              unsafe_rate: 0.004,
+              evidence_kinds: [],
+            },
+          ],
+        }),
+      });
+    });
+    await page.route("**/stage-automation/policies/**", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: "{}",
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: [
+            {
+              id: "r1",
+              pipeline_id: "p1",
+              from_stage_id: "s1",
+              to_stage_id: "s2",
+              mode: "auto",
+              clean_acceptance_threshold: 0.95,
+              correction_reversal_threshold: 0.01,
+              min_reviewed: 200,
+              min_observation_days: 28,
+              window_days: 30,
+              undo_window_hours: 72,
+              version: 3,
+              ...(suspended
+                ? {
+                    suspended_at: "2026-09-03T10:00:00Z",
+                    suspended_reason: SUSPENDED_REASON,
+                  }
+                : {}),
+            },
+          ],
+        }),
+      });
+    });
+  }
+
+  test("a suspended transition says in German why it stopped, and promises no undo while it is stopped", async ({
+    page,
+  }) => {
+    await stubStageAutomation(page);
+    await page.goto("/#/settings/stageautomation");
+    await page.waitForLoadState("networkidle");
+
+    // The switch carries the transition's own stage names, so an admin reading
+    // three rules can tell which move each one governs.
+    await expect(
+      page.getByRole("switch", { name: /Erstkontakt → Angebot/ }),
+    ).toBeVisible();
+
+    // The product's own reason, in the reader's language and unabridged. It is
+    // the entire basis for deciding whether to start the transition again.
+    await expect(page.getByText(SUSPENDED_REASON)).toBeVisible();
+
+    // A SUSPENDED rule promises no undo window, because it applies nothing —
+    // and a screen saying "Rückgängig für 72 h" beside "Margince hat das
+    // gestoppt" would offer an undo for moves that are not being made.
+    await expect(page.getByText(/Rückgängig für/)).toBeHidden();
+
+    // The way back is a deliberate act with its own confirmation, not a
+    // toggle: lifting a safety stop by mis-click is the failure this guards.
+    await page.getByRole("button", { name: "Wieder starten" }).click();
+    await expect(
+      page.getByText(/überspringt die Schwelle nicht/),
+    ).toBeVisible();
+  });
+
+  test("a running transition says in German how long a move can be taken back", async ({
+    page,
+  }) => {
+    await stubStageAutomation(page, { suspended: false });
+    await page.goto("/#/settings/stageautomation");
+    await page.waitForLoadState("networkidle");
+
+    // "Rückgängig", with the window a person actually has. A screen that
+    // offered undo without saying how long it lasts leaves somebody to find
+    // out by trying it too late.
+    await expect(page.getByText(/Rückgängig für 72 h/)).toBeVisible();
+    // And nothing about a stop, because there is none.
+    await expect(page.getByText("Margince hat das gestoppt")).toBeHidden();
+  });
+});

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -9208,6 +9208,23 @@ export const de = {
     "Margince hat auf dieser Pipeline noch keinen Phasenwechsel vorgeschlagen.",
   "stageAutomation.noPipelines":
     "Es gibt noch keine Pipeline, \u00fcber die berichtet werden k\u00f6nnte.",
+  "stageAutomation.readOnly":
+    "Sie sehen, was jeder Übergang verdient hat. Um zu ändern, was einer darf, brauchen Sie das Recht, Pipelines zu bearbeiten.",
+  "stageAutomation.rules": "Was jeder Übergang darf",
+  "stageAutomation.rulesIntro":
+    "Einen Übergang einzuschalten setzt noch nichts in Bewegung. Margince fragt weiter nach, bis die Bilanz oben die Schwelle erreicht, und wendet ihn dann von selbst an — Sie müssen nicht noch einmal herkommen.",
+  "stageAutomation.modeHint":
+    "Ist das an und hat die Bilanz es verdient, verschiebt Margince den Deal und sagt es Ihnen danach.",
+  "stageAutomation.notEarnedYet": "Noch nicht verdient: {why}",
+  "stageAutomation.suspended": "Margince hat das gestoppt",
+  "stageAutomation.suspendedSince": "Gestoppt am {date}",
+  "stageAutomation.resume": "Wieder starten",
+  "stageAutomation.resumeTitle": "Diesen Übergang wieder Deals bewegen lassen?",
+  "stageAutomation.resumeBody":
+    "Margince hat ihn gestoppt, weil: {reason}\n\nEin Neustart überspringt die Schwelle nicht. Der Übergang kehrt zu dem zurück, was Sie eingestellt haben, und muss die Bilanz oben weiterhin erreichen, bevor er von selbst etwas bewegt.",
+  "stageAutomation.noRules":
+    "Über keinen Übergang dieser Pipeline wurde bisher entschieden, also wird jede Bewegung einer Person vorgeschlagen.",
+  "stageAutomation.undoWindow": "Rückgängig für {hours} h",
   "stageAutomation.nothingReviewed":
     "Vorgeschlagen, aber noch nicht beantwortet.",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -9334,6 +9334,23 @@ export const en = {
   "stageAutomation.empty":
     "Margince has not proposed a stage move on this pipeline yet.",
   "stageAutomation.noPipelines": "There is no pipeline to report on yet.",
+  "stageAutomation.readOnly":
+    "You can see what each transition has earned. Changing what one may do needs permission to edit pipelines.",
+  "stageAutomation.rules": "What each transition may do",
+  "stageAutomation.rulesIntro":
+    "Turning a transition on does not start it moving deals. Margince keeps asking until the record above clears the bar, then starts applying on its own — you do not have to come back.",
+  "stageAutomation.modeHint":
+    "When this is on and the record has earned it, Margince moves the deal and tells you afterwards.",
+  "stageAutomation.notEarnedYet": "Not earned yet: {why}",
+  "stageAutomation.suspended": "Margince stopped this",
+  "stageAutomation.suspendedSince": "Stopped {date}",
+  "stageAutomation.resume": "Start again",
+  "stageAutomation.resumeTitle": "Let this transition move deals again?",
+  "stageAutomation.resumeBody":
+    "Margince stopped it because: {reason}\n\nStarting it again does not skip the bar. It goes back to what you asked for, and still has to clear the record above before it moves anything by itself.",
+  "stageAutomation.noRules":
+    "No transition on this pipeline has been decided about yet, so every move is proposed for a person to answer.",
+  "stageAutomation.undoWindow": "Undo for {hours} h",
   "stageAutomation.nothingReviewed":
     "Proposed, but nobody has answered one yet.",
 } as const;

--- a/frontend/src/i18n/record-noun.test.ts
+++ b/frontend/src/i18n/record-noun.test.ts
@@ -81,6 +81,8 @@ const HUMAN_SENSE_KEYS: Record<string, readonly string[]> = {
     // Names this rename leaves alone: Settings → People, and the tab it heads.
     "co.relationships.title",
     "settings.group.people",
+    // "a person" here is a HUMAN BEING deciding, not the contact record.
+    "stageAutomation.noRules",
     "tab.relationships",
     // A colleague, a user, an admin, an operator — somebody with a seat here.
     "confirm.done.body",
@@ -157,6 +159,8 @@ const HUMAN_SENSE_KEYS: Record<string, readonly string[]> = {
     // Names this rename leaves alone: Settings → People, and the tab it heads.
     "co.relationships.title",
     "settings.group.people",
+    // "a person" here is a HUMAN BEING deciding, not the contact record.
+    "stageAutomation.noRules",
     "tab.relationships",
     // A colleague, a user, an admin, an operator — somebody with a seat here.
     "analytics.share.liveHelp",
@@ -342,6 +346,8 @@ const HUMAN_SENSE_KEYS: Record<string, readonly string[]> = {
     "share.rosterLoading",
     "share.subject",
     "signInMethods.sub",
+    // "a person" here is a HUMAN BEING deciding, not the contact record.
+    "stageAutomation.noRules",
     "stageAutomation.reviewedHint",
     "teamweekly.agenda.sub",
     "users.access.title",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -9083,6 +9083,24 @@ export const vi = {
     "Margince ch\u01b0a \u0111\u1ec1 xu\u1ea5t b\u01b0\u1edbc chuy\u1ec3n n\u00e0o tr\u00ean quy tr\u00ecnh n\u00e0y.",
   "stageAutomation.noPipelines":
     "Ch\u01b0a c\u00f3 quy tr\u00ecnh n\u00e0o \u0111\u1ec3 b\u00e1o c\u00e1o.",
+  "stageAutomation.readOnly":
+    "Bạn có thể xem mỗi bước chuyển đã đạt được gì. Để thay đổi điều một bước chuyển được phép làm, bạn cần quyền chỉnh sửa quy trình.",
+  "stageAutomation.rules": "Mỗi bước chuyển được phép làm gì",
+  "stageAutomation.rulesIntro":
+    "Bật một bước chuyển không làm nó bắt đầu di chuyển giao dịch. Margince vẫn hỏi cho đến khi hồ sơ ở trên đạt ngưỡng, rồi tự áp dụng — bạn không phải quay lại.",
+  "stageAutomation.modeHint":
+    "Khi bật và hồ sơ đã đạt, Margince chuyển giao dịch rồi báo cho bạn sau.",
+  "stageAutomation.notEarnedYet": "Chưa đạt: {why}",
+  "stageAutomation.suspended": "Margince đã dừng việc này",
+  "stageAutomation.suspendedSince": "Đã dừng {date}",
+  "stageAutomation.resume": "Bắt đầu lại",
+  "stageAutomation.resumeTitle":
+    "Cho bước chuyển này di chuyển giao dịch trở lại?",
+  "stageAutomation.resumeBody":
+    "Margince đã dừng nó vì: {reason}\n\nBắt đầu lại không bỏ qua ngưỡng. Nó trở về đúng điều bạn đã đặt, và vẫn phải đạt hồ sơ ở trên trước khi tự di chuyển bất cứ điều gì.",
+  "stageAutomation.noRules":
+    "Chưa có bước chuyển nào trên quy trình này được quyết định, nên mọi lần di chuyển đều được đề xuất cho một người trả lời.",
+  "stageAutomation.undoWindow": "Hoàn tác trong {hours} giờ",
   "stageAutomation.nothingReviewed":
     "\u0110\u00e3 \u0111\u1ec1 xu\u1ea5t, nh\u01b0ng ch\u01b0a ai tr\u1ea3 l\u1eddi.",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/screens/settings-stagerules.test.tsx
+++ b/frontend/src/screens/settings-stagerules.test.tsx
@@ -1,0 +1,329 @@
+/** @vitest-environment jsdom */
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { meFixture } from "../app/mefixture";
+import { StageAutomationCard } from "./settings.stageautomation";
+import { jsonResponse, PIPELINE_ADMIN, render } from "./settings.testkit";
+
+// The controls that decide what a transition may do.
+//
+// Every test here turns on one distinction: ASKING IS NOT BEING ALLOWED.
+// Turning a transition on records what an admin wants; the server re-checks
+// the record in the transaction that would apply each move. A screen that said
+// otherwise would have somebody believe deals were moving when they were not,
+// or the reverse.
+
+beforeEach(() => {
+  globalThis.localStorage.setItem("margince.workspaceSlug", "acme");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  globalThis.localStorage.clear();
+});
+
+const PIPELINES = [{ id: "p1", name: "Sales", stages: [], version: 1 }];
+
+function transition(
+  from: string,
+  to: string,
+  fromName: string,
+  toName: string,
+) {
+  return {
+    pipeline_id: "p1",
+    from_stage_id: from,
+    to_stage_id: to,
+    from_stage_name: fromName,
+    to_stage_name: toName,
+    reviewed: 240,
+    proposed: 0,
+    expired: 0,
+    superseded: 0,
+    accepted_clean: 236,
+    accepted_edited: 2,
+    rejected: 2,
+    auto_applied: 0,
+    unsafe: 1,
+    observation_days: 34,
+    clean_acceptance_rate: 0.98,
+    edit_rate: 0.01,
+    rejection_rate: 0.01,
+    unsafe_rate: 0.004,
+    evidence_kinds: [],
+  };
+}
+
+const REPORT = {
+  window_days: 30,
+  data: [
+    transition("s1", "s2", "Discovery", "Negotiation"),
+    transition("s2", "s3", "Negotiation", "Contract"),
+  ],
+};
+
+// A rule on the first transition; the second has none, which is the default
+// state of every transition in the product.
+const RULES = {
+  data: [
+    {
+      id: "r1",
+      pipeline_id: "p1",
+      from_stage_id: "s1",
+      to_stage_id: "s2",
+      mode: "auto",
+      clean_acceptance_threshold: 0.95,
+      correction_reversal_threshold: 0.01,
+      min_reviewed: 200,
+      min_observation_days: 28,
+      window_days: 30,
+      undo_window_hours: 72,
+      version: 3,
+    },
+  ],
+};
+
+type Recorded = { url: string; method: string; body: unknown };
+
+function rulesStub(rules: unknown = RULES, grants = PIPELINE_ADMIN) {
+  const calls: Recorded[] = [];
+  const fetchStub = vi.fn(async (input: RequestInfo | URL) => {
+    // openapi-fetch dispatches a Request object, so both the url and the
+    // method ride it — read off a second argument they are always undefined,
+    // and a test asserting "it did not write" would pass over any write.
+    const request = input instanceof Request ? input : undefined;
+    const url = String(request ? request.url : input);
+    const method = request?.method ?? "GET";
+    if (request && method !== "GET") {
+      calls.push({ url, method, body: await request.clone().json() });
+    }
+    if (url.endsWith("/v1/me")) {
+      return jsonResponse(meFixture({ roles: ["admin"], allow: grants }));
+    }
+    if (url.includes("/stage-automation/policies")) {
+      return jsonResponse(method === "GET" ? rules : { ...RULES.data[0] });
+    }
+    if (url.includes("/stage-automation/report")) {
+      return jsonResponse(REPORT);
+    }
+    if (url.includes("/pipelines")) {
+      return jsonResponse({ data: PIPELINES, page: {} });
+    }
+    return jsonResponse({ data: [], page: {} });
+  });
+  return { fetchStub, calls };
+}
+
+describe("stage automation rules", () => {
+  it("draws a switch for every transition, not only those with a rule", async () => {
+    const { fetchStub } = rulesStub();
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    // Both transitions, though only one has a rule. A transition nobody has
+    // decided about is the DEFAULT, and drawing only the decided ones would
+    // hide every transition an admin has yet to think about.
+    expect(
+      await screen.findByRole("switch", { name: /Discovery → Negotiation/ }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("switch", { name: /Negotiation → Contract/ }),
+    ).toBeTruthy();
+  });
+
+  it("shows a transition with a rule as on, and one without as off", async () => {
+    const { fetchStub } = rulesStub();
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    const withRule = await screen.findByRole("switch", {
+      name: /Discovery → Negotiation/,
+    });
+    const without = screen.getByRole("switch", {
+      name: /Negotiation → Contract/,
+    });
+    expect(withRule.getAttribute("aria-checked")).toBe("true");
+    expect(without.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("sends the version it read, so a save cannot overwrite a change it never saw", async () => {
+    const { fetchStub, calls } = rulesStub();
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    const toggle = await screen.findByRole("switch", {
+      name: /Discovery → Negotiation/,
+    });
+    await userEvent.click(toggle);
+
+    await waitFor(() => expect(calls.length).toBeGreaterThan(0));
+    const save = calls.find((call) => call.method === "PUT");
+    expect(save).toBeTruthy();
+    const body = save?.body as Record<string, unknown>;
+    expect(body.mode).toBe("propose");
+    expect(body.if_version).toBe(3);
+    expect(body.from_stage_id).toBe("s1");
+    expect(body.to_stage_id).toBe("s2");
+  });
+
+  it("sends no version for a transition that has no rule yet", async () => {
+    const { fetchStub, calls } = rulesStub();
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    const toggle = await screen.findByRole("switch", {
+      name: /Negotiation → Contract/,
+    });
+    await userEvent.click(toggle);
+
+    await waitFor(() => expect(calls.length).toBeGreaterThan(0));
+    const body = calls.find((call) => call.method === "PUT")?.body as Record<
+      string,
+      unknown
+    >;
+    // There was no row to have read, so a pin would be a claim about a version
+    // that never existed — and the server answers 409 to one.
+    expect(body.if_version).toBeUndefined();
+    expect(body.mode).toBe("auto");
+  });
+
+  it("shows a suspended rule with the reason the product gave", async () => {
+    const suspended = {
+      data: [
+        {
+          ...RULES.data[0],
+          suspended_at: "2026-09-03T10:00:00Z",
+          suspended_reason:
+            "1.2% of 240 reviewed moves on this transition were undone or corrected, above the 1.0% ceiling",
+        },
+      ],
+    };
+    const { fetchStub } = rulesStub(suspended);
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    // The reason itself, not a summary of it. It is the whole basis on which
+    // somebody decides to start the transition again.
+    expect(await screen.findByText(/above the 1.0% ceiling/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Start again/ })).toBeTruthy();
+  });
+
+  it("asks before starting a suspended transition again, and says the bar still applies", async () => {
+    const suspended = {
+      data: [
+        {
+          ...RULES.data[0],
+          suspended_at: "2026-09-03T10:00:00Z",
+          suspended_reason: "a move reached a record outside its own workspace",
+        },
+      ],
+    };
+    const { fetchStub, calls } = rulesStub(suspended);
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Start again/ }),
+    );
+
+    // Nothing sent yet: the confirmation is the point, and a resume that fired
+    // on the first click would lift a safety stop by mis-click.
+    expect(calls.filter((call) => call.url.includes("/resume"))).toHaveLength(
+      0,
+    );
+    // The dialog says what starting again does NOT do.
+    expect(await screen.findByText(/does not skip the bar/i)).toBeTruthy();
+  });
+
+  it("does not offer a way back on a rule the product has not stopped", async () => {
+    const { fetchStub } = rulesStub();
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    await screen.findByRole("switch", { name: /Discovery → Negotiation/ });
+    // A running rule has nothing to resume, and a control offering it would
+    // ask for a decision about a state the transition is not in.
+    expect(screen.queryByRole("button", { name: /Start again/ })).toBeNull();
+  });
+
+  it("refuses the controls to a reader who may see the report and not change it", async () => {
+    // The report opens on `pipeline` READ; every control here needs update. A
+    // viewer holding only the read must see the evidence with the controls
+    // REFUSED, not live ones that 403 on the first click.
+    const { fetchStub, calls } = rulesStub(
+      {
+        data: [
+          {
+            ...RULES.data[0],
+            suspended_at: "2026-09-03T10:00:00Z",
+            suspended_reason:
+              "a move reached a record outside its own workspace",
+          },
+        ],
+      },
+      { pipeline: ["read"] },
+    );
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    const toggle = await screen.findByRole("switch", {
+      name: /Discovery → Negotiation/,
+    });
+    // The real `disabled` property. The design system reserves aria-disabled
+    // for a control that is mid-write and must keep focus; one nobody may
+    // touch is disabled outright.
+    expect((toggle as HTMLButtonElement).disabled).toBe(true);
+    // The way back is absent rather than refused: resuming is a whole act, and
+    // a disabled control for one is a door that was never theirs to open.
+    expect(screen.queryByRole("button", { name: /Start again/ })).toBeNull();
+    // And the reason is still readable — this reader came to consult it.
+    expect(
+      screen.getByText(/a move reached a record outside its own workspace/),
+    ).toBeTruthy();
+
+    await userEvent.click(toggle);
+    expect(calls.filter((call) => call.method === "PUT")).toHaveLength(0);
+  });
+
+  it("says nothing about thresholds when the rule is counted over a different window", async () => {
+    // The report is fetched over 30 days; this rule counts its own rates over
+    // 7. Judging one against the other would say a transition had earned a bar
+    // it was never measured against.
+    const otherWindow = {
+      data: [{ ...RULES.data[0], window_days: 7, min_reviewed: 400 }],
+    };
+    const { fetchStub } = rulesStub(otherWindow);
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    await screen.findByRole("switch", { name: /Discovery → Negotiation/ });
+    // 240 reviewed is short of 400, so a naive comparison would draw the line.
+    expect(screen.queryByText(/Not earned yet/)).toBeNull();
+  });
+
+  it("says which threshold a transition is short of", async () => {
+    const shortOfVolume = {
+      data: [{ ...RULES.data[0], min_reviewed: 400 }],
+    };
+    const { fetchStub } = rulesStub(shortOfVolume);
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    // A switch that says ON while the server keeps proposing is this page's
+    // worst failure, so the line names the bar rather than leaving the admin
+    // to wonder why cards keep arriving.
+    expect(await screen.findByText(/240\/400/)).toBeTruthy();
+  });
+
+  it("says how long an automatic move can be taken back", async () => {
+    const { fetchStub } = rulesStub();
+    vi.stubGlobal("fetch", fetchStub);
+    render(<StageAutomationCard />);
+
+    // Drawn only where it means something: a transition that proposes has no
+    // automatic move to undo.
+    expect(await screen.findByText(/Undo for 72 h/)).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/settings.stageautomation.tsx
+++ b/frontend/src/screens/settings.stageautomation.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import type { ReactElement } from "react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -14,6 +15,7 @@ import {
 import type { Locale, Translator } from "../i18n";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
+import { StageRulesCard } from "./settings.stagerules";
 
 type TransitionRecord = components["schemas"]["StageTransitionRecord"];
 
@@ -24,12 +26,13 @@ type TransitionRecord = components["schemas"]["StageTransitionRecord"];
 const DEFAULT_WINDOW_DAYS = 30;
 
 /**
- * What each stage transition has earned.
+ * What each stage transition has earned, and what each is allowed to do.
  *
- * READ-ONLY, and that is the whole design. This page exists so a person can
- * decide whether a transition is trustworthy enough to move deals by itself —
- * and a page that both showed the evidence and flipped the switch would invite
- * the flip before the reading.
+ * THE TABLE IS READ-ONLY, and that is the whole design. It exists so a person
+ * can decide whether a transition is trustworthy enough to move deals by
+ * itself, and a control in every row would invite the flip before the reading.
+ * The switches live BELOW it, in their own section, reached after the evidence
+ * rather than beside it.
  *
  * Every rate is a share of ANSWERED proposals, and the answered count is drawn
  * beside them rather than under a tooltip: a transition with a perfect
@@ -77,45 +80,25 @@ export function StageAutomationCard() {
   // or that FAILED means nothing of the kind, and drawing the same words for
   // all three tells somebody to wait for numbers that were refused or never
   // asked for.
-  if (pipelines.isError || report.isError) {
-    return (
-      <Panel title={t("stageAutomation.title")}>
-        <PanelBody>
-          <Callout tone="warn">
-            {problemMessageOf(pipelines.error ?? report.error, t)}
-          </Callout>
-        </PanelBody>
-      </Panel>
-    );
-  }
-  if (pipelines.isPending || (chosen !== "" && report.isPending)) {
-    return (
-      <Panel title={t("stageAutomation.title")}>
-        <PanelBody>
-          <BusyMark />
-        </PanelBody>
-      </Panel>
-    );
-  }
-  if (pipelines.data && pipelines.data.length === 0) {
-    return (
-      <Panel title={t("stageAutomation.title")}>
-        <PanelBody>
-          <EmptyState>{t("stageAutomation.noPipelines")}</EmptyState>
-        </PanelBody>
-      </Panel>
-    );
+  //
+  // Gathered into one helper because they are one question asked three ways —
+  // is there a report to draw — and inlining them put this component over the
+  // complexity ceiling once the rules card joined it.
+  const notYet = beforeTheReport({ pipelines, report, chosen }, t);
+  if (notYet) {
+    return notYet;
   }
 
   const rows = report.data?.data ?? [];
+  // The window the counts actually came over, named once. The rules card needs
+  // it to know whether a rule's own window matches — a rule measured over a
+  // different span cannot be judged from these rows.
+  const windowDays = report.data?.window_days ?? DEFAULT_WINDOW_DAYS;
   return (
     <Panel
       title={t("stageAutomation.title")}
       sub={t("stageAutomation.window", {
-        days: formatNumber(
-          report.data?.window_days ?? DEFAULT_WINDOW_DAYS,
-          locale,
-        ),
+        days: formatNumber(windowDays, locale),
       })}
     >
       <PanelBody>
@@ -156,11 +139,67 @@ export function StageAutomationCard() {
               <dt>{t("stageAutomation.observationDays")}</dt>
               <dd>{t("stageAutomation.observationHint")}</dd>
             </dl>
+            {/* The controls, after the evidence. Given the report's own rows
+                rather than fetching a second list of transitions: the two
+                would otherwise be able to disagree about which transitions
+                this pipeline has. */}
+            <StageRulesCard
+              pipelineId={chosen}
+              transitions={rows}
+              reportWindowDays={report.data?.window_days ?? DEFAULT_WINDOW_DAYS}
+            />
           </>
         )}
       </PanelBody>
     </Panel>
   );
+}
+
+/** The panel to draw when there is no report yet, or null when there is one. */
+function beforeTheReport(
+  state: {
+    pipelines: {
+      isError: boolean;
+      isPending: boolean;
+      error: unknown;
+      data?: unknown[];
+    };
+    report: { isError: boolean; isPending: boolean; error: unknown };
+    chosen: string;
+  },
+  t: Translator,
+): ReactElement | null {
+  const { pipelines, report, chosen } = state;
+  if (pipelines.isError || report.isError) {
+    return (
+      <Panel title={t("stageAutomation.title")}>
+        <PanelBody>
+          <Callout tone="warn">
+            {problemMessageOf(pipelines.error ?? report.error, t)}
+          </Callout>
+        </PanelBody>
+      </Panel>
+    );
+  }
+  if (pipelines.isPending || (chosen !== "" && report.isPending)) {
+    return (
+      <Panel title={t("stageAutomation.title")}>
+        <PanelBody>
+          <BusyMark />
+        </PanelBody>
+      </Panel>
+    );
+  }
+  if (pipelines.data && pipelines.data.length === 0) {
+    return (
+      <Panel title={t("stageAutomation.title")}>
+        <PanelBody>
+          <EmptyState>{t("stageAutomation.noPipelines")}</EmptyState>
+        </PanelBody>
+      </Panel>
+    );
+  }
+  return null;
 }
 
 // A rate, or a dash.

--- a/frontend/src/screens/settings.stagerules.tsx
+++ b/frontend/src/screens/settings.stagerules.tsx
@@ -1,0 +1,362 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { useCanWrite } from "../app/capability";
+import { BusyMark, Button, EmptyState } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { Switch } from "../design-system/switch";
+import { formatDate, formatNumber } from "../format/format";
+import { viewerZone } from "../format/timezone";
+import { useLocale, useT } from "../i18n";
+import { problemMessageOf, throwProblem } from "./common";
+
+type TransitionPolicy = components["schemas"]["TransitionPolicy"];
+type TransitionRecord = components["schemas"]["StageTransitionRecord"];
+
+/**
+ * What each transition is allowed to do, and the controls for changing it.
+ *
+ * SEPARATE from the evidence table above it, deliberately. That table is
+ * read-only so a person reads the record before touching the switch; this is
+ * where they touch it, once they have. Merging the two would put a control in
+ * every row of a table somebody is still reading.
+ *
+ * The rules are keyed by transition, and a transition with no rule is the
+ * DEFAULT state of every transition in the product — it proposes. So this
+ * draws a row per transition the report knows about rather than per rule,
+ * or a transition nobody has decided about would be invisible here and the
+ * page would look like it had nothing to offer.
+ */
+export function StageRulesCard({
+  pipelineId,
+  transitions,
+  reportWindowDays,
+}: Readonly<{
+  pipelineId: string;
+  transitions: readonly TransitionRecord[];
+  /** The window the report's counts were taken over, so a rule measured over
+   * a different one is not judged against them. */
+  reportWindowDays: number;
+}>) {
+  const t = useT();
+  // The report opens on `pipeline` READ, and every control here needs update.
+  // A viewer who holds only the read sees the evidence and controls that
+  // cannot work — so they are drawn refused, with the reason, rather than live
+  // and 403ing on the first click.
+  const mayChange = useCanWrite("pipeline", "update");
+  const queryClient = useQueryClient();
+  const rules = useQuery({
+    queryKey: ["stage-automation", "policies", pipelineId],
+    enabled: pipelineId !== "",
+    queryFn: async () => {
+      const { data, error } = await api.GET("/stage-automation/policies/{id}", {
+        params: { path: { id: pipelineId } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data;
+    },
+  });
+
+  const save = useMutation({
+    mutationFn: async (next: {
+      from: string;
+      to: string;
+      mode: "propose" | "auto";
+      version?: number;
+    }) => {
+      const { data, error } = await api.PUT("/stage-automation/policies/{id}", {
+        params: { path: { id: pipelineId } },
+        body: {
+          from_stage_id: next.from,
+          to_stage_id: next.to,
+          mode: next.mode,
+          // The version the row was READ at, so a save cannot silently
+          // overwrite a change somebody else made while this page was open.
+          // Absent on a transition with no rule yet, because there was none
+          // to have read.
+          ...(next.version === undefined ? {} : { if_version: next.version }),
+        },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["stage-automation"] });
+    },
+  });
+
+  if (rules.isError) {
+    return <Callout tone="warn">{problemMessageOf(rules.error, t)}</Callout>;
+  }
+  if (rules.isPending) {
+    return <BusyMark />;
+  }
+  if (transitions.length === 0) {
+    return <EmptyState>{t("stageAutomation.noRules")}</EmptyState>;
+  }
+
+  const byTransition = new Map(
+    (rules.data ?? []).map((rule) => [
+      keyOf(rule.from_stage_id, rule.to_stage_id),
+      rule,
+    ]),
+  );
+  return (
+    <section>
+      <h3 className="t-caption">{t("stageAutomation.rules")}</h3>
+      <p className="t-caption">{t("stageAutomation.rulesIntro")}</p>
+      {save.isError && (
+        <Callout tone="warn">{problemMessageOf(save.error, t)}</Callout>
+      )}
+      <ul className="u-list-reset">
+        {transitions.map((row) => (
+          <TransitionRule
+            key={keyOf(row.from_stage_id, row.to_stage_id)}
+            row={row}
+            rule={byTransition.get(keyOf(row.from_stage_id, row.to_stage_id))}
+            pipelineId={pipelineId}
+            mayChange={mayChange}
+            reportWindowDays={reportWindowDays}
+            saving={save.isPending}
+            onToggle={(mode, version) =>
+              save.mutate({
+                from: row.from_stage_id,
+                to: row.to_stage_id,
+                mode,
+                version,
+              })
+            }
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/** One transition's switch, and its suspension if the product wrote one. */
+function TransitionRule({
+  row,
+  rule,
+  pipelineId,
+  mayChange,
+  reportWindowDays,
+  saving,
+  onToggle,
+}: Readonly<{
+  row: TransitionRecord;
+  rule: TransitionPolicy | undefined;
+  pipelineId: string;
+  mayChange: boolean;
+  reportWindowDays: number;
+  saving: boolean;
+  onToggle: (mode: "propose" | "auto", version?: number) => void;
+}>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const label = `${row.from_stage_name} → ${row.to_stage_name}`;
+  return (
+    <li>
+      <Switch
+        label={label}
+        hint={t("stageAutomation.modeHint")}
+        checked={rule?.mode === "auto"}
+        disabled={!mayChange}
+        reason={mayChange ? undefined : t("stageAutomation.readOnly")}
+        pending={saving}
+        onChange={(on) => onToggle(on ? "auto" : "propose", rule?.version)}
+      />
+      {rule?.mode === "auto" && !rule.suspended_at && (
+        <p className="t-caption">
+          {notEarnedYet(row, rule, reportWindowDays)
+            ? t("stageAutomation.notEarnedYet", {
+                why: notEarnedYet(row, rule, reportWindowDays),
+              })
+            : t("stageAutomation.undoWindow", {
+                // Through the locale: a bare String() prints the English
+                // notation to every reader, and a magnitude in somebody
+                // else's notation is one they read wrong.
+                hours: formatNumber(rule.undo_window_hours, locale),
+              })}
+        </p>
+      )}
+      {rule?.suspended_at && (
+        <SuspendedRule
+          rule={rule}
+          pipelineId={pipelineId}
+          mayChange={mayChange}
+          transitionLabel={label}
+        />
+      )}
+    </li>
+  );
+}
+
+/**
+ * A rule the PRODUCT turned off, with the reason and a way back.
+ *
+ * The reason is drawn rather than summarised, because it is the whole basis on
+ * which somebody decides to start the transition again — and a suspension
+ * shown without one is a control asking for a decision it gave no grounds for.
+ */
+function SuspendedRule({
+  rule,
+  pipelineId,
+  mayChange,
+  transitionLabel,
+}: Readonly<{
+  rule: TransitionPolicy;
+  pipelineId: string;
+  mayChange: boolean;
+  transitionLabel: string;
+}>) {
+  const t = useT();
+  const { locale } = useLocale();
+  // The READER's zone. A suspension stamped at 23:40 UTC happened on a
+  // different day for half the people who will read this, and a date without a
+  // zone shows one of them the wrong one.
+  const zone = viewerZone();
+  const [asking, setAsking] = useState(false);
+  const queryClient = useQueryClient();
+  const resume = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST(
+        "/stage-automation/policies/{id}/resume",
+        {
+          params: { path: { id: pipelineId } },
+          body: {
+            from_stage_id: rule.from_stage_id,
+            to_stage_id: rule.to_stage_id,
+          },
+        },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      setAsking(false);
+      queryClient.invalidateQueries({ queryKey: ["stage-automation"] });
+    },
+  });
+
+  return (
+    <Callout tone="warn">
+      <p>{t("stageAutomation.suspended")}</p>
+      {rule.suspended_reason && <p>{rule.suspended_reason}</p>}
+      {rule.suspended_at && (
+        <p className="t-caption">
+          {t("stageAutomation.suspendedSince", {
+            date: formatDate(rule.suspended_at, locale, zone),
+          })}
+        </p>
+      )}
+      {mayChange && (
+        <Button onClick={() => setAsking(true)}>
+          {t("stageAutomation.resume")}
+        </Button>
+      )}
+      <ConfirmModal
+        open={asking}
+        onClose={() => setAsking(false)}
+        title={t("stageAutomation.resumeTitle")}
+        confirmLabel={t("stageAutomation.resume")}
+        onConfirm={() => resume.mutate()}
+        pending={resume.isPending}
+        error={resume.isError ? problemMessageOf(resume.error, t) : undefined}
+      >
+        <p>{transitionLabel}</p>
+        <p>
+          {t("stageAutomation.resumeBody", {
+            reason: rule.suspended_reason ?? "",
+          })}
+        </p>
+      </ConfirmModal>
+    </Callout>
+  );
+}
+
+/**
+ * Which threshold this transition has not met yet, or "" when it has met them
+ * all.
+ *
+ * A switch that says ON while the server keeps proposing is the page's worst
+ * failure: the admin turned it on, cards keep arriving, and nothing says the
+ * two are consistent. The reasons are the same four the server checks and in
+ * the same order — the one a reader can act on soonest first, because being
+ * told acceptance is low when the volume bar is also unmet sends somebody
+ * hunting for a quality problem that has not been measured yet.
+ *
+ * It is a RENDERING of the report beside it, never the authority. The server
+ * re-checks in the transaction that would apply, and this can only be stale;
+ * what it must never do is claim a transition is applying when it is not.
+ */
+function notEarnedYet(
+  row: TransitionRecord,
+  rule: TransitionPolicy,
+  reportWindowDays: number,
+): string {
+  // A rule counted over a DIFFERENT window than the report cannot be judged
+  // from it. The server takes each rule's rates over that rule's own
+  // window_days; this row is whatever window the report was fetched with, and
+  // comparing the two would say a transition has earned a bar it was never
+  // measured against — in either direction.
+  //
+  // Silent rather than wrong: the switch still says what the admin asked for,
+  // and the line that would explain a withholding is simply absent.
+  if (rule.window_days !== reportWindowDays) {
+    return "";
+  }
+  if (row.reviewed < rule.min_reviewed) {
+    return `${row.reviewed}/${rule.min_reviewed}`;
+  }
+  if (row.observation_days < rule.min_observation_days) {
+    return `${row.observation_days}/${rule.min_observation_days} d`;
+  }
+  if (row.clean_acceptance_rate < rule.clean_acceptance_threshold) {
+    return comparison(
+      row.clean_acceptance_rate,
+      rule.clean_acceptance_threshold,
+      "<",
+    );
+  }
+  if (row.unsafe_rate > rule.correction_reversal_threshold) {
+    return comparison(row.unsafe_rate, rule.correction_reversal_threshold, ">");
+  }
+  return "";
+}
+
+/**
+ * Two rates and the sign between them, at a precision that keeps the sign true.
+ *
+ * Rounding each side independently prints comparisons that read as false:
+ * 0.946 against 0.954 both round to 95%, so the line says "95% < 95%" and a
+ * reader concludes the screen is broken. So the decimals grow until the two
+ * numbers actually differ as printed — the branch was taken on the exact
+ * values, and the text must not contradict it.
+ */
+function comparison(left: number, right: number, sign: "<" | ">"): string {
+  for (const decimals of [0, 1, 2]) {
+    const a = (left * 100).toFixed(decimals);
+    const b = (right * 100).toFixed(decimals);
+    if (a !== b) {
+      return `${a}% ${sign} ${b}%`;
+    }
+  }
+  // Closer than two decimals apart. The sign is still true — the caller only
+  // reached here on the exact comparison — and printing more digits would
+  // trade one confusion for another.
+  return `${(left * 100).toFixed(2)}% ${sign} ${(right * 100).toFixed(2)}%`;
+}
+
+// One transition's identity, spelled once so the map and the lookup cannot
+// disagree about what a key looks like.
+function keyOf(from: string, to: string): string {
+  return `${from}-${to}`;
+}

--- a/frontend/src/screens/settingscatalog.test.ts
+++ b/frontend/src/screens/settingscatalog.test.ts
@@ -208,9 +208,10 @@ describe("what each page lets a reader change", () => {
 
     pipelines:
       "all(full-seat, any(any(pipeline:update, pipeline:create), pipeline:delete))",
-    // Read-only: the report shows what a transition has earned and changes
-    // nothing. Turning automation on is a different page and a different grant.
-    stageautomation: "same-as-requires",
+    // The report is read-only, but the per-transition switches beneath it are
+    // not: turning a transition on is a pipeline write, so a rep who may only
+    // READ pipelines opens the page and finds every switch refused.
+    stageautomation: "all(full-seat, any(any(pipeline:update)))",
     leads:
       "all(full-seat, any(any(custom_field:update, custom_field:create), custom_field:delete))",
     fields:
@@ -908,11 +909,6 @@ describe("what the rail carries and what it leaves behind", () => {
       // update, which is what CompanyContextCard asks. Existing behaviour that
       // the rail is only now reporting — the card was always editable by them.
       "company",
-      // Stage automation, on `readingIsTheAct`: consulting the record IS what
-      // the page is for, like the audit log and the seat count. It sits here
-      // rather than beside Pipelines in looksUp for that reason — a rep does
-      // not go there to change anything, and there is nothing on it to change.
-      "stageautomation",
       // Products and offer templates: a rep authors both.
       "products",
       // Capture rules, because a rep holds `organization:update` and
@@ -927,6 +923,11 @@ describe("what the rail carries and what it leaves behind", () => {
     const reach = settingsReach(seededRep);
     expect(reach.looksUp.map((page) => page.id)).toEqual([
       "pipelines",
+      // Stage automation MOVED here when the page grew its switches. A rep
+      // holds pipeline read and not update, so the report is still theirs to
+      // consult and every control on it is refused — which is what looksUp
+      // means. It sat in the acted-on half while the page was read-only.
+      "stageautomation",
       "leads",
       "fields",
       "tags",

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -539,10 +539,14 @@ export const SETTINGS_PAGES = [
     // endpoint, so `pipeline` read is exactly what opens it — the same grant
     // that shows the stages the transitions are between.
     requires: reads("pipeline"),
-    // Read-only in this release. The per-transition policy that will turn
-    // automation on is its own page and its own grant; a reader here can see
-    // what a transition has earned and change nothing.
-    changes: readingIsTheAct,
+    // The page now carries the per-transition switches beneath its report, so
+    // it WRITES. The table above them stays read-only, which is a layout
+    // decision rather than a permission one.
+    //
+    // UPDATE only. A rule is created by the same PUT that edits one, and this
+    // page never creates a pipeline — so a custom role holding pipeline:create
+    // without update would open a page whose every switch is refused.
+    changes: acts(writes("pipeline", ["update"])),
   },
   {
     id: "leads",


### PR DESCRIPTION
The per-transition switches reach the settings page, with the suspension the product wrote and a way back from it.

## The table stays read-only

That page's own comment argued a screen which both showed the evidence and flipped the switch would invite the flip before the reading. That still holds, so the controls sit **below** the report in their own section — a control in every row of a table somebody is still reading is exactly what the argument was against.

A switch is drawn for **every** transition the report knows about, not only those with a rule. A transition nobody has decided about is the default state of every transition in the product; drawing only the decided ones would hide the ones an admin has yet to think about.

**A switch that says ON while the server keeps proposing is this page's worst failure.** So a rule on auto whose record has not cleared the bar says which threshold it is short of, in the same order the server checks them.

## Eight findings, all real

Four from the gates:

- A hand-rolled button where the design system has `Button`, and four keys translated three times and rendered nowhere.
- **The settings catalog still declared this page `readingIsTheAct`.** It writes now, so a rep holding pipeline read and not update moves from the acted-on half of the rail to the read-only half — recorded rather than papered over. Declared as **update only**: a role holding `pipeline:create` without update would open a page whose every switch is refused.
- `String(hours)` printed English notation to every reader.

Four from review:

- **The controls carried no permission gate.** The report opens on `pipeline` read and every control needs update, so a viewer holding only the read saw live switches that 403 on the first click. They are now refused with the reason, and Resume is *absent* rather than disabled — a whole act nobody may perform is a door that was never theirs to open.
- **The threshold line compared across different windows.** The report is fetched over 30 days; a rule counts its rates over its own `window_days`. Judging one against the other says a transition has earned a bar it was never measured against. It now says nothing rather than something false.
- **Rounding each side independently printed "95% < 95%"** — which reads as a broken screen. The precision now grows until the two numbers differ as printed.

Two review findings I checked and did not act on: the threshold checks match the server's order and operators exactly, and a save cannot stale a sibling transition's version (the upsert increments only its own row).

## Two of my own tests proved nothing

1. The German spec asserted a suspended rule **and** its undo window together — which the page correctly refuses to draw, because a suspended rule applies nothing and promising an undo would be false. It is now two tests, each asserting something true.
2. The vitest stub ignored its own `grants` argument, so the permission test ran as an admin and passed against an ungated component. That is the "a mock that admits everyone hides the gate" shape.

## Known gap, not fixed here

The screen **cannot see the installation-wide kill switch** — it is absent from the contract. With it off, the server forces every transition to propose while this page still shows auto. Closing that needs a contract change and is its own piece of work.

## Verification

- `make check-fe` green — 635 files, 8366 tests
- `make frontend-e2e` green — 348 Playwright tests, including both German specs
- `make check-backend` green
- Eleven vitest cases and two Playwright cases, each mutation-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-transition switches to the stage automation settings screen, so an admin can turn each transition on or off from the same page as the evidence. The report table stays read-only; the switches sit below it.

- A switch is drawn for every transition the report knows about, not only those with a rule.
- Suspended rules show the product's reason and a confirmed "Start again" that says the threshold still applies.
- Saves carry the version the row was read at, so a save cannot overwrite a change it never saw.
- Readers who may not update see the switches refused with a reason; Resume is absent rather than disabled.
- Rules on auto say which threshold the record is short of, in the server's check order, or stay silent when the rule's window differs from the report's.
- Threshold comparisons round until the printed numbers differ, so a true comparison can't print as "95% < 95%".
- The settings catalog now declares the page update-only, which moves it to the read-only rail half for reps who hold only `pipeline` read.
- Known gap: the screen cannot see the installation-wide kill switch; closing that needs a contract change.

<sup>Written for commit f280f563a20e841a1241c71d6edcc853622f50be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stage-automation rule controls to the settings page.
  - Configure each transition to propose or apply automatically.
  - View eligibility status, suspension reasons, undo windows, and threshold details.
  - Resume suspended rules with confirmation.
  - Controls are read-only for users without update permissions.

- **Localization**
  - Added stage-automation translations in English, German, and Vietnamese.

- **Bug Fixes**
  - Improved handling and messaging for unavailable, suspended, and not-yet-eligible automation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->