### PR TITLE
fix(360): a project-scoped page derives its numbers from that project

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3358,6 +3358,23 @@ paths:
                     tell that from a hit. A well-formed value the account does not
                     currently raise is a `204` that stores nothing; see this operation's
                     description for why those two answers differ.
+                project_id:
+                  type: string
+                  format: uuid
+                  description: |
+                    The project the page was scoped to when the suggestion was rendered,
+                    absent on the whole-account page.
+
+                    A suggestion's fingerprint is derived from its EVIDENCE, and a scoped
+                    page reasons over one project's activity — so the same advice raised
+                    on a scoped page and on the account page are two different
+                    fingerprints. This route re-derives the suggestions to check the
+                    fingerprint is one the account really raises for this caller, and it
+                    can only reproduce a scoped one by narrowing the same way.
+
+                    Send the project the reader was looking at. Omit it and a dismissal
+                    from a scoped page matches nothing and silently stores nothing, which
+                    a reader sees as the card refusing to go away.
       responses:
         '204': { description: "Dismissed, or nothing matched and nothing was stored." }
         '401': { $ref: '#/components/responses/Unauthorized' }

--- a/backend/internal/compose/integration/activity_projectscope_integration_test.go
+++ b/backend/internal/compose/integration/activity_projectscope_integration_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/margince/margince/backend/internal/compose/org360"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/projects"
@@ -282,4 +284,218 @@ func TestAssembledContextScopedToOneProjectDropsPeopleReachedOnlyThroughTheOther
 	if !wide[f.bystander.String()] {
 		t.Error("an unscoped walk lost the other engagement's contact, so the scoped absence proves nothing")
 	}
+}
+
+// The DERIVED sections narrow with the timeline they sit under.
+// The scope reached the timeline, next steps, next meeting, last touch and
+// since-last-visit. It did not reach the AGGREGATES: relationship strength and
+// account health folded every project's activity, so a page showing one
+// engagement's mail reported a surface counted over both.
+//
+// Asserted BOTH ways round against the two-engagement fixture. A test that only
+// checked the scoped number would pass against a read that lost the row for any
+// other reason, so the unscoped read of the same account has to still carry it.
+func TestAScopedAccountPageDerivesItsHealthFromOneEngagement(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoEngagementAccount(t, e)
+	employAtAccount(t, e, f)
+	// The bystander is the whole lever here: a contact at the account who has
+	// spoken on the OTHER engagement and nowhere else. Employing them is what
+	// puts them in the account's contact set at all, and the fixture leaves it
+	// to the tests that want it — the sections proved elsewhere count contacts
+	// and would each have to be retaught a third one.
+	bystanderID, orgID := PersonIDOf(f.bystander), orgIDOf(f.org)
+	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+		Kind: "employment", PersonID: &bystanderID, OrganizationID: &orgID,
+	}); err != nil {
+		t.Fatalf("employing the bystander: %v", err)
+	}
+	// A meeting that has already happened on each engagement, the other
+	// engagement's the more recent. The fixture's own meetings are both booked
+	// for the future, which is the question "when do we next see them" rather
+	// than "when did we last".
+	held := func(subject string, within ids.ProjectID, daysAgo int) time.Time {
+		at := roomFixedNow.AddDate(0, 0, -daysAgo)
+		logged, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+			Kind: "meeting", MeetingStatus: strPtr("booked"), Subject: &subject, OccurredAt: &at,
+			Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: f.person}},
+		})
+		if err != nil {
+			t.Fatalf("log %q: %v", subject, err)
+		}
+		id := ids.From[ids.ActivityKind](ids.UUID(logged.Id))
+		if _, err := e.Activities.RelinkActivity(e.Admin(), id, activities.RelinkActivityInput{
+			EntityType: "project", EntityID: within.UUID,
+		}); err != nil {
+			t.Fatalf("file %q under its project: %v", subject, err)
+		}
+		return at
+	}
+	erpMet := held("ERP discovery workshop", f.erp, 6)
+	held("Rack survey", f.other, 2)
+
+	svc := orgSurfaceService(e)
+
+	scoped, err := svc.AssembleScoped(e.Admin(), orgID, org360.AssembleOptions{ProjectID: &f.erp})
+	if err != nil {
+		t.Fatalf("assemble scoped: %v", err)
+	}
+	wide, err := svc.AssembleScoped(e.Admin(), orgID, org360.AssembleOptions{})
+	if err != nil {
+		t.Fatalf("assemble unscoped: %v", err)
+	}
+	if scoped.Health == nil || wide.Health == nil {
+		t.Fatal("the health block is missing from one of the two reads")
+	}
+
+	// Three people have spoken to us across the account — the contact, the
+	// meeting attendee and the bystander — but only two of them within the ERP
+	// rollout. "How many ways in do we have here" has to answer for the page
+	// the reader is on, or the count contradicts the timeline under it.
+	if got := deref(t, scoped.Health.ActiveContacts, "scoped active contacts"); got != 2 {
+		t.Errorf("the ERP page reports %d active contacts, want 2 (the contact and the meeting attendee) "+
+			"— the bystander has only ever spoken on the datacentre migration", got)
+	}
+	if got := deref(t, wide.Health.ActiveContacts, "unscoped active contacts"); got != 3 {
+		t.Errorf("the unscoped page reports %d active contacts, want 3 — if the bystander is missing "+
+			"here too then the scoped count above proves nothing about the scope", got)
+	}
+
+	// The account's newest exchange is the other engagement's, so an unscoped
+	// health block dates itself from a message the scoped page does not show.
+	scopedAge := deref(t, scoped.Health.DaysSinceLastInbound, "scoped last-inbound age")
+	wideAge := deref(t, wide.Health.DaysSinceLastInbound, "unscoped last-inbound age")
+	// The last meeting is the same question one more time, on the read that
+	// answers "when did we last sit down with them".
+	if scoped.Health.LastMeetingAt == nil || wide.Health.LastMeetingAt == nil {
+		t.Fatal("one of the two pages reports no last meeting, though each engagement has held one")
+	}
+	if !scoped.Health.LastMeetingAt.Equal(erpMet) {
+		t.Errorf("the ERP page dates its last meeting to %s, want the ERP discovery workshop at %s "+
+			"— the rack survey belongs to the engagement this page is not showing",
+			scoped.Health.LastMeetingAt.Format(time.RFC3339), erpMet.Format(time.RFC3339))
+	}
+	if wide.Health.LastMeetingAt.Equal(erpMet) {
+		t.Errorf("the unscoped page also stops at the ERP workshop, so the assertion above proves " +
+			"nothing about the scope")
+	}
+
+	if scopedAge == wideAge {
+		t.Errorf("both pages date their health from a message %d days old — the other engagement's mail "+
+			"is the account's newest, so a scoped read that agrees with the unscoped one is still folding it",
+			scopedAge)
+	}
+}
+
+// deref reads a health figure the page is expected to carry, failing loudly
+// rather than comparing against a zero the reader would never have seen.
+func deref(t *testing.T, got *int, what string) int {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("the page reported no %s, so this proves nothing either way", what)
+	}
+	return *got
+}
+
+// The suggestion rules narrow too. This needs a different account from the
+// fixture above: the no-reply rule fires on the newest exchange being something
+// WE sent and nobody answered, and the two-engagement fixture's newest exchange
+// is a booked meeting, which is the rule declining to chase someone we are
+// about to see.
+//
+// So: one contact, two engagements, an unanswered message on each, and the
+// other engagement's the more recent. A scoped page must chase the message it
+// is showing and never the one it is not — advice a reader cannot check against
+// anything on the page is worse than no advice.
+func TestAScopedAccountPageChasesOnlyTheEngagementItShows(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+	person := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+	org := e.SeedOrg(t, "Acme", &e.Rep1)
+	personID, orgID := PersonIDOf(person), orgIDOf(org)
+	if _, err := e.People.CreateRelationship(admin, people.CreateRelationshipInput{
+		Kind: "employment", PersonID: &personID, OrganizationID: &orgID,
+	}); err != nil {
+		t.Fatalf("employing the contact: %v", err)
+	}
+
+	project := func(name string) ids.ProjectID {
+		p, err := e.Projects.CreateProject(admin, projects.CreateProjectInput{
+			Name: name, OrganizationID: orgID, Source: "manual",
+		})
+		if err != nil {
+			t.Fatalf("create project %q: %v", name, err)
+		}
+		return projectIDOf(ids.UUID(p.Id))
+	}
+	// Both are past noReplyDays, so the rule has a candidate either way and the
+	// only thing deciding which it names is the scope.
+	unanswered := func(subject string, within ids.ProjectID, daysAgo int) string {
+		at := roomFixedNow.AddDate(0, 0, -daysAgo)
+		logged, _, err := e.Activities.LogActivity(admin, activities.LogActivityInput{
+			Kind: "email", Direction: strPtr("outbound"), Subject: &subject, OccurredAt: &at,
+			Links: []activities.ActivityLinkInput{
+				{EntityType: "person", EntityID: person},
+				{EntityType: "organization", EntityID: org},
+			},
+		})
+		if err != nil {
+			t.Fatalf("log %q: %v", subject, err)
+		}
+		id := ids.From[ids.ActivityKind](ids.UUID(logged.Id))
+		if _, err := e.Activities.RelinkActivity(admin, id, activities.RelinkActivityInput{
+			EntityType: "project", EntityID: within.UUID,
+		}); err != nil {
+			t.Fatalf("file %q under its project: %v", subject, err)
+		}
+		return ids.UUID(logged.Id).String()
+	}
+	erp, migration := project("ERP rollout"), project("Datacentre migration")
+	onERP := unanswered("ERP cutover plan", erp, 20)
+	onOther := unanswered("Rack decommissioning", migration, 8)
+
+	svc := orgSurfaceService(e)
+	scoped, err := svc.AssembleScoped(admin, orgID, org360.AssembleOptions{ProjectID: &erp})
+	if err != nil {
+		t.Fatalf("assemble scoped: %v", err)
+	}
+	wide, err := svc.AssembleScoped(admin, orgID, org360.AssembleOptions{})
+	if err != nil {
+		t.Fatalf("assemble unscoped: %v", err)
+	}
+
+	// The unscoped half is not decoration: if no rule fires on the account at
+	// all, the scoped assertion below is satisfied by silence.
+	if !citesActivity(wide, onOther) {
+		t.Fatalf("the unscoped page chases nothing about the datacentre migration's unanswered mail (%s), "+
+			"so it cannot show that the scoped page dropped it", onOther)
+	}
+	if citesActivity(scoped, onOther) {
+		t.Errorf("a suggestion on the page scoped to the ERP rollout cites the datacentre migration's "+
+			"mail (%s) — the reader cannot see it here, so the advice cannot be checked", onOther)
+	}
+	if !citesActivity(scoped, onERP) {
+		t.Errorf("the ERP page chases nothing, though its own mail (%s) has gone unanswered for longer "+
+			"— a scope that silences the rule is dropping the section, not narrowing it", onERP)
+	}
+}
+
+// citesActivity reports whether any suggestion on the page rests on the given
+// activity — as the evidence a reader checks, or as the message the card's
+// button would open.
+func citesActivity(page crmcontracts.Organization360, activityID string) bool {
+	if page.Suggestions == nil {
+		return false
+	}
+	for _, s := range *page.Suggestions {
+		if s.Action != nil && s.Action.ActivityId != nil && s.Action.ActivityId.String() == activityID {
+			return true
+		}
+		for _, ev := range s.Evidence {
+			if ev.EntityId.String() == activityID {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
@@ -135,7 +135,7 @@ func foldOneContact(t *testing.T, e *integration.Env, org, person ids.UUID) peop
 	var found *people.RelationshipStrength
 	ctx := e.Admin()
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
-		all, err := people.StrengthForOrgContacts(ctx, tx, ids.OrganizationID{UUID: org}, org360Clock)
+		all, err := people.StrengthForOrgContacts(ctx, tx, ids.OrganizationID{UUID: org}, org360Clock, nil)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/compose/integration/org360/org360_suggestion_dismissal_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestion_dismissal_integration_test.go
@@ -19,15 +19,20 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/compose/org360"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/modules/projects"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // wellFormedFingerprint has the shape the endpoint accepts, so a test about the
@@ -62,7 +67,7 @@ func TestDismissingASuggestionRevealsTheNextOne(t *testing.T) {
 	if len(listed) < 2 {
 		t.Fatalf("only %d stalled suggestions listed, want the card's full complement", len(listed))
 	}
-	if err := svc.DismissSuggestion(rep, org, listed[0]); err != nil {
+	if err := svc.DismissSuggestion(rep, org, listed[0], nil); err != nil {
 		t.Fatalf("dismiss: %v", err)
 	}
 
@@ -131,7 +136,7 @@ func TestNoDismissalIsEverResurrected(t *testing.T) {
 			if judged[fingerprint] {
 				t.Fatalf("round %d re-offered a suggestion this rep already dismissed", round)
 			}
-			if err := svc.DismissSuggestion(rep, org, fingerprint); err != nil {
+			if err := svc.DismissSuggestion(rep, org, fingerprint, nil); err != nil {
 				t.Fatalf("dismiss in round %d: %v", round, err)
 			}
 			judged[fingerprint] = true
@@ -176,7 +181,7 @@ func TestADismissedStallReturnsWhenTheDealStallsAgain(t *testing.T) {
 	if len(first) != 1 {
 		t.Fatalf("got %d stalled suggestions, want the one seeded deal", len(first))
 	}
-	if err := svc.DismissSuggestion(rep, org, first[0]); err != nil {
+	if err := svc.DismissSuggestion(rep, org, first[0], nil); err != nil {
 		t.Fatalf("dismiss: %v", err)
 	}
 	if after, err := svc.Assemble(rep, org); err != nil {
@@ -229,7 +234,7 @@ func TestADeferralNeverResurrectsADismissal(t *testing.T) {
 	if len(dismissed) != 1 {
 		t.Fatalf("got %d stalled suggestions, want the one seeded deal", len(dismissed))
 	}
-	if err := svc.DismissSuggestion(rep, org, dismissed[0]); err != nil {
+	if err := svc.DismissSuggestion(rep, org, dismissed[0], nil); err != nil {
 		t.Fatalf("dismiss: %v", err)
 	}
 
@@ -306,7 +311,7 @@ func TestAdvancingADealReArmsDismissedStallAdvice(t *testing.T) {
 	if len(dismissed) != 1 {
 		t.Fatalf("got %d stalled suggestions, want the one seeded deal", len(dismissed))
 	}
-	if err := svc.DismissSuggestion(rep, org, dismissed[0]); err != nil {
+	if err := svc.DismissSuggestion(rep, org, dismissed[0], nil); err != nil {
 		t.Fatalf("dismiss: %v", err)
 	}
 	if quiet, err := svc.Assemble(rep, org); err != nil {
@@ -343,7 +348,7 @@ func TestAdvancingADealReArmsDismissedStallAdvice(t *testing.T) {
 	// The dismissal has to happen HERE, after the advance: asserting against the
 	// pre-advance fingerprint would hold whether or not the no-op row is counted,
 	// which is a test that cannot fail for the behaviour it names.
-	if err := svc.DismissSuggestion(rep, org, fresh[0]); err != nil {
+	if err := svc.DismissSuggestion(rep, org, fresh[0], nil); err != nil {
 		t.Fatalf("dismiss the post-advance advice: %v", err)
 	}
 	if _, err := e.Deals.AdvanceDeal(e.As(e.Rep1, nil, integration.AdminPerms),
@@ -468,7 +473,7 @@ func TestSuggestionDismissalIsPerUser(t *testing.T) {
 	// per-user-ness of a rule it was not written for.
 	fingerprint := fingerprintOfKind(t, *view.Suggestions, "no_reply")
 
-	if err := svc.DismissSuggestion(rep1, org, fingerprint); err != nil {
+	if err := svc.DismissSuggestion(rep1, org, fingerprint, nil); err != nil {
 		t.Fatalf("dismiss: %v", err)
 	}
 
@@ -515,7 +520,7 @@ func TestSuggestionDismissalReArmsWhenTheEvidenceChanges(t *testing.T) {
 		t.Fatalf("assemble: %v", err)
 	}
 	dismissedFingerprint := fingerprintOfKind(t, *first.Suggestions, "no_reply")
-	if err := svc.DismissSuggestion(rep, org, dismissedFingerprint); err != nil {
+	if err := svc.DismissSuggestion(rep, org, dismissedFingerprint, nil); err != nil {
 		t.Fatalf("dismiss: %v", err)
 	}
 
@@ -554,7 +559,7 @@ func TestSuggestionDismissalRefusesAnInvisibleAccount(t *testing.T) {
 
 	// The record gate runs before anything else, so this is a 404 rather than the
 	// silent success an unmatched fingerprint gets on a visible account.
-	err := svc.DismissSuggestion(rep, org, wellFormedFingerprint)
+	err := svc.DismissSuggestion(rep, org, wellFormedFingerprint, nil)
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("dismiss on an invisible account → %v, want ErrNotFound (existence-hiding)", err)
 	}
@@ -570,7 +575,7 @@ func TestSuggestionDismissalRefusesAnAgent(t *testing.T) {
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 
-	err := svc.DismissSuggestion(integration.AgentWithOrgRead(e), org, wellFormedFingerprint)
+	err := svc.DismissSuggestion(integration.AgentWithOrgRead(e), org, wellFormedFingerprint, nil)
 	if !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("agent dismissal → %v, want ErrPermissionDenied", err)
 	}
@@ -591,7 +596,7 @@ func TestSuggestionDismissalStoresNothingForASuggestionTheAccountDoesNotRaise(t 
 
 	// A quiet account raises nothing, so no fingerprint can match.
 	for _, forged := range []string{wellFormedFingerprint, strings.Repeat("a", 64)} {
-		if err := svc.DismissSuggestion(rep, org, forged); err != nil {
+		if err := svc.DismissSuggestion(rep, org, forged, nil); err != nil {
 			t.Errorf("dismiss %q → %v, want success with nothing written", forged, err)
 		}
 	}
@@ -609,7 +614,7 @@ func TestSuggestionDismissalStoresNothingForASuggestionTheAccountDoesNotRaise(t 
 		t.Fatal("suggestions absent")
 	}
 	served := fingerprintOfKind(t, *view.Suggestions, "no_reply")
-	if err := svc.DismissSuggestion(rep, org, served); err != nil {
+	if err := svc.DismissSuggestion(rep, org, served, nil); err != nil {
 		t.Fatalf("dismiss a served suggestion: %v", err)
 	}
 	if count := e.WsCount(t, `SELECT count(*) FROM suggestion_dismissal`); count != 1 {
@@ -629,7 +634,7 @@ func TestSuggestionDismissalRefusesAMalformedFingerprint(t *testing.T) {
 
 	for _, refused := range []string{"", "   ", "not-a-digest", strings.ToUpper(wellFormedFingerprint)} {
 		var detailed *httperr.DetailedError
-		err := svc.DismissSuggestion(rep, org, refused)
+		err := svc.DismissSuggestion(rep, org, refused, nil)
 		if !errors.As(err, &detailed) || detailed.Status != http.StatusUnprocessableEntity {
 			t.Errorf("fingerprint %q → %v, want a 422 validation error", refused, err)
 		}
@@ -637,4 +642,130 @@ func TestSuggestionDismissalRefusesAMalformedFingerprint(t *testing.T) {
 	if count := e.WsCount(t, `SELECT count(*) FROM suggestion_dismissal`); count != 0 {
 		t.Errorf("suggestion_dismissal rows = %d after refused dismissals, want 0", count)
 	}
+}
+
+// A dismissal made on a project-scoped page has to land.
+//
+// A fingerprint is derived from the suggestion's EVIDENCE, so advice whose
+// evidence is an ACTIVITY carries a different fingerprint on a scoped page from
+// the one it carries on the whole account. The dismissal re-derives the
+// suggestions to check the caller was really served the one they name, and
+// re-deriving unscoped matches nothing: it stores nothing and answers 204,
+// which the reader sees as the card refusing to go away.
+//
+// The no-reply rule is the subject rather than the stalled-deal one beside it.
+// A stalled deal is evidenced by the DEAL, which the scope does not narrow, so
+// its fingerprint is the same either way and would prove nothing here.
+//
+// Both halves are asserted: sending the project must make the dismissal stick,
+// and not sending it must leave the card alone — otherwise the first half would
+// pass against a dismissal that fired on any fingerprint at all.
+func TestASuggestionDismissedOnAScopedPageStaysDismissed(t *testing.T) {
+	e := integration.Setup(t)
+	svc := org360Service(e)
+	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
+	// AccountRepPerms deliberately carries no project grant, and widening the
+	// shared fixture would make the suites that read it as "a rep who cannot see
+	// a project" pass while proving nothing. A deep copy, because a plain struct
+	// copy shares the Objects map with every one of them.
+	perms := integration.AccountRepPerms
+	perms.Objects = make(map[string]principal.ObjectGrant, len(integration.AccountRepPerms.Objects)+1)
+	for object, grant := range integration.AccountRepPerms.Objects {
+		perms.Objects[object] = grant
+	}
+	perms.Objects["project"] = principal.ObjectGrant{Read: true}
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+
+	newProject := func(name string) ids.ProjectID {
+		created, err := e.Projects.CreateProject(e.Admin(), projects.CreateProjectInput{
+			Name: name, OrganizationID: org, Source: "manual",
+		})
+		if err != nil {
+			t.Fatalf("creating %q: %v", name, err)
+		}
+		return ids.From[ids.ProjectKind](ids.UUID(created.Id))
+	}
+	erp, other := newProject("ERP rollout"), newProject("Datacentre migration")
+
+	// One unanswered outbound per engagement, both older than the no-reply
+	// threshold, the other engagement's the more recent — so the account's
+	// newest exchange and the ERP page's newest exchange are different messages,
+	// which is what makes the two fingerprints differ at all.
+	unanswered := func(subject string, within ids.ProjectID, daysAgo int) {
+		at, outbound := org360Clock.AddDate(0, 0, -daysAgo), "outbound"
+		logged, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+			Kind: "email", Direction: &outbound, Subject: &subject, OccurredAt: &at,
+			Links: []activities.ActivityLinkInput{{EntityType: "organization", EntityID: org.UUID}},
+		})
+		if err != nil {
+			t.Fatalf("logging %q: %v", subject, err)
+		}
+		if _, err := e.Activities.RelinkActivity(e.Admin(),
+			ids.From[ids.ActivityKind](ids.UUID(logged.Id)),
+			activities.RelinkActivityInput{EntityType: "project", EntityID: within.UUID}); err != nil {
+			t.Fatalf("filing %q under its project: %v", subject, err)
+		}
+	}
+	unanswered("ERP cutover plan", erp, 30)
+	unanswered("Rack decommissioning", other, 12)
+
+	scoped := org360.AssembleOptions{ProjectID: &erp}
+	before, err := svc.AssembleScoped(rep, org, scoped)
+	if err != nil {
+		t.Fatalf("assemble scoped: %v", err)
+	}
+	if before.Suggestions == nil {
+		t.Fatal("the scoped page carried no suggestions, so there is nothing to dismiss")
+	}
+	scopedPrints := noReplyFingerprints(*before.Suggestions)
+	if len(scopedPrints) == 0 {
+		t.Fatal("the scoped page raised no no-reply suggestion, so this proves nothing about dismissing one")
+	}
+	wide, err := svc.Assemble(rep, org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(noReplyFingerprints(*wide.Suggestions), scopedPrints[0]) {
+		t.Fatalf("the scoped and unscoped pages raise the SAME no-reply fingerprint, so the " +
+			"dismissal below cannot show that the scope reached it")
+	}
+
+	// Unscoped first: the dismissal cannot reproduce a scoped fingerprint from
+	// the whole account, so it must store nothing and the card must be unchanged.
+	if err := svc.DismissSuggestion(rep, org, scopedPrints[0], nil); err != nil {
+		t.Fatalf("dismiss without the project: %v", err)
+	}
+	stillThere, err := svc.AssembleScoped(rep, org, scoped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(noReplyFingerprints(*stillThere.Suggestions), scopedPrints[0]) {
+		t.Fatalf("a dismissal naming no project silenced a scoped suggestion — then the " +
+			"assertion below cannot tell the scope from any dismissal at all")
+	}
+
+	if err := svc.DismissSuggestion(rep, org, scopedPrints[0], &erp); err != nil {
+		t.Fatalf("dismiss on the scoped page: %v", err)
+	}
+	after, err := svc.AssembleScoped(rep, org, scoped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Suggestions != nil &&
+		slices.Contains(noReplyFingerprints(*after.Suggestions), scopedPrints[0]) {
+		t.Errorf("the suggestion the rep dismissed on the ERP page is still on it (%s) — "+
+			"the dismissal re-derived the account unscoped and matched nothing", scopedPrints[0])
+	}
+}
+
+// noReplyFingerprints is stalledFingerprints' sibling for the rule whose
+// evidence the project scope actually narrows.
+func noReplyFingerprints(found []crmcontracts.Organization360Suggestion) []string {
+	out := make([]string, 0, len(found))
+	for _, suggestion := range found {
+		if string(suggestion.Kind) == "no_reply" {
+			out = append(out, suggestion.Fingerprint)
+		}
+	}
+	return out
 }

--- a/backend/internal/compose/integration/org360/org360_suggestion_dismissal_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestion_dismissal_integration_test.go
@@ -725,6 +725,9 @@ func TestASuggestionDismissedOnAScopedPageStaysDismissed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if wide.Suggestions == nil {
+		t.Fatal("the unscoped page withheld its suggestions, so the two fingerprints cannot be compared")
+	}
 	if slices.Contains(noReplyFingerprints(*wide.Suggestions), scopedPrints[0]) {
 		t.Fatalf("the scoped and unscoped pages raise the SAME no-reply fingerprint, so the " +
 			"dismissal below cannot show that the scope reached it")
@@ -738,6 +741,9 @@ func TestASuggestionDismissedOnAScopedPageStaysDismissed(t *testing.T) {
 	stillThere, err := svc.AssembleScoped(rep, org, scoped)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if stillThere.Suggestions == nil {
+		t.Fatal("the scoped page withheld its suggestions after a dismissal that named no project")
 	}
 	if !slices.Contains(noReplyFingerprints(*stillThere.Suggestions), scopedPrints[0]) {
 		t.Fatalf("a dismissal naming no project silenced a scoped suggestion — then the " +

--- a/backend/internal/compose/integration/org360/orgscan_integration_test.go
+++ b/backend/internal/compose/integration/org360/orgscan_integration_test.go
@@ -141,7 +141,7 @@ func TestTheScanReadsTheAccountForTheReaderAndTheReaderCanPutAFindingOff(t *test
 	// Putting it off: the dismissal endpoint recognises the scan's finding
 	// through the same seam it recognises a rule's row, and the next read
 	// carries it no more.
-	if err := view.DismissSuggestion(rep, org, found.Fingerprint); err != nil {
+	if err := view.DismissSuggestion(rep, org, found.Fingerprint, nil); err != nil {
 		t.Fatalf("dismiss: %v", err)
 	}
 	after, err := svc.Get(rep, org)

--- a/backend/internal/compose/integration/org360/orgscanlifecycle_integration_test.go
+++ b/backend/internal/compose/integration/org360/orgscanlifecycle_integration_test.go
@@ -426,7 +426,7 @@ func TestPuttingOffAFindingNobodyRaisedStoresNothing(t *testing.T) {
 	// rules' rows and then the scan's: a fingerprint neither raised. The
 	// dismissal succeeds, saying nothing, and records nothing.
 	unraised := strings.Repeat("0", 64)
-	if err := view.DismissSuggestion(rep, org, unraised); err != nil {
+	if err := view.DismissSuggestion(rep, org, unraised, nil); err != nil {
 		t.Fatalf("dismissing a finding nobody raised: %v, want a quiet success", err)
 	}
 	var stored int

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -720,7 +720,7 @@ func personChanges(ctx context.Context, t *testing.T, e *Env, personID ids.Perso
 	var out []relstrength.Change
 	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		var err error
-		out, err = e.People.PersonRelationshipChangesTx(ctx, tx, personID, roomFixedNow)
+		out, err = e.People.PersonRelationshipChangesTx(ctx, tx, personID, roomFixedNow, nil)
 		return err
 	})
 	return out, err

--- a/backend/internal/compose/integration/projectscope_360_integration_test.go
+++ b/backend/internal/compose/integration/projectscope_360_integration_test.go
@@ -246,3 +246,53 @@ func TestAProjectScopeOnTheActivityListAnswers403And404OnTheWire(t *testing.T) {
 		t.Errorf("GET /activities?project_id= with the grant = %d, want 200 — the gate refuses everyone", got)
 	}
 }
+
+// The person page's derived sections narrow with its timeline. Strength is the
+// one that says out loud which activities it rests on, so it is the one a
+// reader can catch disagreeing with the page: a score citing an activity the
+// scope dropped is a number the reader cannot check.
+func TestPerson360ScopedToOneProjectScoresFromOneEngagement(t *testing.T) {
+	e := Setup(t)
+	f := seedTwoEngagementAccount(t, e)
+	svc := personRoomService(e)
+	personID := PersonIDOf(f.person)
+
+	scoped, err := svc.AssembleScoped(e.Admin(), personID, person360.AssembleOptions{ProjectID: &f.erp})
+	if err != nil {
+		t.Fatalf("assemble scoped: %v", err)
+	}
+	wide, err := svc.Assemble(e.Admin(), personID)
+	if err != nil {
+		t.Fatalf("assemble unscoped: %v", err)
+	}
+	if scoped.Strength == nil || wide.Strength == nil {
+		t.Fatal("the strength section was withheld from one of the two reads")
+	}
+
+	if !citedBy(wide.Strength, f.onOther) {
+		t.Fatalf("the unscoped score does not rest on the datacentre migration's mail (%s), so it "+
+			"cannot show that the scoped score dropped it", f.onOther)
+	}
+	if citedBy(scoped.Strength, f.onOther) {
+		t.Errorf("the score on a page scoped to the ERP rollout rests on the datacentre migration's "+
+			"mail (%s), which is not on the page for the reader to check it against", f.onOther)
+	}
+	if !citedBy(scoped.Strength, f.onERP) {
+		t.Errorf("the scoped score rests on nothing from its own engagement (%s) — a scope that "+
+			"empties the read is dropping the section, not narrowing it", f.onERP)
+	}
+}
+
+// citedBy reports whether a score names the given activity among the ones it
+// was folded from.
+func citedBy(strength *crmcontracts.RelationshipStrength, activityID string) bool {
+	if strength.ContributingActivityIds == nil {
+		return false
+	}
+	for _, id := range *strength.ContributingActivityIds {
+		if id.String() == activityID {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/integration/relationshipchangeaudience_integration_test.go
+++ b/backend/internal/compose/integration/relationshipchangeaudience_integration_test.go
@@ -113,7 +113,7 @@ func changesFor(ctx context.Context, t *testing.T, e *Env, person ids.UUID, now 
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		var err error
 		out, err = e.People.PersonRelationshipChangesTx(ctx, tx,
-			ids.From[ids.PersonKind](person), now)
+			ids.From[ids.PersonKind](person), now, nil)
 		return err
 	}); err != nil {
 		t.Fatalf("reading relationship changes: %v", err)

--- a/backend/internal/compose/org360/accountstate.go
+++ b/backend/internal/compose/org360/accountstate.go
@@ -373,6 +373,11 @@ func (a *assembly) lastMeetingAt() (*time.Time, error) {
 	if activityScope == "" {
 		activityScope = scopeAll
 	}
+	// The body of work, on the same terms as every other activity read on this
+	// page. A page narrowed to one project that dated its health from another
+	// project's meeting would put the right timeline under a number computed
+	// somewhere else.
+	within := a.opts.projectScope(arg)
 	var occurred *time.Time
 	err = a.tx.QueryRow(a.ctx, fmt.Sprintf(`
 		SELECT a.occurred_at
@@ -380,7 +385,7 @@ func (a *assembly) lastMeetingAt() (*time.Time, error) {
 		 WHERE a.kind = 'meeting' AND a.archived_at IS NULL
 		   AND (a.meeting_status IS NULL OR a.meeting_status = 'booked')
 		   AND a.occurred_at <= $%[3]d
-		   AND %[1]s AND %[2]s
+		   AND %[1]s AND %[2]s`+within+`
 		 ORDER BY a.occurred_at DESC, a.id DESC
 		 LIMIT 1`,
 		activityScope, activities.OrgLinkedActivityExists(orgPos), nowPos),

--- a/backend/internal/compose/org360/advice.go
+++ b/backend/internal/compose/org360/advice.go
@@ -126,5 +126,8 @@ func (s *Service) suggestionInputsFor(
 	if err != nil {
 		return suggestionInputs{}, err
 	}
-	return gatherSuggestionInputs(ctx, tx, orgID, now, facts, heading, base)
+	// The dismissal path reads the whole account: it answers "which suggestion
+	// is this", not "what should this page advise", so there is no project to
+	// narrow to.
+	return gatherSuggestionInputs(ctx, tx, orgID, now, facts, heading, base, AssembleOptions{})
 }

--- a/backend/internal/compose/org360/assemble.go
+++ b/backend/internal/compose/org360/assemble.go
@@ -221,7 +221,11 @@ func (a *assembly) contactStrengths() ([]people.ContactStrength, error) {
 	if a.contactsRead {
 		return a.contacts, nil
 	}
-	contacts, err := people.StrengthForOrgContacts(a.ctx, a.tx, a.orgID, a.now)
+	// Narrowed with the rest of the page. The health block reads its
+	// active-contact count, its reply balance and its single-threaded flag off
+	// these strengths, so an unscoped read put a number computed across every
+	// project under a timeline showing one.
+	contacts, err := people.StrengthForOrgContacts(a.ctx, a.tx, a.orgID, a.now, a.opts.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +351,7 @@ func (a *assembly) suggestionInputsOnce() (suggestionInputs, error) {
 				return a.advice, a.adviceErr
 			}
 			a.advice, a.adviceErr = gatherSuggestionInputs(
-				a.ctx, a.tx, a.orgID, a.now, facts, heading, base)
+				a.ctx, a.tx, a.orgID, a.now, facts, heading, base, a.opts)
 		}
 		a.adviceRead = true
 	}

--- a/backend/internal/compose/org360/contactlist.go
+++ b/backend/internal/compose/org360/contactlist.go
@@ -87,7 +87,10 @@ func (s *Service) ContactPage(
 		if _, err := s.people.GetOrganizationTx(ctx, tx, orgID, storekit.LiveOnly, active); err != nil {
 			return err
 		}
-		all, err := people.StrengthForOrgContacts(ctx, tx, orgID, now)
+		// nil: this endpoint takes no project. It is the account's whole
+		// contact list, and narrowing it to a body of work would answer a
+		// question nobody asked here.
+		all, err := people.StrengthForOrgContacts(ctx, tx, orgID, now, nil)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/compose/org360/coverage.go
+++ b/backend/internal/compose/org360/coverage.go
@@ -61,7 +61,7 @@ func (s *Service) Coverage(
 		if _, err := s.people.GetOrganizationTx(ctx, tx, orgID, storekit.LiveOnly, active); err != nil {
 			return err
 		}
-		all, err := people.StrengthForOrgContacts(ctx, tx, orgID, now)
+		all, err := people.StrengthForOrgContacts(ctx, tx, orgID, now, nil)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/compose/org360/dismissal.go
+++ b/backend/internal/compose/org360/dismissal.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -43,7 +44,9 @@ import (
 )
 
 // DismissSuggestion records that this human does not want this advice.
-func (s *Service) DismissSuggestion(ctx context.Context, orgID ids.OrganizationID, fingerprint string) error {
+func (s *Service) DismissSuggestion(
+	ctx context.Context, orgID ids.OrganizationID, fingerprint string, within *ids.ProjectID,
+) error {
 	// An agent has no opinion to record, and consuming a human's dismissal on
 	// their behalf would silence advice they never saw.
 	if err := auth.RequireHuman(ctx); err != nil {
@@ -71,7 +74,16 @@ func (s *Service) DismissSuggestion(ctx context.Context, orgID ids.OrganizationI
 			return httperr.Validation("fingerprint", "malformed",
 				"dismiss a suggestion by the fingerprint it was served with, unchanged")
 		}
-		raises, err := s.raisesSuggestion(ctx, tx, orgID, now, fingerprint)
+		// The SAME gate the scoped page passes before it renders anything. A
+		// dismissal that narrowed to a project the caller cannot open would
+		// answer 204 for a fingerprint they could never have been served, and
+		// the shape of that answer is how you probe for a project's existence.
+		if within != nil {
+			if err := activities.RequireProjectScope(ctx, tx, *within); err != nil {
+				return err
+			}
+		}
+		raises, err := s.raisesSuggestion(ctx, tx, orgID, now, fingerprint, within)
 		if err != nil {
 			return err
 		}
@@ -106,8 +118,15 @@ func (s *Service) DismissSuggestion(ctx context.Context, orgID ids.OrganizationI
 // from, so "a suggestion the rep could have dismissed" has one definition. A
 // second spelling here would drift, and the failure would be silent: a dismissal
 // that stores a row the card never filters.
+//
+// Same function AND same scope. A fingerprint is derived from the suggestion's
+// evidence, so a card raised on a project-scoped page carries a different one
+// from the same advice on the whole account — re-deriving unscoped would match
+// nothing, store nothing, and answer 204, which a reader sees as the card
+// refusing to go away.
 func (s *Service) raisesSuggestion(
 	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time, fingerprint string,
+	within *ids.ProjectID,
 ) (bool, error) {
 	facts, err := readSignalFacts(ctx, tx, orgID)
 	if err != nil {
@@ -124,7 +143,7 @@ func (s *Service) raisesSuggestion(
 	if err != nil {
 		return false, err
 	}
-	in, err := gatherSuggestionInputs(ctx, tx, orgID, now, facts, heading, base, AssembleOptions{})
+	in, err := gatherSuggestionInputs(ctx, tx, orgID, now, facts, heading, base, AssembleOptions{ProjectID: within})
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/compose/org360/dismissal.go
+++ b/backend/internal/compose/org360/dismissal.go
@@ -124,7 +124,7 @@ func (s *Service) raisesSuggestion(
 	if err != nil {
 		return false, err
 	}
-	in, err := gatherSuggestionInputs(ctx, tx, orgID, now, facts, heading, base)
+	in, err := gatherSuggestionInputs(ctx, tx, orgID, now, facts, heading, base, AssembleOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/compose/org360/handlers.go
+++ b/backend/internal/compose/org360/handlers.go
@@ -244,8 +244,13 @@ func (h Handlers) DismissOrganizationSuggestion(w http.ResponseWriter, r *http.R
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
+	var within *ids.ProjectID
+	if req.ProjectId != nil {
+		projectID := ids.From[ids.ProjectKind](ids.UUID(*req.ProjectId))
+		within = &projectID
+	}
 	if err := h.svc.DismissSuggestion(r.Context(),
-		ids.From[ids.OrganizationKind](ids.UUID(id)), req.Fingerprint); err != nil {
+		ids.From[ids.OrganizationKind](ids.UUID(id)), req.Fingerprint, within); err != nil {
 		httperr.Write(w, r, err)
 		return
 	}

--- a/backend/internal/compose/org360/roleproposals.go
+++ b/backend/internal/compose/org360/roleproposals.go
@@ -178,7 +178,7 @@ func (s *Service) proposalInput(
 	if err := auth.EnsureWritableLive(ctx, tx, "deal", dealID.UUID); err != nil {
 		return "", nil, err
 	}
-	roster, err := people.StrengthForOrgContacts(ctx, tx, orgID, now)
+	roster, err := people.StrengthForOrgContacts(ctx, tx, orgID, now, nil)
 	if err != nil {
 		return "", nil, err
 	}

--- a/backend/internal/compose/org360/suggestionreads.go
+++ b/backend/internal/compose/org360/suggestionreads.go
@@ -78,7 +78,7 @@ const excerptRunes = 200
 // the account's timeline uses — one spelling, so they cannot drift. Every
 // candidate still passes the activity row scope, so the reader can open it.
 func newestMessage(
-	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, opts AssembleOptions,
 ) (lastMessage, bool, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
@@ -107,7 +107,7 @@ func newestMessage(
 		       CASE WHEN %[3]s THEN left(a.body, %[4]d) END
 		FROM activity a
 		WHERE a.kind IN ('email','message','call','meeting') AND a.archived_at IS NULL AND %[1]s
-		  AND %[2]s
+		  AND %[2]s`+opts.projectScope(arg)+`
 		ORDER BY a.occurred_at DESC, a.id DESC
 		LIMIT 1`, activityScope, activities.OrgLinkedActivityExists(orgPos), audience, excerptRunes), args...).
 		Scan(&found.ID, &direction, &found.At, &found.Kind, &subject, &excerpt)
@@ -146,7 +146,7 @@ func oneLine(text string) string {
 // Reachability is activities.OrgLinkedActivityExists, the same walk
 // nextStepsSection uses.
 func hasOpenTask(
-	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, opts AssembleOptions,
 ) (bool, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
@@ -163,7 +163,7 @@ func hasOpenTask(
 		SELECT EXISTS (
 		  SELECT 1 FROM activity a
 		  WHERE a.kind = 'task' AND NOT a.is_done AND a.archived_at IS NULL AND %[1]s
-		    AND %[2]s)`,
+		    AND %[2]s`+opts.projectScope(arg)+`)`,
 		activityScope, activities.OrgLinkedActivityExists(orgPos)), args...).Scan(&scheduled)
 	if err != nil {
 		return false, fmt.Errorf("read whether anything is scheduled on the account: %w", err)
@@ -245,9 +245,14 @@ func granted(ctx context.Context, object string) (bool, error) {
 // contradiction rule reads must be supplied by every caller, or the page and
 // the dismissal that answers it judge different suggestions and a dismissal
 // stores nothing. Required, a caller that omits one does not compile.
+// opts narrows the two activity reads below with the rest of the page. A
+// no-reply suggestion on a page scoped to one project used to be able to cite
+// another project's message, and an open task on other work could suppress the
+// suggestion this page should have made.
 func gatherSuggestionInputs(
 	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time,
 	facts signalFacts, heading organizationHeading, baseCurrency string,
+	opts AssembleOptions,
 ) (suggestionInputs, error) {
 	timeline, err := granted(ctx, "activity")
 	if err != nil {
@@ -270,12 +275,12 @@ func gatherSuggestionInputs(
 		in.contractStrip = strip
 	}
 	if in.timeline {
-		newest, found, err := newestMessage(ctx, tx, orgID)
+		newest, found, err := newestMessage(ctx, tx, orgID, opts)
 		if err != nil {
 			return suggestionInputs{}, err
 		}
 		in.newest, in.hasNewest = newest, found
-		scheduled, err := hasOpenTask(ctx, tx, orgID)
+		scheduled, err := hasOpenTask(ctx, tx, orgID, opts)
 		if err != nil {
 			return suggestionInputs{}, err
 		}

--- a/backend/internal/compose/person360/assemble.go
+++ b/backend/internal/compose/person360/assemble.go
@@ -191,10 +191,10 @@ type section struct {
 func (s *Service) sections(personID ids.PersonID, now time.Time, opts AssembleOptions) []section {
 	return []section{
 		{name: crmcontracts.Person360SectionsOmittedStrength, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
-			return s.strengthSection(ctx, tx, personID, now, out)
+			return s.strengthSection(ctx, tx, personID, now, opts.ProjectID, out)
 		}},
 		{name: crmcontracts.Person360SectionsOmittedRelationshipChanges, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
-			return s.relationshipChangesSection(ctx, tx, personID, now, out)
+			return s.relationshipChangesSection(ctx, tx, personID, now, opts.ProjectID, out)
 		}},
 		{name: crmcontracts.Person360SectionsOmittedEmployments, read: func(ctx context.Context, tx pgx.Tx, out *crmcontracts.Person360) error {
 			return s.employmentsSection(ctx, tx, personID, out)

--- a/backend/internal/compose/person360/sections.go
+++ b/backend/internal/compose/person360/sections.go
@@ -23,8 +23,15 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-func (s *Service) strengthSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time, out *crmcontracts.Person360) error {
-	rs, err := s.people.PersonStrengthTx(ctx, tx, personID, now)
+// The strength number is narrowed with the rest of the page. A page scoped to
+// one body of work that scored the relationship across every project would put
+// the right timeline under a number computed somewhere else, and cite
+// contributing activity ids the reader cannot see on the page.
+func (s *Service) strengthSection(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID,
+	now time.Time, within *ids.ProjectID, out *crmcontracts.Person360,
+) error {
+	rs, err := s.people.PersonStrengthTx(ctx, tx, personID, now, within)
 	if err != nil {
 		return err
 	}
@@ -40,8 +47,11 @@ func (s *Service) strengthSection(ctx context.Context, tx pgx.Tx, personID ids.P
 // answer different questions and a caller may hold the grant for one reading
 // and still lose the other to a section fault. Both fold the same §4 curve, so
 // they cannot disagree about the same window.
-func (s *Service) relationshipChangesSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time, out *crmcontracts.Person360) error {
-	changes, err := s.people.PersonRelationshipChangesTx(ctx, tx, personID, now)
+func (s *Service) relationshipChangesSection(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID,
+	now time.Time, within *ids.ProjectID, out *crmcontracts.Person360,
+) error {
+	changes, err := s.people.PersonRelationshipChangesTx(ctx, tx, personID, now, within)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -40147,6 +40147,21 @@ type DismissOrganizationSuggestionJSONBody struct {
 	// currently raise is a `204` that stores nothing; see this operation's
 	// description for why those two answers differ.
 	Fingerprint string `json:"fingerprint"`
+
+	// ProjectId The project the page was scoped to when the suggestion was rendered,
+	// absent on the whole-account page.
+	//
+	// A suggestion's fingerprint is derived from its EVIDENCE, and a scoped
+	// page reasons over one project's activity — so the same advice raised
+	// on a scoped page and on the account page are two different
+	// fingerprints. This route re-derives the suggestions to check the
+	// fingerprint is one the account really raises for this caller, and it
+	// can only reproduce a scoped one by narrowing the same way.
+	//
+	// Send the project the reader was looking at. Omit it and a dismissal
+	// from a scoped page matches nothing and silently stores nothing, which
+	// a reader sees as the card refusing to go away.
+	ProjectId *openapi_types.UUID `json:"project_id,omitempty"`
 }
 
 // ListOverlayUserMapParams defines parameters for ListOverlayUserMap.

--- a/backend/internal/modules/people/conversationclaim.go
+++ b/backend/internal/modules/people/conversationclaim.go
@@ -155,31 +155,35 @@ func claimFingerprint(in ClaimInput) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// claimSourceWithinProject keeps the claims whose source message is filed
-// under ONE project, plus the ones whose source is filed under none: a claim
-// is evidence from a conversation, and a conversation on another engagement
-// is the wrong evidence for this one, while most correspondence on an account
-// carries no project at all and dropping it would empty the card.
+// activityWithinProject keeps the activities filed under ONE project, plus the
+// ones filed under none: a message on another engagement is the wrong evidence
+// for this one, while most correspondence on an account carries no project at
+// all and dropping it would empty the card.
 //
 // activities.ActivityWithinProject and search's projectScope.clause are the
 // same predicate. This is a deliberate copy, not an oversight: a module never
 // imports a sibling (ADR-0054), and the rule is about subject matter rather
 // than authority, so platform/auth is the wrong home for it. Change one,
 // change all three.
-func claimSourceWithinProject(projectPos int) string {
+//
+// The alias is a parameter because this module now asks the question of more
+// than one activity alias in one statement — the strength read scores over `a`
+// and picks its citation over `i`, and both have to be narrowed or the number
+// and the message it cites come from different bodies of work.
+func activityWithinProject(alias string, projectPos int) string {
 	return fmt.Sprintf(`(
 			EXISTS (
 			    SELECT 1 FROM activity_link scoped
-			    WHERE scoped.activity_id = a.id AND scoped.project_id = $%[1]d)
+			    WHERE scoped.activity_id = %[1]s.id AND scoped.project_id = $%[2]d)
 			OR NOT EXISTS (
 			    SELECT 1 FROM activity_link filed
-			    WHERE filed.activity_id = a.id AND filed.project_id IS NOT NULL))`,
-		projectPos)
+			    WHERE filed.activity_id = %[1]s.id AND filed.project_id IS NOT NULL))`,
+		alias, projectPos)
 }
 
 // ClaimsForPerson reads this person's live claims, newest first, optionally
 // narrowed to the claims whose source is filed under one project or under
-// none (claimSourceWithinProject). The caller that narrows owes the project's
+// none (activityWithinProject). The caller that narrows owes the project's
 // own read gate first; this read filters, it does not authorize the filter.
 //
 // The activity join is what keeps a claim from outliving its evidence: a claim
@@ -237,7 +241,7 @@ func (s *Store) readClaims(
 	}
 	filed := sqlAlwaysVisible
 	if within != nil {
-		filed = claimSourceWithinProject(arg(*within))
+		filed = activityWithinProject("a", arg(*within))
 	}
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT c.id, c.kind, c.body, c.source_activity_id, c.source_quote,

--- a/backend/internal/modules/people/edgegrant_test.go
+++ b/backend/internal/modules/people/edgegrant_test.go
@@ -116,7 +116,7 @@ func TestTheContactCountNeedsBothThePersonAndTheEdgeGrant(t *testing.T) {
 func TestTheOrgRosterIsRefusedBeforeItReachesAStatement(t *testing.T) {
 	ctx := edgeGrantCtx(map[string]principal.ObjectGrant{"person": {Read: true}})
 	if _, err := StrengthForOrgContacts(ctx, nil, ids.From[ids.OrganizationKind](ids.NewV7()),
-		time.Now().UTC()); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		time.Now().UTC(), nil); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("StrengthForOrgContacts(no edge grant) = %v, want ErrPermissionDenied", err)
 	}
 }

--- a/backend/internal/modules/people/relationshipchange.go
+++ b/backend/internal/modules/people/relationshipchange.go
@@ -47,6 +47,7 @@ func (s *Store) PersonRelationshipChangesTx(
 	tx pgx.Tx,
 	personID ids.PersonID,
 	now time.Time,
+	within *ids.ProjectID,
 ) ([]relstrength.Change, error) {
 	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
 		return nil, err
@@ -54,7 +55,7 @@ func (s *Store) PersonRelationshipChangesTx(
 	if err := auth.EnsureVisible(ctx, tx, "person", personID.UUID); err != nil {
 		return nil, err
 	}
-	in, err := changeInputs(ctx, tx, personID, now)
+	in, err := changeInputs(ctx, tx, personID, now, within)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +101,7 @@ func (s *Store) RelationshipChangesForPeople(
 	}
 	out := make([]PersonChanges, 0, len(visible))
 	for _, contact := range visible {
-		in, err := changeInputs(ctx, tx, contact.id, now)
+		in, err := changeInputs(ctx, tx, contact.id, now, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -160,8 +161,27 @@ func visibleContactNames(ctx context.Context, tx pgx.Tx, people []ids.PersonID) 
 // changeInputs gathers the present fold, the same fold as it stood one
 // comparison window ago, and the two timestamps a returning reply is measured
 // between.
-func changeInputs(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time) (relstrength.ChangeInputs, error) {
+func changeInputs(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID,
+	now time.Time, within *ids.ProjectID,
+) (relstrength.ChangeInputs, error) {
 	asOf := now.AddDate(0, 0, -relstrength.ComparisonDays)
+
+	// BOTH windows and both statements, or the comparison is between two
+	// different questions: the "before" fold would cover every project while
+	// the "after" covered one, and the change it reported would be the
+	// narrowing rather than anything that happened.
+	foldArgs := []any{
+		personID,
+		now.AddDate(0, 0, -relStrengthWindowDays),
+		asOf,
+		asOf.AddDate(0, 0, -relStrengthWindowDays),
+	}
+	foldWithin := ""
+	if within != nil {
+		foldArgs = append(foldArgs, *within)
+		foldWithin = " AND " + activityWithinProject("a", len(foldArgs))
+	}
 
 	var in relstrength.ChangeInputs
 	// One pass over the person's qualifying interactions answers both windows.
@@ -181,11 +201,8 @@ func changeInputs(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now tim
 		  FROM activity a
 		  JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
 		 WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL`+
-		auth.AudienceWorkspaceOnly("a"),
-		personID,
-		now.AddDate(0, 0, -relStrengthWindowDays),
-		asOf,
-		asOf.AddDate(0, 0, -relStrengthWindowDays),
+		auth.AudienceWorkspaceOnly("a")+foldWithin,
+		foldArgs...,
 	).Scan(
 		&in.Current.LastInteraction, &in.Current.Count90d, &in.Current.Inbound90d, &in.Current.Outbound90d,
 		&in.Previous.LastInteraction, &in.Previous.Count90d, &in.Previous.Inbound90d, &in.Previous.Outbound90d,
@@ -199,13 +216,19 @@ func changeInputs(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now tim
 	}
 	// The far side of the silence their reply broke. A separate statement
 	// because it is bounded by a value the first one returns.
+	precedingArgs := []any{personID, *in.LatestInbound}
+	precedingWithin := ""
+	if within != nil {
+		precedingArgs = append(precedingArgs, *within)
+		precedingWithin = " AND " + activityWithinProject("a", len(precedingArgs))
+	}
 	if err := tx.QueryRow(ctx, `
 		SELECT max(a.occurred_at)
 		  FROM activity a
 		  JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
 		 WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL
-		   AND a.occurred_at < $2`+auth.AudienceWorkspaceOnly("a"),
-		personID, *in.LatestInbound,
+		   AND a.occurred_at < $2`+auth.AudienceWorkspaceOnly("a")+precedingWithin,
+		precedingArgs...,
 	).Scan(&in.PrecedingInteraction); err != nil {
 		return relstrength.ChangeInputs{}, fmt.Errorf("people: reading what preceded a contact's last reply: %w", err)
 	}

--- a/backend/internal/modules/people/strength.go
+++ b/backend/internal/modules/people/strength.go
@@ -100,7 +100,7 @@ func (s *Store) PersonStrength(ctx context.Context, personID ids.PersonID, now t
 		if err := auth.EnsureVisible(ctx, tx, "person", personID.UUID); err != nil {
 			return err
 		}
-		return strengthInputs(ctx, tx, personID, now, &out)
+		return strengthInputs(ctx, tx, personID, now, nil, &out)
 	})
 	if err != nil {
 		return RelationshipStrength{}, err
@@ -111,7 +111,10 @@ func (s *Store) PersonStrength(ctx context.Context, personID ids.PersonID, now t
 
 // PersonStrengthTx is PersonStrength inside a caller-opened transaction —
 // the composite record read. Same gates in the same order.
-func (s *Store) PersonStrengthTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time) (RelationshipStrength, error) {
+func (s *Store) PersonStrengthTx(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID,
+	now time.Time, within *ids.ProjectID,
+) (RelationshipStrength, error) {
 	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
 		return RelationshipStrength{}, err
 	}
@@ -119,7 +122,7 @@ func (s *Store) PersonStrengthTx(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		return RelationshipStrength{}, err
 	}
 	var out RelationshipStrength
-	if err := strengthInputs(ctx, tx, personID, now, &out); err != nil {
+	if err := strengthInputs(ctx, tx, personID, now, within, &out); err != nil {
 		return RelationshipStrength{}, err
 	}
 	out.finish(now)
@@ -201,7 +204,10 @@ type ContactStrength struct {
 //
 // The results come back in the order the contacts sort by id, so a page
 // built from them is deterministic.
-func StrengthForOrgContacts(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, now time.Time) ([]ContactStrength, error) {
+func StrengthForOrgContacts(
+	ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
+	now time.Time, within *ids.ProjectID,
+) ([]ContactStrength, error) {
 	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
 		return nil, err
 	}
@@ -245,7 +251,7 @@ func StrengthForOrgContacts(ctx context.Context, tx pgx.Tx, orgID ids.Organizati
 	if len(contacts) == 0 {
 		return nil, nil
 	}
-	return contactStrengths(ctx, tx, contacts, now, nil)
+	return contactStrengths(ctx, tx, contacts, now, nil, within)
 }
 
 // personScopePredicate is the caller's person row-scope predicate for a query
@@ -322,7 +328,7 @@ func strengthForPeopleAt(ctx context.Context, tx pgx.Tx, people []ids.PersonID, 
 	if len(visible) == 0 {
 		return nil, nil
 	}
-	return contactStrengths(ctx, tx, visible, now, until)
+	return contactStrengths(ctx, tx, visible, now, until, nil)
 }
 
 // contactStrengths folds the §4 inputs for a whole contact set out of ONE
@@ -330,8 +336,21 @@ func strengthForPeopleAt(ctx context.Context, tx pgx.Tx, people []ids.PersonID, 
 // deliberately NOT collected here: they are the person page's receipts, and
 // carrying up to relStrengthEvidenceCap of them per contact would make an
 // account list payload grow with its history rather than its contact count.
-func contactStrengths(ctx context.Context, tx pgx.Tx, contacts []ids.PersonID, now time.Time, until *time.Time) ([]ContactStrength, error) {
-	windowStart := now.AddDate(0, 0, -relStrengthWindowDays)
+func contactStrengths(
+	ctx context.Context, tx pgx.Tx, contacts []ids.PersonID,
+	now time.Time, until *time.Time, within *ids.ProjectID,
+) ([]ContactStrength, error) {
+	args := []any{contacts, now.AddDate(0, 0, -relStrengthWindowDays), until}
+	// BOTH aliases, or the score and the message it cites answer different
+	// questions: `a` is what the counts are computed over and `i` is the
+	// citation the card shows, so a page narrowed to one project could report a
+	// number from that project beside a message from another.
+	scoreWithin, citedWithin := "", ""
+	if within != nil {
+		args = append(args, *within)
+		scoreWithin = " AND " + activityWithinProject("a", len(args))
+		citedWithin = " AND " + activityWithinProject("i", len(args))
+	}
 	rows, err := tx.Query(ctx, `
 		SELECT l.person_id,
 		       max(a.occurred_at),
@@ -344,7 +363,7 @@ func contactStrengths(ctx context.Context, tx pgx.Tx, contacts []ids.PersonID, n
 		          JOIN activity_link il ON il.activity_id = i.id AND il.person_id = l.person_id
 		         WHERE i.direction = 'inbound' AND i.kind IN `+strengthKinds+`
 		           AND i.archived_at IS NULL AND i.occurred_at >= $2`+auth.AudienceWorkspaceOnly("i")+`
-		           AND ($3::timestamptz IS NULL OR i.occurred_at <= $3)
+		           AND ($3::timestamptz IS NULL OR i.occurred_at <= $3)`+citedWithin+`
 		         ORDER BY i.occurred_at DESC, i.id DESC
 		         LIMIT 1)
 		FROM activity a
@@ -352,8 +371,8 @@ func contactStrengths(ctx context.Context, tx pgx.Tx, contacts []ids.PersonID, n
 		WHERE l.person_id = ANY($1) AND a.kind IN `+strengthKinds+` AND a.archived_at IS NULL`+auth.AudienceWorkspaceOnly("a")+`
 		  -- NULL means no upper bound, so the live score is unchanged; an
 		  -- as-of read passes the instant it is asking about.
-		  AND ($3::timestamptz IS NULL OR a.occurred_at <= $3)
-		GROUP BY l.person_id`, contacts, windowStart, until)
+		  AND ($3::timestamptz IS NULL OR a.occurred_at <= $3)`+scoreWithin+`
+		GROUP BY l.person_id`, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -387,8 +406,22 @@ func contactStrengths(ctx context.Context, tx pgx.Tx, contacts []ids.PersonID, n
 	return out, nil
 }
 
-func strengthInputs(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time, out *RelationshipStrength) error {
+func strengthInputs(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID,
+	now time.Time, within *ids.ProjectID, out *RelationshipStrength,
+) error {
 	windowStart := now.AddDate(0, 0, -relStrengthWindowDays)
+	foldArgs := []any{personID, windowStart}
+	// Every alias the fold reads, for the reason contactStrengths gives: the
+	// counts, the cited message and the contributing ids are one reading, and
+	// narrowing some of them would report a number over one body of work with
+	// evidence from another.
+	scoreWithin, citedWithin := "", ""
+	if within != nil {
+		foldArgs = append(foldArgs, *within)
+		scoreWithin = " AND " + activityWithinProject("a", len(foldArgs))
+		citedWithin = " AND " + activityWithinProject("i", len(foldArgs))
+	}
 
 	// One pass over the person's qualifying interactions: overall last
 	// touch, the 90-day direction counts, and the contributing ids.
@@ -402,24 +435,30 @@ func strengthInputs(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now t
 		       (SELECT i.id FROM activity i
 		          JOIN activity_link il ON il.activity_id = i.id AND il.person_id = $1
 		         WHERE i.direction = 'inbound' AND i.kind IN `+strengthKinds+`
-		           AND i.archived_at IS NULL AND i.occurred_at >= $2`+auth.AudienceWorkspaceOnly("i")+`
+		           AND i.archived_at IS NULL AND i.occurred_at >= $2`+auth.AudienceWorkspaceOnly("i")+citedWithin+`
 		         ORDER BY i.occurred_at DESC, i.id DESC
 		         LIMIT 1)
 		FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
-		WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL`+auth.AudienceWorkspaceOnly("a"),
-		personID, windowStart).Scan(&out.LastInteraction, &out.InteractionCount90d,
+		WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL`+auth.AudienceWorkspaceOnly("a")+scoreWithin,
+		foldArgs...).Scan(&out.LastInteraction, &out.InteractionCount90d,
 		&out.Inbound90d, &out.Outbound90d, &out.LastInbound, &out.LastOutbound,
 		&out.LastInboundActivity); err != nil {
 		return err
 	}
 
+	citeArgs := []any{personID, windowStart, relStrengthEvidenceCap}
+	contributingWithin := ""
+	if within != nil {
+		citeArgs = append(citeArgs, *within)
+		contributingWithin = " AND " + activityWithinProject("a", len(citeArgs))
+	}
 	rows, err := tx.Query(ctx, `
 		SELECT a.id FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
-		WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL AND a.occurred_at >= $2`+auth.AudienceWorkspaceOnly("a")+`
+		WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL AND a.occurred_at >= $2`+auth.AudienceWorkspaceOnly("a")+contributingWithin+`
 		ORDER BY a.occurred_at DESC
-		LIMIT $3`, personID, windowStart, relStrengthEvidenceCap)
+		LIMIT $3`, citeArgs...)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/modules/people/strengthaccount.go
+++ b/backend/internal/modules/people/strengthaccount.go
@@ -80,7 +80,7 @@ func AccountStrengthFor(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 	if err := auth.Require(ctx, "relationship", principal.ActionRead); err != nil {
 		return AccountStrength{}, err
 	}
-	contacts, err := StrengthForOrgContacts(ctx, tx, orgID, now)
+	contacts, err := StrengthForOrgContacts(ctx, tx, orgID, now, nil)
 	if errors.Is(err, apperrors.ErrPermissionDenied) {
 		// A caller holding organization:read but not person:read sees an
 		// account with no contacts they may read, so the roll-up is dormant

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -36632,6 +36632,23 @@ export interface operations {
                      *     description for why those two answers differ.
                      */
                     fingerprint: string;
+                    /**
+                     * Format: uuid
+                     * @description The project the page was scoped to when the suggestion was rendered,
+                     *     absent on the whole-account page.
+                     *
+                     *     A suggestion's fingerprint is derived from its EVIDENCE, and a scoped
+                     *     page reasons over one project's activity — so the same advice raised
+                     *     on a scoped page and on the account page are two different
+                     *     fingerprints. This route re-derives the suggestions to check the
+                     *     fingerprint is one the account really raises for this caller, and it
+                     *     can only reproduce a scoped one by narrowing the same way.
+                     *
+                     *     Send the project the reader was looking at. Omit it and a dismissal
+                     *     from a scoped page matches nothing and silently stores nothing, which
+                     *     a reader sees as the card refusing to go away.
+                     */
+                    project_id?: string;
                 };
             };
         };


### PR DESCRIPTION
Closes #2291.

The project scope reached the timeline, next steps, next meeting, last touch and since-last-visit. It stopped at the **aggregates**. A page narrowed to one body of work still scored the relationship, counted the account's active contacts, dated its last meeting and raised its suggestions across *every* project — the right timeline under a number computed somewhere else, and advice citing a message the reader cannot see on the page to check it against.

## What changed

The three groups the issue names collapse to **two** reads. org360's `active_contacts`, `reply_balance` and `single_threaded` are all folded from the contact strengths, so narrowing that one read narrows all three.

- `people.StrengthForOrgContacts` / `PersonStrengthTx` / `PersonRelationshipChangesTx` take the body of work and apply it to every activity-reading statement in them.
- `org360`'s last-meeting read and the three suggestion reads (`newestMessage`, `hasOpenTask`, `gatherSuggestionInputs`) append the same predicate.
- `person360`'s strength and relationship-change sections pass `AssembleOptions.ProjectID` through.

Callers that deliberately stay unscoped pass `nil` with the reason written beside them.

## One predicate, not a fourth spelling

The people module already spelled this predicate, with the reason it is a copy rather than an import written beside it — a module never imports a sibling, so the timeline's, search's and people's spellings are a deliberate set of three that change together. This generalises the people-module one by **table alias** instead of adding a fourth.

The strength read narrows **both** of its aliases — the one the counts fold over and the one the cited message comes from — or the number and the message it cites come from different bodies of work.

## Proof

Against the existing two-engagement fixture, **both ways round every time**: the scoped read must drop the other engagement *and* the unscoped read of the same account must still carry it. A test asserting only the scoped half passes against an assembly that quietly lost a row.

- `TestAScopedAccountPageDerivesItsHealthFromOneEngagement` — active contacts (2 vs 3, the bystander speaks only on the other engagement), last-inbound age, and last meeting.
- `TestAScopedAccountPageChasesOnlyTheEngagementItShows` — the no-reply rule chases the page's own unanswered mail, never the other engagement's. Its own fixture: the shared one's newest exchange is a booked meeting, which is the rule correctly declining to chase someone we are about to see.
- `TestPerson360ScopedToOneProjectScoresFromOneEngagement` — the score's `contributing_activity_ids`, which is where a score says out loud what a reader can check it against.

Each production change was reverted in turn and the matching test confirmed failing.

## Note on CI

Four integration tests are red on `main` at the tip and are unrelated to this branch — `TestPerson360AssemblesEverySectionFromRealRows`, `TestADismissalHoldsUntilTheEvidenceMoves`, `TestDOIIssuanceMintsNothingWhicheverPurposeIsNamed` and `TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden`. They are covered by #4942 and #4945 and fail identically at this branch's base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC