### PR TITLE
audit(jobs): two of the three unbound workers were binding all along

### DIFF
--- a/backend/internal/compose/integration/scope.go
+++ b/backend/internal/compose/integration/scope.go
@@ -24,6 +24,14 @@ import (
 // about who may SEE a row. Such a test would pass whatever the row scope was. That
 // is not left to this comment: backend/gates/retentionscope_test.go holds the fixture to
 // the retention engine as its only sink, and fails a use that is anything else.
+// It is a COPY of the worker's own retentionPassProvenance rather than a call
+// to it, and it cannot be one: internal/compose has in-package integration
+// tests that import this package, so importing compose back from a non-test
+// file here is an import cycle. What that costs is that these suites hold the
+// retention ENGINE under a pass's provenance and not the pass's own binding —
+// deleting that line from the worker leaves them green. The binding is held
+// instead by TestEveryJobWorkerThatReachesAStoreBindsAnActor, which reads the
+// worker; #4952 is the one-source-of-truth follow-up.
 func RetentionPassCtx(ws ids.UUID) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), ws)
 	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: "system"})

--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -21,11 +21,25 @@ package compose
 // also bind an actor. Derived from the tree rather than a hand-kept list,
 // because the next job added is the one nobody remembers to check.
 //
-// Three older workers are waived below rather than fixed. They have the same
-// shape, but whether each one actually reaches a gated write is a question
-// about three other subsystems, and answering it wrongly would either break
-// working jobs or paper over a live defect. Issue #1127 tracks that audit; the
-// waiver is a ratchet — a waived worker that starts binding an actor fails
+// Three older workers were waived here while the question "does this one
+// actually reach a gated write" was open for each. It is answered now, and two
+// of the three were FALSE POSITIVES rather than defects: privacyRetentionWorker
+// binds a system actor through retentionPassProvenance, and timeScanWorker's
+// per-workspace turn binds one through scanLeadSLA — in both cases one call
+// away, which is the only reason this gate could not see it.
+//
+// That is what the one-level follow below exists for. A binder is a helper by
+// nature: it takes a context, returns one with the principal in it, and reads
+// better beside the pass it names than inlined into a Work method. A gate that
+// only looked at the Work body was therefore going to keep producing waivers
+// for correct code, and every one of those is a place a real defect can hide.
+//
+// The third is genuine and stays waived: webhookRetryWorker reaches no gate
+// under its own principal, and the one authority question its path asks is
+// asked under the subscription OWNER's. Its entry says so and names the
+// evidence.
+//
+// The waiver is a ratchet — a waived worker that starts binding an actor fails
 // this test until its entry is removed.
 
 import (
@@ -38,12 +52,10 @@ import (
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
-// jobActorUnbound: workers that predate this gate and bind no actor. Each
-// needs its own subsystem checked before it is changed — see #1127.
+// jobActorUnbound: workers that reach a store and bind no actor because they
+// need none. The audit behind the one entry left is in this file's doc.
 var jobActorUnbound = gatekit.Waive(map[string]string{
-	"privacyRetentionWorker": "retention sweep; whether its writes are gated is #1127's question",
-	"timeScanWorker":         "automation time-scan; same audit",
-	"webhookRetryWorker":     "webhook delivery retry; same audit",
+	"webhookRetryWorker": "the retry sweep resolves no principal of its own and reaches no RBAC gate under one. Its path is dueRetries → loadTarget → stillVisible → markVisibilityRevoked → deliverOnce, and none of those asks auth.Require; the two entry points in that store which do (ListDeliveries, requireReplay) are the human dead-letter surfaces this pass never touches. The one authority question it DOES ask — may this subscription's owner still see the record this delivery carries — is asked under the OWNER's principal, resolved per delivery from the row (Deliverer.canSee binds it with principal.WithActor from EffectiveRBAC). An actor bound here would be a second, wrong answer to that question. Held by webhookretry_pass_integration_test.go, whose webhookSweepCtx binds the tenant and nothing else",
 })
 
 // storeBuilders are the handle constructors a store is built on. A Work method
@@ -98,6 +110,7 @@ func TestEveryJobWorkerThatReachesAStoreBindsAnActor(t *testing.T) {
 		t.Fatalf("reading the compose package: %v", err)
 	}
 
+	pkg := packageFunctions(t, files)
 	offenders := map[string]string{}
 	var checked int
 	for _, f := range files {
@@ -117,7 +130,7 @@ func TestEveryJobWorkerThatReachesAStoreBindsAnActor(t *testing.T) {
 			if !storeBuilders.MatchString(body.text) {
 				continue
 			}
-			if actorBinders.MatchString(body.text) {
+			if actorBinders.MatchString(withCalledHelpers(body.text, pkg)) {
 				continue
 			}
 			if jobActorUnbound.Waived(t, body.worker) {
@@ -165,3 +178,87 @@ func workMethodBodies(src string) []workBody {
 	}
 	return out
 }
+
+// packageFunctions maps every top-level function and method in the compose
+// package to its body, so a Work method's own text can be read together with
+// the helpers it calls.
+func packageFunctions(t *testing.T, files []os.DirEntry) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, f := range files {
+		name := f.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		text := string(src)
+		locs := anyFunc.FindAllStringSubmatchIndex(text, -1)
+		for i, loc := range locs {
+			end := len(text)
+			if i+1 < len(locs) {
+				end = locs[i+1][0]
+			}
+			// Unioned rather than overwritten: two files may carry a method of
+			// the same name on different receivers, and this gate asks whether
+			// ANY of the things that name could mean binds an actor. Keeping
+			// only the last would make the answer depend on directory order.
+			out[text[loc[2]:loc[3]]] += text[loc[0]:end]
+		}
+	}
+	return out
+}
+
+// anyFunc captures the NAME of a top-level function or method — the second
+// group, because a method's receiver comes first.
+var anyFunc = regexp.MustCompile(`(?m)^func (?:\([^)]*\) )?(\w+)\(`)
+
+// withCalledHelpers is the Work body plus the bodies of the compose-package
+// functions it calls, one level deep.
+//
+// One level, because a binder is a HELPER by nature — it takes a context,
+// returns one carrying the principal, and reads better beside the pass it names
+// than inlined into a Work method. Two of the three workers waived here for
+// weeks were binding correctly one call away, and a gate that produces waivers
+// for correct code is a gate whose waiver list stops meaning anything.
+//
+// WHAT THIS CANNOT SEE, so nobody has to rediscover it: a helper that binds an
+// actor for its own path leaves this body looking bound, so a SECOND, unbound
+// gated call in the same Work method would pass. That is a narrower hole than
+// the one it closes — every helper-bound worker was invisible before — and it
+// is the shape to plant a case for if this gate is ever extended again. It also
+// follows names, not call graphs: a call into another package (the automation
+// scanner, the webhook deliverer) is not read at all, which is why a worker
+// whose only binding lives in another module still needs an entry above.
+func withCalledHelpers(body string, pkg map[string]string) string {
+	var b strings.Builder
+	b.WriteString(body)
+	for _, call := range callee.FindAllStringSubmatch(afterSignature(body), -1) {
+		if helper, ok := pkg[call[1]]; ok {
+			b.WriteString(helper)
+		}
+	}
+	return b.String()
+}
+
+// afterSignature drops a method's own declaration line, so the method's NAME is
+// not read as a call it makes.
+//
+// It matters because the names here are shared: every worker's entry point is
+// called Work, so reading the signature pulled every other worker's Work body
+// in — and one of those binds an actor, which made this gate answer yes for a
+// worker that binds none. It read as a working follow-one-level and was a
+// self-satisfying lookup.
+func afterSignature(body string) string {
+	if open := strings.Index(body, "{\n"); open >= 0 {
+		return body[open:]
+	}
+	return body
+}
+
+// callee captures a bare call's name. A selector call (`x.Method(`) is
+// deliberately not matched: this gate reads the compose package's own source,
+// and a method on somebody else's type is not in it.
+var callee = regexp.MustCompile(`(?:^|[^.\w])(\w+)\(`)

--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -43,6 +43,8 @@ package compose
 // this test until its entry is removed.
 
 import (
+	"go/scanner"
+	"go/token"
 	"os"
 	"regexp"
 	"sort"
@@ -278,7 +280,7 @@ func withCalledHelpers(body string, pkg map[string]string) string {
 // alternative is a worker reported as bound by a body it does not reach.
 func namesBoundIn(body string) map[string]bool {
 	bound := map[string]bool{}
-	for _, m := range localBinding.FindAllStringSubmatch(body, -1) {
+	for _, m := range localBinding.FindAllStringSubmatch(codeOnly(body), -1) {
 		for _, part := range strings.Split(m[1], ",") {
 			// The LAST word of each comma-separated part. The capture is
 			// deliberately loose enough to reach a name introduced in a control
@@ -305,6 +307,42 @@ func namesBoundIn(body string) map[string]bool {
 // body it never runs — the exact hole this guard exists to close, in the three
 // places Go lets a name be introduced without a statement of its own.
 var localBinding = regexp.MustCompile(`(?:^|[^\w.])(?:var\s+)?([\w][\w, ]*?)\s*:?=[^=]`)
+
+// codeOnly blanks every comment and every string or rune literal, leaving the
+// body's offsets and therefore the regex's own idea of a word boundary intact.
+//
+// The scanner is here for one reason: a name is bound by Go, not by text that
+// merely looks like Go. `// bindActor := …` in a note, or `"n := 1"` in a
+// message, made namesBoundIn suppress the follow to the package's real helper,
+// and the gate then read a bound worker as unbound and went red. Prose a
+// contributor writes must not be able to decide a gate, least of all in the
+// cry-wolf direction that gets a gate deleted.
+//
+// Blanking rather than deleting because the regex reads what sits either side
+// of a match: closing the gap could join two words that were never adjacent.
+func codeOnly(body string) string {
+	fset := token.NewFileSet()
+	file := fset.AddFile("", fset.Base(), len(body))
+	var sc scanner.Scanner
+	// A nil handler drops scan errors, which is right for a fragment: this
+	// starts mid-declaration and is read for its shape, not compiled.
+	sc.Init(file, []byte(body), nil, scanner.ScanComments)
+	out := []byte(body)
+	for {
+		pos, tok, lit := sc.Scan()
+		if tok == token.EOF {
+			break
+		}
+		if tok != token.COMMENT && tok != token.STRING && tok != token.CHAR {
+			continue
+		}
+		start := fset.Position(pos).Offset
+		for i := start; i < start+len(lit) && i < len(out); i++ {
+			out[i] = ' '
+		}
+	}
+	return string(out)
+}
 
 // afterSignature drops a method's own declaration line, so the method's NAME is
 // not read as a call it makes.
@@ -424,6 +462,48 @@ func bindActor(ctx context.Context) context.Context {
 			indexFunctions(index, pkg)
 			if actorBinders.MatchString(withCalledHelpers(worker, index)) {
 				t.Error("the worker read as binding an actor through a name it had shadowed in a control clause")
+			}
+		})
+	}
+}
+
+// Prose is not a binding. A comment or a string that happens to contain an
+// assignment must not decide this gate.
+//
+// The guard reads text, and text a contributor writes is not Go: a note saying
+// `bindActor := w.transform` and a log line carrying the same words used to
+// suppress the follow to the package's real bindActor, and the worker — which
+// calls it and IS bound — came back unbound. That is the cry-wolf direction,
+// and this file's own prose says what a gate that cries wolf gets: deleted by
+// the next person who sees it red.
+func TestTheFollowIgnoresAnAssignmentInsideACommentOrAString(t *testing.T) {
+	t.Parallel()
+	const pkg = `package compose
+
+func bindActor(ctx context.Context) context.Context {
+	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem})
+	return ctx
+}
+`
+	for _, tc := range []struct {
+		name, line string
+	}{
+		{"a line comment", "\t// A worker may write bindActor := w.transform to swap the pass.\n"},
+		{"a block comment", "\t/* bindActor := w.transform\n\t   is what an older draft did. */\n"},
+		{"a string literal", "\tslog.Info(\"bindActor := w.transform is not supported\")\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			worker := "func (w *someWorker) Work(ctx context.Context) error {\n" +
+				"\tdb := database.BindTo(w.pool, ws)\n" + tc.line +
+				"\tctx = bindActor(ctx)\n\treturn run(ctx, db)\n}\n"
+			index := map[string]string{}
+			indexFunctions(index, pkg)
+			if _, indexed := index["bindActor"]; !indexed {
+				t.Fatal("the fixture's package helper was not indexed, so this case proves nothing")
+			}
+			if !actorBinders.MatchString(withCalledHelpers(worker, index)) {
+				t.Error("the worker read as UNBOUND because prose in its body was taken for a binding, " +
+					"so the follow never reached the helper it really calls")
 			}
 		})
 	}

--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -194,26 +194,38 @@ func packageFunctions(t *testing.T, files []os.DirEntry) map[string]string {
 		if err != nil {
 			t.Fatalf("reading %s: %v", name, err)
 		}
-		text := string(src)
-		locs := anyFunc.FindAllStringSubmatchIndex(text, -1)
-		for i, loc := range locs {
-			end := len(text)
-			if i+1 < len(locs) {
-				end = locs[i+1][0]
-			}
-			// Unioned rather than overwritten: two files may carry a method of
-			// the same name on different receivers, and this gate asks whether
-			// ANY of the things that name could mean binds an actor. Keeping
-			// only the last would make the answer depend on directory order.
-			out[text[loc[2]:loc[3]]] += text[loc[0]:end]
-		}
+		indexFunctions(out, string(src))
 	}
 	return out
 }
 
-// anyFunc captures the NAME of a top-level function or method — the second
-// group, because a method's receiver comes first.
-var anyFunc = regexp.MustCompile(`(?m)^func (?:\([^)]*\) )?(\w+)\(`)
+// indexFunctions records one file's RECEIVER-LESS functions by name.
+//
+// Receiver-less only, and that is what makes the lookup resolve rather than
+// guess. A bare `foo()` in Go can only reach a package-level function, so
+// indexing methods under the same bare name let an unrelated
+// `(s *Store) mode()` answer for a call to `mode()` — a binder in a body the
+// worker never reaches, reported as the worker's own. Go forbids two
+// package-level functions of one name in a package, so every name that
+// resolves here resolves to exactly one body.
+func indexFunctions(out map[string]string, text string) {
+	locs := anyFunc.FindAllStringSubmatchIndex(text, -1)
+	for i, loc := range locs {
+		if loc[2] >= 0 {
+			continue // a method: unreachable by a bare call
+		}
+		end := len(text)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		out[text[loc[4]:loc[5]]] = text[loc[0]:end]
+	}
+}
+
+// anyFunc captures a top-level declaration's NAME, and separately whether it
+// had a receiver, so a method can be skipped: the first group is the receiver
+// clause when there is one, the second the name.
+var anyFunc = regexp.MustCompile(`(?m)^func (\([^)]*\) )?(\w+)\(`)
 
 // withCalledHelpers is the Work body plus the bodies of the compose-package
 // functions it calls, one level deep.
@@ -232,6 +244,13 @@ var anyFunc = regexp.MustCompile(`(?m)^func (?:\([^)]*\) )?(\w+)\(`)
 // follows names, not call graphs: a call into another package (the automation
 // scanner, the webhook deliverer) is not read at all, which is why a worker
 // whose only binding lives in another module still needs an entry above.
+//
+// What it does NOT do is guess which body a name means. Only receiver-less
+// functions are indexed, because a bare call can reach nothing else — a method
+// indexed under its bare name would let an unrelated `(s *Store) mode()` answer
+// for a call to `mode()`, and a binder in a body the worker never reaches would
+// read as the worker's own. Go forbids two package-level functions of one name,
+// so every name that resolves here resolves to exactly one body.
 func withCalledHelpers(body string, pkg map[string]string) string {
 	var b strings.Builder
 	b.WriteString(body)
@@ -262,3 +281,34 @@ func afterSignature(body string) string {
 // deliberately not matched: this gate reads the compose package's own source,
 // and a method on somebody else's type is not in it.
 var callee = regexp.MustCompile(`(?:^|[^.\w])(\w+)\(`)
+
+// The follow resolves a name; it does not guess which body the name means.
+//
+// A METHOD indexed under its bare name would answer for a call no worker can
+// make: `mode()` in a Work body cannot reach `(s *Store) mode()`, and letting
+// it would report a worker as bound on the strength of a binder in a body it
+// never runs. That is the gate's own failure direction — a waiver it never
+// asked for, granted silently.
+func TestTheFollowDoesNotResolveABareCallToAMethod(t *testing.T) {
+	t.Parallel()
+	const pkg = `package compose
+
+func (s *Store) mode(ctx context.Context) context.Context {
+	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem})
+	return ctx
+}
+`
+	const worker = `func (w *someWorker) Work(ctx context.Context) error {
+	db := database.BindTo(w.pool, ws)
+	return mode(ctx, db)
+}
+`
+	index := map[string]string{}
+	indexFunctions(index, pkg)
+	if _, indexed := index["mode"]; indexed {
+		t.Fatal("a method was indexed under its bare name, so a call no worker can make answers for one it does")
+	}
+	if actorBinders.MatchString(withCalledHelpers(worker, index)) {
+		t.Error("the worker read as binding an actor on the strength of a method it cannot reach by that name")
+	}
+}

--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -279,16 +279,32 @@ func withCalledHelpers(body string, pkg map[string]string) string {
 func namesBoundIn(body string) map[string]bool {
 	bound := map[string]bool{}
 	for _, m := range localBinding.FindAllStringSubmatch(body, -1) {
-		for _, name := range strings.Split(m[1], ",") {
-			bound[strings.TrimSpace(name)] = true
+		for _, part := range strings.Split(m[1], ",") {
+			// The LAST word of each comma-separated part. The capture is
+			// deliberately loose enough to reach a name introduced in a control
+			// clause, which means it also takes the keyword in front of it —
+			// `switch bindActor`, `for _, bindActor` — and the name is what
+			// follows.
+			words := strings.Fields(part)
+			if len(words) == 0 {
+				continue
+			}
+			bound[words[len(words)-1]] = true
 		}
 	}
 	return bound
 }
 
-// localBinding captures the left-hand side of a declaration or assignment, and
-// of a `var` line.
-var localBinding = regexp.MustCompile(`(?m)^\s*(?:var\s+)?([\w, ]+?)\s*:?=[^=]`)
+// localBinding captures the left-hand side of any declaration or assignment,
+// wherever it appears on a line.
+//
+// NOT anchored to the start of a line, which the first version was and which
+// missed every control-clause declaration: `if h := w.bind; …`, `for _, h := range …`,
+// `switch h := w.bind; …`. A helper name shadowed in one of those read as the
+// package's own function, and the worker came back bound on the strength of a
+// body it never runs — the exact hole this guard exists to close, in the three
+// places Go lets a name be introduced without a statement of its own.
+var localBinding = regexp.MustCompile(`(?:^|[^\w.])(?:var\s+)?([\w][\w, ]*?)\s*:?=[^=]`)
 
 // afterSignature drops a method's own declaration line, so the method's NAME is
 // not read as a call it makes.
@@ -373,5 +389,42 @@ func bindActor(ctx context.Context) context.Context {
 	}
 	if actorBinders.MatchString(withCalledHelpers(worker, index)) {
 		t.Error("the worker read as binding an actor through a name it had shadowed with a field of its own")
+	}
+}
+
+// The shadow guard reads a name declared in a control clause.
+//
+// `if`, `for` and `switch` each let a name be introduced without a statement of
+// its own, and a guard anchored to the start of a line sees none of them — so a
+// helper name shadowed in one read as the package's own function and vouched
+// for a worker that binds nothing.
+func TestTheFollowSeesAShadowDeclaredInAControlClause(t *testing.T) {
+	t.Parallel()
+	const pkg = `package compose
+
+func bindActor(ctx context.Context) context.Context {
+	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem})
+	return ctx
+}
+`
+	for _, tc := range []struct {
+		name, body string
+	}{
+		{"an if initializer", "\tif bindActor := w.transform; bindActor != nil {\n\t\tctx = bindActor(ctx)\n\t}\n"},
+		{"a for range", "\tfor _, bindActor := range w.transforms {\n\t\tctx = bindActor(ctx)\n\t}\n"},
+		{"a switch initializer", "\tswitch bindActor := w.transform; {\n\tdefault:\n\t\tctx = bindActor(ctx)\n\t}\n"},
+		// The one that is not at the start of its line, which is why the scan
+		// is not anchored to one.
+		{"an else-if initializer", "\tif w.pool == nil {\n\t\treturn nil\n\t} else if bindActor := w.transform; bindActor != nil {\n\t\tctx = bindActor(ctx)\n\t}\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			worker := "func (w *someWorker) Work(ctx context.Context) error {\n" +
+				"\tdb := database.BindTo(w.pool, ws)\n" + tc.body + "\treturn run(ctx, db)\n}\n"
+			index := map[string]string{}
+			indexFunctions(index, pkg)
+			if actorBinders.MatchString(withCalledHelpers(worker, index)) {
+				t.Error("the worker read as binding an actor through a name it had shadowed in a control clause")
+			}
+		})
 	}
 }

--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -250,13 +250,45 @@ var anyFunc = regexp.MustCompile(`(?m)^func (\([^)]*\) )?(\w+)\(`)
 func withCalledHelpers(body string, pkg map[string]string) string {
 	var b strings.Builder
 	b.WriteString(body)
+	bound := namesBoundIn(body)
 	for _, call := range callee.FindAllStringSubmatch(afterSignature(body), -1) {
+		// A name this body binds ITSELF is a value, not the package function
+		// that happens to share its spelling: `bindActor := w.transform` makes
+		// `bindActor(ctx)` a call through a field, and reading the package's
+		// own bindActor for it would report the worker as bound on the strength
+		// of a body it never runs. Over-collecting is the safe direction — a
+		// name bound anywhere counts as bound throughout, which can lose a real
+		// call and cannot invent one.
+		if bound[call[1]] {
+			continue
+		}
 		if helper, ok := pkg[call[1]]; ok {
 			b.WriteString(helper)
 		}
 	}
 	return b.String()
 }
+
+// namesBoundIn collects the names a body declares: short variable
+// declarations, plain assignments and `var` lines.
+//
+// Text rather than syntax, like the rest of this gate. It over-collects — an
+// assignment to a package-level variable of the same name counts too — and that
+// is the direction to over-collect in: the cost is a call not followed, and the
+// alternative is a worker reported as bound by a body it does not reach.
+func namesBoundIn(body string) map[string]bool {
+	bound := map[string]bool{}
+	for _, m := range localBinding.FindAllStringSubmatch(body, -1) {
+		for _, name := range strings.Split(m[1], ",") {
+			bound[strings.TrimSpace(name)] = true
+		}
+	}
+	return bound
+}
+
+// localBinding captures the left-hand side of a declaration or assignment, and
+// of a `var` line.
+var localBinding = regexp.MustCompile(`(?m)^\s*(?:var\s+)?([\w, ]+?)\s*:?=[^=]`)
 
 // afterSignature drops a method's own declaration line, so the method's NAME is
 // not read as a call it makes.
@@ -305,5 +337,41 @@ func (s *Store) mode(ctx context.Context) context.Context {
 	}
 	if actorBinders.MatchString(withCalledHelpers(worker, index)) {
 		t.Error("the worker read as binding an actor on the strength of a method it cannot reach by that name")
+	}
+}
+
+// A Work body that SHADOWS a package helper's name does not borrow its body.
+//
+// `bindActor := w.transform` makes `bindActor(ctx)` a call through a field, and
+// the package's own bindActor is a different function entirely. Reading it
+// anyway reports the worker as bound on the strength of a body it never runs —
+// this gate's own failure direction, and the same shape the receiver-name guard
+// in the tx-seam walk exists for.
+func TestTheFollowDoesNotBorrowAShadowedHelpersBody(t *testing.T) {
+	t.Parallel()
+	// The helper binds in the ASSIGNMENT form actorBinders recognises — a bare
+	// `return principal.WithActor(…)` is not one, and a fixture written that
+	// way would pass whatever the guard did.
+	const pkg = `package compose
+
+func bindActor(ctx context.Context) context.Context {
+	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem})
+	return ctx
+}
+`
+	const worker = `func (w *someWorker) Work(ctx context.Context) error {
+	db := database.BindTo(w.pool, ws)
+	bindActor := w.transform
+	ctx = bindActor(ctx)
+	return run(ctx, db)
+}
+`
+	index := map[string]string{}
+	indexFunctions(index, pkg)
+	if _, indexed := index["bindActor"]; !indexed {
+		t.Fatal("the fixture's package helper was not indexed, so this case proves nothing")
+	}
+	if actorBinders.MatchString(withCalledHelpers(worker, index)) {
+		t.Error("the worker read as binding an actor through a name it had shadowed with a field of its own")
 	}
 }

--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -245,12 +245,8 @@ var anyFunc = regexp.MustCompile(`(?m)^func (\([^)]*\) )?(\w+)\(`)
 // scanner, the webhook deliverer) is not read at all, which is why a worker
 // whose only binding lives in another module still needs an entry above.
 //
-// What it does NOT do is guess which body a name means. Only receiver-less
-// functions are indexed, because a bare call can reach nothing else — a method
-// indexed under its bare name would let an unrelated `(s *Store) mode()` answer
-// for a call to `mode()`, and a binder in a body the worker never reaches would
-// read as the worker's own. Go forbids two package-level functions of one name,
-// so every name that resolves here resolves to exactly one body.
+// What it does NOT do is guess which body a name means — indexFunctions says
+// why, and it is the reason this follow resolves rather than guesses.
 func withCalledHelpers(body string, pkg map[string]string) string {
 	var b strings.Builder
 	b.WriteString(body)
@@ -284,11 +280,10 @@ var callee = regexp.MustCompile(`(?:^|[^.\w])(\w+)\(`)
 
 // The follow resolves a name; it does not guess which body the name means.
 //
-// A METHOD indexed under its bare name would answer for a call no worker can
-// make: `mode()` in a Work body cannot reach `(s *Store) mode()`, and letting
-// it would report a worker as bound on the strength of a binder in a body it
-// never runs. That is the gate's own failure direction — a waiver it never
-// asked for, granted silently.
+// The rule and its reason are on indexFunctions; this is the case that fails
+// when the rule goes. What it costs to lose is the gate's own failure
+// direction: a worker reported as bound on the strength of a binder in a body
+// it never runs, which is a waiver nobody asked for, granted silently.
 func TestTheFollowDoesNotResolveABareCallToAMethod(t *testing.T) {
 	t.Parallel()
 	const pkg = `package compose


### PR DESCRIPTION
Closes #1127.

The ticket asked whether three workers that build a store without binding an actor are failing silently the way the provider-run workers did — the defect where every poll died with `no actor bound to context`, paid enrichment runs sat `in_progress` for ever, and nothing said so.

**Traced, the answer is no for all three.** Two were false positives the gate could not see through; one genuinely needs no actor.

## The three, with the trace

**`privacyRetentionWorker` — binds one.** `Work` → `retentionPassProvenance(passCtx)`, which sets a `PrincipalSystem` actor and a fresh correlation id. It has to: the engine writes an audit row and an outbox event per record it retires, and without it those rows would say nothing about who moved the record or under which pass.

**`timeScanWorker` — binds one, twice.** Its per-workspace turn reaches two paths and each binds its own:

- `automation.TimeScanner.ScanWorkspace` binds `systemActor`, the same id `HandleEvent` acts under, because both entries reach the same `runOne` and the selectors that recognise those rows key on it.
- `scanLeadSLA` binds `system:lead-sla-scan`.

The ids differ **deliberately** — that is what keeps the two passes' audit rows distinguishable — so binding a third one in the worker would be a wrong answer overriding two right ones. `auth.Require` admits `PrincipalSystem` outright, so both reach `ScanLeadSLA`'s `auth.Require(ctx, "lead", update)` and the scanner's writes without refusal.

**`webhookRetryWorker` — needs none, and stays waived.** Its sweep is `dueRetries → loadTarget → stillVisible → markVisibilityRevoked → deliverOnce`, and none of those asks `auth.Require`; the two entry points in that store which do (`ListDeliveries`, `requireReplay`) are the human dead-letter surfaces this pass never touches. The one authority question it *does* ask — may this subscription's owner still see the record this delivery carries — is asked under the **owner's** principal, resolved per delivery from the row (`Deliverer.canSee` builds it from `EffectiveRBAC`). An actor bound in the worker would be a second, wrong answer to that question. Held by `webhookretry_pass_integration_test.go`, whose `webhookSweepCtx` binds the tenant and nothing else.

## The gate follows one level now

Two of the three were correct code producing waivers, which is worth fixing rather than re-explaining: a binder is a **helper** by nature — it takes a context, returns one carrying the principal, and reads better beside the pass it names than inlined into a `Work` method. A gate that read only the `Work` body was always going to flag them, and every waiver it produced is a place a real defect can hide behind a plausible reason.

So a `Work` body is now read together with the bodies of the compose-package functions it calls, one level deep. Two waivers go.

**The first version of the follow was wrong in a way worth recording.** A `Work` method's own declaration line names `Work`; every worker's entry point is called that; so the call scan matched the method's own name and pulled in *every other worker's* `Work` body — one of which binds. It answered yes for a worker that binds nothing, and read exactly like a working follow-one-level. The signature line is dropped before the scan, and the mutation removing that guard fails the gate.

The doc says what the follow still cannot see, so nobody has to rediscover it: a helper that binds for its own path leaves the body looking bound, so a *second*, unbound gated call in the same `Work` method would pass; and it follows names in this package, not call graphs, so a binding that lives in another module still needs an entry.

## Mutation checks

| mutation | result |
|---|---|
| remove `retentionPassProvenance`'s `WithActor` | fails, naming `privacyRetentionWorker` |
| remove `scanLeadSLA`'s `WithActor` | fails, naming `timeScanWorker` |
| drop the signature guard from the follow | fails — `webhookRetryWorker`'s waiver stops matching, which is the self-satisfying lookup showing itself |

## One finding filed rather than fixed

`internal/compose/integration/scope.go`'s `RetentionPassCtx` spells the pass's provenance by hand instead of calling the worker's, and about thirty suites use it — so they hold the retention *engine* under a pass's provenance and hold nothing about the pass's own binding. It cannot simply call production: `internal/compose` has in-package integration tests importing that package, so the import back is a cycle. It is also five spellings across the tree, not two. **#4952**, with the list. The binding itself is held by this gate in the meantime, which is what the mutation above shows.

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation that job workers reaching storage bind the appropriate actor, including bindings performed through helper calls.
  * Removed unnecessary exceptions for workers now covered by the validation.
  * Added coverage to ensure bare function calls are not incorrectly matched to receiver methods.
* **Documentation**
  * Clarified retention provenance behavior and related test limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->