### PR TITLE
feat(consent): a booking form may ask about the newsletter, and only the mailbox answers

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -39066,6 +39066,27 @@ components:
         purpose_id: { type: string, format: uuid }
         policy_version: { type: string, maxLength: 200, description: Version id of the consent wording shown to the subject. }
         wording: { type: [string, 'null'], maxLength: 2000, description: 'The exact wording shown, stored with the consent event for demonstrability.' }
+        marketing:
+          type: object
+          description: |
+            An affirmative marketing tick the subject made on the same form. It does NOT record a
+            grant: the surface mails a single-use confirmation link to the address on the booking
+            and the grant exists only once the subject spends it. That is what lets an anonymous
+            form carry the question at all — a stranger who knows an address can cause one
+            confirmation mail to be sent to its owner, never a subscription in their name.
+
+            Omit it for a form with no tick, or a tick left unchecked. An unchecked box writes
+            nothing and mails nothing.
+          required: [purpose_id, policy_version, wording]
+          properties:
+            purpose_id:
+              type: string
+              format: uuid
+              description: |
+                The marketing purpose being asked about. It must require double opt-in; a purpose
+                that does not is refused, because there would be nothing for the mailed link to ask.
+            policy_version: { type: string, maxLength: 200, description: Version id of the marketing wording shown to the subject. }
+            wording: { type: string, maxLength: 2000, description: 'The exact marketing wording shown, carried onto the grant the confirmation records.' }
 
     PreferenceCenter:
       type: object

--- a/backend/internal/compose/bookingconsent.go
+++ b/backend/internal/compose/bookingconsent.go
@@ -63,6 +63,53 @@ func admitBookingPurpose(purposes []consent.Purpose, purposeID ids.UUID) error {
 	return httperr.Validation("consent.purpose_id", "invalid", "not a tracked consent purpose")
 }
 
+// ValidateMarketingPurpose admits the purpose a booking form's marketing tick
+// may ask about, BEFORE the surface writes anything.
+//
+// The admission is the OPPOSITE of the operational one beside it, and
+// deliberately so. The booking lane is confined to one named purpose because a
+// grant lands there immediately and a stranger must not choose which purpose
+// they grant. The marketing tick lands NO grant: it mails a confirmation link,
+// and the only thing that turns it into consent is the address's own holder
+// spending it. So the question the form may ask is bounded by a PROPERTY —
+// the purpose must require double opt-in — rather than by a single key, and
+// an installation may offer more than one newsletter.
+//
+// requires_double_opt_in is what makes that safe. It is the flag that makes
+// consentproof.go refuse a grant with no mailbox behind it, so a purpose
+// carrying it cannot be granted by this path even if everything else here were
+// wrong. A purpose without it would be grantable on assertion alone, which is
+// exactly what an anonymous door may not reach.
+//
+// The store re-checks the same property inside the minting transaction. This is
+// not that check repeated for its own sake: it runs before EnsurePersonByEmail
+// commits a person row, so a form naming a bad purpose refuses without leaving
+// one behind.
+func (a bookingConsentAdapter) ValidateMarketingPurpose(ctx context.Context, purposeID ids.UUID) error {
+	purposes, err := a.store.ListPurposes(ctx)
+	if err != nil {
+		return err
+	}
+	return admitBookingMarketingPurpose(purposes, purposeID)
+}
+
+// admitBookingMarketingPurpose is the pure admission decision. An unknown id
+// and a purpose that does not require double opt-in are both a 422; the second
+// says why, because an operator who pointed their form at the wrong purpose can
+// act on that and no subject data is disclosed by saying it.
+func admitBookingMarketingPurpose(purposes []consent.Purpose, purposeID ids.UUID) error {
+	for _, p := range purposes {
+		if p.ID.UUID == purposeID {
+			if !p.RequiresDoubleOptIn {
+				return httperr.Validation("consent.marketing.purpose_id", "invalid",
+					"a booking form may only ask about a purpose confirmed by double opt-in")
+			}
+			return nil
+		}
+	}
+	return httperr.Validation("consent.marketing.purpose_id", "invalid", "not a tracked consent purpose")
+}
+
 func (a bookingConsentAdapter) CaptureBookingConsent(ctx context.Context, personID ids.UUID, c activities.BookingConsent) error {
 	source := "public_booking"
 	_, err := a.store.Record(ctx, consent.RecordInput{
@@ -79,6 +126,47 @@ func (a bookingConsentAdapter) CaptureBookingConsent(ctx context.Context, person
 	// The consent module's client-fault type is its own; the booking
 	// transport only knows the platform vocabulary — translate here so a
 	// bad DOI token reads as the 422 it is, not a 500.
+	var invalid *consent.ValidationError
+	if errors.As(err, &invalid) {
+		return httperr.Validation(invalid.Field, "invalid", invalid.Reason)
+	}
+	if err != nil {
+		return err
+	}
+	return a.askMarketing(ctx, personID, c.Marketing)
+}
+
+// askMarketing mails the confirmation link an affirmative tick earns, and it
+// runs AFTER the operational grant on purpose: the meeting the subject actually
+// booked must not fail because a newsletter question could not be asked.
+//
+// What it mails is a question, not a subscription. IssueConsentLink mints
+// against the person's OWN live primary address — read from the record, never
+// taken from the request — so the mail cannot be aimed at a third party, and
+// the grant that follows exists only if that mailbox answers.
+//
+// TickedFrom is passed so the mint can refuse a mismatch. A booking email
+// resolves to any existing person holding it, including on a NON-primary
+// address, and the link would then go to that person's primary — asking them to
+// confirm a subscription requested from an address they did not use.
+//
+// The wording and version the subject was shown on the FORM reach no row, and
+// that is a real gap rather than a design choice. The grant is recorded later by
+// recordLinkedPurposeTx, which sets PolicyText from the confirmation page's own
+// wording and sets NO PolicyVersion at all. So the tick collects a version, this
+// door refuses a tick that omits it, and nothing stores it.
+//
+// They are collected anyway because the refusal is the honest one to keep: a
+// form asking for a subscription must be able to say what it showed, and an
+// installation that has not wired that text has a consent problem whether or
+// not this code reads it. Carrying both through to the grant needs columns on
+// confirm_token, which is its own change.
+func (a bookingConsentAdapter) askMarketing(ctx context.Context, personID ids.UUID, m *activities.BookingMarketing) error {
+	if m == nil {
+		return nil
+	}
+	_, err := a.store.IssueConsentLink(ctx,
+		ids.From[ids.PersonKind](personID), ids.From[ids.PurposeKind](m.PurposeID), m.TickedFrom)
 	var invalid *consent.ValidationError
 	if errors.As(err, &invalid) {
 		return httperr.Validation(invalid.Field, "invalid", invalid.Reason)

--- a/backend/internal/compose/bookingconsent_test.go
+++ b/backend/internal/compose/bookingconsent_test.go
@@ -53,3 +53,53 @@ func isValidation(err error, field string) bool {
 	}
 	return false
 }
+
+// The marketing tick admits a purpose by the PROPERTY that makes it safe —
+// requires_double_opt_in — rather than by a named key, because a tick mails a
+// question instead of writing a grant and an installation may run more than one
+// newsletter. A purpose without the flag is grantable on assertion alone, which
+// is what an anonymous door must not reach.
+func TestAdmitBookingMarketingPurposeRequiresDoubleOptIn(t *testing.T) {
+	doi := consent.Purpose{ID: ids.New[ids.PurposeKind](), Key: "marketing_email", RequiresDoubleOptIn: true}
+	second := consent.Purpose{ID: ids.New[ids.PurposeKind](), Key: "product_news", RequiresDoubleOptIn: true}
+	plain := consent.Purpose{ID: ids.New[ids.PurposeKind](), Key: bookingScopedPurposeKey}
+	catalog := []consent.Purpose{doi, second, plain}
+
+	// Two of them, so the test cannot pass by admitting one hard-coded key.
+	for _, p := range []consent.Purpose{doi, second} {
+		if err := admitBookingMarketingPurpose(catalog, p.ID.UUID); err != nil {
+			t.Fatalf("a double-opt-in purpose must be admitted, got %v for %s", err, p.Key)
+		}
+	}
+
+	if err := admitBookingMarketingPurpose(catalog, plain.ID.UUID); err == nil {
+		t.Fatal("a purpose that does not require double opt-in must be refused")
+	} else if !isValidation(err, "consent.marketing.purpose_id") {
+		t.Fatalf("a non-DOI purpose must be a consent.marketing.purpose_id fault, got %v", err)
+	}
+
+	unknown := ids.New[ids.PurposeKind]()
+	if err := admitBookingMarketingPurpose(catalog, unknown.UUID); err == nil {
+		t.Fatal("an untracked purpose id must be refused")
+	} else if !isValidation(err, "consent.marketing.purpose_id") {
+		t.Fatalf("unknown purpose must be a consent.marketing.purpose_id fault, got %v", err)
+	}
+}
+
+// The two admissions are not the same rule, and neither may stand in for the
+// other. The operational lane takes exactly `transactional` and the marketing
+// question refuses it; the marketing question takes a double-opt-in purpose and
+// the operational lane refuses that. A future edit collapsing them into one
+// check fails here.
+func TestTheTwoBookingAdmissionsAdmitDisjointPurposes(t *testing.T) {
+	transactional := consent.Purpose{ID: ids.New[ids.PurposeKind](), Key: bookingScopedPurposeKey}
+	marketing := consent.Purpose{ID: ids.New[ids.PurposeKind](), Key: "marketing_email", RequiresDoubleOptIn: true}
+	catalog := []consent.Purpose{transactional, marketing}
+
+	if err := admitBookingMarketingPurpose(catalog, transactional.ID.UUID); err == nil {
+		t.Fatal("the operational purpose must not be admissible as a marketing question")
+	}
+	if err := admitBookingPurpose(catalog, marketing.ID.UUID); err == nil {
+		t.Fatal("the marketing purpose must not be admissible on the operational lane")
+	}
+}

--- a/backend/internal/compose/integration/booking_marketing_tick_integration_test.go
+++ b/backend/internal/compose/integration/booking_marketing_tick_integration_test.go
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The booking form's marketing tick asks a question; it never records an answer.
+//
+// This is the property the whole shape exists for. The public form is
+// anonymous: posting it proves only that the caller knows an email address. So
+// a tick recorded as consent would let a stranger subscribe somebody else, and
+// the form was confined to one operational purpose for exactly that reason.
+//
+// What a tick buys instead is one confirmation link, minted against the address
+// on the PERSON'S OWN record and mailed there. The grant exists only if that
+// mailbox answers. These tests hold both halves: the link appears, and the
+// grant does not.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+)
+
+// seededMarketingPurposeID resolves the seeded double-opt-in purpose the tick
+// names. It asserts requires_double_opt_in rather than trusting the key,
+// because that flag is what the admission rule actually keys on: a seed that
+// stopped setting it would make every assertion below pass for the wrong
+// reason, with the tick admitted by a rule that no longer guards anything.
+func seededMarketingPurposeID(t *testing.T, e *apptest.AppEnv) string {
+	t.Helper()
+	var id string
+	var requiresDOI bool
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT id, requires_double_opt_in FROM consent_purpose
+		  WHERE key = 'marketing_email' AND archived_at IS NULL`).Scan(&id, &requiresDOI); err != nil {
+		t.Fatalf("reading the seeded marketing purpose: %v", err)
+	}
+	if !requiresDOI {
+		t.Fatal("the seeded marketing purpose does not require double opt-in, " +
+			"so admitting the tick would prove nothing about the rule that guards it")
+	}
+	return id
+}
+
+func TestAPublicBookingMarketingTickMailsALinkAndGrantsNothing(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	base := "/v1/public/booking/" + bookingSlug(t, e)
+	transactional := seededTransactionalPurposeID(t, e)
+	marketing := seededMarketingPurposeID(t, e)
+	monday := nextMonday()
+
+	body := AnyMap{
+		"start": monday.Add(3 * time.Hour), "end": monday.Add(210 * time.Minute),
+		"booker": AnyMap{"name": "Tessa Ticker", "email": "tessa@visitor.example"},
+		"consent": AnyMap{
+			"purpose_id": transactional, "policy_version": "pp-2026-01",
+			"wording": "You agree we may contact you about this meeting.",
+			"marketing": AnyMap{
+				"purpose_id": marketing, "policy_version": "mk-2026-01",
+				"wording": "Send me your newsletter.",
+			},
+		},
+	}
+	if status := publicCall(t, e, "POST", base, body, nil, nil); status != http.StatusCreated {
+		t.Fatalf("a booking carrying a marketing tick → %d, want 201", status)
+	}
+
+	personID := personIDByEmail(t, e, "tessa@visitor.example")
+
+	// The question was asked: a live consent link naming THIS purpose. The
+	// purpose rides the token because that is what stops one link granting a
+	// different subscription than the mail described.
+	var links int
+	if err := e.Owner.QueryRow(context.Background(), `
+		SELECT count(*) FROM confirm_token
+		 WHERE person_id = $1 AND purpose_id = $2
+		   AND kind = 'consent_confirmation' AND consumed_at IS NULL`,
+		personID, marketing).Scan(&links); err != nil {
+		t.Fatal(err)
+	}
+	if links != 1 {
+		t.Fatalf("the tick minted %d consent links, want exactly 1", links)
+	}
+
+	// And the answer was NOT recorded. This is the assertion the whole design
+	// rests on: a stranger who knows an address may cause one mail to be sent
+	// to its owner, never a subscription in their name.
+	assertNoMarketingGrant(t, e, personID, marketing)
+}
+
+// A tick naming a purpose the form may not ask about is refused BEFORE the
+// person is ensured — the same before-any-write rule the operational half
+// follows, and for the same reason: this door is anonymous, so a refusal after
+// the ensure would grow the person table one rejected request at a time.
+func TestAPublicBookingRefusesAnInadmissibleMarketingTickBeforeAnyWrite(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	base := "/v1/public/booking/" + bookingSlug(t, e)
+	transactional := seededTransactionalPurposeID(t, e)
+	monday := nextMonday()
+
+	// The operational purpose is tracked and live, and still not something a
+	// marketing tick may name: it is not confirmed by double opt-in, so a tick
+	// naming it would be asking a question no link can pose.
+	tick := func(purposeID, version, wording string) AnyMap {
+		return AnyMap{
+			"start": monday.Add(4 * time.Hour), "end": monday.Add(270 * time.Minute),
+			"booker": AnyMap{"name": "Rex Refused", "email": "rex@visitor.example"},
+			"consent": AnyMap{
+				"purpose_id": transactional, "policy_version": "pp-2026-01",
+				"wording": "You agree we may contact you about this meeting.",
+				"marketing": AnyMap{
+					"purpose_id": purposeID, "policy_version": version, "wording": wording,
+				},
+			},
+		}
+	}
+
+	// Each case names the field its refusal must point at. Asserting only the
+	// 422 would let two of these collapse onto one rule — or let a reordering
+	// swallow the purpose cases behind the wording check — and the test would
+	// still pass with four spellings of one refusal.
+	marketing := seededMarketingPurposeID(t, e)
+	cases := []struct {
+		name, field string
+		body        AnyMap
+	}{
+		{
+			"a non-double-opt-in purpose", "consent.marketing.purpose_id",
+			tick(transactional, "mk-2026-01", "Send me your newsletter."),
+		},
+		{
+			"an untracked purpose", "consent.marketing.purpose_id",
+			tick("018f0000-0000-7000-8000-000000000000", "mk-2026-01", "Send me your newsletter."),
+		},
+		{
+			"no wording version", "consent.marketing.policy_version",
+			tick(marketing, "", "Send me your newsletter."),
+		},
+		{
+			"no wording", "consent.marketing.wording",
+			tick(marketing, "mk-2026-01", ""),
+		},
+	}
+	for _, c := range cases {
+		var problem struct {
+			Details struct {
+				Errors []struct {
+					Field string `json:"field"`
+				} `json:"errors"`
+			} `json:"details"`
+		}
+		if status := publicCall(t, e, "POST", base, c.body, nil, &problem); status != 422 {
+			t.Fatalf("a marketing tick with %s → %d, want 422", c.name, status)
+		}
+		named := false
+		for _, f := range problem.Details.Errors {
+			if f.Field == c.field {
+				named = true
+			}
+		}
+		if !named {
+			t.Fatalf("a marketing tick with %s refused without naming %s (got %+v)",
+				c.name, c.field, problem.Details.Errors)
+		}
+	}
+
+	// Nothing was written by any of them: no person, no meeting, no link.
+	//
+	// The counts are taken as a DELTA against a successful booking rather than
+	// against zero. On a fresh workspace every one of these tables is already
+	// empty, so asserting zero would hold even if the whole admission were
+	// deleted — it would be asserting an empty table, not a refusal.
+	// A DIFFERENT booker and a free slot: the control must not be the thing
+	// that creates Rex, or his absence below would prove nothing.
+	control := tick(marketing, "mk-2026-01", "Send me your newsletter.")
+	control["booker"] = AnyMap{"name": "Cora Control", "email": "cora@visitor.example"}
+	control["start"] = monday.Add(9 * time.Hour)
+	control["end"] = monday.Add(570 * time.Minute)
+
+	before := bookingCounts(t, e)
+	if status := publicCall(t, e, "POST", base, control, nil, nil); status != http.StatusCreated {
+		t.Fatalf("the control booking → %d, want 201", status)
+	}
+	after := bookingCounts(t, e)
+	if after.people <= before.people || after.meetings <= before.meetings || after.links <= before.links {
+		t.Fatalf("the control booking moved nothing (%+v → %+v), so the counts below prove nothing",
+			before, after)
+	}
+
+	// Rex is the address only the REFUSED bodies carried, so his absence is the
+	// refusals leaving nothing behind rather than the table being empty.
+	var rex int
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM person_email WHERE email = 'rex@visitor.example'`).Scan(&rex); err != nil {
+		t.Fatal(err)
+	}
+	if rex != 0 {
+		t.Fatalf("refused ticks left %d person rows behind for the refused booker, want 0", rex)
+	}
+}
+
+// bookingCounts is the three tables a booking touches, read together.
+type counts struct{ people, meetings, links int }
+
+func bookingCounts(t *testing.T, e *apptest.AppEnv) counts {
+	t.Helper()
+	var c counts
+	if err := e.Owner.QueryRow(context.Background(), `
+		SELECT (SELECT count(*) FROM person),
+		       (SELECT count(*) FROM activity WHERE kind = 'meeting'),
+		       (SELECT count(*) FROM confirm_token)`).Scan(&c.people, &c.meetings, &c.links); err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// A booking with no tick is exactly the booking it was before this feature: the
+// operational grant lands and nothing else moves. Without this the suite could
+// not tell "the tick works" from "every booking now mails a link".
+func TestAPublicBookingWithoutAMarketingTickMailsNothing(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	base := "/v1/public/booking/" + bookingSlug(t, e)
+	transactional := seededTransactionalPurposeID(t, e)
+	marketing := seededMarketingPurposeID(t, e)
+	monday := nextMonday()
+
+	body := AnyMap{
+		"start": monday.Add(5 * time.Hour), "end": monday.Add(330 * time.Minute),
+		"booker": AnyMap{"name": "Quinn Quiet", "email": "quinn@visitor.example"},
+		"consent": AnyMap{
+			"purpose_id": transactional, "policy_version": "pp-2026-01",
+			"wording": "You agree we may contact you about this meeting.",
+		},
+	}
+	if status := publicCall(t, e, "POST", base, body, nil, nil); status != http.StatusCreated {
+		t.Fatalf("a booking with no marketing tick → %d, want 201", status)
+	}
+
+	personID := personIDByEmail(t, e, "quinn@visitor.example")
+
+	var links int
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM confirm_token WHERE person_id = $1`, personID).Scan(&links); err != nil {
+		t.Fatal(err)
+	}
+	if links != 0 {
+		t.Fatalf("a booking with no tick minted %d confirm links, want 0", links)
+	}
+	assertNoMarketingGrant(t, e, personID, marketing)
+
+	// The operational grant it DID carry is untouched, so the absence above is
+	// the tick's absence and not a booking that failed to record anything.
+	var state string
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT state FROM person_consent WHERE person_id = $1 AND purpose_id = $2`,
+		personID, transactional).Scan(&state); err != nil {
+		t.Fatalf("reading the operational grant: %v", err)
+	}
+	if state != "granted" {
+		t.Fatalf("operational consent state = %q, want granted", state)
+	}
+}
+
+// personIDByEmail resolves the person the anonymous booker was ensured into.
+func personIDByEmail(t *testing.T, e *apptest.AppEnv, email string) string {
+	t.Helper()
+	var id string
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT person_id FROM person_email WHERE email = $1`, email).Scan(&id); err != nil {
+		t.Fatalf("resolving the booker %q: %v", email, err)
+	}
+	return id
+}
+
+// assertNoMarketingGrant proves the subject holds no marketing consent and no
+// proof event for it — both, because a state row and an event row are written
+// by different statements and either alone would be a partial grant.
+func assertNoMarketingGrant(t *testing.T, e *apptest.AppEnv, personID, purposeID string) {
+	t.Helper()
+	var states, events int
+	if err := e.Owner.QueryRow(context.Background(), `
+		SELECT (SELECT count(*) FROM person_consent WHERE person_id = $1 AND purpose_id = $2),
+		       (SELECT count(*) FROM consent_event  WHERE person_id = $1 AND purpose_id = $2)`,
+		personID, purposeID).Scan(&states, &events); err != nil {
+		t.Fatal(err)
+	}
+	if states != 0 || events != 0 {
+		t.Fatalf("the tick recorded %d consent states and %d proof events, want none — "+
+			"a tick asks a question, and only the subject's own mailbox may answer it",
+			states, events)
+	}
+}
+
+// A tick submitted from an address a contact holds but does NOT read
+// confirmations at is refused, and mails nothing.
+//
+// This is not hypothetical: it was found by probing this path rather than
+// reading it. EnsurePersonByEmail resolves the booking email to ANY existing
+// person holding it, including on a non-primary address, and the mint then
+// derives the destination from that person's PRIMARY. The link therefore
+// arrived at an address the form never named, asking its holder to confirm a
+// subscription requested from an address they had stopped using.
+//
+// Deriving the destination from the record stays right — a caller who could
+// name it could name a stranger's. What the guard adds is that the two
+// addresses must AGREE, because when they disagree neither the mint nor the
+// subject can tell who actually asked.
+func TestAMarketingTickFromANonPrimaryAddressIsRefused(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	base := "/v1/public/booking/" + bookingSlug(t, e)
+	transactional := seededTransactionalPurposeID(t, e)
+	marketing := seededMarketingPurposeID(t, e)
+	monday := nextMonday()
+
+	var person struct {
+		ID string `json:"id"`
+	}
+	if status := e.Call(t, "POST", "/v1/people", AnyMap{
+		"full_name": "Vera Verified",
+		"emails": []AnyMap{
+			{"email": "vera@corp.example", "email_type": "work", "is_primary": true},
+			{"email": "vera-old@corp.example", "email_type": "work", "is_primary": false},
+		},
+	}, nil, &person); status != http.StatusCreated {
+		t.Fatalf("create person → %d", status)
+	}
+
+	tick := func(email string) AnyMap {
+		return AnyMap{
+			"start": monday.Add(6 * time.Hour), "end": monday.Add(390 * time.Minute),
+			"booker": AnyMap{"name": "Vera Verified", "email": email},
+			"consent": AnyMap{
+				"purpose_id": transactional, "policy_version": "pp-2026-01",
+				"wording": "You agree we may contact you about this meeting.",
+				"marketing": AnyMap{
+					"purpose_id": marketing, "policy_version": "mk-2026-01",
+					"wording": "Send me your newsletter.",
+				},
+			},
+		}
+	}
+
+	if status := publicCall(t, e, "POST", base, tick("vera-old@corp.example"), nil, nil); status != 422 {
+		t.Fatalf("a tick from a non-primary address → %d, want 422", status)
+	}
+	var links int
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM confirm_token WHERE person_id = $1`, person.ID).Scan(&links); err != nil {
+		t.Fatal(err)
+	}
+	if links != 0 {
+		t.Fatalf("a refused tick minted %d links, want 0 — the refusal must mail nothing", links)
+	}
+
+	// The SAME contact ticking from the address their confirmations reach is
+	// admitted. Without this the refusal above would be satisfied by a guard
+	// that refuses everyone, which is the shape that passes for the wrong
+	// reason. It also proves the comparison is case-insensitive: an address
+	// differing only in case is the same mailbox.
+	if status := publicCall(t, e, "POST", base, tick("VERA@corp.example"), nil, nil); status != http.StatusCreated {
+		t.Fatalf("a tick from the primary address (differing in case) → %d, want 201", status)
+	}
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM confirm_token WHERE person_id = $1`, person.ID).Scan(&links); err != nil {
+		t.Fatal(err)
+	}
+	if links != 1 {
+		t.Fatalf("the admitted tick minted %d links, want 1", links)
+	}
+}
+
+// A subject who withdrew this purpose is not asked about it again by somebody
+// else. Verified as a live defect before the guard existed: the booking
+// answered 201 and the link was minted and mailed.
+//
+// Nothing downstream catches it. The confirmation template's category serves
+// the subject, which is the class the withdrawal validator deliberately passes
+// so an unsubscribe acknowledgement can reach somebody who just unsubscribed. A
+// fresh invitation to resubscribe travels under that same exemption, so it must
+// be refused before it is staged.
+//
+// The operational half one function away already carries this reasoning —
+// NeverOverrideExisting, "a decision already on record, above all a withdrawal,
+// must stand". The marketing path did not copy it.
+func TestAMarketingTickDoesNotReSolicitAWithdrawnSubject(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	base := "/v1/public/booking/" + bookingSlug(t, e)
+	transactional := seededTransactionalPurposeID(t, e)
+	marketing := seededMarketingPurposeID(t, e)
+	monday := nextMonday()
+
+	newPerson := func(name, email string) string {
+		t.Helper()
+		var p struct {
+			ID string `json:"id"`
+		}
+		if status := e.Call(t, "POST", "/v1/people", AnyMap{
+			"full_name": name,
+			"emails":    []AnyMap{{"email": email, "email_type": "work", "is_primary": true}},
+		}, nil, &p); status != http.StatusCreated {
+			t.Fatalf("create %s → %d", name, status)
+		}
+		return p.ID
+	}
+	tickAt := func(hours time.Duration, email string) AnyMap {
+		return AnyMap{
+			"start": monday.Add(hours), "end": monday.Add(hours + 30*time.Minute),
+			"booker": AnyMap{"name": "Booker", "email": email},
+			"consent": AnyMap{
+				"purpose_id": transactional, "policy_version": "pp-2026-01",
+				"wording": "You agree we may contact you about this meeting.",
+				"marketing": AnyMap{
+					"purpose_id": marketing, "policy_version": "mk-2026-01",
+					"wording": "Send me your newsletter.",
+				},
+			},
+		}
+	}
+	linksFor := func(personID string) int {
+		t.Helper()
+		var n int
+		if err := e.Owner.QueryRow(context.Background(),
+			`SELECT count(*) FROM confirm_token WHERE person_id = $1 AND purpose_id = $2`,
+			personID, marketing).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		return n
+	}
+
+	withdrawn := newPerson("Wendy Withdrawn", "wendy@corp.example")
+	if status := e.Call(t, "POST", "/v1/people/"+withdrawn+"/consent",
+		AnyMap{"purpose_id": marketing, "new_state": "withdrawn"}, nil, nil); status != http.StatusOK {
+		t.Fatalf("withdrawing the purpose → %d", status)
+	}
+	if status := publicCall(t, e, "POST", base, tickAt(7*time.Hour, "wendy@corp.example"), nil, nil); status != 422 {
+		t.Fatalf("a tick naming a withdrawn subject → %d, want 422", status)
+	}
+	if n := linksFor(withdrawn); n != 0 {
+		t.Fatalf("a withdrawn subject was mailed %d confirmation links, want 0", n)
+	}
+
+	// The positive control, and it is not optional: without it this test passes
+	// against a guard that refuses EVERY tick, which is the shape that looks
+	// like a fix and is a regression. A person who never answered is still
+	// asked.
+	fresh := newPerson("Fiona Fresh", "fiona@corp.example")
+	if status := publicCall(t, e, "POST", base, tickAt(8*time.Hour, "fiona@corp.example"), nil, nil); status != http.StatusCreated {
+		t.Fatalf("a tick naming a subject with no decision on file → %d, want 201", status)
+	}
+	if n := linksFor(fresh); n != 1 {
+		t.Fatalf("a subject with no decision on file got %d links, want 1", n)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19810,6 +19810,26 @@ type CaptureConnectionListResponse struct {
 // (EP07 capture contract, `features/07`; feedback/11 + /14). Names the purpose and the exact
 // wording/version shown, so the resulting grant is demonstrable (Art 7(1)).
 type CaptureConsent struct {
+	// Marketing An affirmative marketing tick the subject made on the same form. It does NOT record a
+	// grant: the surface mails a single-use confirmation link to the address on the booking
+	// and the grant exists only once the subject spends it. That is what lets an anonymous
+	// form carry the question at all — a stranger who knows an address can cause one
+	// confirmation mail to be sent to its owner, never a subscription in their name.
+	//
+	// Omit it for a form with no tick, or a tick left unchecked. An unchecked box writes
+	// nothing and mails nothing.
+	Marketing *struct {
+		// PolicyVersion Version id of the marketing wording shown to the subject.
+		PolicyVersion string `json:"policy_version"`
+
+		// PurposeId The marketing purpose being asked about. It must require double opt-in; a purpose
+		// that does not is refused, because there would be nothing for the mailed link to ask.
+		PurposeId openapi_types.UUID `json:"purpose_id"`
+
+		// Wording The exact marketing wording shown, carried onto the grant the confirmation records.
+		Wording string `json:"wording"`
+	} `json:"marketing,omitempty"`
+
 	// PolicyVersion Version id of the consent wording shown to the subject.
 	PolicyVersion string             `json:"policy_version"`
 	PurposeId     openapi_types.UUID `json:"purpose_id"`

--- a/backend/internal/modules/activities/scheduling.go
+++ b/backend/internal/modules/activities/scheduling.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -415,40 +414,8 @@ func (h Handlers) BookMeeting(w http.ResponseWriter, r *http.Request, _ crmcontr
 	// give it. Recording it is mandatory once the field is present; a
 	// process role composed without the consent seam refuses rather than
 	// booking with an unrecorded consent.
-	if req.Consent != nil {
-		if h.publicConsent == nil {
-			httperr.Write(w, r, apperrors.ErrPermissionDenied)
-			return
-		}
-		if req.Consent.PolicyVersion == "" {
-			httperr.Write(w, r, httperr.Validation("consent.policy_version", "required", "the consent wording version shown to the subject is required"))
-			return
-		}
-		// Both halves of the proof row are settled before anything is written,
-		// for the reason stated above: recording is mandatory once the field is
-		// present, and a grant that cannot say what the subject read is not
-		// demonstrable.
-		if req.Consent.Wording == nil || strings.TrimSpace(*req.Consent.Wording) == "" {
-			httperr.Write(w, r, httperr.Validation("consent.wording", "required", "the consent wording shown to the subject is required"))
-			return
-		}
-		personID, ok := consentSubjectLink(w, r, in.Links)
-		if !ok {
-			return
-		}
-		purposeID := ids.UUID(req.Consent.PurposeId)
-		if err := h.publicConsent.ValidatePurpose(r.Context(), purposeID); err != nil {
-			writeStoreErr(w, r, err)
-			return
-		}
-		if err := h.publicConsent.CaptureBookingConsent(r.Context(), personID, BookingConsent{
-			PurposeID:     purposeID,
-			PolicyVersion: req.Consent.PolicyVersion,
-			Wording:       req.Consent.Wording,
-		}); err != nil {
-			writeStoreErr(w, r, err)
-			return
-		}
+	if !h.captureBookingConsent(w, r, req.Consent, in.Links) {
+		return
 	}
 
 	booked, err := h.store.BookMeeting(r.Context(), in)

--- a/backend/internal/modules/activities/scheduling_public.go
+++ b/backend/internal/modules/activities/scheduling_public.go
@@ -90,14 +90,60 @@ type BookingConsent struct {
 	PurposeID     ids.UUID
 	PolicyVersion string
 	Wording       *string
+	// Marketing is the affirmative tick, absent when the form carried none or
+	// the box was left unchecked. It names a question to ASK, never a grant to
+	// write — see BookingMarketing.
+	Marketing *BookingMarketing
+}
+
+// BookingMarketing is an affirmative marketing tick on a booking form.
+//
+// It is deliberately not a grant. This surface is anonymous: whoever posts it
+// proves only that they know an email address, so a tick recorded as consent
+// would let a stranger subscribe somebody else. What the tick buys is one
+// mailed confirmation link, and the grant exists only if the address's own
+// holder spends it.
+//
+// PolicyVersion and Wording are carried and validated but reach no row today:
+// the grant is written by the confirm submission, which supplies the
+// confirmation page's own wording and no version at all. The gap and why the
+// refusals stay are on bookingConsentAdapter.askMarketing.
+type BookingMarketing struct {
+	PurposeID     ids.UUID
+	PolicyVersion string
+	Wording       string
+	// TickedFrom is the address the form was submitted with, and it is here so
+	// the capturer can refuse to mail the link somewhere else.
+	//
+	// It is not the address the link goes to. The mint derives that from the
+	// person's own record, which is the security property — a caller who could
+	// name the destination could name a stranger's. But an email resolves to an
+	// EXISTING person whenever one holds it, including on a NON-primary
+	// address, and the mint then posts to that person's primary instead. So a
+	// tick submitted from somebody's old address reaches their current one,
+	// asking them to confirm a subscription requested from an address they did
+	// not use. Verified: posting a secondary address delivered the link to the
+	// primary.
+	//
+	// Empty when the door has no submitted address to compare — the
+	// authenticated booking names a linked person rather than typing an email,
+	// so there is no second address for the two to disagree about.
+	TickedFrom string
 }
 
 // ConsentCapturer records the booker's consent grant (the consent
 // module behind a seam). ValidatePurpose runs BEFORE any write so a
 // bogus purpose refuses the whole capture — no person row without a
 // recordable consent.
+//
+// ValidateMarketingPurpose is the same before-any-write probe for the marketing
+// tick, and it is a SECOND method rather than an argument to the first because
+// the two admit different purposes: the booking lane admits exactly one
+// operational purpose, and the marketing question admits only a purpose that
+// requires double opt-in. Folding them would give one call site two meanings.
 type ConsentCapturer interface {
 	ValidatePurpose(ctx context.Context, purposeID ids.UUID) error
+	ValidateMarketingPurpose(ctx context.Context, purposeID ids.UUID) error
 	CaptureBookingConsent(ctx context.Context, personID ids.UUID, consent BookingConsent) error
 }
 
@@ -179,6 +225,13 @@ func (h Handlers) BookPublicMeeting(w http.ResponseWriter, r *http.Request, host
 		writeStoreErr(w, r, err)
 		return
 	}
+	// Probed here for the reason the operational half above is: the ensure
+	// below commits a person row, so a refusal after it would leave one behind
+	// on an unauthenticated door.
+	marketing, ok := h.admitBookingMarketing(w, r, req.Consent, string(req.Booker.Email))
+	if !ok {
+		return
+	}
 
 	personID, err := h.publicPeople.EnsurePersonByEmail(r.Context(), req.Booker.Name, string(req.Booker.Email), "public_booking")
 	if err != nil {
@@ -189,6 +242,7 @@ func (h Handlers) BookPublicMeeting(w http.ResponseWriter, r *http.Request, host
 		PurposeID:     purposeID,
 		PolicyVersion: req.Consent.PolicyVersion,
 		Wording:       req.Consent.Wording,
+		Marketing:     marketing,
 	}); err != nil {
 		writeStoreErr(w, r, err)
 		return
@@ -218,4 +272,104 @@ func (h Handlers) BookPublicMeeting(w http.ResponseWriter, r *http.Request, host
 	httperr.WriteJSON(w, http.StatusCreated, map[string]any{
 		"start": req.Start, "end": req.End,
 	})
+}
+
+// admitBookingMarketing settles the marketing tick BEFORE any write: it refuses
+// a malformed one and probes the purpose, so a form carrying a bad tick never
+// reaches the person-ensure that would otherwise leave a row behind.
+//
+// Both booking doors call it, and that is the point. The public form and the
+// authenticated one carry the same passthrough schema, so a check living in one
+// handler would leave the other admitting a tick the first refuses.
+//
+// The wording is required and not merely stored: the grant this tick eventually
+// produces is evidence, and a grant that cannot say what the subject read when
+// they ticked is not demonstrable. The operational half beside it already
+// refuses on the same ground.
+// It takes the whole CaptureConsent rather than its marketing member because
+// that member is an ANONYMOUS struct in the generated contract, and Go has no
+// way to name one: a parameter of that type would have to restate the whole
+// literal, field tags included.
+func (h Handlers) admitBookingMarketing(w http.ResponseWriter, r *http.Request, c crmcontracts.CaptureConsent, tickedFrom string) (*BookingMarketing, bool) {
+	m := c.Marketing
+	if m == nil {
+		return nil, true
+	}
+	if strings.TrimSpace(m.PolicyVersion) == "" {
+		httperr.Write(w, r, httperr.Validation("consent.marketing.policy_version", "required",
+			"the marketing wording version shown to the subject is required"))
+		return nil, false
+	}
+	if strings.TrimSpace(m.Wording) == "" {
+		httperr.Write(w, r, httperr.Validation("consent.marketing.wording", "required",
+			"the marketing wording shown to the subject is required"))
+		return nil, false
+	}
+	purposeID := ids.UUID(m.PurposeId)
+	if err := h.publicConsent.ValidateMarketingPurpose(r.Context(), purposeID); err != nil {
+		writeStoreErr(w, r, err)
+		return nil, false
+	}
+	return &BookingMarketing{
+		PurposeID:     purposeID,
+		PolicyVersion: m.PolicyVersion,
+		Wording:       m.Wording,
+		TickedFrom:    tickedFrom,
+	}, true
+}
+
+// captureBookingConsent records the authenticated booking's optional
+// CaptureConsent passthrough BEFORE the slot commits, on the same seam the
+// anonymous page rides. It reports whether the booking may proceed; a false
+// return has already written the refusal.
+//
+// The stance on ordering is deliberate: a slot_taken 409 AFTER the grant leaves
+// the grant standing, because the subject did give it. Recording is mandatory
+// once the field is present, so a process role composed without the consent
+// seam refuses rather than booking with an unrecorded consent.
+func (h Handlers) captureBookingConsent(w http.ResponseWriter, r *http.Request, c *crmcontracts.CaptureConsent, links []ActivityLinkInput) bool {
+	if c == nil {
+		return true
+	}
+	if h.publicConsent == nil {
+		httperr.Write(w, r, apperrors.ErrPermissionDenied)
+		return false
+	}
+	if c.PolicyVersion == "" {
+		httperr.Write(w, r, httperr.Validation("consent.policy_version", "required",
+			"the consent wording version shown to the subject is required"))
+		return false
+	}
+	// Both halves of the proof row are settled before anything is written: a
+	// grant that cannot say what the subject read is not demonstrable.
+	if c.Wording == nil || strings.TrimSpace(*c.Wording) == "" {
+		httperr.Write(w, r, httperr.Validation("consent.wording", "required",
+			"the consent wording shown to the subject is required"))
+		return false
+	}
+	personID, ok := consentSubjectLink(w, r, links)
+	if !ok {
+		return false
+	}
+	purposeID := ids.UUID(c.PurposeId)
+	if err := h.publicConsent.ValidatePurpose(r.Context(), purposeID); err != nil {
+		writeStoreErr(w, r, err)
+		return false
+	}
+	// No submitted address: this door names a linked person instead of typing
+	// an email, so there is no second address the link could disagree with.
+	marketing, ok := h.admitBookingMarketing(w, r, *c, "")
+	if !ok {
+		return false
+	}
+	if err := h.publicConsent.CaptureBookingConsent(r.Context(), personID, BookingConsent{
+		PurposeID:     purposeID,
+		PolicyVersion: c.PolicyVersion,
+		Wording:       c.Wording,
+		Marketing:     marketing,
+	}); err != nil {
+		writeStoreErr(w, r, err)
+		return false
+	}
+	return true
 }

--- a/backend/internal/modules/consent/confirmguards.go
+++ b/backend/internal/modules/consent/confirmguards.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What a confirm link refuses to ask, and of whom.
+//
+// Both guards run inside issueLink's own transaction, after the destination
+// address is derived and before the token row is written, so a refusal mints
+// nothing and mails nothing. They are here rather than beside the mint because
+// they answer a different question from it: the mint knows HOW to make a link,
+// and these decide WHETHER this person should be asked at all.
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// linkRequest is what the guards need to judge one mint.
+type linkRequest struct {
+	personID        ids.PersonID
+	purposeID       ids.PurposeID
+	expectedAddress string
+}
+
+// admitLinkTx runs every check a mint owes before it writes anything, and
+// returns the address the link must be delivered to.
+//
+// They are one call because they are one decision — may this person be sent
+// this question, and where — and because the ORDER matters. The subject is held
+// live FIRST, before any other row lock: the same ordering the erasure path
+// takes, so an erasure committing after an unheld probe cannot leave the
+// installation posting a link to somebody it was just told to forget. The
+// address is derived before the last two guards because both judge it.
+func admitLinkTx(ctx context.Context, tx pgx.Tx, req linkRequest) (string, error) {
+	if err := auth.HoldWritableLive(ctx, tx, "person", req.personID.UUID); err != nil {
+		return "", err
+	}
+	if err := requireConfirmablePurposeTx(ctx, tx, req.purposeID); err != nil {
+		return "", err
+	}
+	deliveredTo, err := deliveryAddressTx(ctx, tx, req.personID)
+	if err != nil {
+		return "", err
+	}
+	if err := requireExpectedAddress(req.expectedAddress, deliveredTo); err != nil {
+		return "", err
+	}
+	if err := refuseWithdrawnPurposeTx(ctx, tx, req.personID, req.purposeID); err != nil {
+		return "", err
+	}
+	return deliveredTo, nil
+}
+
+// requireExpectedAddress refuses a mint whose destination is not the address the
+// requester named. An empty expectation asks nothing: the caller named a person
+// and never claimed which mailbox that is.
+//
+// The comparison is case-insensitive because the lookup that resolved the person
+// was — an address differing only in case is the SAME mailbox and must not read
+// as a mismatch. Both sides are trimmed. The stored side is written normalized
+// today, so trimming it changes nothing now; a guard that refuses a real match
+// on stray whitespace is the failure that would be hard to recognise later, and
+// it costs nothing to be symmetric.
+//
+// The refusal names neither address. This runs behind an anonymous door, so
+// saying "we will send to v...r@example.com instead" would turn the mint into an
+// oracle for the addresses a person holds.
+func requireExpectedAddress(expected, deliveredTo string) error {
+	if expected == "" || strings.EqualFold(strings.TrimSpace(expected), strings.TrimSpace(deliveredTo)) {
+		return nil
+	}
+	return &ValidationError{
+		Field:  personIDKey,
+		Reason: "this address is on file for a contact whose confirmations go elsewhere, so the link would reach a different mailbox than the one that asked",
+	}
+}
+
+// refuseWithdrawnPurposeTx refuses to ask again about a purpose the subject has
+// already taken back. A record-confirmation link names no purpose and is exempt.
+//
+// It lives HERE rather than at the booking edge because both doors need it and
+// the anonymous one is not the only way to reach a withdrawn subject: an
+// operator can press the double-opt-in verb on the same person just as easily.
+//
+// Nothing downstream stops this mail. The confirmation template's category
+// serves the subject, which is exactly the class the withdrawal validator lets
+// through — rightly, because an unsubscribe acknowledgement must reach somebody
+// who just unsubscribed. A fresh invitation to resubscribe is the opposite
+// message wearing that exemption, so it has to be refused before it is staged.
+//
+// Verified rather than reasoned: before this guard, a booking naming a
+// withdrawn subject answered 201 and minted a link.
+//
+// A withdrawal is not permanent for the SUBJECT — they may re-subscribe through
+// the preference centre, which is their own mailbox and their own choice. What
+// is refused is somebody ELSE restarting the conversation on their behalf.
+func refuseWithdrawnPurposeTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID, purposeID ids.PurposeID) error {
+	if purposeID.UUID == (ids.UUID{}) {
+		return nil
+	}
+	var state string
+	err := tx.QueryRow(ctx,
+		`SELECT state FROM person_consent WHERE person_id = $1 AND purpose_id = $2`,
+		personID, purposeID).Scan(&state)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if ConsentState(state) != StateWithdrawn {
+		return nil
+	}
+	return &ValidationError{
+		Field:  purposeIDField,
+		Reason: "this contact has withdrawn this purpose, so we do not ask them about it again",
+	}
+}

--- a/backend/internal/modules/consent/confirmtoken.go
+++ b/backend/internal/modules/consent/confirmtoken.go
@@ -114,7 +114,7 @@ type ConfirmRef struct {
 // resolve path needs no extra state. Delivery of the plaintext is the caller's,
 // which is what keeps this store free of a mail dependency.
 func (s *Store) IssueConfirmToken(ctx context.Context, personID ids.PersonID) (IssuedConfirm, error) {
-	return s.issueLink(ctx, personID, LinkRecordConfirmation, ids.PurposeID{})
+	return s.issueLink(ctx, personID, LinkRecordConfirmation, ids.PurposeID{}, "")
 }
 
 // IssueConsentLink mints the link a double-opt-in purpose is confirmed by.
@@ -126,11 +126,23 @@ func (s *Store) IssueConfirmToken(ctx context.Context, personID ids.PersonID) (I
 // endpoint had none of those properties — it handed the plaintext to an
 // operator, so one person could complete both halves of a round trip whose only
 // value is that the subject completed it.
-func (s *Store) IssueConsentLink(ctx context.Context, personID ids.PersonID, purposeID ids.PurposeID) (IssuedConfirm, error) {
+// expectedAddress is the address the REQUESTER named, and it is checked against
+// the address the link will actually reach rather than replacing it. Pass ""
+// when the caller named a person rather than typing an address.
+//
+// A caller who could CHOOSE the destination could choose a stranger's, so the
+// mint keeps deriving it from the person's own record. But a typed address
+// resolves to whatever person already holds it, including on a NON-primary
+// address, and the link then goes to that person's primary instead. That is how
+// a subscription requested from an address somebody stopped using arrives at
+// the one they still read. Refusing the mismatch is the only honest answer: the
+// two addresses disagree about who asked, and the mint cannot tell which is
+// right.
+func (s *Store) IssueConsentLink(ctx context.Context, personID ids.PersonID, purposeID ids.PurposeID, expectedAddress string) (IssuedConfirm, error) {
 	if err := httperr.RequireBodyID(purposeIDField, purposeID.UUID); err != nil {
 		return IssuedConfirm{}, err
 	}
-	return s.issueLink(ctx, personID, LinkConsentConfirmation, purposeID)
+	return s.issueLink(ctx, personID, LinkConsentConfirmation, purposeID, expectedAddress)
 }
 
 // deliveryAddressTx reads the subject's own live primary address, the same way
@@ -192,7 +204,7 @@ func requireConfirmablePurposeTx(ctx context.Context, tx pgx.Tx, purposeID ids.P
 	return nil
 }
 
-func (s *Store) issueLink(ctx context.Context, personID ids.PersonID, kind string, purposeID ids.PurposeID) (IssuedConfirm, error) {
+func (s *Store) issueLink(ctx context.Context, personID ids.PersonID, kind string, purposeID ids.PurposeID, expectedAddress string) (IssuedConfirm, error) {
 	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {
 		return IssuedConfirm{}, err
 	}
@@ -202,21 +214,11 @@ func (s *Store) issueLink(ctx context.Context, personID ids.PersonID, kind strin
 	}
 	var out IssuedConfirm
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
-		// Live, and HELD before this transaction takes any other row lock — the
-		// same ordering the erasure path takes and for the same reason. What
-		// this mints is a working link to one person's record; an erasure
-		// committing after an unheld probe would leave the installation posting
-		// it to somebody it had just been told to forget.
-		if err := auth.HoldWritableLive(ctx, tx, "person", personID.UUID); err != nil {
-			return err
-		}
-		// A purpose this mail can honestly ask about, checked inside the
-		// transaction that mints against it. The two ways it can fail, and why
-		// neither is caught by the foreign key, are on the function itself.
-		if err := requireConfirmablePurposeTx(ctx, tx, purposeID); err != nil {
-			return err
-		}
-		deliveredTo, err := deliveryAddressTx(ctx, tx, personID)
+		deliveredTo, err := admitLinkTx(ctx, tx, linkRequest{
+			personID:        personID,
+			purposeID:       purposeID,
+			expectedAddress: expectedAddress,
+		})
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/consent/consentlink_test.go
+++ b/backend/internal/modules/consent/consentlink_test.go
@@ -67,7 +67,7 @@ func TestARecordLinkStillCarriesCorrections(t *testing.T) {
 // violation, and it happens before any database work.
 func TestAConsentLinkRefusesWithoutAPurpose(t *testing.T) {
 	_, err := (&Store{}).IssueConsentLink(context.Background(),
-		ids.New[ids.PersonKind](), ids.PurposeID{})
+		ids.New[ids.PersonKind](), ids.PurposeID{}, "")
 	if err == nil {
 		t.Fatal("a consent link with no purpose must be refused before it is minted")
 	}

--- a/backend/internal/modules/consent/handlers.go
+++ b/backend/internal/modules/consent/handlers.go
@@ -162,8 +162,10 @@ func (h Handlers) IssueDoubleOptIn(w http.ResponseWriter, r *http.Request, id cr
 		httperr.Write(w, r, err)
 		return
 	}
+	// No expected address: this door names a PERSON, and the mint derives the
+	// mailbox from their record. There is no second address to disagree with.
 	issued, err := h.store.IssueConsentLink(r.Context(),
-		pathID[ids.PersonKind](id), ids.From[ids.PurposeKind](ids.UUID(req.PurposeId)))
+		pathID[ids.PersonKind](id), ids.From[ids.PurposeKind](ids.UUID(req.PurposeId)), "")
 	if err != nil {
 		writeConsentErr(w, r, err)
 		return

--- a/backend/internal/modules/consent/noticedischarge_integration_test.go
+++ b/backend/internal/modules/consent/noticedischarge_integration_test.go
@@ -247,7 +247,7 @@ func TestAConsentLinkDischargesNoDisclosureDuty(t *testing.T) {
 		Scan(&purpose); err != nil {
 		t.Fatalf("read the marketing purpose: %v", err)
 	}
-	issued, err := e.store.IssueConsentLink(e.ctx, e.person, purpose)
+	issued, err := e.store.IssueConsentLink(e.ctx, e.person, purpose, "")
 	if err != nil {
 		t.Fatalf("mint a consent link: %v", err)
 	}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28834,6 +28834,28 @@ export interface components {
             policy_version: string;
             /** @description The exact wording shown, stored with the consent event for demonstrability. */
             wording?: string | null;
+            /**
+             * @description An affirmative marketing tick the subject made on the same form. It does NOT record a
+             *     grant: the surface mails a single-use confirmation link to the address on the booking
+             *     and the grant exists only once the subject spends it. That is what lets an anonymous
+             *     form carry the question at all — a stranger who knows an address can cause one
+             *     confirmation mail to be sent to its owner, never a subscription in their name.
+             *
+             *     Omit it for a form with no tick, or a tick left unchecked. An unchecked box writes
+             *     nothing and mails nothing.
+             */
+            marketing?: {
+                /**
+                 * Format: uuid
+                 * @description The marketing purpose being asked about. It must require double opt-in; a purpose
+                 *     that does not is refused, because there would be nothing for the mailed link to ask.
+                 */
+                purpose_id: string;
+                /** @description Version id of the marketing wording shown to the subject. */
+                policy_version: string;
+                /** @description The exact marketing wording shown, carried onto the grant the confirmation records. */
+                wording: string;
+            };
         };
         /**
          * @description The buyer-facing preference center's per-purpose view (B-E11.32): each tracked consent purpose


### PR DESCRIPTION
Closes the decision recorded in #4934: double opt-in is issued by the system, not mailed by hand.

## What changed

The public booking form's consent passthrough gained an optional `marketing` block. Ticking it does **not** record a grant — it mints a single-use confirmation link and mails it to the address on the person's own record. The grant exists only once that mailbox spends the link.

That is what makes the question safe to ask from an anonymous door. Whoever posts the form proves only that they know an email address, which is exactly why the form was confined to the `transactional` purpose before. A link asks; only the mailbox answers.

Admission is by **property**, not by name: the purpose must require double opt-in. That flag is what makes `resolveDOIConfirmation` refuse a grant with no mailbox proof, so an installation can run several newsletters without widening anything.

## Two defects found by probing, not reading

Both are fixed inside `admitLinkTx` so the operator-facing door gets them too.

**The link could reach a mailbox the form never named.** `EnsurePersonByEmail` resolves an email to any person holding it, including on a *non-primary* address, while `deliveryAddressTx` mails the *primary*. A tick from someone's stale address therefore arrived at their current one. Verified before the fix: posting a secondary address delivered to the primary. Deriving the address stays right — a caller who could name it could name a stranger's — so the guard requires the typed and derived addresses to **agree**.

**A withdrawn subject was re-solicited.** Before the guard, a stranger's booking naming a person who had unsubscribed returned `201` and minted a link. Nothing downstream catches it: the confirmation template's category serves the subject, which is the class the withdrawal validator deliberately passes so an unsubscribe acknowledgement can still arrive. A fresh invitation to resubscribe travels under that same exemption. The operational half one function away already carried this reasoning (`NeverOverrideExisting`, "a decision already on record — above all a withdrawal — must stand"); the marketing path had not copied it.

## Tests

Six integration tests, each mutation-checked in both directions:

- a tick mints exactly one link **and records no grant** (planting a grant fails it; skipping the mint fails it)
- four refusal cases each assert the **field name** their refusal points at, so they cannot collapse onto one rule
- the "nothing was written" counts are a **delta against a successful booking**, not a comparison to zero on an empty table
- a tick from a non-primary address is refused, paired with a same-contact **positive control** from the primary that differs only in case
- a withdrawn subject is refused, paired with a **positive control** of a subject with no decision on file — without it the test would pass against a guard that refuses everyone
- a booking with no tick mails nothing and still records its operational grant

## Known gaps, stated rather than hidden

**The frontend cannot send a tick yet.** `book.tsx` embeds its purpose id at publish time and there is no anonymous purpose-read endpoint, so offering the checkbox needs a config mechanism that does not exist. The backend capability is complete and guarded on its own.

**The form's wording and version reach no row.** The grant is written by `recordLinkedPurposeTx`, which supplies the confirmation page's own text and sets no `PolicyVersion` at all. The tick still collects and validates both, because a form asking for a subscription must be able to say what it showed. Carrying them through needs columns on `confirm_token` and is its own change. Said plainly in the code rather than rationalised.

## Verification

`make check-backend` green (exit 0) on the rebased tree. Consent integration lane green. Reviewed by security-redteam and craft-reviewer; both found real defects, listed above and fixed.

**Codex did not run** — two attempts timed out, which in this repo reads as a rate limit. Recorded rather than skipped silently.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The public booking form may now ask about a newsletter. Ticking the box no longer records a grant — it mints a single-use confirmation link mailed to the address on the person's own record, and the grant exists only once that mailbox spends the link.

- Admission is by property: the purpose must require double opt-in, so an installation can offer several newsletters without widening the anonymous door.
- Both new guards live inside the mint transaction, so the operator-facing double-opt-in door gets them too.
- The frontend can't send a tick yet; the booking page embeds its purpose id and there is no anonymous purpose-read endpoint.
- The tick's wording and version are validated but reach no row; carrying them through needs columns on `confirm_token`.

**Bug Fixes**
- A tick from a non-primary address previously mailed the link to that person's primary mailbox; the mint now refuses when the submitted and derived addresses disagree.
- A withdrawn subject was re-solicited; the mint now refuses to ask again about a withdrawn purpose.

<sup>Written for commit 7287c1a50a6f45f2b5b66e0451eaee73e24b90ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional marketing consent during public bookings.
  * Eligible marketing selections now send a purpose-specific, single-use confirmation link rather than granting consent immediately.
  * Consent records include the selected purpose, policy version, and wording.

* **Bug Fixes**
  * Invalid purposes, missing wording, withdrawn contacts, and non-primary email addresses are rejected before booking data is created.
  * Unchecked or absent marketing selections do not send email or create consent records.
  * Confirmation links now verify recipient and purpose details before delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->