### PR TITLE
fix(contracts): a deal that names no company still takes a contract

### DIFF
--- a/backend/internal/compose/integration/contract_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/contract_lifecycle_integration_test.go
@@ -429,3 +429,71 @@ func TestTwoConcurrentRenewalsLeaveOneSuccessor(t *testing.T) {
 		}
 	}
 }
+
+// A deal may name no company. The create form leaves Company optional and
+// `deal.organization_id` is nullable, so a deal worked before anyone knows
+// whose it is is an ordinary state, not a broken one.
+//
+// It used to end the request in a 500: the cross-company check scanned that
+// column into a non-nullable target, so the read failed before the rule it
+// serves was ever asked. Because winning a deal requires a signed contract on
+// it, that made a company-less deal impossible to win, and said nothing about
+// why.
+//
+// The rule itself still has to hold, so this asserts both halves: the absent
+// company is admitted, and a company that DISAGREES is still refused by field.
+func TestAContractAttachesToADealThatNamesNoCompany(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+	pipeline, open, _ := DealFixture(t, e)
+
+	unattached, err := e.Deals.CreateDeal(admin, deals.CreateDealInput{
+		Name: "Inbound, company unknown", PipelineID: pipeline, StageID: open,
+	})
+	if err != nil {
+		t.Fatalf("creating a deal with no company: %v", err)
+	}
+	if unattached.OrganizationId != nil {
+		t.Fatalf("the fixture deal names a company (%v), so it cannot prove anything about one that does not",
+			unattached.OrganizationId)
+	}
+	dealID := ids.From[ids.DealKind](ids.UUID(unattached.Id))
+	org := e.SeedOrg(t, "Acme", nil)
+
+	created, err := e.Contracts.CreateContract(admin, contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          "MSA 2026", ValueBasis: contracts.BasisTotal, Source: "manual",
+		DealID: &dealID,
+	})
+	if err != nil {
+		t.Fatalf("a contract on a company-less deal was refused: %v", err)
+	}
+	if created.DealId == nil || ids.UUID(*created.DealId) != ids.UUID(unattached.Id) {
+		t.Errorf("the contract came back naming deal %v, want %v", created.DealId, unattached.Id)
+	}
+
+	// The other way round, so the admission above is the absent company and not
+	// the check having stopped asking: a deal belonging to somebody ELSE is
+	// still refused, and named by field.
+	elsewhere := e.SeedOrg(t, "Contoso", nil)
+	elsewhereID := ids.From[ids.OrganizationKind](elsewhere)
+	otherDeal, err := e.Deals.CreateDeal(admin, deals.CreateDealInput{
+		Name: "Contoso expansion", PipelineID: pipeline, StageID: open, OrganizationID: &elsewhereID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherDealID := ids.From[ids.DealKind](ids.UUID(otherDeal.Id))
+	_, err = e.Contracts.CreateContract(admin, contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          "MSA 2026 (misfiled)", ValueBasis: contracts.BasisTotal, Source: "manual",
+		DealID: &otherDealID,
+	})
+	var crossOrg *contracts.CrossOrganizationLinkError
+	if !errors.As(err, &crossOrg) {
+		t.Fatalf("a contract on another company's deal was admitted (err = %v)", err)
+	}
+	if crossOrg.Field != "deal_id" {
+		t.Errorf("refused by field %q, want deal_id", crossOrg.Field)
+	}
+}

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -360,7 +360,11 @@ func ensureLinksShareOrganization(ctx context.Context, tx pgx.Tx, orgID ids.UUID
 		if ref.id == nil {
 			continue
 		}
-		var linkedOrg ids.UUID
+		// Nullable, because deal.organization_id is — a deal may be worked
+		// before anyone knows whose it is, and the create form leaves Company
+		// optional. project.organization_id is NOT NULL, so only the deal arm
+		// ever reads absent.
+		var linkedOrg *ids.UUID
 		//nolint:gosec // the table name is a package literal from dealRef/projectRef, never client input
 		query := "SELECT organization_id FROM " + ref.table + " WHERE id = $1"
 		err := tx.QueryRow(ctx, query, *ref.id).Scan(&linkedOrg)
@@ -372,7 +376,14 @@ func ensureLinksShareOrganization(ctx context.Context, tx pgx.Tx, orgID ids.UUID
 		if err != nil {
 			return fmt.Errorf("read %s organization: %w", ref.table, err)
 		}
-		if linkedOrg != orgID {
+		// A deal naming no company is not a company this contract disagrees
+		// with. The leak this check exists against is A's agreement reaching
+		// everyone who can see B's deal; with no B there is nobody it reaches
+		// that the deal itself does not already admit.
+		if linkedOrg == nil {
+			continue
+		}
+		if *linkedOrg != orgID {
 			return &CrossOrganizationLinkError{Field: ref.table + "_id"}
 		}
 	}


### PR DESCRIPTION
Closes #2085.

A deal may be worked before anyone knows whose it is — the create form leaves Company optional and `deal.organization_id` is nullable. Attaching a contract to one answered **500** with nothing a reader could act on. Because winning a deal needs a signed contract on it, that also made a company-less deal impossible to win, and said nothing about why.

## One correction to the issue

The issue attributes the crash to `resolveBuyerOrg` in `deals/offer.go`. That function is fine: it scans into `*ids.OrganizationID`, a pointer, and pgx sets it to nil on NULL. I checked directly, and the whole existing offer suite already proves it — `Env.SeedDeal` creates deals with **no** company, so every offer test in the tree builds offers on exactly the shape the issue says is refused.

The real site is `ensureLinksShareOrganization` in `contracts/contract_write.go`, which declared `var linkedOrg ids.UUID` — a non-pointer `[16]byte`. That is where the reported `*[16]byte` comes from, and its error wrapper renders the same `read deal organization` text the issue quotes from the log, which is what made the two look alike. Reverting the fix reproduces the logged message verbatim:

```
read deal organization: can't scan into dest[0] (col: organization_id): cannot scan NULL into *[16]byte
```

So **offers were never broken; contracts were.**

## Why absent is admitted rather than refused

Only the deal arm can be absent — `project.organization_id` is `NOT NULL`. An absent company is not a company the contract disagrees with. The leak this rule exists against is A's agreement reaching everyone who can see **B's** deal; with no B, there is nobody it reaches that the deal itself does not already admit — `VisibleClause` judges a deal-anchored contract by its deal alone.

## The sweep

Fixing the shape rather than the line: I derived the 128 nullable uuid columns from the schema and cross-referenced every single-column read of one. 34 such reads; six scan into a non-pointer. The other five are all already guarded — three by an explicit `AND <col> IS NOT NULL`, and two by a CHECK constraint (`rel_stakeholder_shape`, `activity_link_shape`) that makes the column non-null for the very kind the query filters on. This was the only unguarded one.

I did **not** turn that sweep into a gate. It needs to model both `IS NOT NULL` guards and per-kind CHECK constraints to tell a real finding from a safe one — five of the six candidates were safe for one of those two reasons — and a gate that cannot would report five false positives on a clean tree.

## Test

`TestAContractAttachesToADealThatNamesNoCompany` asserts both halves, because a test that only checked the admission would pass against a check that had stopped asking: the company-less deal is admitted, and a deal belonging to a **different** company is still refused by field. Mutation-checked — reverting the scan fails it with the reported error.

## CI note

Four integration tests are red on `main` at the tip, unrelated to this branch: `TestPerson360AssemblesEverySectionFromRealRows`, `TestADismissalHoldsUntilTheEvidenceMoves`, `TestDOIIssuanceMintsNothingWhicheverPurposeIsNamed` and `TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden`. They are covered by #4942 and #4945 and fail identically at this branch's base. `make check-backend` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC