### PR TITLE
fix(httperr): a constraint on a row the caller never wrote is ours

### DIFF
--- a/backend/internal/compose/integration/sideeffectconstraint_integration_test.go
+++ b/backend/internal/compose/integration/sideeffectconstraint_integration_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Postgres names the TABLE a constraint refused, for a real refusal.
+//
+// httperr's classifier reads that name to tell a constraint on the record the
+// request wrote from one on the audit or outbox row written beside it — the
+// first is the caller's input to fix, the second is ours. Every unit case for
+// that classifier builds the error itself, so all of them would keep passing if
+// Postgres sent no table at all and the classifier silently stopped separating
+// the two. Only a real violation can say the field is there.
+//
+// One case, on one constraint, because the claim is about the WIRE PROTOCOL
+// rather than about any table: if `TableName` arrives for this violation, it
+// arrives for the rest.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestARefusedAuditRowNamesItsOwnTable(t *testing.T) {
+	e := Setup(t)
+	// An actor type audit_log_actor_type_check does not admit. The verb would
+	// have been the closer analogue of the original defect, but writing an
+	// illegal one is a thing the tree already forbids: TestEveryAuditVerbTheCodeWritesIsLegal
+	// scans every storekit.Audit call and fails on a literal the DDL rejects,
+	// which is the STATIC half of this same fix. So the fixture breaks the
+	// audit row's other CHECK — the same table, the same class of defect, the
+	// same 23514 — and leaves that gate looking at a tree it can still vouch for.
+	ctx := principal.WithCorrelationID(
+		principal.WithActor(principal.WithWorkspaceID(context.Background(), e.WS),
+			principal.Principal{Type: principal.PrincipalType("neither_human_nor_machine"), ID: "system"}), ids.NewV7())
+
+	// Written through the REAL writer, which is the point: an audit row is
+	// filled by code the caller never sees, so nothing in a request could have
+	// caused this and nothing in a request can fix it.
+	// The refusal is RETURNED from the transaction rather than captured inside
+	// it: the failed statement aborts the transaction, so a callback that
+	// swallowed the error would meet a commit that cannot succeed and this test
+	// would read the rollback instead of the constraint.
+	refusal := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		_, err := storekit.AuditEvent(ctx, tx, "update", "organization", ids.NewV7(), nil)
+		return err
+	})
+	if refusal == nil {
+		t.Fatal("an unknown actor type was accepted — audit_log_actor_type_check is what this test reads, and it did not fire")
+	}
+
+	table, ok := storekit.ViolatedTable(refusal)
+	if !ok {
+		t.Fatalf("Postgres named no table for %v — the classifier cannot tell our own broken audit row from a value the caller sent, and answers every one of them as the caller's", refusal)
+	}
+	if table != storekit.TableAudit {
+		t.Fatalf("the refusal names table %q, want %q", table, storekit.TableAudit)
+	}
+	if !storekit.IsSideEffectTable(table) {
+		t.Fatalf("%q is not recognised as a row written beside the caller's own", table)
+	}
+
+	// And the whole way out: this is ours, so the caller gets the opaque 500
+	// rather than advice about a value they never sent.
+	fault, classified := httperr.Classify(refusal)
+	if !classified || fault.Status != 500 || fault.Detail != "" {
+		t.Fatalf("classified=%v status=%d detail=%q, want a 500 with nothing to say to the caller",
+			classified, fault.Status, fault.Detail)
+	}
+}

--- a/backend/internal/platform/database/storekit/auditevent.go
+++ b/backend/internal/platform/database/storekit/auditevent.go
@@ -88,7 +88,10 @@ func writeAuditRow(ctx context.Context, tx pgx.Tx, action, entityType string, en
 		// ADR-0091 §8 phase D reached the ledgers — the last two tables that
 		// carried one — so an audit row now names WHAT happened and WHO did it,
 		// and the installation is the only answer to where.
-		`INSERT INTO audit_log (id, actor_type, actor_id, passport_id, on_behalf_of, action, entity_type, entity_id, before, after, evidence, authorization_rule)
+		// The table name is the constant the fault classifier reads, so a rename
+		// moves both or neither: a stale classifier would report our own broken
+		// audit row to the caller as a value they sent.
+		`INSERT INTO `+TableAudit+` (id, actor_type, actor_id, passport_id, on_behalf_of, action, entity_type, entity_id, before, after, evidence, authorization_rule)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
 		id, string(p.Type), p.ID, UUIDOrNil(p.PassportID), UUIDOrNil(p.OnBehalfOf),
 		action, entityType, entityID, beforeJSON, afterJSON, evidenceJSON,

--- a/backend/internal/platform/database/storekit/sideeffecttables.go
+++ b/backend/internal/platform/database/storekit/sideeffecttables.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+// The rows every mutation writes BESIDE the caller's own record.
+//
+// The write shape is domain row + audit entry + outbox event in one
+// transaction, and only the first of those three carries anything the caller
+// sent. That distinction is invisible from a SQLSTATE — a CHECK is a CHECK —
+// and it decides who is at fault: a constraint on the record the request names
+// is the caller's input to fix, while a constraint on one of these is ours,
+// written by code the caller cannot see and cannot change.
+//
+// Named here because this package is what writes them (AuditEvent and Emit,
+// whose statements are built from these constants), so the classifier reading
+// them cannot drift from the writer that fills them.
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+const (
+	// TableAudit holds one row per mutation: what happened and who did it.
+	TableAudit = "audit_log"
+	// TableOutbox holds the event a mutation publishes, taken from here by the
+	// relay rather than sent from domain code.
+	TableOutbox = "event_outbox"
+)
+
+// IsSideEffectTable reports whether a table is one this package writes on every
+// mutation's behalf rather than one the caller named.
+func IsSideEffectTable(table string) bool {
+	return table == TableAudit || table == TableOutbox
+}
+
+// ViolatedTable names the table whose constraint refused a write.
+//
+// Postgres sends it alongside the constraint name for every integrity
+// violation (23xxx), which is what makes this answerable without guessing at
+// the constraint's spelling: `audit_log_action_check` happens to start with its
+// table's name, and a table called `audit_log_export` would too.
+//
+// Absent for a failure that names no table — a serialization conflict, a
+// connection that went away — so a caller must treat "no table" as "this is not
+// a constraint on any one row" rather than as any particular table.
+func ViolatedTable(err error) (table string, ok bool) {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.TableName == "" {
+		return "", false
+	}
+	return pgErr.TableName, true
+}

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -236,7 +236,7 @@ func Emit(ctx context.Context, tx pgx.Tx, auditID ids.UUID, eventType, entityTyp
 		return err
 	}
 	_, err = tx.Exec(ctx,
-		`INSERT INTO event_outbox (stream, envelope) VALUES ($1, $2)`,
+		`INSERT INTO `+TableOutbox+` (stream, envelope) VALUES ($1, $2)`,
 		stream, body)
 	return err
 }

--- a/backend/internal/platform/httperr/constraintfault.go
+++ b/backend/internal/platform/httperr/constraintfault.go
@@ -44,6 +44,9 @@ func constraintFault(err error) (Fault, bool) {
 	if fault, ok := retentionHoldFault(err); ok {
 		return fault, true
 	}
+	if fault, ok := sideEffectFault(err); ok {
+		return fault, true
+	}
 	switch {
 	case storekit.IsForeignKeyViolation(err):
 		return Fault{
@@ -69,6 +72,42 @@ func constraintFault(err error) (Fault, bool) {
 	default:
 		return Fault{}, false
 	}
+}
+
+// sideEffectFault answers a constraint on a row the REQUEST never wrote.
+//
+// Every mutation writes three rows in one transaction — the domain record, an
+// audit entry and an outbox event — and only the first carries anything the
+// caller sent. From a SQLSTATE the three are indistinguishable, so the net
+// below answered all of them the same way: 422, "a value in this request is
+// outside what its field accepts", "do not retry unchanged".
+//
+// For the two the caller did not write, every clause of that is wrong. It is
+// not their value; there is nothing in their request to check against the
+// schema; and "do not retry unchanged" tells a client to give up on a call that
+// would succeed the moment the defect is fixed. The case that surfaced it was a
+// connector write whose audit verb was missing from audit_log_action_check: the
+// admin was told to check a request that was entirely valid, and the real fault
+// — ours — took a browser walk to find rather than one log line.
+//
+// So it is what it is: a server fault. The caller gets the opaque 500 that says
+// so, and the operator gets the constraint through InfraCause, which is where a
+// defect in code the caller cannot see belongs.
+//
+// A Detail is deliberately absent. There is nothing true to say to the caller
+// beyond the status — naming the constraint would leak the schema this file
+// exists not to leak, and any sentence about "a value" would be the same
+// falsehood in shorter form.
+func sideEffectFault(err error) (Fault, bool) {
+	table, ok := storekit.ViolatedTable(err)
+	if !ok || !storekit.IsSideEffectTable(table) {
+		return Fault{}, false
+	}
+	return Fault{
+		Status:     http.StatusInternalServerError,
+		Code:       "internal",
+		InfraCause: err,
+	}, true
 }
 
 // activityRestrictedImmutable is the constraint name the data-layer guard

--- a/backend/internal/platform/httperr/sideeffectfault_test.go
+++ b/backend/internal/platform/httperr/sideeffectfault_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httperr
+
+// Whose fault a constraint is, when the SQLSTATE cannot say.
+//
+// Every mutation writes three rows in one transaction — the record, its audit
+// entry, its outbox event — and only the first carries anything the caller
+// sent. Told apart by SQLSTATE alone they are the same event, and the net under
+// the per-path validations answered all three as the caller's input to fix.
+//
+// For the two the caller never wrote, that answer is wrong in every clause it
+// makes: not their value, nothing in their request to check, and "do not retry
+// unchanged" said to a client whose next call would succeed the moment somebody
+// fixes our code. The table is what separates them, and Postgres sends it.
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+func TestAConstraintOnARowTheCallerNeverWroteIsOurFault(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		table      string
+		constraint string
+	}{
+		{
+			// The case that surfaced this: connecting a data provider wrote an
+			// audit row whose verb was missing from the CHECK. The admin was
+			// told to check values in a request that was entirely valid.
+			name:  "an audit verb the CHECK does not admit",
+			table: storekit.TableAudit, constraint: "audit_log_action_check",
+		},
+		{
+			name:  "an actor type the CHECK does not admit",
+			table: storekit.TableAudit, constraint: "audit_log_actor_type_check",
+		},
+		{
+			name:  "an outbox envelope the schema refuses",
+			table: storekit.TableOutbox, constraint: "event_outbox_stream_check",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cause := &pgconn.PgError{
+				Code: "23514", TableName: tc.table, ConstraintName: tc.constraint,
+				Message: `new row for relation "` + tc.table + `" violates check constraint`,
+			}
+			fault, ok := Classify(fmt.Errorf("recording the write: %w", cause))
+			if !ok {
+				t.Fatal("the fault reached the unhandled path — which answers the same 500, but logs it as unknown rather than as the constraint it is")
+			}
+			if fault.Status != http.StatusInternalServerError {
+				t.Errorf("status = %d, want 500 — the caller wrote no part of this row, so there is nothing in their request to fix", fault.Status)
+			}
+			if fault.Code != "internal" {
+				t.Errorf("code = %q, want internal", fault.Code)
+			}
+			// No sentence at all. Naming the constraint would leak the schema,
+			// and any sentence about "a value in this request" would be the
+			// same falsehood the 422 was telling, one line shorter.
+			if fault.Detail != "" {
+				t.Errorf("detail = %q, want none — every true thing about this fault is already in the status", fault.Detail)
+			}
+			// The operator still gets the constraint: httperr.Write logs
+			// InfraCause, and without it this defect is a bare 500 with nothing
+			// to chase, which is worse than the wrong 422 it replaces.
+			if !errors.Is(fault.InfraCause, cause) {
+				t.Errorf("InfraCause = %v, want the Postgres error — the caller learns nothing, so the log has to learn everything", fault.InfraCause)
+			}
+		})
+	}
+}
+
+// The control, one field apart. Without it the case above would pass against a
+// classifier that answered 500 for every constraint — which would take every
+// per-path validation's fallback with it.
+func TestAConstraintOnTheCallersOwnRecordIsStillTheirs(t *testing.T) {
+	fault, ok := Classify(fmt.Errorf("writing the row: %w", &pgconn.PgError{
+		Code: "23514", TableName: "organization", ConstraintName: "organization_size_band_check",
+		Message: `new row for relation "organization" violates check constraint`,
+	}))
+	if !ok {
+		t.Fatal("the constraint reached the unhandled path")
+	}
+	if fault.Status != http.StatusUnprocessableEntity || fault.Code != "value_not_allowed" {
+		t.Fatalf("status/code = %d/%q, want 422/value_not_allowed — a CHECK on the record the request names is the caller's to fix",
+			fault.Status, fault.Code)
+	}
+}
+
+// A constraint failure that names no table is not evidence of anything: it must
+// not be read as a side effect, and it must not be read as the caller's record
+// either — it falls through to whatever the SQLSTATE says on its own.
+func TestAViolationThatNamesNoTableIsNotClaimedByEitherSide(t *testing.T) {
+	if table, ok := storekit.ViolatedTable(&pgconn.PgError{Code: "23514"}); ok {
+		t.Fatalf("ViolatedTable answered %q for an error naming none", table)
+	}
+	fault, ok := Classify(&pgconn.PgError{Code: "23514", ConstraintName: "some_check"})
+	if !ok || fault.Status != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d (classified %v), want the 422 a nameless CHECK has always answered", fault.Status, ok)
+	}
+}


### PR DESCRIPTION
Closes #1123.

Every mutation writes three rows in one transaction — the record, its `audit_log` entry, its `event_outbox` event — and **only the first carries anything the caller sent**. A SQLSTATE cannot tell the three apart, so the net under the per-path validations answered all of them identically:

> 422 `value_not_allowed` — a value in this request is outside what its field accepts. Check each value against this operation's schema; do not retry unchanged.

For the two the caller never wrote, every clause of that is false. It is not their value. There is nothing in their request to check against the schema. And "do not retry unchanged" tells a client to give up on a call that would succeed the moment somebody fixes *our* code. The case that surfaced it: a connector write whose audit verb was missing from `audit_log_action_check`. The admin was told to check a request that was entirely valid, and the real fault — ours — took a browser walk to find rather than one log line.

## How the two are told apart

Postgres sends the **table** alongside the constraint name for every integrity violation. That is what makes this answerable without guessing at a constraint's spelling: `audit_log_action_check` happens to start with its table's name, and a table called `audit_log_export` would too.

So `storekit.ViolatedTable` reads it, `storekit.IsSideEffectTable` answers whether it is one of the rows this package writes on every mutation's behalf, and `httperr` maps that to the 500 it is — opaque to the caller, and the constraint to the operator through `InfraCause`, which `Write` already logs.

**No `Detail`.** Naming the constraint would leak the schema `constraintfault.go` exists not to leak, and any sentence about "a value" would be the same falsehood one line shorter. Everything true about this fault is already in the status.

The two table names are **constants in storekit, and the `INSERT` statements are built from them** — `"INSERT INTO "+TableAudit+" (…)"`. A rename moves the writer and the classifier together; a stale classifier would go straight back to reporting our own broken audit row as a value the caller sent.

## What was already covered, and what this adds

The audit-verb half of the original defect is caught **statically** today: `TestEveryAuditVerbTheCodeWritesIsLegal` scans every `storekit.Audit` call and fails on a literal the DDL rejects. That gate is the reason this change is a net rather than the fix — it sees a verb written as a literal, and nothing else. This covers what it cannot: the outbox side, a `NOT NULL` or a column added to either table, and any future constraint on a row the request does not name.

Which is also why the integration fixture breaks the audit row's **actor-type** CHECK rather than its action CHECK. Writing an illegal verb is a thing that gate exists to forbid, so the fixture uses the other constraint on the same table — same class of defect, same 23514 — and leaves the static gate looking at a tree it can still vouch for.

## Tests

**Unit**, over the classification: three side-effect constraints answer 500 with `InfraCause` set and no detail; the control — the same SQLSTATE on `organization` — still answers 422 `value_not_allowed`; and a violation naming no table is claimed by neither side and falls through to what the SQLSTATE said on its own.

**Integration**, because the unit cases build the error themselves and every one of them would keep passing if Postgres sent no table at all and the classifier silently stopped separating the two. `TestARefusedAuditRowNamesItsOwnTable` provokes a real refusal through `storekit.AuditEvent` and reads `TableName` off the wire.

**Mutation checks:**

| mutation | result |
|---|---|
| remove the `sideEffectFault` arm | both the unit case and the integration case fail |
| drop `audit_log` from the side-effect set | both fail |

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for failures affecting system-generated audit and event records.
  - These infrastructure failures now return a generic server error instead of being incorrectly reported as caller-provided validation errors.
  - Validation errors on records submitted by the caller continue to return the expected validation response.
  - Added coverage to ensure constraint violations are classified consistently and sensitive implementation details are not exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->