### PR TITLE
fix(attachments): a file with no content is refused at the door

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -32620,6 +32620,14 @@ components:
             Repeated ids are collapsed — attaching one file twice is not something a message
             can mean — and naming more distinct files than `maxItems` is refused with
             422 `too_many_attachments`.
+
+            A file with NO CONTENT is refused with 422 `empty_attachment`, naming the file.
+            It is a separate code from the size one on purpose: an empty file is not a file
+            that is too big, and a client that reported it as a limit would send somebody
+            off to shrink something already as small as it can be. Nothing anywhere can send
+            it, so it is refused here rather than by whichever transport happens to carry
+            the message — an upload is refused for the same reason, so a file that reaches
+            this field with no bytes was captured that way from an inbound message.
         to: { type: array, items: { type: string, format: email } }
         cc: { type: array, items: { type: string, format: email } }
         bcc:
@@ -33068,6 +33076,14 @@ components:
             Repeated ids are collapsed — attaching one file twice is not something a message
             can mean — and naming more distinct files than `maxItems` is refused with
             422 `too_many_attachments`.
+
+            A file with NO CONTENT is refused with 422 `empty_attachment`, naming the file.
+            It is a separate code from the size one on purpose: an empty file is not a file
+            that is too big, and a client that reported it as a limit would send somebody
+            off to shrink something already as small as it can be. Nothing anywhere can send
+            it, so it is refused here rather than by whichever transport happens to carry
+            the message — an upload is refused for the same reason, so a file that reaches
+            this field with no bytes was captured that way from an inbound message.
         to:
           type: array
           minItems: 1
@@ -33270,6 +33286,14 @@ components:
             Repeated ids are collapsed — attaching one file twice is not something a message
             can mean — and naming more distinct files than `maxItems` is refused with
             422 `too_many_attachments`.
+
+            A file with NO CONTENT is refused with 422 `empty_attachment`, naming the file.
+            It is a separate code from the size one on purpose: an empty file is not a file
+            that is too big, and a client that reported it as a limit would send somebody
+            off to shrink something already as small as it can be. Nothing anywhere can send
+            it, so it is refused here rather than by whichever transport happens to carry
+            the message — an upload is refused for the same reason, so a file that reaches
+            this field with no bytes was captured that way from an inbound message.
 
             A messaging channel carries this message's text as a CAPTION, which is bounded
             far below a text-only message; `GET /v1/channel-providers` publishes that bound

--- a/backend/internal/compose/integration/attachment_integration_test.go
+++ b/backend/internal/compose/integration/attachment_integration_test.go
@@ -449,3 +449,47 @@ func TestArchiveAttachmentHidesItButKeepsTheObject(t *testing.T) {
 		t.Fatalf("blob health: %v", err)
 	}
 }
+
+// An empty file is refused at the DOOR, not at the transport.
+//
+// A file with no content is not a limit one channel dislikes — no send path
+// anywhere can do anything with it. Left to the connector, the provider's
+// refusal reads like a transient condition and the delivery burns its whole
+// retry ladder on a file that will never have bytes; and the person hears about
+// it long after they stopped looking at the file. Refused on upload, they hear
+// it while they can still pick the right one.
+//
+// Asserted with the ordinary upload beside it, because a check that refused
+// everything would satisfy the empty case on its own.
+func TestAnEmptyFileIsRefusedOnUpload(t *testing.T) {
+	e := Setup(t)
+	h := activities.NewHandlers(e.DB()).WithUploadLimit(uploadCeiling).WithBlobstore(blobstore.NewMemory())
+	ctx := e.Admin()
+	person := e.SeedPerson(t, "Empty Upload", &e.Rep1)
+
+	body, ctype := multipartAttachment(t, "person", person.String(), "scan.pdf", []byte{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/attachments", body).WithContext(ctx)
+	req.Header.Set("Content-Type", ctype)
+	rec := httptest.NewRecorder()
+	h.UploadAttachment(rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("uploading an empty file: status %d, want 422; body %s", rec.Code, rec.Body.String())
+	}
+	// The reader has to be told which file and what to do, or the refusal is a
+	// wall. It must NOT read as a size limit — that sends them off to shrink
+	// something that is already as small as it can be.
+	if got := rec.Body.String(); !strings.Contains(got, "scan.pdf") || !strings.Contains(got, "empty") {
+		t.Errorf("the refusal does not name the file or say what is wrong: %s", got)
+	}
+
+	// One byte is enough to be a file, so the rule is about content and not
+	// about a threshold somebody has to guess.
+	okBody, okType := multipartAttachment(t, "person", person.String(), "scan.pdf", []byte{0x25})
+	okReq := httptest.NewRequest(http.MethodPost, "/v1/attachments", okBody).WithContext(ctx)
+	okReq.Header.Set("Content-Type", okType)
+	okRec := httptest.NewRecorder()
+	h.UploadAttachment(okRec, okReq)
+	if okRec.Code != http.StatusCreated {
+		t.Errorf("a one-byte file was refused too: status %d, body %s", okRec.Code, okRec.Body.String())
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -32498,6 +32498,14 @@ type SendAccountEmailRequest struct {
 	// Repeated ids are collapsed — attaching one file twice is not something a message
 	// can mean — and naming more distinct files than `maxItems` is refused with
 	// 422 `too_many_attachments`.
+	//
+	// A file with NO CONTENT is refused with 422 `empty_attachment`, naming the file.
+	// It is a separate code from the size one on purpose: an empty file is not a file
+	// that is too big, and a client that reported it as a limit would send somebody
+	// off to shrink something already as small as it can be. Nothing anywhere can send
+	// it, so it is refused here rather than by whichever transport happens to carry
+	// the message — an upload is refused for the same reason, so a file that reaches
+	// this field with no bytes was captured that way from an inbound message.
 	AttachmentIds *[]openapi_types.UUID `json:"attachment_ids,omitempty"`
 
 	// Bcc Blind copies. They receive the message and are therefore owed consent
@@ -32759,6 +32767,14 @@ type SendEmailRequest struct {
 	// Repeated ids are collapsed — attaching one file twice is not something a message
 	// can mean — and naming more distinct files than `maxItems` is refused with
 	// 422 `too_many_attachments`.
+	//
+	// A file with NO CONTENT is refused with 422 `empty_attachment`, naming the file.
+	// It is a separate code from the size one on purpose: an empty file is not a file
+	// that is too big, and a client that reported it as a limit would send somebody
+	// off to shrink something already as small as it can be. Nothing anywhere can send
+	// it, so it is refused here rather than by whichever transport happens to carry
+	// the message — an upload is refused for the same reason, so a file that reaches
+	// this field with no bytes was captured that way from an inbound message.
 	AttachmentIds *[]openapi_types.UUID `json:"attachment_ids,omitempty"`
 
 	// Bcc Blind copies. They receive the message and are therefore owed consent
@@ -32896,6 +32912,14 @@ type SendMessageRequest struct {
 	// Repeated ids are collapsed — attaching one file twice is not something a message
 	// can mean — and naming more distinct files than `maxItems` is refused with
 	// 422 `too_many_attachments`.
+	//
+	// A file with NO CONTENT is refused with 422 `empty_attachment`, naming the file.
+	// It is a separate code from the size one on purpose: an empty file is not a file
+	// that is too big, and a client that reported it as a limit would send somebody
+	// off to shrink something already as small as it can be. Nothing anywhere can send
+	// it, so it is refused here rather than by whichever transport happens to carry
+	// the message — an upload is refused for the same reason, so a file that reaches
+	// this field with no bytes was captured that way from an inbound message.
 	//
 	// A messaging channel carries this message's text as a CAPTION, which is bounded
 	// far below a text-only message; `GET /v1/channel-providers` publishes that bound

--- a/backend/internal/modules/activities/attachmentupload.go
+++ b/backend/internal/modules/activities/attachmentupload.go
@@ -13,6 +13,7 @@ package activities
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/jackc/pgx/v5"
@@ -45,6 +46,22 @@ type AttachmentInput struct {
 	// roll-up like the account column beside it, not a second parent: the
 	// primary entity still owns the file's visibility.
 	ContractID *ids.UUID
+}
+
+// EmptyUploadError refuses an upload carrying no bytes. It maps to 422: the
+// caller fixes it by choosing the file they meant.
+//
+// The size is the one COUNTED on the hashing pass, never a declared length —
+// see AttachmentInput.Content for why the two are not allowed to disagree.
+type EmptyUploadError struct{ Filename string }
+
+func (e *EmptyUploadError) Error() string {
+	return fmt.Sprintf("%q is empty, so there is nothing to upload; choose the file again", e.Filename)
+}
+
+// FieldFault names the part of the upload the caller must correct.
+func (e *EmptyUploadError) FieldFault() (field, code, message string) {
+	return "file", "empty_file", e.Error()
 }
 
 // UploadAttachment stores an object and records its metadata row. Authority
@@ -92,6 +109,16 @@ func (s *Store) UploadAttachment(ctx context.Context, in AttachmentInput) (crmco
 	checksum, size, err := blobstore.Digest(in.Content)
 	if err != nil {
 		return crmcontracts.Attachment{}, err
+	}
+	// Refused HERE, where the person still has the file in front of them and can
+	// pick the one they meant. A file with no content is not a limit one
+	// transport dislikes — no send path anywhere can do anything with it — and
+	// the counted size is the only honest witness: a declared length can
+	// disagree with the bytes, which is why nothing declares one.
+	//
+	// Before the object is stored, so an empty upload leaves nothing behind.
+	if size == 0 {
+		return crmcontracts.Attachment{}, &EmptyUploadError{Filename: in.Filename}
 	}
 
 	if err := s.blob.Put(ctx, key, in.Content, size, in.ContentType); err != nil {

--- a/backend/internal/modules/activities/emptyattachment_integration_test.go
+++ b/backend/internal/modules/activities/emptyattachment_integration_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package activities
+
+// The second door an empty file can arrive at.
+//
+// The upload door refuses one outright, so the only way a row with no content
+// reaches the tree is CAPTURE: an inbound message may legitimately carry an
+// empty part, and recording what actually arrived is that path's job — it is
+// not the connector's place to decide a received message was wrong. Sending one
+// back out is a different question, and this is where it gets asked.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/blobstore"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// captureAFile lands one attachment on the anchor through the REAL capture
+// writer — staged then recorded, exactly as a connector does it. Seeding the
+// row by hand would prove nothing about the column production writes.
+func (e *sendEnv) captureAFile(t *testing.T, anchor ids.ActivityID, filename string, body []byte) ids.UUID {
+	t.Helper()
+	ctx := principal.WithCorrelationID(
+		principal.WithActor(principal.WithWorkspaceID(context.Background(), e.ws),
+			principal.Principal{
+				Type: principal.PrincipalSystem, ID: "connector:imap",
+				Permissions: principal.Permissions{
+					Objects: map[string]principal.ObjectGrant{"activity": {Create: true, Read: true, Update: true}},
+				},
+			}), ids.NewV7())
+	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws))).WithBlobstore(blobstore.NewMemory())
+	staged, err := store.StageCapturedFiles(ctx, []CapturedFile{{
+		PartID: "1", Filename: filename, ContentType: "application/pdf", Body: body,
+	}})
+	if err != nil {
+		t.Fatalf("staging %q: %v", filename, err)
+	}
+	if err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		return store.RecordCapturedFiles(ctx, tx, anchor, CapturedFileSource{
+			System: "imap", MessageID: filename + "-" + anchor.String(),
+			CapturedBy: "connector:imap", Category: "email_attachment",
+		}, staged)
+	}); err != nil {
+		t.Fatalf("recording %q: %v", filename, err)
+	}
+	var id ids.UUID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT id FROM attachment WHERE entity_id = $1 AND filename = $2`, anchor, filename).Scan(&id); err != nil {
+		t.Fatalf("reading back %q: %v", filename, err)
+	}
+	return id
+}
+
+// A file with no content cannot be sent, whichever channel would carry it.
+//
+// Left to the connector this parks the delivery under a transport error that
+// reads like a transient condition, so the send burns its whole retry ladder on
+// a file that will never have bytes — and every transport has to state the rule
+// separately. Refused while staging, the sender is told once, in words naming
+// the file.
+//
+// The captured file BESIDE it is not decoration: a refusal that fired on any
+// attachment at all would satisfy the first half on its own.
+func TestAnEmptyCapturedFileCannotBeSentBackOut(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+	empty := e.captureAFile(t, anchor, "empty.pdf", []byte{})
+	withBytes := e.captureAFile(t, anchor, "quote.pdf", []byte("%PDF-1.4"))
+
+	// The row exists and records the truth — capture's job is to say what
+	// arrived, so this is the state the send path has to be ready for.
+	var size *int64
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT byte_size FROM attachment WHERE id = $1`, empty).Scan(&size); err != nil {
+		t.Fatalf("reading the captured size: %v", err)
+	}
+	if size == nil || *size != 0 {
+		t.Fatalf("the captured empty part recorded byte_size %v, want 0 — the fixture is not the shape under test", size)
+	}
+
+	withEmpty := soloSendInput("transactional")
+	withEmpty.AttachmentIDs = []ids.UUID{empty}
+	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll), FromActivity(anchor), withEmpty, stubConsentGate{}, &recordingStager{})
+
+	var emptyErr *EmptyAttachmentError
+	if !errors.As(err, &emptyErr) {
+		t.Fatalf("sending an empty file → %v, want EmptyAttachmentError", err)
+	}
+	if emptyErr.Filename != "empty.pdf" {
+		t.Errorf("the refusal names %q, want the file the sender attached", emptyErr.Filename)
+	}
+	field, code, _ := emptyErr.FieldFault()
+	if field != "attachment_ids" || code != "empty_attachment" {
+		t.Errorf("field fault = (%q, %q), want (attachment_ids, empty_attachment)", field, code)
+	}
+
+	withReal := soloSendInput("transactional")
+	withReal.AttachmentIDs = []ids.UUID{withBytes}
+	if _, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll), FromActivity(anchor), withReal, stubConsentGate{}, &recordingStager{}); err != nil {
+		t.Fatalf("a file WITH content was refused too, so the rule is not about content: %v", err)
+	}
+}

--- a/backend/internal/modules/activities/sendattachments.go
+++ b/backend/internal/modules/activities/sendattachments.go
@@ -84,6 +84,32 @@ func (e *TooManyAttachmentsError) FieldFault() (field, code, message string) {
 	return "attachment_ids", "too_many_attachments", e.Error()
 }
 
+// EmptyAttachmentError refuses a send carrying a file with no content. It maps
+// to 422: the caller fixes it by attaching the file they meant.
+//
+// A file with nothing in it is not a limit one transport dislikes — no send
+// path anywhere can do anything useful with it, and a provider that refuses it
+// answers with a transport error that reads like a transient condition, so the
+// delivery burns its whole retry ladder on a file that will never have bytes.
+// Refused here, where the sender still has the file in front of them.
+//
+// "No recorded size" is refused by the SAME rule rather than admitted as a
+// maybe. The column is nullable while every writer records a real count, so an
+// unmeasured row is not a state the product reaches — and if one ever appears,
+// a send is the wrong place to discover that nobody knows what is in it.
+type EmptyAttachmentError struct{ Filename string }
+
+func (e *EmptyAttachmentError) Error() string {
+	return fmt.Sprintf(
+		"%q has no content, so it cannot be sent; attach the file again, or remove it from this message",
+		e.Filename)
+}
+
+// FieldFault names the field the caller must correct.
+func (e *EmptyAttachmentError) FieldFault() (field, code, message string) {
+	return "attachment_ids", "empty_attachment", e.Error()
+}
+
 // boundAttachmentIDs collapses repeats and refuses a set larger than one
 // message may carry.
 //
@@ -137,11 +163,14 @@ func (s *Store) resolveAttachments(ctx context.Context, attachmentIDs []ids.UUID
 			// without this layer inventing a second vocabulary for it.
 			return nil, fmt.Errorf("resolving an attached file: %w", err)
 		}
+		if meta.ByteSize == nil || *meta.ByteSize <= 0 {
+			return nil, &EmptyAttachmentError{Filename: meta.Filename}
+		}
 		out = append(out, OutboundFile{
 			AttachmentID: id,
 			Filename:     meta.Filename,
 			ContentType:  orEmpty(meta.ContentType),
-			ByteSize:     orZero(meta.ByteSize),
+			ByteSize:     *meta.ByteSize,
 			Checksum:     orEmpty(meta.Checksum),
 		})
 	}
@@ -151,13 +180,6 @@ func (s *Store) resolveAttachments(ctx context.Context, attachmentIDs []ids.UUID
 func orEmpty(value *string) string {
 	if value == nil {
 		return ""
-	}
-	return *value
-}
-
-func orZero(value *int64) int64 {
-	if value == nil {
-		return 0
 	}
 	return *value
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23607,6 +23607,14 @@ export interface components {
              *     Repeated ids are collapsed — attaching one file twice is not something a message
              *     can mean — and naming more distinct files than `maxItems` is refused with
              *     422 `too_many_attachments`.
+             *
+             *     A file with NO CONTENT is refused with 422 `empty_attachment`, naming the file.
+             *     It is a separate code from the size one on purpose: an empty file is not a file
+             *     that is too big, and a client that reported it as a limit would send somebody
+             *     off to shrink something already as small as it can be. Nothing anywhere can send
+             *     it, so it is refused here rather than by whichever transport happens to carry
+             *     the message — an upload is refused for the same reason, so a file that reaches
+             *     this field with no bytes was captured that way from an inbound message.
              */
             attachment_ids?: string[];
             to: string[];
@@ -24017,6 +24025,14 @@ export interface components {
              *     Repeated ids are collapsed — attaching one file twice is not something a message
              *     can mean — and naming more distinct files than `maxItems` is refused with
              *     422 `too_many_attachments`.
+             *
+             *     A file with NO CONTENT is refused with 422 `empty_attachment`, naming the file.
+             *     It is a separate code from the size one on purpose: an empty file is not a file
+             *     that is too big, and a client that reported it as a limit would send somebody
+             *     off to shrink something already as small as it can be. Nothing anywhere can send
+             *     it, so it is refused here rather than by whichever transport happens to carry
+             *     the message — an upload is refused for the same reason, so a file that reaches
+             *     this field with no bytes was captured that way from an inbound message.
              */
             attachment_ids?: string[];
             /**
@@ -24200,6 +24216,14 @@ export interface components {
              *     Repeated ids are collapsed — attaching one file twice is not something a message
              *     can mean — and naming more distinct files than `maxItems` is refused with
              *     422 `too_many_attachments`.
+             *
+             *     A file with NO CONTENT is refused with 422 `empty_attachment`, naming the file.
+             *     It is a separate code from the size one on purpose: an empty file is not a file
+             *     that is too big, and a client that reported it as a limit would send somebody
+             *     off to shrink something already as small as it can be. Nothing anywhere can send
+             *     it, so it is refused here rather than by whichever transport happens to carry
+             *     the message — an upload is refused for the same reason, so a file that reaches
+             *     this field with no bytes was captured that way from an inbound message.
              *
              *     A messaging channel carries this message's text as a CAPTION, which is bounded
              *     far below a text-only message; `GET /v1/channel-providers` publishes that bound


### PR DESCRIPTION
Closes #2062.

Nothing on the attachment write path rejected a **zero-byte** upload — the size ceiling is an upper bound only. A person could attach an empty file, be told the message would go, and have the delivery refused at the far end for a reason that reads like a size problem. Worse, the provider's `400` reads as a transient condition, so the send burned its whole retry ladder on a file that will never have any bytes.

## Refused at the door, not at the connector

Following the issue's ruling. An empty file is not a limit one transport dislikes — no send path anywhere can do anything useful with it — so putting the rule in each connector means every transport states it separately and the connector check is the only line of defence.

- **Upload** refuses it, *before* the object is stored, so an empty upload leaves nothing behind and the person hears about it while the file is still in front of them.
- **Staging** refuses it for a send.
- **Capture still records one.** An inbound message may legitimately carry an empty part, and saying what actually arrived is that path's job; it is not the connector's place to decide a received message was wrong. Sending it back out is the different question, and staging is where it gets asked.

So #2057's connector-level check becomes the belt-and-braces it should be. **No `connector.Carriage` field and no contract change**: a universal rule is not a per-provider bound, and `GET /v1/channel-providers` should not describe it as one.

## The nullable-size sharp edge

`attachment.byte_size` is nullable and the send path read it through `orZero`, so a NULL size and a genuinely empty file were the same answer to any gate reading the column. Both writers (upload, capture) always record a real count, so an unmeasured row is not a state the product reaches — and if one ever appeared, a send is the wrong place to discover nobody knows what is in it. Both are now refused by the same rule, and `orZero` is gone along with its only caller.

I did not make the column `NOT NULL`: that needs a migration against deployed data I cannot inspect, and it would fail the install rather than the send. The gate above closes the hole either way.

## Tests

Two, one per door, each mutation-checked:

- `TestAnEmptyFileIsRefusedOnUpload` — 422, the message names the file and does **not** read as a size limit (which would send someone off to shrink a file that is already as small as it can be). A one-byte file is still accepted beside it, so the rule is about content and not a threshold anyone has to guess.
- `TestAnEmptyCapturedFileCannotBeSentBackOut` — seeded through the **real** capture writer (`StageCapturedFiles` + `RecordCapturedFiles`), since upload now refuses one and a hand-written row would prove nothing about the column production writes. Asserts the recorded `byte_size` really is 0, that the send is refused by field, and that a captured file *with* bytes still sends — a refusal firing on any attachment at all would satisfy the first half on its own.

## CI note

Four integration tests are red on `main` at the tip and unrelated to this branch: `TestPerson360AssemblesEverySectionFromRealRows`, `TestADismissalHoldsUntilTheEvidenceMoves`, `TestDOIIssuanceMintsNothingWhicheverPurposeIsNamed` and `TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden`. They are covered by #4942 and #4945 and fail identically at this branch's base. `make check-backend` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC