### PR TITLE
fix(gates): a transaction held in a field is a transaction borrowed

### DIFF
--- a/backend/gates/txseamacquire_test.go
+++ b/backend/gates/txseamacquire_test.go
@@ -39,7 +39,9 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -89,17 +91,27 @@ func TestATxAcceptingFunctionAcquiresNoConnectionOfItsOwn(t *testing.T) {
 		// owns its own connection is not one.
 	})
 	roots := []string{"internal", "cmd"}
+	holders := txHoldingReceivers(t, roots)
 	scope := gatekit.Scope{
-		Roots:   roots,
-		Subject: func(_ string, file *ast.File) bool { return len(txBorrowingBodies(file)) > 0 },
-		Exempt:  exempt,
+		Roots: roots,
+		// A file holding any tx-borrowing body, by either rule. The parameter
+		// rule alone excluded a port that keeps the caller's transaction in a
+		// FIELD — its methods take no pgx.Tx at all — so `holders` is read
+		// here too, and it is built from a walk of its own rather than from
+		// this scope: the type and its verbs live in the same file today, and
+		// a subject rule that assumed so would report PASS the day somebody
+		// moves them apart.
+		Subject: func(p string, file *ast.File) bool {
+			return len(txBorrowingBodies(file, holders[path.Dir(p)])) > 0
+		},
+		Exempt: exempt,
 	}
 	defer exempt.AssertAllMatched(t)
 
 	index := indexPackageFunctions(t, roots)
 	for _, parsed := range scope.Files(t) {
 		dir := path.Dir(parsed.Path)
-		for _, body := range txBorrowingBodies(parsed.File) {
+		for _, body := range txBorrowingBodies(parsed.File, holders[dir]) {
 			for _, found := range body.acquires() {
 				t.Errorf("%s: %s runs on a caller's pgx.Tx and then %s (%s) — fetch it before the "+
 					"transaction opens and thread the result in, as mergePersonTx and createDealTx do; "+
@@ -139,11 +151,22 @@ type txBorrowing struct {
 	// pgxName is the local name the file imports pgx under, so a seam in a
 	// file that aliases the import is judged rather than skipped.
 	pgxName string
+	// recv and heldTx describe the third shape: a method on a receiver that
+	// HOLDS the caller's transaction in a field. `recv` is the receiver's own
+	// name in this method (`c` in `func (c extensionCore) …`) and heldTx the
+	// fields carrying a pgx.Tx, so a call spelled `c.tx.Query(…)` is read as
+	// running on the borrowed transaction rather than as a second connection.
+	// Both empty for the parameter and callback shapes. recvType names the
+	// receiver's type, which is what lets the reach walk resolve a call on it.
+	recv     string
+	recvType string
+	heldTx   []string
 }
 
 // txBorrowingBodies answers every tx-borrowing body in one file, outermost
-// first.
-func txBorrowingBodies(file *ast.File) []txBorrowing {
+// first. `holders` names the receiver types in this file's PACKAGE that keep a
+// caller's transaction in a field, and the fields that carry it.
+func txBorrowingBodies(file *ast.File, holders map[string][]string) []txBorrowing {
 	pgxName, imported := pgxLocalName(file)
 	if !imported {
 		return nil
@@ -161,7 +184,9 @@ func txBorrowingBodies(file *ast.File) []txBorrowing {
 		if !ok || fn.Body == nil {
 			continue
 		}
-		add(fn.Name.Name, fn.Type.Params, fn.Body)
+		if !add(fn.Name.Name, fn.Type.Params, fn.Body) {
+			addHeldTxMethod(&out, fn, holders, pgxName)
+		}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			lit, ok := n.(*ast.FuncLit)
 			if !ok {
@@ -173,6 +198,121 @@ func txBorrowingBodies(file *ast.File) []txBorrowing {
 		})
 	}
 	return out
+}
+
+// addHeldTxMethod records a method whose RECEIVER holds the caller's
+// transaction, which is the same obligation reached a different way.
+//
+// It exists because a port can keep the transaction instead of passing it:
+// compose/extcore.go's extensionCore does, and every verb on it runs on that
+// field. Judged by the parameter rule alone the whole file was invisible, and
+// it did not stay hypothetical — the first version of that port read the
+// workspace's mode through a second pool acquire inside the caller's open
+// transaction, the exact deadlock this gate refuses, and the gate was green.
+// Review caught it; the class was still uncaught.
+func addHeldTxMethod(out *[]txBorrowing, fn *ast.FuncDecl, holders map[string][]string, pgxName string) {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return
+	}
+	fields, holds := holders[receiverTypeName(fn)]
+	if !holds {
+		return
+	}
+	// An unnamed or blank receiver cannot spell `c.tx`, so nothing in the body
+	// can be reading the held transaction and every acquirer found is a second
+	// connection. Judged with no receiver name rather than skipped.
+	var recv string
+	if names := fn.Recv.List[0].Names; len(names) > 0 && names[0].Name != "_" {
+		recv = names[0].Name
+	}
+	*out = append(*out, txBorrowing{
+		name:     receiverTypeName(fn) + "." + fn.Name.Name,
+		params:   fn.Type.Params,
+		body:     fn.Body,
+		pgxName:  pgxName,
+		recv:     recv,
+		recvType: receiverTypeName(fn),
+		heldTx:   fields,
+	})
+}
+
+// txHoldingReceivers indexes, per package directory, the struct types that keep
+// a pgx.Tx in a field and the fields that hold it.
+//
+// It walks the roots itself rather than reading the gate's own scope, and the
+// two reasons are the same reason. The scope is SELECTED by this answer, so
+// deriving it from the scope would be circular; and a type declared in one file
+// and given its verbs in another is the ordinary arrangement, which a per-file
+// answer would report PASS on. A census that can only see the tidy case has
+// already failed.
+func txHoldingReceivers(t *testing.T, roots []string) map[string]map[string][]string {
+	t.Helper()
+	tree := moduleRoot(t)
+	out := map[string]map[string][]string{}
+	fset := token.NewFileSet()
+	for _, root := range roots {
+		err := filepath.WalkDir(filepath.Join(tree, root),
+			func(p string, d fs.DirEntry, err error) error {
+				if err != nil || d.IsDir() || !strings.HasSuffix(p, ".go") ||
+					strings.HasSuffix(p, "_test.go") {
+					return err
+				}
+				file, parseErr := parser.ParseFile(fset, p, nil, 0)
+				if parseErr != nil {
+					return parseErr
+				}
+				rel, relErr := filepath.Rel(tree, p)
+				if relErr != nil {
+					return relErr
+				}
+				addTxHolders(out, filepath.ToSlash(filepath.Dir(rel)), file)
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("indexing %s for tx-holding receivers: %v", root, err)
+		}
+	}
+	return out
+}
+
+// addTxHolders records one file's struct types that hold a pgx.Tx.
+func addTxHolders(out map[string]map[string][]string, dir string, file *ast.File) {
+	pgxName, imported := pgxLocalName(file)
+	if !imported {
+		return
+	}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok || st.Fields == nil {
+				continue
+			}
+			var held []string
+			for _, field := range st.Fields.List {
+				if !isPgxTx(field.Type, pgxName) {
+					continue
+				}
+				for _, name := range field.Names {
+					held = append(held, name.Name)
+				}
+			}
+			if len(held) == 0 {
+				continue
+			}
+			if out[dir] == nil {
+				out[dir] = map[string][]string{}
+			}
+			out[dir][ts.Name.Name] = held
+		}
+	}
 }
 
 // pgxLocalName answers the name this file spells the pgx package under, and
@@ -255,9 +395,13 @@ func (b txBorrowing) acquires() []string {
 	return found
 }
 
-// receiverIsTheBorrowedTx reports whether a call's receiver is one of this
-// body's own pgx.Tx parameters.
+// receiverIsTheBorrowedTx reports whether a call's receiver is the transaction
+// this body borrowed: one of its own pgx.Tx parameters, or the field its
+// receiver holds one in.
 func (b txBorrowing) receiverIsTheBorrowedTx(recv ast.Expr) bool {
+	if sel, ok := recv.(*ast.SelectorExpr); ok {
+		return b.isHeldTxField(sel)
+	}
 	ident, ok := recv.(*ast.Ident)
 	if !ok {
 		return false
@@ -270,6 +414,25 @@ func (b txBorrowing) receiverIsTheBorrowedTx(recv ast.Expr) bool {
 			if name.Name == ident.Name {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// isHeldTxField reports whether `x.y` names the transaction this method's
+// receiver holds — `c.tx` in a method on extensionCore.
+//
+// Anchored on the RECEIVER's name and not on the field's alone: `other.tx` is a
+// different object's transaction, and reading it as this one's would wave
+// through a call on a handle this body never borrowed.
+func (b txBorrowing) isHeldTxField(sel *ast.SelectorExpr) bool {
+	base, ok := sel.X.(*ast.Ident)
+	if !ok || b.recv == "" || base.Name != b.recv {
+		return false
+	}
+	for _, field := range b.heldTx {
+		if sel.Sel.Name == field {
+			return true
 		}
 	}
 	return false
@@ -377,7 +540,7 @@ import "github.com/jackc/pgx/v5"
 // count.
 func assertGateReads(t *testing.T, src, body string, want ...string) {
 	t.Helper()
-	bodies := txBorrowingBodies(parseGateFixture(t, src))
+	bodies := txBorrowingBodies(parseGateFixture(t, src), nil)
 	for _, b := range bodies {
 		if b.name != body {
 			continue
@@ -406,7 +569,7 @@ func (s *Store) ClaimAndEnqueue(ctx context.Context, enqueue func(tx pgx.Tx) err
 	return s.claim(ctx, enqueue)
 }
 `
-	for _, b := range txBorrowingBodies(parseGateFixture(t, callbackTaker)) {
+	for _, b := range txBorrowingBodies(parseGateFixture(t, callbackTaker), nil) {
 		if b.name == "ClaimAndEnqueue" {
 			t.Fatal("a function whose only pgx.Tx is the type of a callback it accepts was judged as borrowing a transaction")
 		}
@@ -420,4 +583,132 @@ func parseGateFixture(t *testing.T, src string) *ast.File {
 		t.Fatalf("parsing the gate fixture: %v\n%s", err, strings.TrimSpace(src))
 	}
 	return file
+}
+
+// A port that HOLDS the caller's transaction is judged like one that takes it.
+//
+// This is the shape the parameter rule could not see, and it is not a
+// hypothetical one: compose/extcore.go's first version read the workspace's
+// record mode through a second pool acquire inside the caller's open
+// transaction — the deadlock this gate refuses — and the gate was green,
+// because no method on that receiver takes a pgx.Tx.
+func TestTheGateSeesAnAcquireInAMethodOnAReceiverHoldingTheTransaction(t *testing.T) {
+	t.Parallel()
+	const port = fixtureImports + `
+type core struct {
+	tx   pgx.Tx
+	pool *pgxpool.Pool
+}
+
+func (c core) RefuseOverlay(ctx context.Context) error {
+	conn, err := c.pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+	return readMode(ctx, conn)
+}
+`
+	assertHeldTxGateReads(t, port, "core.RefuseOverlay", "Acquire")
+}
+
+// The repair, one line apart: the same read on the transaction the receiver is
+// already holding. Without this case the one above would pass against a rule
+// that flagged every method on a tx-holding type, which would make the gate
+// unusable and get it waived rather than obeyed.
+func TestTheGateLeavesAMethodThatReadsTheHeldTransactionAlone(t *testing.T) {
+	t.Parallel()
+	const repaired = fixtureImports + `
+type core struct {
+	tx pgx.Tx
+}
+
+func (c core) RefuseOverlay(ctx context.Context) error {
+	return readMode(ctx, c.tx)
+}
+
+func (c core) Nested(ctx context.Context) error {
+	_, err := c.tx.Begin(ctx)
+	return err
+}
+`
+	assertHeldTxGateReads(t, repaired, "core.RefuseOverlay")
+	// `Begin` IS a registered acquirer, and on the borrowed handle it is a
+	// savepoint rather than a second connection — the same reasoning the
+	// parameter rule already applies to `tx.Begin`.
+	assertHeldTxGateReads(t, repaired, "core.Nested")
+}
+
+// Another object's transaction is not this body's to read. A rule keyed on the
+// FIELD name alone would wave `other.tx` through, which is a second connection
+// wearing the borrowed one's spelling.
+func TestTheGateReadsAnotherObjectsTransactionAsAnAcquire(t *testing.T) {
+	t.Parallel()
+	// `other` is a local, so the call reads `other.tx` — an identifier that is
+	// not this method's receiver. It is the shape the anchor exists for: a
+	// rule keyed on the field name alone reads it as the borrowed handle and
+	// waves the second connection through, and it is the ONLY shape that
+	// distinguishes the two rules — `c.other.tx` fails a receiver-name test
+	// for the unrelated reason that its base is not an identifier at all.
+	const foreign = fixtureImports + `
+type core struct {
+	tx pgx.Tx
+}
+
+func (c core) Read(ctx context.Context) error {
+	other := sibling()
+	_, err := other.tx.Begin(ctx)
+	return err
+}
+`
+	assertHeldTxGateReads(t, foreign, "core.Read", "Begin")
+}
+
+// assertHeldTxGateReads is assertGateReads for the receiver-held shape: the
+// holder index is derived from the fixture itself, exactly as the live gate
+// derives it from the package.
+func assertHeldTxGateReads(t *testing.T, src, body string, want ...string) {
+	t.Helper()
+	file := parseGateFixture(t, src)
+	holders := map[string]map[string][]string{}
+	addTxHolders(holders, ".", file)
+	bodies := txBorrowingBodies(file, holders["."])
+	for _, b := range bodies {
+		if b.name != body {
+			continue
+		}
+		got := b.acquires()
+		if len(got) != len(want) {
+			t.Fatalf("the gate read %v from %q, want %v", got, body, want)
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("the gate read %v from %q, want %v", got, body, want)
+			}
+		}
+		return
+	}
+	t.Fatalf("the gate found no body named %q in the fixture — it judged %d others", body, len(bodies))
+}
+
+// The rule has a live subject, and says so if it stops having one.
+//
+// Every case above is a fixture, and a widened rule that matches nothing in the
+// tree is a rule nobody is held to: it would report PASS over a tree it had
+// stopped reading, which is the one way a gate must not fail. This names the
+// port the widening was written for.
+func TestTheHeldTransactionRuleHasARealSubject(t *testing.T) {
+	t.Parallel()
+	holders := txHoldingReceivers(t, []string{"internal", "cmd"})
+	compose, ok := holders["internal/compose"]
+	if !ok {
+		t.Fatal("no receiver in internal/compose holds a pgx.Tx — the rule this file widened for reads nothing, and every case proving it is a fixture")
+	}
+	fields, held := compose["extensionCore"]
+	if !held {
+		t.Fatalf("extensionCore no longer holds a transaction; internal/compose holds %d other(s) that do — if the port was renamed, name the new one here", len(compose))
+	}
+	if len(fields) != 1 || fields[0] != "tx" {
+		t.Fatalf("extensionCore holds its transaction in %v, want [tx]", fields)
+	}
 }

--- a/backend/gates/txseamacquire_test.go
+++ b/backend/gates/txseamacquire_test.go
@@ -158,19 +158,40 @@ type txBorrowing struct {
 	// running on the borrowed transaction rather than as a second connection.
 	// Both empty for the parameter and callback shapes. recvType names the
 	// receiver's type, which is what lets the reach walk resolve a call on it.
+	// A heldTx entry of promotedTx means the type EMBEDS the transaction, so
+	// its methods are reached on the receiver itself.
 	recv     string
 	recvType string
 	heldTx   []string
+}
+
+// promotedTx is the heldTx entry for an EMBEDDED pgx.Tx, which has no field
+// name to spell: its methods are promoted onto the receiver.
+const promotedTx = ""
+
+// embedsTx reports whether this body's receiver embeds the transaction rather
+// than naming a field for it.
+func (b txBorrowing) embedsTx() bool {
+	for _, field := range b.heldTx {
+		if field == promotedTx {
+			return true
+		}
+	}
+	return false
 }
 
 // txBorrowingBodies answers every tx-borrowing body in one file, outermost
 // first. `holders` names the receiver types in this file's PACKAGE that keep a
 // caller's transaction in a field, and the fields that carry it.
 func txBorrowingBodies(file *ast.File, holders map[string][]string) []txBorrowing {
-	pgxName, imported := pgxLocalName(file)
-	if !imported {
-		return nil
-	}
+	// No early return on a file that does not import pgx. The parameter rule
+	// needs the import — a body cannot take a pgx.Tx without naming the package
+	// — but a METHOD on a receiver that holds one does not: it reads `c.tx` and
+	// mentions pgx nowhere. Returning here left every verb of a port whose type
+	// is declared in a SIBLING file invisible, which is the same blindness this
+	// rule was widened to remove, one file over. An absent import makes the
+	// parameter rule match nothing, which is the right answer for it.
+	pgxName, _ := pgxLocalName(file)
 	var out []txBorrowing
 	add := func(name string, params *ast.FieldList, body *ast.BlockStmt) bool {
 		if body == nil || !takesPgxTx(params, pgxName) {
@@ -184,7 +205,14 @@ func txBorrowingBodies(file *ast.File, holders map[string][]string) []txBorrowin
 		if !ok || fn.Body == nil {
 			continue
 		}
-		if !add(fn.Name.Name, fn.Type.Params, fn.Body) {
+		// Both rules, not one or the other. A method on a tx-holding receiver
+		// that ALSO takes a pgx.Tx borrows two, and recording it under the
+		// parameter rule alone left its receiver unknown — so its own `c.tx`
+		// read came back as a second connection, and the gate accused a body
+		// that was doing the right thing twice over.
+		if add(fn.Name.Name, fn.Type.Params, fn.Body) {
+			attachHeldTx(&out[len(out)-1], fn, holders)
+		} else {
 			addHeldTxMethod(&out, fn, holders, pgxName)
 		}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
@@ -214,26 +242,37 @@ func addHeldTxMethod(out *[]txBorrowing, fn *ast.FuncDecl, holders map[string][]
 	if fn.Recv == nil || len(fn.Recv.List) == 0 {
 		return
 	}
+	if _, holds := holders[receiverTypeName(fn)]; !holds {
+		return
+	}
+	body := txBorrowing{
+		name:    receiverTypeName(fn) + "." + fn.Name.Name,
+		params:  fn.Type.Params,
+		body:    fn.Body,
+		pgxName: pgxName,
+	}
+	attachHeldTx(&body, fn, holders)
+	*out = append(*out, body)
+}
+
+// attachHeldTx records which transaction a body's receiver holds, so a call on
+// it reads as the borrowed handle rather than as a second connection.
+//
+// An unnamed or blank receiver cannot spell `c.tx`, so nothing in the body can
+// be reading the held transaction and every acquirer found is a second
+// connection. Left with no receiver name rather than skipped.
+func attachHeldTx(body *txBorrowing, fn *ast.FuncDecl, holders map[string][]string) {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return
+	}
 	fields, holds := holders[receiverTypeName(fn)]
 	if !holds {
 		return
 	}
-	// An unnamed or blank receiver cannot spell `c.tx`, so nothing in the body
-	// can be reading the held transaction and every acquirer found is a second
-	// connection. Judged with no receiver name rather than skipped.
-	var recv string
+	body.recvType, body.heldTx = receiverTypeName(fn), fields
 	if names := fn.Recv.List[0].Names; len(names) > 0 && names[0].Name != "_" {
-		recv = names[0].Name
+		body.recv = names[0].Name
 	}
-	*out = append(*out, txBorrowing{
-		name:     receiverTypeName(fn) + "." + fn.Name.Name,
-		params:   fn.Type.Params,
-		body:     fn.Body,
-		pgxName:  pgxName,
-		recv:     recv,
-		recvType: receiverTypeName(fn),
-		heldTx:   fields,
-	})
 }
 
 // txHoldingReceivers indexes, per package directory, the struct types that keep
@@ -298,6 +337,15 @@ func addTxHolders(out map[string]map[string][]string, dir string, file *ast.File
 			var held []string
 			for _, field := range st.Fields.List {
 				if !isPgxTx(field.Type, pgxName) {
+					continue
+				}
+				if len(field.Names) == 0 {
+					// EMBEDDED. There is no field name to spell, and the
+					// transaction's own methods are promoted onto the receiver:
+					// the borrowed handle is reached as `c.Begin(…)`, which
+					// without this reads as a second connection taken by the
+					// very body already holding one.
+					held = append(held, promotedTx)
 					continue
 				}
 				for _, name := range field.Names {
@@ -405,6 +453,12 @@ func (b txBorrowing) receiverIsTheBorrowedTx(recv ast.Expr) bool {
 	ident, ok := recv.(*ast.Ident)
 	if !ok {
 		return false
+	}
+	// A receiver that EMBEDS the transaction reaches it by its own name: the
+	// promoted `c.Begin(…)` is a savepoint on the borrowed handle, not a
+	// connection taken beside it.
+	if b.recv != "" && ident.Name == b.recv && b.embedsTx() {
+		return true
 	}
 	for _, param := range b.params.List {
 		if !isPgxTx(param.Type, b.pgxName) {
@@ -711,4 +765,106 @@ func TestTheHeldTransactionRuleHasARealSubject(t *testing.T) {
 	if len(fields) != 1 || fields[0] != "tx" {
 		t.Fatalf("extensionCore holds its transaction in %v, want [tx]", fields)
 	}
+}
+
+// A port's VERBS may live in a file that never names pgx.
+//
+// A method on a tx-holding receiver reads `c.tx` and mentions the package
+// nowhere, so a file holding nothing but such methods has no pgx import — and
+// the walk used to return before consulting the holder index at all. Every verb
+// of a port whose type is declared in a sibling file was therefore invisible,
+// which is the blindness this rule was widened to remove, one file over.
+//
+// It was not hypothetical either: dropping that early return immediately found
+// project360's organization section reading the custom-field catalog inside the
+// page's own transaction, fixed in the same change.
+func TestTheGateJudgesAHolderMethodInAFileThatNeverNamesPgx(t *testing.T) {
+	t.Parallel()
+	const declaration = `package compose
+
+import "github.com/jackc/pgx/v5"
+
+type core struct {
+	tx   pgx.Tx
+	pool *pgxpool.Pool
+}
+`
+	// No pgx import: this file needs none, which is the whole point.
+	const verbs = `package compose
+
+func (c core) RefuseOverlay(ctx context.Context) error {
+	conn, err := c.pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+	return nil
+}
+`
+	holders := map[string]map[string][]string{}
+	addTxHolders(holders, ".", parseGateFixture(t, declaration))
+	bodies := txBorrowingBodies(parseGateFixture(t, verbs), holders["."])
+	if len(bodies) != 1 || bodies[0].name != "core.RefuseOverlay" {
+		t.Fatalf("the walk judged %d body/bodies in a file with no pgx import, want the one method on the holder", len(bodies))
+	}
+	if got := bodies[0].acquires(); len(got) != 1 || got[0] != "Acquire" {
+		t.Fatalf("the gate read %v, want [Acquire]", got)
+	}
+}
+
+// A method that holds a transaction AND takes one borrows two.
+//
+// Recorded under the parameter rule alone its receiver was unknown, so its own
+// `c.tx` read came back as a second connection: the gate accused a body that
+// was doing the right thing twice over. A false positive here is worse than the
+// hole it closes, because a gate that cries wolf gets waived.
+func TestTheGateReadsBothTransactionsOfAMethodThatHoldsAndTakesOne(t *testing.T) {
+	t.Parallel()
+	const both = fixtureImports + `
+type core struct {
+	tx pgx.Tx
+}
+
+func (c core) Reconcile(ctx context.Context, other pgx.Tx) error {
+	if _, err := c.tx.Begin(ctx); err != nil {
+		return err
+	}
+	_, err := other.Begin(ctx)
+	return err
+}
+`
+	assertHeldTxGateReads(t, both, "Reconcile")
+}
+
+// A receiver that EMBEDS the transaction reaches it by its own name.
+//
+// The census dropped it — an anonymous field has no `field.Names` — so the type
+// held nothing as far as the gate could see, and its verbs went unjudged. Worse
+// than absent: the promoted `c.Begin(…)` is a savepoint on the borrowed handle,
+// and once the type IS recognised, reading it as an acquire would accuse every
+// such method.
+func TestTheGateReadsAnEmbeddedTransactionAsTheBorrowedOne(t *testing.T) {
+	t.Parallel()
+	const embedded = fixtureImports + `
+type core struct {
+	pgx.Tx
+	pool *pgxpool.Pool
+}
+
+func (c core) Nested(ctx context.Context) error {
+	_, err := c.Begin(ctx)
+	return err
+}
+
+func (c core) Second(ctx context.Context) error {
+	conn, err := c.pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+	return nil
+}
+`
+	assertHeldTxGateReads(t, embedded, "core.Nested")
+	assertHeldTxGateReads(t, embedded, "core.Second", "Acquire")
 }

--- a/backend/gates/txseamacquire_test.go
+++ b/backend/gates/txseamacquire_test.go
@@ -91,7 +91,7 @@ func TestATxAcceptingFunctionAcquiresNoConnectionOfItsOwn(t *testing.T) {
 		// owns its own connection is not one.
 	})
 	roots := []string{"internal", "cmd"}
-	holders := txHoldingReceivers(t, roots)
+	holders, declared := txHoldingReceivers(t, roots)
 	scope := gatekit.Scope{
 		Roots: roots,
 		// A file holding any tx-borrowing body, by either rule. The parameter
@@ -102,7 +102,7 @@ func TestATxAcceptingFunctionAcquiresNoConnectionOfItsOwn(t *testing.T) {
 		// a subject rule that assumed so would report PASS the day somebody
 		// moves them apart.
 		Subject: func(p string, file *ast.File) bool {
-			return len(txBorrowingBodies(file, holders[path.Dir(p)])) > 0
+			return len(txBorrowingBodies(file, holders[path.Dir(p)], declared[path.Dir(p)])) > 0
 		},
 		Exempt: exempt,
 	}
@@ -111,7 +111,7 @@ func TestATxAcceptingFunctionAcquiresNoConnectionOfItsOwn(t *testing.T) {
 	index := indexPackageFunctions(t, roots)
 	for _, parsed := range scope.Files(t) {
 		dir := path.Dir(parsed.Path)
-		for _, body := range txBorrowingBodies(parsed.File, holders[dir]) {
+		for _, body := range txBorrowingBodies(parsed.File, holders[dir], declared[dir]) {
 			for _, found := range body.acquires() {
 				t.Errorf("%s: %s runs on a caller's pgx.Tx and then %s (%s) — fetch it before the "+
 					"transaction opens and thread the result in, as mergePersonTx and createDealTx do; "+
@@ -163,6 +163,9 @@ type txBorrowing struct {
 	recv     string
 	recvType string
 	heldTx   []string
+	// declares names the methods the receiver's type declares itself, so a
+	// declared name is not mistaken for a promoted one.
+	declares map[string]bool
 }
 
 // promotedTx is the heldTx entry for an EMBEDDED pgx.Tx, which has no field
@@ -195,7 +198,7 @@ func (b txBorrowing) embedsTx() bool {
 // txBorrowingBodies answers every tx-borrowing body in one file, outermost
 // first. `holders` names the receiver types in this file's PACKAGE that keep a
 // caller's transaction in a field, and the fields that carry it.
-func txBorrowingBodies(file *ast.File, holders map[string][]string) []txBorrowing {
+func txBorrowingBodies(file *ast.File, holders map[string][]string, declared map[string]map[string]bool) []txBorrowing {
 	// No early return on a file that does not import pgx. The parameter rule
 	// needs the import — a body cannot take a pgx.Tx without naming the package
 	// — but a METHOD on a receiver that holds one does not: it reads `c.tx` and
@@ -223,9 +226,9 @@ func txBorrowingBodies(file *ast.File, holders map[string][]string) []txBorrowin
 		// read came back as a second connection, and the gate accused a body
 		// that was doing the right thing twice over.
 		if add(fn.Name.Name, fn.Type.Params, fn.Body) {
-			attachHeldTx(&out[len(out)-1], fn, holders)
+			attachHeldTx(&out[len(out)-1], fn, holders, declared)
 		} else {
-			addHeldTxMethod(&out, fn, holders, pgxName)
+			addHeldTxMethod(&out, fn, holders, declared, pgxName)
 		}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			lit, ok := n.(*ast.FuncLit)
@@ -250,7 +253,7 @@ func txBorrowingBodies(file *ast.File, holders map[string][]string) []txBorrowin
 // workspace's mode through a second pool acquire inside the caller's open
 // transaction, the exact deadlock this gate refuses, and the gate was green.
 // Review caught it; the class was still uncaught.
-func addHeldTxMethod(out *[]txBorrowing, fn *ast.FuncDecl, holders map[string][]string, pgxName string) {
+func addHeldTxMethod(out *[]txBorrowing, fn *ast.FuncDecl, holders map[string][]string, declared map[string]map[string]bool, pgxName string) {
 	if fn.Recv == nil || len(fn.Recv.List) == 0 {
 		return
 	}
@@ -263,7 +266,7 @@ func addHeldTxMethod(out *[]txBorrowing, fn *ast.FuncDecl, holders map[string][]
 		body:    fn.Body,
 		pgxName: pgxName,
 	}
-	attachHeldTx(&body, fn, holders)
+	attachHeldTx(&body, fn, holders, declared)
 	*out = append(*out, body)
 }
 
@@ -273,7 +276,7 @@ func addHeldTxMethod(out *[]txBorrowing, fn *ast.FuncDecl, holders map[string][]
 // An unnamed or blank receiver cannot spell `c.tx`, so nothing in the body can
 // be reading the held transaction and every acquirer found is a second
 // connection. Left with no receiver name rather than skipped.
-func attachHeldTx(body *txBorrowing, fn *ast.FuncDecl, holders map[string][]string) {
+func attachHeldTx(body *txBorrowing, fn *ast.FuncDecl, holders map[string][]string, declared map[string]map[string]bool) {
 	if fn.Recv == nil || len(fn.Recv.List) == 0 {
 		return
 	}
@@ -282,6 +285,7 @@ func attachHeldTx(body *txBorrowing, fn *ast.FuncDecl, holders map[string][]stri
 		return
 	}
 	body.recvType, body.heldTx = receiverTypeName(fn), fields
+	body.declares = declared[receiverTypeName(fn)]
 	if names := fn.Recv.List[0].Names; len(names) > 0 && names[0].Name != "_" {
 		body.recv = names[0].Name
 	}
@@ -296,10 +300,11 @@ func attachHeldTx(body *txBorrowing, fn *ast.FuncDecl, holders map[string][]stri
 // and given its verbs in another is the ordinary arrangement, which a per-file
 // answer would report PASS on. A census that can only see the tidy case has
 // already failed.
-func txHoldingReceivers(t *testing.T, roots []string) map[string]map[string][]string {
+func txHoldingReceivers(t *testing.T, roots []string) (map[string]map[string][]string, map[string]map[string]map[string]bool) {
 	t.Helper()
 	tree := moduleRoot(t)
 	out := map[string]map[string][]string{}
+	declared := map[string]map[string]map[string]bool{}
 	fset := token.NewFileSet()
 	for _, root := range roots {
 		err := filepath.WalkDir(filepath.Join(tree, root),
@@ -316,14 +321,44 @@ func txHoldingReceivers(t *testing.T, roots []string) map[string]map[string][]st
 				if relErr != nil {
 					return relErr
 				}
-				addTxHolders(out, filepath.ToSlash(filepath.Dir(rel)), file)
+				dir := filepath.ToSlash(filepath.Dir(rel))
+				addTxHolders(out, dir, file)
+				addTxDeclaredMethods(declared, dir, file)
 				return nil
 			})
 		if err != nil {
 			t.Fatalf("indexing %s for tx-holding receivers: %v", root, err)
 		}
 	}
-	return out
+	return out, declared
+}
+
+// addTxDeclaredMethods records, per package directory, the method names each
+// type declares itself.
+//
+// It exists for the case a type that EMBEDS pgx.Tx creates by declaring its own
+// `Begin`. `c.Begin(…)` resolves to that method, not to the promoted
+// transaction's, so exempting it by name waves through an acquire wearing a
+// name this walk otherwise reads as a savepoint. A declared name wins over a
+// promoted one in Go, and this is what lets the walk say so.
+func addTxDeclaredMethods(out map[string]map[string]map[string]bool, dir string, file *ast.File) {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil {
+			continue
+		}
+		recv := receiverTypeName(fn)
+		if recv == "" {
+			continue
+		}
+		if out[dir] == nil {
+			out[dir] = map[string]map[string]bool{}
+		}
+		if out[dir][recv] == nil {
+			out[dir][recv] = map[string]bool{}
+		}
+		out[dir][recv][fn.Name.Name] = true
+	}
 }
 
 // addTxHolders records one file's struct types that hold a pgx.Tx.
@@ -467,12 +502,14 @@ func (b txBorrowing) receiverIsTheBorrowedTx(recv ast.Expr, called string) bool 
 		return false
 	}
 	// A receiver that EMBEDS the transaction reaches it by its own name — but
-	// only for pgx.Tx's OWN methods. `c.Begin(…)` on such a receiver is the
-	// promoted savepoint; `c.ActiveColumns(…)` is a method the embedding type
-	// declared, and waving it through because the receiver happens to embed a
-	// transaction would hide the acquire inside the one shape that looks most
-	// like a borrowed handle.
-	if b.recv != "" && ident.Name == b.recv && b.embedsTx() && promotedTxMethods[called] {
+	// only for pgx.Tx's OWN methods, and only where the type has not DECLARED
+	// one of that name itself. `c.Begin(…)` on such a receiver is the promoted
+	// savepoint; `c.ActiveColumns(…)` is a method the embedding type declared,
+	// and so is a `Begin` it declared, which in Go wins over the promoted one.
+	// Exempting either by name alone waves through an acquire wearing a name
+	// this walk otherwise reads as a savepoint.
+	if b.recv != "" && ident.Name == b.recv && b.embedsTx() &&
+		promotedTxMethods[called] && !b.declares[called] {
 		return true
 	}
 	for _, param := range b.params.List {
@@ -609,7 +646,7 @@ import "github.com/jackc/pgx/v5"
 // count.
 func assertGateReads(t *testing.T, src, body string, want ...string) {
 	t.Helper()
-	bodies := txBorrowingBodies(parseGateFixture(t, src), nil)
+	bodies := txBorrowingBodies(parseGateFixture(t, src), nil, nil)
 	for _, b := range bodies {
 		if b.name != body {
 			continue
@@ -638,7 +675,7 @@ func (s *Store) ClaimAndEnqueue(ctx context.Context, enqueue func(tx pgx.Tx) err
 	return s.claim(ctx, enqueue)
 }
 `
-	for _, b := range txBorrowingBodies(parseGateFixture(t, callbackTaker), nil) {
+	for _, b := range txBorrowingBodies(parseGateFixture(t, callbackTaker), nil, nil) {
 		if b.name == "ClaimAndEnqueue" {
 			t.Fatal("a function whose only pgx.Tx is the type of a callback it accepts was judged as borrowing a transaction")
 		}
@@ -740,8 +777,10 @@ func assertHeldTxGateReads(t *testing.T, src, body string, want ...string) {
 	t.Helper()
 	file := parseGateFixture(t, src)
 	holders := map[string]map[string][]string{}
+	declared := map[string]map[string]map[string]bool{}
 	addTxHolders(holders, ".", file)
-	bodies := txBorrowingBodies(file, holders["."])
+	addTxDeclaredMethods(declared, ".", file)
+	bodies := txBorrowingBodies(file, holders["."], declared["."])
 	for _, b := range bodies {
 		if b.name != body {
 			continue
@@ -768,7 +807,7 @@ func assertHeldTxGateReads(t *testing.T, src, body string, want ...string) {
 // port the widening was written for.
 func TestTheHeldTransactionRuleHasARealSubject(t *testing.T) {
 	t.Parallel()
-	holders := txHoldingReceivers(t, []string{"internal", "cmd"})
+	holders, _ := txHoldingReceivers(t, []string{"internal", "cmd"})
 	compose, ok := holders["internal/compose"]
 	if !ok {
 		t.Fatal("no receiver in internal/compose holds a pgx.Tx — the rule this file widened for reads nothing, and every case proving it is a fixture")
@@ -817,8 +856,11 @@ func (c core) RefuseOverlay(ctx context.Context) error {
 }
 `
 	holders := map[string]map[string][]string{}
+	declared := map[string]map[string]map[string]bool{}
 	addTxHolders(holders, ".", parseGateFixture(t, declaration))
-	bodies := txBorrowingBodies(parseGateFixture(t, verbs), holders["."])
+	verbsFile := parseGateFixture(t, verbs)
+	addTxDeclaredMethods(declared, ".", verbsFile)
+	bodies := txBorrowingBodies(verbsFile, holders["."], declared["."])
 	if len(bodies) != 1 || bodies[0].name != "core.RefuseOverlay" {
 		t.Fatalf("the walk judged %d body/bodies in a file with no pgx import, want the one method on the holder", len(bodies))
 	}
@@ -904,4 +946,39 @@ func (c core) Read(ctx context.Context) error {
 }
 `
 	assertHeldTxGateReads(t, shadowing, "core.Read", "activeColumns")
+}
+
+// A `Begin` the embedding type DECLARES is that method, not the promoted one.
+//
+// Go resolves a declared method over a promoted one, so `c.Begin(…)` here runs
+// the type's own — and exempting it by name would wave through an acquire
+// wearing a name this walk otherwise treats as a savepoint. That is the worst
+// place to leave a hole: a shape that reads as a borrowed handle.
+func TestTheGateJudgesADeclaredBeginOverThePromotedOne(t *testing.T) {
+	t.Parallel()
+	const shadowed = fixtureImports + `
+type core struct {
+	pgx.Tx
+	pool *pgxpool.Pool
+}
+
+func (c core) Begin(ctx context.Context) error {
+	conn, err := c.pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+	return nil
+}
+
+func (c core) Nested(ctx context.Context) error {
+	_, err := c.Begin(ctx)
+	return err
+}
+`
+	// The declaring method is judged on its own body, which takes a connection.
+	assertHeldTxGateReads(t, shadowed, "core.Begin", "Acquire")
+	// And its CALLER's `c.Begin(…)` is that method rather than a savepoint, so
+	// the promoted exemption does not apply to it either.
+	assertHeldTxGateReads(t, shadowed, "core.Nested", "Begin")
 }

--- a/backend/gates/txseamacquire_test.go
+++ b/backend/gates/txseamacquire_test.go
@@ -169,6 +169,18 @@ type txBorrowing struct {
 // name to spell: its methods are promoted onto the receiver.
 const promotedTx = ""
 
+// promotedTxMethods are the acquirer names that belong to pgx.Tx ITSELF, so a
+// call on a receiver embedding one is the borrowed handle rather than a method
+// the embedding type declared.
+//
+// Only Begin, because it is the only name in connectionAcquirers that pgx.Tx
+// has: the rest are the pool's, the bound handle's, or this tree's own catalog
+// reads, and a type embedding a transaction is as free to declare a method
+// called Acquire or activeColumns as any other. Read without this, an
+// embedding receiver made every acquirer on itself invisible — the one shape
+// that looks most like a borrowed handle hiding the defect best.
+var promotedTxMethods = map[string]bool{"Begin": true}
+
 // embedsTx reports whether this body's receiver embeds the transaction rather
 // than naming a field for it.
 func (b txBorrowing) embedsTx() bool {
@@ -421,7 +433,7 @@ func (b txBorrowing) acquires() []string {
 			if _, isAcquirer := connectionAcquirers[fn.Sel.Name]; !isAcquirer {
 				return true
 			}
-			if b.receiverIsTheBorrowedTx(fn.X) {
+			if b.receiverIsTheBorrowedTx(fn.X, fn.Sel.Name) {
 				return true
 			}
 			found = append(found, fn.Sel.Name)
@@ -446,7 +458,7 @@ func (b txBorrowing) acquires() []string {
 // receiverIsTheBorrowedTx reports whether a call's receiver is the transaction
 // this body borrowed: one of its own pgx.Tx parameters, or the field its
 // receiver holds one in.
-func (b txBorrowing) receiverIsTheBorrowedTx(recv ast.Expr) bool {
+func (b txBorrowing) receiverIsTheBorrowedTx(recv ast.Expr, called string) bool {
 	if sel, ok := recv.(*ast.SelectorExpr); ok {
 		return b.isHeldTxField(sel)
 	}
@@ -454,10 +466,13 @@ func (b txBorrowing) receiverIsTheBorrowedTx(recv ast.Expr) bool {
 	if !ok {
 		return false
 	}
-	// A receiver that EMBEDS the transaction reaches it by its own name: the
-	// promoted `c.Begin(…)` is a savepoint on the borrowed handle, not a
-	// connection taken beside it.
-	if b.recv != "" && ident.Name == b.recv && b.embedsTx() {
+	// A receiver that EMBEDS the transaction reaches it by its own name — but
+	// only for pgx.Tx's OWN methods. `c.Begin(…)` on such a receiver is the
+	// promoted savepoint; `c.ActiveColumns(…)` is a method the embedding type
+	// declared, and waving it through because the receiver happens to embed a
+	// transaction would hide the acquire inside the one shape that looks most
+	// like a borrowed handle.
+	if b.recv != "" && ident.Name == b.recv && b.embedsTx() && promotedTxMethods[called] {
 		return true
 	}
 	for _, param := range b.params.List {
@@ -867,4 +882,26 @@ func (c core) Second(ctx context.Context) error {
 `
 	assertHeldTxGateReads(t, embedded, "core.Nested")
 	assertHeldTxGateReads(t, embedded, "core.Second", "Acquire")
+}
+
+// An embedding type's OWN method is not the promoted transaction.
+//
+// `c.Begin(…)` on a receiver embedding pgx.Tx is that transaction's; `c.Tx(…)`
+// or `c.activeColumns(…)` is a method the type declared, and reading it as the
+// borrowed handle because the receiver happens to embed one would hide an
+// acquire inside the shape that looks most like a borrowed handle. Nothing
+// stops a type embedding a transaction from declaring either name.
+func TestTheGateJudgesAnEmbeddingTypesOwnMethodRatherThanPromotingIt(t *testing.T) {
+	t.Parallel()
+	const shadowing = fixtureImports + `
+type core struct {
+	pgx.Tx
+}
+
+func (c core) Read(ctx context.Context) error {
+	_, err := c.activeColumns(ctx, "person")
+	return err
+}
+`
+	assertHeldTxGateReads(t, shadowing, "core.Read", "activeColumns")
 }

--- a/backend/gates/txseamreach_test.go
+++ b/backend/gates/txseamreach_test.go
@@ -262,7 +262,14 @@ func (b txBorrowing) calledNames() []string {
 			// the receiver's TYPE is the method's own, so the name resolves to
 			// exactly one entry, keyed `Type.Method`. A field that happens to
 			// hold a function resolves to no entry and costs nothing.
-			if base, ok := fn.X.(*ast.Ident); ok && b.recvType != "" && base.Name == b.recv {
+			// `!bound[b.recv]` for the reason the bare-identifier branch
+			// above carries the same guard: a name this body binds itself is a
+			// VALUE, and `c := other` makes `c.mode()` a call on somebody
+			// else's object. Following it would walk into this type's method
+			// and report a deadlock in a body that has none, which is the one
+			// thing this walk's case for existing rests on not doing.
+			if base, ok := fn.X.(*ast.Ident); ok && b.recvType != "" &&
+				base.Name == b.recv && !bound[b.recv] {
 				names = append(names, b.recvType+"."+fn.Sel.Name)
 			}
 		}
@@ -644,4 +651,38 @@ func (s store) mode(ctx context.Context) error {
 }
 `
 	assertReaches(t, fixtureIndex(t, ordinary), "WriteTx")
+}
+
+// A local that SHADOWS the receiver's name is not the receiver.
+//
+// `c := other; c.mode()` is a call on somebody else's object, and following it
+// into this type's method reports a deadlock in a body that has none. The
+// bare-identifier branch has carried that guard since the walk was written; the
+// receiver path needed the same one.
+func TestTheWalkDoesNotFollowAShadowedReceiverName(t *testing.T) {
+	t.Parallel()
+	const shadowed = `package compose
+
+import "github.com/jackc/pgx/v5"
+
+type core struct {
+	tx   pgx.Tx
+	pool *pgxpool.Pool
+}
+
+func (c core) File(ctx context.Context) error {
+	c := somebodyElse()
+	return c.mode(ctx)
+}
+
+func (c core) mode(ctx context.Context) error {
+	conn, err := c.pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+	return nil
+}
+`
+	assertReaches(t, fixtureIndex(t, shadowed), "core.File")
 }

--- a/backend/gates/txseamreach_test.go
+++ b/backend/gates/txseamreach_test.go
@@ -268,6 +268,15 @@ func (b txBorrowing) calledNames() []string {
 			// else's object. Following it would walk into this type's method
 			// and report a deadlock in a body that has none, which is the one
 			// thing this walk's case for existing rests on not doing.
+			//
+			// locallyBound over-collects — a name bound ANYWHERE in the body is
+			// bound throughout it — so a method that writes `for _, c := range …`
+			// once loses the follow for every `c.method()` in it. That is a
+			// MISS, and it is the direction chosen on purpose here as it is
+			// there: the alternative to losing a call is accusing a body that
+			// does not have the defect, and a gate that cries wolf gets deleted.
+			// Block scoping would need the type information this walk
+			// deliberately does without.
 			if base, ok := fn.X.(*ast.Ident); ok && b.recvType != "" &&
 				base.Name == b.recv && !bound[b.recv] {
 				names = append(names, b.recvType+"."+fn.Sel.Name)

--- a/backend/gates/txseamreach_test.go
+++ b/backend/gates/txseamreach_test.go
@@ -73,12 +73,22 @@ import (
 type declaredFunc struct {
 	decl    *ast.FuncDecl
 	pgxName string
+	// recv, recvType and heldTx carry the receiver-held shape into the walk, so
+	// a method reached through a chain is judged with the same knowledge as one
+	// reached directly — otherwise a read of its OWN borrowed `c.tx` would be
+	// reported as a second connection the moment something called it.
+	recv     string
+	recvType string
+	heldTx   []string
 }
 
 // funcIndex maps directory → function name → the declarations with that name.
 //
-// Keyed by directory because that is a Go package. It holds only RECEIVER-LESS
-// functions, because a bare identifier is the only call this walk follows and a
+// Keyed by directory because that is a Go package. Receiver-less functions are
+// keyed by their bare name, and a METHOD by `Type.Method` — a key no bare-name
+// lookup can reach, which is what keeps the two vocabularies from colliding.
+//
+// It held only receiver-less functions, because a bare identifier is the only call this walk follows and a
 // bare identifier cannot reach a method: Go requires `s.StageSemantic(…)` for
 // one, never `StageSemantic(…)`. Indexing methods too is not a wider net, it is
 // a wrong one — `deals` has both a `StageSemantic` string type and a
@@ -107,6 +117,7 @@ const indexedFunctionFloor = 2000
 func indexPackageFunctions(t *testing.T, roots []string) funcIndex {
 	t.Helper()
 	tree := moduleRoot(t)
+	holders := txHoldingReceivers(t, roots)
 	idx := funcIndex{}
 	fset := token.NewFileSet()
 	counted := 0
@@ -125,7 +136,8 @@ func indexPackageFunctions(t *testing.T, roots []string) funcIndex {
 				if relErr != nil {
 					return relErr
 				}
-				counted += idx.add(filepath.ToSlash(filepath.Dir(rel)), file)
+				dir := filepath.ToSlash(filepath.Dir(rel))
+				counted += idx.add(dir, file, holders[dir])
 				return nil
 			})
 		if err != nil {
@@ -140,20 +152,41 @@ func indexPackageFunctions(t *testing.T, roots []string) funcIndex {
 	return idx
 }
 
-// add records one file's package-level functions, answering how many.
-func (idx funcIndex) add(dir string, file *ast.File) int {
+// add records one file's package-level functions and the methods of its
+// tx-holding receivers, answering how many.
+func (idx funcIndex) add(dir string, file *ast.File, holders map[string][]string) int {
 	pgxName, _ := pgxLocalName(file)
 	added := 0
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil || fn.Recv != nil {
+		if !ok || fn.Body == nil {
 			continue
+		}
+		entry := declaredFunc{decl: fn, pgxName: pgxName}
+		key := fn.Name.Name
+		if fn.Recv != nil {
+			// Only the methods of a receiver that HOLDS a transaction. Every
+			// other method is out of the walk's reach for the reason
+			// calledNames gives at length: a selector call cannot be resolved
+			// to a type without type information, so following one by name is
+			// a different question than the one being asked. A held-tx
+			// receiver is the exception because the type IS known — it is the
+			// caller's own — so `c.helper()` resolves to exactly one entry.
+			recvType := receiverTypeName(fn)
+			fields, held := holders[recvType]
+			if !held {
+				continue
+			}
+			entry.recvType, entry.heldTx = recvType, fields
+			if names := fn.Recv.List[0].Names; len(names) > 0 && names[0].Name != "_" {
+				entry.recv = names[0].Name
+			}
+			key = recvType + "." + fn.Name.Name
 		}
 		if idx[dir] == nil {
 			idx[dir] = map[string][]declaredFunc{}
 		}
-		idx[dir][fn.Name.Name] = append(idx[dir][fn.Name.Name],
-			declaredFunc{decl: fn, pgxName: pgxName})
+		idx[dir][key] = append(idx[dir][key], entry)
 		added++
 	}
 	return added
@@ -172,7 +205,10 @@ func (idx funcIndex) reachesAcquirer(dir, name string, seen map[string]bool) ([]
 	}
 	seen[key] = true
 	for _, fn := range idx[dir][name] {
-		body := txBorrowing{name: name, params: fn.decl.Type.Params, body: fn.decl.Body, pgxName: fn.pgxName}
+		body := txBorrowing{
+			name: name, params: fn.decl.Type.Params, body: fn.decl.Body, pgxName: fn.pgxName,
+			recv: fn.recv, recvType: fn.recvType, heldTx: fn.heldTx,
+		}
 		if found := body.acquires(); len(found) > 0 {
 			return []string{name, found[0]}, true
 		}
@@ -213,8 +249,22 @@ func (b txBorrowing) calledNames() []string {
 		if !ok {
 			return true
 		}
-		if fn, ok := call.Fun.(*ast.Ident); ok && !bound[fn.Name] {
-			names = append(names, fn.Name)
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			if !bound[fn.Name] {
+				names = append(names, fn.Name)
+			}
+		case *ast.SelectorExpr:
+			// The one selector this walk resolves: a call on the receiver of a
+			// method whose receiver holds the transaction. It is not the
+			// excluded case above — that one cannot tell `e.blob.Delete` from
+			// `PolicyStore.Delete` because nothing says what `e.blob` is. Here
+			// the receiver's TYPE is the method's own, so the name resolves to
+			// exactly one entry, keyed `Type.Method`. A field that happens to
+			// hold a function resolves to no entry and costs nothing.
+			if base, ok := fn.X.(*ast.Ident); ok && b.recvType != "" && base.Name == b.recv {
+				names = append(names, b.recvType+"."+fn.Sel.Name)
+			}
 		}
 		return true
 	})
@@ -311,8 +361,18 @@ func moduleRoot(t *testing.T) string {
 func fixtureIndex(t *testing.T, sources ...string) funcIndex {
 	t.Helper()
 	idx := funcIndex{}
+	holders := map[string]map[string][]string{}
+	parsed := make([]*ast.File, 0, len(sources))
 	for _, src := range sources {
-		idx.add("fixture", parseGateFixture(t, src))
+		file := parseGateFixture(t, src)
+		parsed = append(parsed, file)
+		// The holder pass first and over ALL the sources, exactly as the live
+		// index does it: a type declared in one fixture file and given verbs in
+		// another is the arrangement a per-file answer would miss.
+		addTxHolders(holders, "fixture", file)
+	}
+	for _, file := range parsed {
+		idx.add("fixture", file, holders["fixture"])
 	}
 	return idx
 }
@@ -490,4 +550,98 @@ func outer(ctx context.Context, s *Store) error {
 func inner(ctx context.Context, s *Store) error { return s.db.Tx(ctx, nil) }
 `
 	assertReaches(t, fixtureIndex(t, genuine), "outer", "outer", "inner", "Tx")
+}
+
+// A verb on a tx-holding port reaches the pool through a SIBLING METHOD.
+//
+// This is the second half of what the parameter rule could not see. The verb
+// itself takes no connection; the helper beside it does, and both run inside
+// the caller's transaction. Following it is safe here for the reason the bare
+// selector rule is not followed anywhere else: the receiver's type is the
+// method's own, so `c.mode()` resolves to one entry and not to every `mode`
+// in the package.
+func TestTheWalkFollowsASiblingMethodOfATxHoldingReceiver(t *testing.T) {
+	t.Parallel()
+	const port = `package compose
+
+import "github.com/jackc/pgx/v5"
+
+type core struct {
+	tx   pgx.Tx
+	pool *pgxpool.Pool
+}
+
+func (c core) File(ctx context.Context) error {
+	if err := c.mode(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c core) mode(ctx context.Context) error {
+	conn, err := c.pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+	return nil
+}
+`
+	assertReaches(t, fixtureIndex(t, port), "core.File", "core.File", "core.mode", "Acquire")
+}
+
+// And the sibling's own read of the HELD transaction is left alone. Without
+// this the case above would pass against a walk that flagged every method it
+// followed, which would make the widening a source of false findings rather
+// than a gate.
+func TestTheWalkLeavesASiblingReadingTheHeldTransactionAlone(t *testing.T) {
+	t.Parallel()
+	const port = `package compose
+
+import "github.com/jackc/pgx/v5"
+
+type core struct {
+	tx pgx.Tx
+}
+
+func (c core) File(ctx context.Context) error {
+	return c.mode(ctx)
+}
+
+func (c core) mode(ctx context.Context) error {
+	_, err := c.tx.Begin(ctx)
+	return err
+}
+`
+	assertReaches(t, fixtureIndex(t, port), "core.File")
+}
+
+// A method on a receiver that holds NO transaction is not followed at all —
+// the excluded selector case, unchanged. `e.blob.Delete` and
+// `PolicyStore.Delete` are still two questions this walk cannot tell apart,
+// and the widening does not pretend otherwise.
+func TestTheWalkStillDoesNotFollowAnOrdinaryReceiversMethod(t *testing.T) {
+	t.Parallel()
+	const ordinary = `package compose
+
+import "github.com/jackc/pgx/v5"
+
+type store struct {
+	pool *pgxpool.Pool
+}
+
+func (s store) WriteTx(ctx context.Context, tx pgx.Tx) error {
+	return s.mode(ctx)
+}
+
+func (s store) mode(ctx context.Context) error {
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+	return nil
+}
+`
+	assertReaches(t, fixtureIndex(t, ordinary), "WriteTx")
 }

--- a/backend/gates/txseamreach_test.go
+++ b/backend/gates/txseamreach_test.go
@@ -80,6 +80,11 @@ type declaredFunc struct {
 	recv     string
 	recvType string
 	heldTx   []string
+	// declares names the methods recvType declares itself. It rides along for
+	// the same reason heldTx does: attachHeldTx's promoted-method exemption
+	// consults it, and a walk that left it nil would answer a different
+	// question about the same body than the direct gate next door does.
+	declares map[string]bool
 }
 
 // funcIndex maps directory → function name → the declarations with that name.
@@ -117,7 +122,7 @@ const indexedFunctionFloor = 2000
 func indexPackageFunctions(t *testing.T, roots []string) funcIndex {
 	t.Helper()
 	tree := moduleRoot(t)
-	holders, _ := txHoldingReceivers(t, roots)
+	holders, declared := txHoldingReceivers(t, roots)
 	idx := funcIndex{}
 	fset := token.NewFileSet()
 	counted := 0
@@ -137,7 +142,7 @@ func indexPackageFunctions(t *testing.T, roots []string) funcIndex {
 					return relErr
 				}
 				dir := filepath.ToSlash(filepath.Dir(rel))
-				counted += idx.add(dir, file, holders[dir])
+				counted += idx.add(dir, file, holders[dir], declared[dir])
 				return nil
 			})
 		if err != nil {
@@ -154,7 +159,9 @@ func indexPackageFunctions(t *testing.T, roots []string) funcIndex {
 
 // add records one file's package-level functions and the methods of its
 // tx-holding receivers, answering how many.
-func (idx funcIndex) add(dir string, file *ast.File, holders map[string][]string) int {
+func (idx funcIndex) add(dir string, file *ast.File,
+	holders map[string][]string, declared map[string]map[string]bool,
+) int {
 	pgxName, _ := pgxLocalName(file)
 	added := 0
 	for _, decl := range file.Decls {
@@ -178,6 +185,7 @@ func (idx funcIndex) add(dir string, file *ast.File, holders map[string][]string
 				continue
 			}
 			entry.recvType, entry.heldTx = recvType, fields
+			entry.declares = declared[recvType]
 			if names := fn.Recv.List[0].Names; len(names) > 0 && names[0].Name != "_" {
 				entry.recv = names[0].Name
 			}
@@ -207,7 +215,7 @@ func (idx funcIndex) reachesAcquirer(dir, name string, seen map[string]bool) ([]
 	for _, fn := range idx[dir][name] {
 		body := txBorrowing{
 			name: name, params: fn.decl.Type.Params, body: fn.decl.Body, pgxName: fn.pgxName,
-			recv: fn.recv, recvType: fn.recvType, heldTx: fn.heldTx,
+			recv: fn.recv, recvType: fn.recvType, heldTx: fn.heldTx, declares: fn.declares,
 		}
 		if found := body.acquires(); len(found) > 0 {
 			return []string{name, found[0]}, true
@@ -378,17 +386,19 @@ func fixtureIndex(t *testing.T, sources ...string) funcIndex {
 	t.Helper()
 	idx := funcIndex{}
 	holders := map[string]map[string][]string{}
+	declared := map[string]map[string]map[string]bool{}
 	parsed := make([]*ast.File, 0, len(sources))
 	for _, src := range sources {
 		file := parseGateFixture(t, src)
 		parsed = append(parsed, file)
-		// The holder pass first and over ALL the sources, exactly as the live
-		// index does it: a type declared in one fixture file and given verbs in
+		// Both passes first and over ALL the sources, exactly as the live index
+		// does it: a type declared in one fixture file and given verbs in
 		// another is the arrangement a per-file answer would miss.
 		addTxHolders(holders, "fixture", file)
+		addTxDeclaredMethods(declared, "fixture", file)
 	}
 	for _, file := range parsed {
-		idx.add("fixture", file, holders["fixture"])
+		idx.add("fixture", file, holders["fixture"], declared["fixture"])
 	}
 	return idx
 }
@@ -630,6 +640,45 @@ func (c core) mode(ctx context.Context) error {
 }
 `
 	assertReaches(t, fixtureIndex(t, port), "core.File")
+}
+
+// An EMBEDDING receiver's promoted `Begin` is the borrowed transaction's own
+// savepoint; a `Begin` the type declared itself is not, and in Go the declared
+// one is what `c.Begin(…)` resolves to.
+//
+// The walk needs the type's declared-method census to tell those apart, and it
+// is here because the walk was built without it: it read every `c.Begin(…)` on
+// an embedding receiver as the promoted savepoint and waved this body through,
+// while the direct gate beside it — judging the same body with the census in
+// hand — reported it. Two answers to one question, and the gate's own fixtures
+// would not have shown the disagreement.
+func TestTheWalkReadsADeclaredBeginOnAnEmbeddingReceiverAsAnAcquire(t *testing.T) {
+	t.Parallel()
+	const declaredBegin = `package compose
+
+import "github.com/jackc/pgx/v5"
+
+type core struct {
+	pgx.Tx
+	pool *pgxpool.Pool
+}
+
+func (c core) File(ctx context.Context) error {
+	return c.open(ctx)
+}
+
+func (c core) open(ctx context.Context) error {
+	_, err := c.Begin(ctx)
+	return err
+}
+
+// Declared, so it shadows the embedded transaction's promoted Begin — and it
+// takes a connection of its own.
+func (c core) Begin(ctx context.Context) (pgx.Tx, error) {
+	return c.pool.Begin(ctx)
+}
+`
+	assertReaches(t, fixtureIndex(t, declaredBegin), "core.File", "core.File", "core.open", "Begin")
 }
 
 // A method on a receiver that holds NO transaction is not followed at all —

--- a/backend/gates/txseamreach_test.go
+++ b/backend/gates/txseamreach_test.go
@@ -117,7 +117,7 @@ const indexedFunctionFloor = 2000
 func indexPackageFunctions(t *testing.T, roots []string) funcIndex {
 	t.Helper()
 	tree := moduleRoot(t)
-	holders := txHoldingReceivers(t, roots)
+	holders, _ := txHoldingReceivers(t, roots)
 	idx := funcIndex{}
 	fset := token.NewFileSet()
 	counted := 0

--- a/backend/internal/compose/extcore.go
+++ b/backend/internal/compose/extcore.go
@@ -37,13 +37,14 @@ import (
 // the unit's own row and the core record it writes are in the same transaction,
 // so they commit together or not at all.
 type extensionCore struct {
-	// tx is the CALLER's transaction, held rather than taken as a parameter —
-	// which is also why this file is outside what backend/gates/txseamacquire_test.go
-	// can see. That gate walks functions that TAKE a pgx.Tx; nothing here does,
-	// so a verb added below that reaches for a connection of its own would pass
-	// it green and deadlock under a saturated pool. It happened once already in
-	// this file's own history. Every verb runs on this handle and asks for
-	// nothing else.
+	// tx is the CALLER's transaction, held rather than taken as a parameter.
+	// Every verb runs on this handle and asks for nothing else: a second
+	// connection taken inside somebody's open transaction commits separately
+	// and deadlocks undetectably against a lock that transaction holds. It
+	// happened once in this file's own history, and the field is what
+	// backend/gates/txseamacquire_test.go now reads to judge the verbs below —
+	// it walks a receiver holding a pgx.Tx as well as a function taking one, so
+	// a verb added here that reaches for the pool fails that gate.
 	tx pgx.Tx
 	// authority re-binds the INVOCATION's workspace, actor, correlation and
 	// attribution onto whatever context a verb is handed. It is the Runtime's

--- a/backend/internal/compose/project360/assemble.go
+++ b/backend/internal/compose/project360/assemble.go
@@ -90,7 +90,21 @@ func (s *Service) readCatalogs(ctx context.Context) (catalogs, error) {
 	if c.deal, err = s.deals.ActiveDealColumns(ctx); err != nil {
 		return catalogs{}, err
 	}
-	if c.organization, err = s.people.ActiveOrganizationColumns(ctx); err != nil {
+	// The organization catalog is read HERE like the two above, and a caller
+	// without the organization grant is not refused the page for it.
+	//
+	// That read is gated on organization:read — the same grant the section
+	// itself is gated on — so a refusal here is not news: readOrganization
+	// still asks, still refuses, and the assembly still omits the section and
+	// names it. Propagating it would turn a NARROWED page into a refused one
+	// for every reader who may see the project and not its company.
+	//
+	// Only a denial is swallowed. Any other failure is a real one, and empty
+	// columns handed to a caller who does hold the grant would silently drop
+	// the company's custom fields from the page.
+	switch c.organization, err = s.people.ActiveOrganizationColumns(ctx); {
+	case err == nil, errors.Is(err, apperrors.ErrPermissionDenied):
+	default:
 		return catalogs{}, err
 	}
 	return c, nil

--- a/backend/internal/compose/project360/assemble.go
+++ b/backend/internal/compose/project360/assemble.go
@@ -72,6 +72,13 @@ func NewService(
 type catalogs struct {
 	project projects.CustomColumns
 	deal    deals.CustomColumns
+	// organization is here for the same reason as the two above and was
+	// missing: the organization section read the catalog itself, from inside
+	// the page's transaction, which is a second connection taken while this
+	// one is held. Under a loaded pool that waits on the connection it is
+	// already inside — a deadlock Postgres cannot break, because it sees two
+	// unrelated sessions rather than one goroutine waiting on itself.
+	organization people.CustomColumns
 }
 
 func (s *Service) readCatalogs(ctx context.Context) (catalogs, error) {
@@ -81,6 +88,9 @@ func (s *Service) readCatalogs(ctx context.Context) (catalogs, error) {
 		return catalogs{}, err
 	}
 	if c.deal, err = s.deals.ActiveDealColumns(ctx); err != nil {
+		return catalogs{}, err
+	}
+	if c.organization, err = s.people.ActiveOrganizationColumns(ctx); err != nil {
 		return catalogs{}, err
 	}
 	return c, nil

--- a/backend/internal/compose/project360/sections.go
+++ b/backend/internal/compose/project360/sections.go
@@ -35,12 +35,11 @@ func (a *assembly) readOrganization() error {
 	if a.out.Project.OrganizationId == nil {
 		return apperrors.ErrPermissionDenied
 	}
-	active, err := a.svc.people.ActiveOrganizationColumns(a.ctx)
-	if err != nil {
-		return err
-	}
 	orgID := ids.From[ids.OrganizationKind](ids.UUID(*a.out.Project.OrganizationId))
-	org, err := a.svc.people.GetOrganizationTx(a.ctx, a.tx, orgID, storekit.LiveOnly, active)
+	// The catalog comes from ABOVE the transaction, like the project's and the
+	// deal's. Read here it opened a connection of its own while this one held
+	// the page's transaction.
+	org, err := a.svc.people.GetOrganizationTx(a.ctx, a.tx, orgID, storekit.LiveOnly, a.cats.organization)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #1095.

`backend/gates/txseamacquire_test.go` derives its subjects from functions that **take** a `pgx.Tx`. `internal/compose/extcore.go` holds the caller's transaction in a struct **field** and every verb runs on it, so the whole file was outside the gate's reach — and the class still was, whatever that file did next.

Not hypothetical: the first version of that port read the workspace's record mode through a second pool acquire **inside the caller's open transaction** — the exact deadlock the gate exists to refuse — and the gate was green. Review caught the instance (#1092); nothing caught the class.

The ticket offered two closures. This is the first: extend the subject rule to a receiver holding a `pgx.Tx`, and the acquirer walk to the methods on it.

## What the gate now sees

**The subject rule** covers a method whose receiver holds a `pgx.Tx` field, and the walk knows what that means: a call on the held field is the borrowed transaction, exactly as a call on a `pgx.Tx` parameter is — so `c.tx.Begin(ctx)` stays a savepoint rather than becoming a finding.

**The receiver's name anchors it.** A rule keyed on the field name alone reads *another object's* `tx` as this body's own and waves a second connection through. That case has its own fixture, and it took a second attempt to write: `c.other.tx` fails a receiver-name test for the unrelated reason that its base is not an identifier, so it does not distinguish the two rules. `other := sibling(); other.tx.Begin(…)` does, and it is the case the anchor exists for.

**The reach walk follows a sibling method** of such a receiver, which is where the port's own helpers live — a verb that takes no connection, calling one beside it that does.

That is the **one** selector this walk resolves, and it is deliberately not the case `calledNames` excludes at length. That exclusion is measured, not feared — an earlier draft produced seventeen findings, all false, because `e.blob.Delete` cannot be told from `PolicyStore.Delete` without type information. Here the receiver's type is the **method's own**, so `c.mode()` resolves to exactly one entry, keyed `Type.Method` — a key no bare-name lookup can reach. Methods of receivers that hold no transaction are still not indexed at all.

**The holder index walks the roots itself** rather than reading the gate's scope, for two reasons that are the same reason: the scope is *selected* by that answer, so deriving it from the scope would be circular; and a type declared in one file with its verbs in another is the ordinary arrangement, which a per-file answer would report PASS on.

## Guarding the widening

Six cases, in the file's existing "Guarding the gate" style — each a shape the gate had to start seeing, or a false positive it must not produce:

| case | asserts |
|---|---|
| an acquire in a method on a tx-holding receiver | the finding, naming `Acquire` |
| the repair — the same read on `c.tx` | clean, and `c.tx.Begin` stays clean |
| another object's transaction, reached through a local | a finding: the anchor is doing work |
| a sibling method that acquires | the chain `core.File → core.mode → Acquire` |
| that sibling's own read of the held transaction | clean |
| an ordinary receiver's method | still not followed |

Plus `TestTheHeldTransactionRuleHasARealSubject`, which fails if the rule ever stops matching anything in the tree — every case above is a fixture, and a widened rule matching nothing would report PASS over a tree it had stopped reading.

**Mutation checks**, each killing its own case and no other:

| mutation | killed |
|---|---|
| drop the held-receiver subject rule | all three held-tx gate cases |
| stop reading `c.tx` as the borrowed handle | the repair case |
| drop the receiver-name anchor | another-object's-transaction |

`extensionCore.tx`'s comment said the file was outside the gate's reach. It now says what the gate reads and what fails.

`make check-backend` green.