### PR TITLE
fix(capture): a company names its primary domain, and a new contact's first mail is read

### DIFF
--- a/backend/cmd/worker/captureenrichtrigger.go
+++ b/backend/cmd/worker/captureenrichtrigger.go
@@ -19,9 +19,10 @@ import (
 	"github.com/margince/margince/backend/internal/platform/jobs"
 )
 
-// startCaptureEnrichTrigger starts the cg:capture-enrich consumer: mail landing
-// queues the workspace's signature pass now, instead of leaving a contact who
-// wrote this morning to be read tonight.
+// startCaptureEnrichTrigger starts the cg:capture-enrich consumer: mail landing,
+// a contact appearing, or a message opening queues the workspace's signature
+// pass now, instead of leaving a contact who wrote this morning to be read
+// tonight.
 //
 // Started only where the enrich lane exists, which the caller decides. River
 // DISCARDS a job whose kind no worker claims rather than holding it, and a
@@ -40,7 +41,7 @@ func startCaptureEnrichTrigger(ctx context.Context, pool *pgxpool.Pool, rdb *red
 		return fmt.Errorf("worker: the capture-enrich trigger inserter: %w", err)
 	}
 	trigger := compose.NewCaptureEnrichTrigger(pool, inserter, logger)
-	_, _ = fmt.Fprintln(stdout, "worker queueing signature passes as mail lands (cg:capture-enrich)")
+	_, _ = fmt.Fprintln(stdout, "worker queueing signature passes as mail lands and as contacts appear (cg:capture-enrich)")
 	background.Go(func() { runSubscriber(ctx, rdb, "cg:capture-enrich", trigger.HandleEvent, logger, 0) })
 	return nil
 }

--- a/backend/internal/compose/captureenrichtrigger.go
+++ b/backend/internal/compose/captureenrichtrigger.go
@@ -21,6 +21,26 @@ package compose
 // pass owns the gates — the per-mailbox setting, the model budget, the read
 // watermark — and re-derives who is due, so this consumer cannot become a
 // second spelling of that decision and a burst of mail collapses onto one job.
+//
+// THREE DOORS, because mail arriving is not the only way somebody becomes
+// readable. The pass selects a person joined to their own open inbound mail, so
+// either half of that pair can be the thing that was missing:
+//
+//   - the mail arrives (activity.captured), the ordinary case;
+//   - the PERSON arrives (person.created). A sender nobody had classified yet
+//     has no contact while their mail lands, so the capture door queues a pass
+//     that cannot see them. The counterparty verdict mints them ten minutes
+//     later and that mail becomes readable at exactly that moment — which is
+//     the FIRST mail from a new correspondent, the one most likely to carry a
+//     full signature block. Without this door nothing queues a pass, and the
+//     24-hour reconciler is what eventually reads them;
+//   - the mail OPENS (activity.updated naming a workspace audience). A message
+//     held while its thread awaited a confidentiality answer is not signature
+//     material — the pass reads open mail only — and the verdict that opens it
+//     writes that event through the derivation.
+//
+// All three queue the same deduplicated pass, so a verdict that both mints a
+// person and opens their mail costs one job rather than two.
 
 import (
 	"context"
@@ -47,6 +67,13 @@ import (
 // delivery lag while excluding any replayed backlog.
 const captureEnrichFreshWindow = time.Hour
 
+// enrichableKind is the one activity kind that can carry a signature block.
+//
+// Its own constant rather than the CSV surface's fieldEmail, which happens to
+// hold the same word for a column header: two unrelated vocabularies sharing one
+// name is how a rename in either silently changes the other.
+const enrichableKind = "email"
+
 // CaptureEnrichTrigger queues one signature-enrich pass per captured email.
 type CaptureEnrichTrigger struct {
 	pool    *pgxpool.Pool
@@ -59,6 +86,52 @@ func NewCaptureEnrichTrigger(pool *pgxpool.Pool, enqueue *jobs.Runner, log *slog
 	return &CaptureEnrichTrigger{pool: pool, enqueue: enqueue, log: log}
 }
 
+// queues answers whether this envelope can have made somebody newly readable.
+//
+// An unreadable payload answers no rather than guessing: the reconciler covers
+// whatever the event announced, and a consumer that wedged its group on one
+// malformed body would stop reading every later one.
+func (g *CaptureEnrichTrigger) queues(ctx context.Context, env events.Envelope) bool {
+	switch env.Type {
+	case "activity.captured":
+		// EMAIL only, decided before anything is queued. The signature pass
+		// reads a mail's trailing lines and nothing else can carry a signature
+		// block, so a meeting or a call would queue a model-backed pass that has
+		// no work to do — this consumer's whole job is promptness, and paying
+		// for a pass per logged call is not that.
+		var payload crmcontracts.PublicEventActivityCaptured
+		if err := json.Unmarshal(env.Payload, &payload); err != nil {
+			g.log.WarnContext(ctx, "capture enrich trigger: unreadable capture payload",
+				"event", env.EventID.String(), "err", err)
+			return false
+		}
+		return payload.Kind == enrichableKind
+	case personCreatedEvent:
+		// Every new contact, not only the ones a verdict minted. The event does
+		// not say who created the person, and asking would be this consumer
+		// guessing at the pass's own selection: a hand-typed contact with no
+		// mail simply is not a candidate, which costs one query that returns
+		// nobody. Narrowing here to the capture-created case would instead mean
+		// two spellings of who is due, and the quieter one wins arguments.
+		return true
+	case "activity.updated":
+		// Only an OPENING. The pass reads workspace mail, so a message narrowed
+		// to its participants is not new work — and the derivation emits this
+		// event for a narrowing exactly as it does for a widening, so a
+		// consumer that skipped the check would queue a model-backed pass every
+		// time a message was held.
+		var payload crmcontracts.PublicEventActivityUpdated
+		if err := json.Unmarshal(env.Payload, &payload); err != nil {
+			g.log.WarnContext(ctx, "capture enrich trigger: unreadable update payload",
+				"event", env.EventID.String(), "err", err)
+			return false
+		}
+		audience := payload.ChangedFields.Audience
+		return audience != nil && *audience == crmcontracts.Workspace
+	}
+	return false
+}
+
 // HandleEvent routes one envelope. An event this consumer does not care about
 // answers nil, so the group keeps flowing rather than wedging on somebody
 // else's traffic. An enqueue failure comes back as an error and the bus
@@ -66,29 +139,17 @@ func NewCaptureEnrichTrigger(pool *pgxpool.Pool, enqueue *jobs.Runner, log *slog
 // first delivery queued, and the nightly pass still reconciles what slips
 // through.
 func (g *CaptureEnrichTrigger) HandleEvent(ctx context.Context, env events.Envelope) error {
-	if env.Type != "activity.captured" {
-		return nil
-	}
-	// EMAIL only, decided before anything is queued. The signature pass reads
-	// a mail's trailing lines and nothing else can carry a signature block, so
-	// a meeting or a call would queue a model-backed pass that has no work to
-	// do — this consumer's whole job is promptness, and paying for a pass per
-	// logged call is not that.
-	var payload crmcontracts.PublicEventActivityCaptured
-	if err := json.Unmarshal(env.Payload, &payload); err != nil {
-		// A payload this consumer cannot read is not a reason to wedge the
-		// group or to guess: the nightly pass covers whatever it announced.
-		g.log.WarnContext(ctx, "capture enrich trigger: unreadable capture payload",
-			"event", env.EventID.String(), "err", err)
-		return nil
-	}
-	if payload.Kind != "email" {
+	if !g.queues(ctx, env) {
 		return nil
 	}
 	// A stale event has no promptness left to buy: it is either replayed
 	// backlog or a delivery the bus held for hours, and in both cases the
 	// nightly pass already covers it. Skipping is nil, not an error — erroring
 	// would redeliver the same stale event forever.
+	//
+	// Asked AFTER the type routing rather than before it, so the cheap answer
+	// stays cheap: an event of a type this consumer ignores never reaches the
+	// clock at all.
 	if time.Since(env.OccurredAt) > captureEnrichFreshWindow {
 		return nil
 	}

--- a/backend/internal/compose/captureenrichtrigger.go
+++ b/backend/internal/compose/captureenrichtrigger.go
@@ -67,13 +67,6 @@ import (
 // delivery lag while excluding any replayed backlog.
 const captureEnrichFreshWindow = time.Hour
 
-// enrichableKind is the one activity kind that can carry a signature block.
-//
-// Its own constant rather than the CSV surface's fieldEmail, which happens to
-// hold the same word for a column header: two unrelated vocabularies sharing one
-// name is how a rename in either silently changes the other.
-const enrichableKind = "email"
-
 // CaptureEnrichTrigger queues one signature-enrich pass per captured email.
 type CaptureEnrichTrigger struct {
 	pool    *pgxpool.Pool
@@ -93,7 +86,7 @@ func NewCaptureEnrichTrigger(pool *pgxpool.Pool, enqueue *jobs.Runner, log *slog
 // malformed body would stop reading every later one.
 func (g *CaptureEnrichTrigger) queues(ctx context.Context, env events.Envelope) bool {
 	switch env.Type {
-	case "activity.captured":
+	case eventActivityCaptured:
 		// EMAIL only, decided before anything is queued. The signature pass
 		// reads a mail's trailing lines and nothing else can carry a signature
 		// block, so a meeting or a call would queue a model-backed pass that has
@@ -105,7 +98,10 @@ func (g *CaptureEnrichTrigger) queues(ctx context.Context, env events.Envelope) 
 				"event", env.EventID.String(), "err", err)
 			return false
 		}
-		return payload.Kind == enrichableKind
+		// The generated enum, not a literal: crm.yaml owns this vocabulary, and
+		// a word hand-typed here would not move when the contract does. The
+		// same comparison the vCard trigger makes on the same field.
+		return payload.Kind == string(crmcontracts.ActivityKindEmail)
 	case personCreatedEvent:
 		// Every new contact, not only the ones a verdict minted. The event does
 		// not say who created the person, and asking would be this consumer
@@ -114,7 +110,7 @@ func (g *CaptureEnrichTrigger) queues(ctx context.Context, env events.Envelope) 
 		// nobody. Narrowing here to the capture-created case would instead mean
 		// two spellings of who is due, and the quieter one wins arguments.
 		return true
-	case "activity.updated":
+	case eventActivityUpdated:
 		// Only an OPENING. The pass reads workspace mail, so a message narrowed
 		// to its participants is not new work — and the derivation emits this
 		// event for a narrowing exactly as it does for a widening, so a

--- a/backend/internal/compose/captureenrichtrigger_test.go
+++ b/backend/internal/compose/captureenrichtrigger_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/events"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// enrichEvent builds an envelope of one type carrying one payload, occurring
+// now. A payload marshalling failure is the test's own bug, so it fails here
+// rather than travelling into the subject as an empty body that every arm
+// happens to refuse.
+//
+// The payload is already JSON, so each caller marshals its own typed contract
+// struct and this takes the bytes. A helper that marshalled for them would need
+// to accept every payload type at once, and the one signature that does is the
+// one that stops the compiler checking any of them.
+func enrichEvent(t *testing.T, eventType, entityType string, payload json.RawMessage) events.Envelope {
+	t.Helper()
+	return events.Envelope{
+		Type:       eventType,
+		EventID:    ids.NewV7(),
+		OccurredAt: time.Now().UTC(),
+		Entity:     events.EntityRef{Type: entityType, ID: ids.NewV7()},
+		Payload:    payload,
+	}
+}
+
+// noPayload is the body of an event this consumer routes on its TYPE alone.
+var noPayload = json.RawMessage(`{}`)
+
+func capturedMail(t *testing.T, kind string) events.Envelope {
+	t.Helper()
+	body, err := json.Marshal(crmcontracts.PublicEventActivityCaptured{Kind: kind})
+	if err != nil {
+		t.Fatalf("marshalling a captured %s: %v", kind, err)
+	}
+	return enrichEvent(t, "activity.captured", "activity", body)
+}
+
+func audienceChange(t *testing.T, to crmcontracts.PublicEventActivityChangedFieldsAudience) events.Envelope {
+	t.Helper()
+	body, err := json.Marshal(crmcontracts.PublicEventActivityUpdated{
+		ChangedFields: crmcontracts.PublicEventActivityChangedFields{Audience: &to},
+	})
+	if err != nil {
+		t.Fatalf("marshalling an audience change to %s: %v", to, err)
+	}
+	return enrichEvent(t, "activity.updated", "activity", body)
+}
+
+// quietTrigger is the subject with no pool and no runner. Every case below
+// stops at the envelope, so neither is ever reached — and a nil pool is the
+// assertion that it was not: anything that queued or queried would panic.
+func quietTrigger() *CaptureEnrichTrigger {
+	return &CaptureEnrichTrigger{log: slog.New(slog.DiscardHandler)}
+}
+
+// The three doors, each named by what it is the only notice of. Without the
+// person door a sender's FIRST mail — the one carrying their signature block —
+// is read by nothing until the next day's reconciler, because the contact did
+// not exist when their mail landed and no later event says it now does.
+func TestTheSignaturePassIsQueuedByEveryDoorThatMakesSomebodyReadable(t *testing.T) {
+	g := quietTrigger()
+	ctx := context.Background()
+
+	for name, env := range map[string]events.Envelope{
+		"mail landing":           capturedMail(t, "email"),
+		"a contact appearing":    enrichEvent(t, "person.created", "person", noPayload),
+		"a held message opening": audienceChange(t, crmcontracts.Workspace),
+	} {
+		if !g.queues(ctx, env) {
+			t.Errorf("%s: queued no pass, so nobody reads that signature until tomorrow", name)
+		}
+	}
+}
+
+// The refusals, and each one costs a model-backed pass when it is wrong.
+func TestTheSignaturePassIsNotQueuedByWhatCannotMakeSomebodyReadable(t *testing.T) {
+	g := quietTrigger()
+	ctx := context.Background()
+
+	for name, env := range map[string]events.Envelope{
+		// Nothing but mail carries a signature block.
+		"a captured meeting": capturedMail(t, "meeting"),
+		"a captured call":    capturedMail(t, "call"),
+		// The derivation emits the same event for a NARROWING, and the pass
+		// reads open mail only — so this arm queues a paid pass per held
+		// message if it stops reading the value.
+		"a message being narrowed to its participants": audienceChange(t, crmcontracts.Participants),
+		"a message narrowed to named seats":            audienceChange(t, crmcontracts.Selected),
+		// An update about something else entirely.
+		"an update naming no audience": enrichEvent(t, "activity.updated", "activity", noPayload),
+		// A person who cannot have become newly readable.
+		"a contact being archived": enrichEvent(t, "person.archived", "person", noPayload),
+		"a contact being updated":  enrichEvent(t, "person.updated", "person", noPayload),
+		// Streams the group also carries for its sibling consumers.
+		"an unrelated entity's event": enrichEvent(t, "organization.created", "organization", noPayload),
+	} {
+		if g.queues(ctx, env) {
+			t.Errorf("%s: queued a model-backed pass with no work in it", name)
+		}
+	}
+}
+
+// A body this consumer cannot read answers no rather than guessing, and answers
+// it without an error — a group that wedged on one malformed payload would stop
+// reading every later one.
+func TestAnUnreadablePayloadQueuesNothingAndWedgesNothing(t *testing.T) {
+	g := quietTrigger()
+	ctx := context.Background()
+
+	for _, eventType := range []string{"activity.captured", "activity.updated"} {
+		env := events.Envelope{
+			Type:       eventType,
+			EventID:    ids.NewV7(),
+			OccurredAt: time.Now().UTC(),
+			Entity:     events.EntityRef{Type: "activity", ID: ids.NewV7()},
+			Payload:    json.RawMessage(`{"kind":`),
+		}
+		if g.queues(ctx, env) {
+			t.Errorf("%s: an unreadable payload queued a pass", eventType)
+		}
+		if err := g.HandleEvent(ctx, env); err != nil {
+			t.Errorf("%s: HandleEvent returned %v, want a silent skip", eventType, err)
+		}
+	}
+}
+
+// A stale event is replayed backlog — a new consumer group starts at stream
+// position 0 — and the reconciler owns everything that old. The nil pool is the
+// assertion: reaching the enqueue would panic rather than fail.
+func TestAStaleEventQueuesNothing(t *testing.T) {
+	g := quietTrigger()
+	ctx := context.Background()
+
+	for name, env := range map[string]events.Envelope{
+		"stale mail":      capturedMail(t, "email"),
+		"a stale contact": enrichEvent(t, "person.created", "person", noPayload),
+		"a stale opening": audienceChange(t, crmcontracts.Workspace),
+	} {
+		env.OccurredAt = time.Now().UTC().Add(-2 * captureEnrichFreshWindow)
+		if err := g.HandleEvent(ctx, env); err != nil {
+			t.Errorf("%s: HandleEvent returned %v, want a silent skip", name, err)
+		}
+	}
+}

--- a/backend/internal/modules/people/organization_domains.go
+++ b/backend/internal/modules/people/organization_domains.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/jackc/pgx/v5"
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -216,6 +217,46 @@ func dedupeDomains(domains []OrgDomainInput) []OrgDomainInput {
 	return out
 }
 
+// electPrimary makes sure a non-empty domain set names a primary, because an
+// organization with live domains and none primary is not a state any reader of
+// this table can act on.
+//
+// Three readers key on is_primary and each fails differently without one. The
+// auto-enrich sweep INNER JOINs it (capture/autoenrich.go), so such a company is
+// never a candidate and is never enriched — silently, with no job, no error and
+// no state saying so. The company read derives website_url from it, so the page
+// shows no website. Provider enrichment reads it for the employer domain.
+//
+// Nothing else elects one later: there is no path that promotes a sole domain,
+// so a record born this way stays this way. The contract admits the state —
+// is_primary defaults to false and only domain is required — which makes an
+// agent constructing the minimal valid body the ordinary way to reach it.
+//
+// current is the primary already live on the record, and keeping it is what
+// makes an edit that merely adds a domain leave the choice alone. A caller who
+// named a primary is obeyed; only silence is filled in, and it is filled with
+// the first domain because the caller offered nothing else to prefer.
+func electPrimary(desired []OrgDomainInput, current string) []OrgDomainInput {
+	if len(desired) == 0 {
+		return desired
+	}
+	for _, d := range desired {
+		if d.IsPrimary {
+			return desired
+		}
+	}
+	elected := 0
+	for i, d := range desired {
+		if d.Domain == current {
+			elected = i
+			break
+		}
+	}
+	out := slices.Clone(desired)
+	out[elected].IsPrimary = true
+	return out
+}
+
 // singleDesiredPrimary returns the one domain marked primary, or "" for
 // none. uq_org_domain_primary is a single-row invariant, so more than one
 // is the typed 409 up front rather than a constraint failure mid-write.
@@ -245,7 +286,10 @@ func reconcileOrgDomains(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, o
 	if err != nil {
 		return nil, err
 	}
-	primary, err := singleDesiredPrimary(desired)
+	// The election happens against the LIVE primary, so an edit that only adds
+	// a domain keeps the one the record already had rather than moving it to
+	// whatever the caller happened to list first.
+	primary, err := singleDesiredPrimary(electPrimary(desired, currentPrimary))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/modules/people/organization_domains.go
+++ b/backend/internal/modules/people/organization_domains.go
@@ -217,6 +217,17 @@ func dedupeDomains(domains []OrgDomainInput) []OrgDomainInput {
 	return out
 }
 
+// livePrimaryDomain answers which domain an organization currently holds as
+// primary, or "" for none.
+//
+// One question, one spelling. The patch path needs it to elect on the slice it
+// audits and reconcileOrgDomains needs it to write, and two SELECTs asking it
+// would be two definitions of "live" to keep in step with the archival column.
+func livePrimaryDomain(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (string, error) {
+	_, _, primary, err := readLiveDomains(ctx, tx, orgID)
+	return primary, err
+}
+
 // electPrimary makes sure a non-empty domain set names a primary, because an
 // organization with live domains and none primary is not a state any reader of
 // this table can act on.
@@ -289,6 +300,12 @@ func reconcileOrgDomains(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, o
 	// The election happens against the LIVE primary, so an edit that only adds
 	// a domain keeps the one the record already had rather than moving it to
 	// whatever the caller happened to list first.
+	//
+	// The patch path has already elected on the slice it audits, and this
+	// re-elects the same domain from the same inputs — it is not the belt to
+	// that braces. It is what makes the rule hold for a caller that reconciles
+	// WITHOUT staging, and staging is a property of the HTTP patch rather than
+	// of this function.
 	primary, err := singleDesiredPrimary(electPrimary(desired, currentPrimary))
 	if err != nil {
 		return nil, err

--- a/backend/internal/modules/people/organization_domains_map_test.go
+++ b/backend/internal/modules/people/organization_domains_map_test.go
@@ -63,6 +63,83 @@ func TestDedupeDomains(t *testing.T) {
 	}
 }
 
+// A domain set that names no primary is the state the contract admits and no
+// reader can act on, so the election fills it. The cases below are the four
+// answers it has to tell apart; the create path passes "" for current and the
+// edit path passes the live primary.
+func TestElectPrimary(t *testing.T) {
+	primaryOf := func(t *testing.T, got []OrgDomainInput) string {
+		t.Helper()
+		primary := ""
+		for _, d := range got {
+			if !d.IsPrimary {
+				continue
+			}
+			if primary != "" {
+				t.Fatalf("elected two primaries: %+v", got)
+			}
+			primary = d.Domain
+		}
+		return primary
+	}
+
+	t.Run("silence elects the first domain", func(t *testing.T) {
+		got := electPrimary([]OrgDomainInput{{Domain: "a.test"}, {Domain: "b.test"}}, "")
+		if p := primaryOf(t, got); p != "a.test" {
+			t.Fatalf("elected %q, want a.test", p)
+		}
+	})
+
+	t.Run("a sole domain is the case the sweep needs", func(t *testing.T) {
+		got := electPrimary([]OrgDomainInput{{Domain: "acme.test"}}, "")
+		if p := primaryOf(t, got); p != "acme.test" {
+			t.Fatalf("elected %q, want acme.test", p)
+		}
+	})
+
+	t.Run("a caller who named one is obeyed", func(t *testing.T) {
+		got := electPrimary([]OrgDomainInput{{Domain: "a.test"}, {Domain: "b.test", IsPrimary: true}}, "")
+		if p := primaryOf(t, got); p != "b.test" {
+			t.Fatalf("elected %q, want the caller's b.test", p)
+		}
+	})
+
+	// The edit case, and the reason current is a parameter at all: adding a
+	// domain to a record must not move the primary the record already had.
+	t.Run("the live primary is kept when it survives the edit", func(t *testing.T) {
+		got := electPrimary([]OrgDomainInput{{Domain: "a.test"}, {Domain: "b.test"}}, "b.test")
+		if p := primaryOf(t, got); p != "b.test" {
+			t.Fatalf("elected %q, want the live b.test", p)
+		}
+	})
+
+	t.Run("a live primary the edit removes falls back to the first", func(t *testing.T) {
+		got := electPrimary([]OrgDomainInput{{Domain: "a.test"}, {Domain: "b.test"}}, "gone.test")
+		if p := primaryOf(t, got); p != "a.test" {
+			t.Fatalf("elected %q, want a.test", p)
+		}
+	})
+
+	// Clearing every domain is a real answer, and electing into an empty set
+	// would invent a row the caller did not ask for.
+	t.Run("an empty set elects nothing", func(t *testing.T) {
+		if got := electPrimary(nil, ""); len(got) != 0 {
+			t.Fatalf("elected %+v from nothing", got)
+		}
+	})
+
+	// The input is the caller's slice, and the create path hands it one it
+	// still holds. Writing through it would move a primary in the caller's own
+	// copy of the request.
+	t.Run("the caller's slice is not written through", func(t *testing.T) {
+		in := []OrgDomainInput{{Domain: "a.test"}}
+		electPrimary(in, "")
+		if in[0].IsPrimary {
+			t.Fatal("electPrimary wrote its election back into the caller's slice")
+		}
+	})
+}
+
 func TestSingleDesiredPrimary(t *testing.T) {
 	if p, err := singleDesiredPrimary([]OrgDomainInput{{Domain: "a.test"}, {Domain: "b.test"}}); err != nil || p != "" {
 		t.Fatalf("no primary → (%q, %v), want ('', nil)", p, err)

--- a/backend/internal/modules/people/organization_update.go
+++ b/backend/internal/modules/people/organization_update.go
@@ -289,6 +289,18 @@ func stageOrgReplaceSets(ctx context.Context, tx pgx.Tx, id ids.OrganizationID,
 		if err := ensureOrgDomainsUnclaimedExcept(ctx, tx, id, *in.Domains); err != nil {
 			return "", err
 		}
+		// And elect the primary HERE, for the same reason and on the same
+		// slice. The reconcile elects one either way, but on a copy — so an
+		// election left to it lands on the row while the audit after-image,
+		// built from this slice, still reports the domain as ordinary. The
+		// trail would then say a company has no primary domain while the row
+		// says it does, and is_primary is exactly what admits that company to
+		// the website read the trail exists to explain.
+		live, err := livePrimaryDomain(ctx, tx, id)
+		if err != nil {
+			return "", err
+		}
+		*in.Domains = electPrimary(*in.Domains, live)
 	}
 	// A replace-set changes no column on the row itself, so this bump is what
 	// makes the patch non-empty and carries the version guard. Once, after both

--- a/backend/internal/modules/people/organizationdomainprimary_integration_test.go
+++ b/backend/internal/modules/people/organizationdomainprimary_integration_test.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -153,4 +155,78 @@ func TestAnEditThatDropsTheLivePrimaryElectsAnother(t *testing.T) {
 	if got := livePrimaryOf(ctx, t, e, orgID); got != "ostsee-new.test" {
 		t.Fatalf("primary domain is %q, want ostsee-new.test", got)
 	}
+}
+
+// The audit trail has to say what the row says.
+//
+// is_primary is what admits a company to the website read, so the after-image is
+// the record of why that read happened. An election applied to the row but not
+// to the image the patch audits leaves a trail claiming the company has no
+// primary domain — the exact state that would mean no read was due — while the
+// row that triggered one says otherwise.
+func TestTheAuditImageNamesThePrimaryTheRowActuallyCarries(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Rheinfels Guss", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "rheinfels-old.test", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("creating the organization: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	// A replace-set naming no primary: the election has to fill it, and the
+	// image has to report what it filled.
+	desired := []OrgDomainInput{{Domain: "rheinfels-new.test"}}
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{Domains: &desired}); err != nil {
+		t.Fatalf("updating the organization: %v", err)
+	}
+
+	onRow := livePrimaryOf(ctx, t, e, orgID)
+	if onRow != "rheinfels-new.test" {
+		t.Fatalf("primary domain on the row is %q, want rheinfels-new.test", onRow)
+	}
+
+	inTrail := auditedPrimaryDomain(ctx, t, e, orgID)
+	if inTrail != onRow {
+		t.Fatalf("the audit trail names %q as primary and the row carries %q — an auditor replaying the log would conclude no website read was due", inTrail, onRow)
+	}
+}
+
+// auditedPrimaryDomain reads the primary domain the newest organization update
+// recorded in its after-image, or "" when it recorded none.
+func auditedPrimaryDomain(ctx context.Context, t *testing.T, e *dedupeEnv, orgID ids.OrganizationID) string {
+	t.Helper()
+	var after map[string]any
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT after FROM audit_log
+			 WHERE entity_type = 'organization' AND entity_id = $1 AND action = 'update'
+			 ORDER BY occurred_at DESC, id DESC
+			 LIMIT 1`, orgID).Scan(&after)
+	}); err != nil {
+		t.Fatalf("reading the organization's newest audit image: %v", err)
+	}
+	domains, ok := after["domains"].([]any)
+	if !ok {
+		t.Fatalf("the audit image records no domains at all: %v", after)
+	}
+	primary := ""
+	for _, entry := range domains {
+		row, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("a domain entry is not an object: %v", entry)
+		}
+		if isPrimary, _ := row["is_primary"].(bool); !isPrimary {
+			continue
+		}
+		domain, _ := row["domain"].(string)
+		if primary != "" {
+			t.Fatalf("the audit image names two primaries: %q and %q", primary, domain)
+		}
+		primary = domain
+	}
+	return primary
 }

--- a/backend/internal/modules/people/organizationdomainprimary_integration_test.go
+++ b/backend/internal/modules/people/organizationdomainprimary_integration_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// An organization with live domains names one of them primary, whatever the
+// caller sent.
+//
+// The column is not decoration. capture's auto-enrich sweep INNER JOINs on it,
+// so a company whose only domain carries false is never a candidate for the
+// website read — silently, with no job and no error. The contract admits that
+// state: is_primary defaults to false and only domain is required, so an agent
+// constructing the minimal valid body reaches it through the ordinary door.
+//
+// The sweep's own query lives in capture and cannot be called from here, so
+// these tests assert the column this module writes; the compose integration
+// test asserts the sweep then finds such an organization.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// livePrimaryOf reads the primary domain the record actually carries, or "" for
+// the state this whole file exists to prevent. It reads through liveDomainsOf
+// rather than its own query, because a second SELECT over organization_domain
+// would be a second definition of "live" to keep in step with the archival
+// column.
+func livePrimaryOf(ctx context.Context, t *testing.T, e *dedupeEnv, orgID ids.OrganizationID) string {
+	t.Helper()
+	primary := ""
+	for domain, isPrimary := range liveDomainsOf(ctx, t, e, orgID) {
+		if !isPrimary {
+			continue
+		}
+		if primary != "" {
+			t.Fatalf("two live primaries on one organization: %q and %q", primary, domain)
+		}
+		primary = domain
+	}
+	return primary
+}
+
+// The reported defect, at the door it came through: one domain, no is_primary,
+// which is the whole of a valid minimal request body.
+func TestACompanyCreatedWithOneDomainAndNoPrimaryStillNamesIt(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Terralogic", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "terralogic.test"}},
+	})
+	if err != nil {
+		t.Fatalf("creating the organization: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	if got := livePrimaryOf(ctx, t, e, orgID); got != "terralogic.test" {
+		t.Fatalf("primary domain is %q, want terralogic.test — the auto-enrich sweep joins on it, so this company would never be read", got)
+	}
+}
+
+// Several domains and no primary is the same defect with more rows: the sweep
+// needs exactly one, and the caller named none.
+func TestACompanyCreatedWithSeveralDomainsAndNoPrimaryNamesTheFirst(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Northwind Handel", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "northwind-a.test"}, {Domain: "northwind-b.test"}},
+	})
+	if err != nil {
+		t.Fatalf("creating the organization: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	if got := livePrimaryOf(ctx, t, e, orgID); got != "northwind-a.test" {
+		t.Fatalf("primary domain is %q, want the first domain northwind-a.test", got)
+	}
+}
+
+// The election fills SILENCE and never overrules a choice. Without this the
+// two tests above would also pass against a writer that ignored the caller.
+func TestACallerWhoNamesThePrimaryKeepsIt(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Kestrel Labs", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "kestrel-a.test"}, {Domain: "kestrel-b.test", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("creating the organization: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	if got := livePrimaryOf(ctx, t, e, orgID); got != "kestrel-b.test" {
+		t.Fatalf("primary domain is %q, want the caller's kestrel-b.test", got)
+	}
+}
+
+// The edit path has the same hole and one extra rule: an edit that merely adds
+// a domain must not move the primary the record already had.
+func TestAnEditThatNamesNoPrimaryLeavesTheLiveOneAlone(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Halden Werke", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "halden-a.test", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("creating the organization: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	desired := []OrgDomainInput{{Domain: "halden-a.test"}, {Domain: "halden-b.test"}}
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{Domains: &desired}); err != nil {
+		t.Fatalf("updating the organization: %v", err)
+	}
+
+	if got := livePrimaryOf(ctx, t, e, orgID); got != "halden-a.test" {
+		t.Fatalf("primary domain is %q, want the live halden-a.test kept", got)
+	}
+}
+
+// And an edit that REMOVES the live primary still leaves one, rather than a
+// record the sweep cannot see.
+func TestAnEditThatDropsTheLivePrimaryElectsAnother(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Ostsee Fracht", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "ostsee-old.test", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("creating the organization: %v", err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	desired := []OrgDomainInput{{Domain: "ostsee-new.test"}}
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{Domains: &desired}); err != nil {
+		t.Fatalf("updating the organization: %v", err)
+	}
+
+	if got := livePrimaryOf(ctx, t, e, orgID); got != "ostsee-new.test" {
+		t.Fatalf("primary domain is %q, want ostsee-new.test", got)
+	}
+}

--- a/backend/internal/modules/people/resolvecreate.go
+++ b/backend/internal/modules/people/resolvecreate.go
@@ -299,7 +299,13 @@ func createOrganization(ctx context.Context, tx pgx.Tx, match OrganizationMatch,
 		args...); err != nil {
 		return ids.OrganizationID{}, fmt.Errorf("insert organization: %w", err)
 	}
-	if err := insertOrgDomains(ctx, tx, id, spec.Source, spec.CapturedBy, spec.Domains); err != nil {
+	// A new organization has no primary yet, so the election has nothing to
+	// preserve and fills the caller's silence. Here rather than in the HTTP
+	// mapping because every producer of a company converges on this call — the
+	// API, the tool surface, CSV import, cold start, domain triage and the
+	// overlay flip — and a rule spelled at one of those doors binds only that
+	// door.
+	if err := insertOrgDomains(ctx, tx, id, spec.Source, spec.CapturedBy, electPrimary(spec.Domains, "")); err != nil {
 		return ids.OrganizationID{}, err
 	}
 	return id, nil

--- a/backend/internal/shared/kernel/events/events_test.go
+++ b/backend/internal/shared/kernel/events/events_test.go
@@ -244,7 +244,7 @@ func TestGroupStreamSetsMatchSpecTable(t *testing.T) {
 		// cg:person-data's reason: this one spends the customer's token budget,
 		// and a consumer whose retries cost money must not share a cursor with
 		// one whose retries are free.
-		"cg:capture-enrich": {"gw:events:crm:activity"},
+		"cg:capture-enrich": {"gw:events:crm:activity", "gw:events:crm:person"},
 		// A card attached to captured mail imports itself. Its own group beside
 		// the one above: that one needs a model and this one only parses, so
 		// they run in different deployments and must not share a cursor.

--- a/backend/internal/shared/kernel/events/groups.go
+++ b/backend/internal/shared/kernel/events/groups.go
@@ -150,7 +150,14 @@ func Groups() []Group {
 		// queues a MODEL-backed pass, and a group whose retries spend the
 		// customer's token budget must not share a cursor with a projection
 		// that is cheap to replay.
-		{Name: "cg:capture-enrich", Streams: forEntities(activityStreamEntity)},
+		//
+		// The PERSON stream too, because the pass selects a contact joined to
+		// their own open mail and either half can be what was missing. A sender
+		// nobody had classified has no contact while their mail lands; the
+		// counterparty verdict mints them minutes later, and person.created is
+		// the only notice that their first mail — the one carrying the signature
+		// block — has become readable.
+		{Name: "cg:capture-enrich", Streams: forEntities(activityStreamEntity, personStreamEntity)},
 		// A card attached to captured mail imports itself. Its own group beside
 		// the one above rather than a second handler on it, because the two do
 		// not fail alike: that one queues a MODEL-backed pass and this one

--- a/backend/migrations/core/1788850225_a_company_with_domains_has_a_primary.down.sql
+++ b/backend/migrations/core/1788850225_a_company_with_domains_has_a_primary.down.sql
@@ -1,0 +1,8 @@
+-- Irreversible by design, and empty rather than a guess.
+--
+-- The up migration elected a primary for organizations that had none. Undoing
+-- it would mean clearing is_primary from rows that carry it — and after the
+-- migration nothing tells an elected row apart from one a human chose. Clearing
+-- all of them would silently un-enrich companies whose primary was never in
+-- question, which is a larger break than the one this reverses.
+SELECT 1;

--- a/backend/migrations/core/1788850225_a_company_with_domains_has_a_primary.up.sql
+++ b/backend/migrations/core/1788850225_a_company_with_domains_has_a_primary.up.sql
@@ -1,0 +1,39 @@
+-- Every organization with live domains names one of them primary.
+--
+-- Three readers key on is_primary, and the first of them is why this backfill
+-- exists rather than only the code change beside it: the auto-enrich sweep
+-- INNER JOINs organization_domain on is_primary, so a company whose only domain
+-- was written with the column false is not a candidate and never becomes one.
+-- Nothing retries, nothing errors, and no state records the omission — the
+-- company simply stays empty. The company read derives website_url from the
+-- same column, and provider enrichment reads it for the employer domain.
+--
+-- The rows this repairs were written through an API that admits the state: the
+-- contract defaults is_primary to false and requires only domain, so a caller
+-- constructing the minimal valid body lands here. The code now elects a primary
+-- at the store for every new record; these are the ones already written.
+--
+-- The oldest live domain is elected, which is the same tie-break the electing
+-- code applies at the door — the first domain the caller offered — carried over
+-- to rows whose caller is long gone. id breaks a created_at tie so the choice is
+-- deterministic rather than dependent on scan order.
+--
+-- uq_org_domain_primary is a partial unique index on organization_id where
+-- is_primary and archived_at IS NULL. The NOT EXISTS arm is what keeps this
+-- inside it: only organizations with NO live primary are touched, and exactly
+-- one row is elected per organization. Re-running promotes nothing, because the
+-- organizations it would select no longer qualify.
+UPDATE organization_domain d
+   SET is_primary = true
+ WHERE d.archived_at IS NULL
+   AND NOT EXISTS (
+       SELECT 1 FROM organization_domain held
+        WHERE held.organization_id = d.organization_id
+          AND held.is_primary
+          AND held.archived_at IS NULL)
+   AND d.id = (
+       SELECT oldest.id FROM organization_domain oldest
+        WHERE oldest.organization_id = d.organization_id
+          AND oldest.archived_at IS NULL
+        ORDER BY oldest.created_at, oldest.id
+        LIMIT 1);


### PR DESCRIPTION
Two silent gaps on the first-contact path. Each leaves a record half-filled with no error, no queued retry and no state saying so, which is why both were found by noticing an empty field rather than by anything failing.

## A company created with one domain and no `is_primary` was never enriched

The contract defaults `is_primary` to false and requires only `domain`, so a caller sending the minimal valid body creates a company with no primary domain. The auto-enrich sweep INNER JOINs on that column, so such a company is not a candidate and never becomes one — nothing promotes a sole domain later. The company page also shows no website, because `website_url` is derived from the same column.

The election now happens at the store, in `electPrimary`, called from the two functions every producer converges on: the create path and the domain reconcile. That covers the API, the tool surface, CSV import, cold start, domain triage and the overlay flip in one place, rather than at whichever door happened to be looked at. A caller who names a primary is obeyed; only silence is filled. An edit that merely adds a domain keeps the primary the record already had, which is why the election takes the live primary as an argument.

A data-only migration promotes the rows already written that way, electing the oldest live domain per company. It touches only companies with no live primary, so it stays inside `uq_org_domain_primary` and re-running it promotes nothing. Verified against all five shapes: a stuck sole domain, a stuck multi-domain set, a company that already chose, an archived-only set, and a live domain sitting beside an older archived one.

## A person created by a counterparty verdict had their signature read by nothing

The signature pass is queued when mail arrives. But a sender nobody has classified yet has no contact while their mail lands, so the pass that mail queues cannot see them — and the verdict that mints the person ten minutes later queued nothing at all. Their mail was then read only by the next day's reconciler. That is the first mail from a new correspondent, which is the one most likely to carry a full signature block.

The trigger now wakes on three events instead of one: mail arriving, a contact appearing, and a held message opening to a workspace audience. The third covers the confidentiality verdict, which opens mail through the audience derivation. All three queue the same deduplicated pass, so a verdict that both mints a person and opens their mail costs one job. The `cg:capture-enrich` consumer group subscribes to the person stream as well, without which the new door would be unreachable.

### The reported diagnosis for this one does not hold

#4953 attributes it to the enricher's `audience = 'workspace'` filter excluding the mail. That filter is correct and unchanged here. The evidence against the original reading:

- The `participants` audience on the reproduction was set by hand during the injection, not derived by the product.
- All eight real inbound mails from that sender are `workspace` with a cleared verdict, so the filter would not have excluded a genuine delivery.
- The signature pass last ran at 05:12:03 and the person was created at 05:46:23. It never looked at all.

The session that filed the issue has confirmed this and commented the correction.

## Tests

Every new test was mutation-checked: each fails against the pre-fix code, by the assertion meant to catch it.

- `electPrimary` unit cases, including that it does not write through the caller's slice.
- Five integration tests through the real store: create with one domain, create with several, a caller who names their own primary (the control — it passes both before and after, which is what proves the election never overrules a choice), an edit that keeps the live primary, and an edit that drops it.
- Trigger tests covering all three doors, seven refusals including narrowings, unreadable payloads, and stale events.

## Out of scope, worth a look separately

`linkCapturedCohort` takes only mail linked to nobody, so a contact re-created after the previous record was archived inherits none of that record's mail. Not on the demo path and not touched here.

Closes #4958
Closes #4953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two silent gaps on the first-contact path: a company created without a primary domain was never enriched, and a new contact's first mail — the one most likely to carry a full signature block — was read by nothing until the next day's reconciler.

**Bug Fixes**
- Companies created or edited with no primary domain now elect one at the store, where every producer converges; a caller who names a primary is obeyed, and an edit that only adds a domain keeps the live one.
- The patch path elects on the slice it audits, so the audit after-image names the primary the row carries.
- The signature pass now queues on three events instead of one: mail arriving, a contact appearing, and a held message opening to a workspace audience; all three collapse onto the same deduplicated pass.
- `cg:capture-enrich` now subscribes to the person stream so the new door is reachable; the trigger routes on declared event constants and the generated contract enum, so a typo cannot silently disable it.
- The reported diagnosis that the enricher's workspace filter excluded the mail does not hold: the filter was correct and unchanged, and the pass had never run after the person was created.

**Migration**
- A data-only migration promotes existing companies with live domains but no primary, electing the oldest live domain; it touches only companies with no live primary, re-running promotes nothing, and it is irreversible.

Closes #4958 and #4953.

<sup>Written for commit 07a42f1c99339d0b98185f63ed4d132e770926a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enrichment processing now responds when contacts appear and when workspace emails are opened, in addition to newly captured mail.
  * Organizations now consistently maintain a primary domain when domains are added, edited, or recovered.

* **Bug Fixes**
  * Existing primary domains are preserved during domain updates when they remain active.
  * Organizations without a primary domain are automatically assigned one based on the oldest active domain.
  * Invalid or outdated enrichment events are handled without interrupting processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->