### PR TITLE
fix(360): two moment texts say what the page can see

### DIFF
--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -13,6 +13,7 @@ package person360
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -107,10 +108,21 @@ func missingNextStepMoment(_ context.Context, _ time.Time, page *crmcontracts.Pe
 		RuleVersion:         ptr(ruleVersion),
 		EvidenceFingerprint: fingerprintOf(evidence),
 		Headline:            "No next step with them on an open deal",
-		WhyNow:              "The deal is live and nothing is scheduled with the person whose seat decides it.",
-		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
-		Evidence:            evidence,
-		RecommendedAction:   bookMeeting(),
+		// The seat this person actually holds, named — not "the person whose
+		// seat decides it", which the record does not say. The rung fires on
+		// ANY recorded stakeholder role, and the vocabulary distinguishes the
+		// ones that decide (economic_buyer, decision_maker) from the ones that
+		// do not (champion, influencer, user). Telling a rep the deal turns on
+		// somebody who is recorded as an influencer is a claim the row refuses.
+		//
+		// The rung is not narrowed to the deciding roles instead, because a
+		// deal with no next step is worth saying whoever the seat belongs to —
+		// what was wrong was the sentence, not the trigger.
+		WhyNow: fmt.Sprintf("The deal is live and nothing is scheduled with them. They are %s on it.",
+			recordedSeat(page.Commercial.Role)),
+		Confidence:        crmcontracts.PersonMomentConfidenceObservedFact,
+		Evidence:          evidence,
+		RecommendedAction: bookMeeting(),
 		SecondaryActions: &[]crmcontracts.PersonMomentAction{{
 			Kind:        crmcontracts.PersonMomentActionKindOpenRecord,
 			Label:       "Open the deal",
@@ -302,3 +314,16 @@ func entityType(v crmcontracts.PersonMomentDestinationEntityType) *crmcontracts.
 
 // prefill lifts the string map the contract carries as an optional object.
 func prefill(v map[string]string) *map[string]string { return &v }
+
+// recordedSeat names this person's seat on the deal as the record spells it,
+// falling back to what is true when no role was recorded.
+//
+// The fallback is the load-bearing half: a stakeholder edge may carry no role
+// at all, and a sentence that named one anyway would be inventing the fact the
+// rung exists to report.
+func recordedSeat(role *string) string {
+	if role == nil || strings.TrimSpace(*role) == "" {
+		return "a stakeholder"
+	}
+	return "the recorded " + strings.ReplaceAll(*role, "_", " ")
+}

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -298,13 +298,15 @@ func reEngagedMoment(_ context.Context, now time.Time, page *crmcontracts.Person
 		// not news.
 		return crmcontracts.PersonMoment{}, false
 	}
-	// The silence this message broke: measured against our own last outbound,
-	// because a gap only means something relative to what came before it.
+	// The gap this rung fires on, and it is OURS: the page carries the latest
+	// message in each direction and nothing between them, so the only interval
+	// derivable here is from our most recent outbound to their most recent
+	// inbound. What that measures is how long it has been since WE wrote.
 	if page.LastOutboundAt == nil {
 		return crmcontracts.PersonMoment{}, false
 	}
-	quiet := elapsed.Days(*page.LastOutboundAt, inbound)
-	if quiet < reEngagedQuietDays {
+	sinceWeWrote := elapsed.Days(*page.LastOutboundAt, inbound)
+	if sinceWeWrote < reEngagedQuietDays {
 		return crmcontracts.PersonMoment{}, false
 	}
 	evidence := []crmcontracts.PersonMomentEvidence{inboundEvidence(page, inbound)}
@@ -313,11 +315,23 @@ func reEngagedMoment(_ context.Context, now time.Time, page *crmcontracts.Person
 		Rule:                crmcontracts.PersonMomentRuleReEngaged,
 		RuleVersion:         ptr(ruleVersion),
 		EvidenceFingerprint: fingerprintOf(evidence),
-		Headline:            fmt.Sprintf("They replied after %d quiet days", quiet),
-		WhyNow:              "A conversation that had stopped has restarted. The window where a reply is expected is now.",
-		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
-		Evidence:            evidence,
-		FreshnessAt:         &inbound,
+		// What the two dates support, and no more. "They replied after N quiet
+		// days" said the SILENCE was theirs, and the page cannot know that: it
+		// holds one timestamp per direction, so every message between the two
+		// is invisible here. A contact who wrote every week for two months
+		// while nobody answered produced "They replied after 60 quiet days" —
+		// a number specific enough to sound checked, about a quiet period that
+		// never happened. A rep who tests one of these against the thread and
+		// finds it wrong stops believing the parts that are right.
+		//
+		// The interval itself is real; only its owner was wrong. It is the age
+		// of OUR last message, which is the fact this rung fires on anyway.
+		Headline: fmt.Sprintf("They wrote — we last wrote %d days before", sinceWeWrote),
+		WhyNow: "They are waiting on us, and our last message to them is older than the re-engagement " +
+			"rule allows. The window where a reply is expected is now.",
+		Confidence:  crmcontracts.PersonMomentConfidenceObservedFact,
+		Evidence:    evidence,
+		FreshnessAt: &inbound,
 		RecommendedAction: crmcontracts.PersonMomentAction{
 			Kind:  crmcontracts.PersonMomentActionKindDraftReply,
 			Label: "Draft a reply",

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -887,3 +887,84 @@ func TestDismissingEveryPromiseReachesTheQuietState(t *testing.T) {
 		t.Errorf("rule = %q, want nothing_needed once every card is dismissed", got.Rule)
 	}
 }
+
+// The re-engagement rung says whose silence it measured.
+//
+// The page carries ONE timestamp per direction, so the only interval derivable
+// from it runs from our most recent outbound to their most recent inbound —
+// which measures how long WE have been silent, not how long they were. The rung
+// used to report it as "They replied after N quiet days".
+//
+// A contact who wrote every week for two months while nobody answered produced
+// exactly that sentence with N = 60: a number specific enough to sound checked,
+// about a quiet period that never happened. This fixture is that contact —
+// their traffic is invisible to the rule by construction, which is the whole
+// reason the old sentence could not be true.
+func TestTheReEngagementRungAttributesTheSilenceToUs(t *testing.T) {
+	page := &crmcontracts.Person360{
+		LastOutboundAt: ptr(at(60)),
+		LastInboundAt:  ptr(at(1)),
+	}
+
+	got := deriveMoment(readerCtx(), now, page)
+
+	if got.Rule != crmcontracts.PersonMomentRuleReEngaged {
+		t.Fatalf("rule = %q, want re_engaged", got.Rule)
+	}
+	if want := "They wrote — we last wrote 59 days before"; got.Headline != want {
+		t.Errorf("headline = %q, want %q", got.Headline, want)
+	}
+	// The claim that could not be checked, gone in both sentences. A reader who
+	// tests one number against the thread and finds it wrong stops believing
+	// the parts that are right.
+	for _, text := range []string{got.Headline, got.WhyNow} {
+		if strings.Contains(text, "quiet days") || strings.Contains(text, "They replied") {
+			t.Errorf("%q still claims the silence was theirs — the page holds no message between the two dates it has", text)
+		}
+	}
+}
+
+// The next-step rung names the seat the record actually holds.
+//
+// It said "the person whose seat decides it" and fired on ANY recorded
+// stakeholder role. The vocabulary distinguishes the seats that decide
+// (economic_buyer, decision_maker) from the ones that do not (champion,
+// influencer, user), so telling a rep the deal turns on somebody recorded as an
+// influencer is a claim the row refuses.
+//
+// The rung is deliberately not narrowed to the deciding roles: a deal with no
+// next step is worth saying whoever the seat belongs to. What was wrong was the
+// sentence.
+func TestTheNextStepRungNamesTheRecordedSeat(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		role *string
+		want string
+	}{
+		{"an influencer", ptr("influencer"), "The deal is live and nothing is scheduled with them. They are the recorded influencer on it."},
+		{"an economic buyer", ptr("economic_buyer"), "The deal is live and nothing is scheduled with them. They are the recorded economic buyer on it."},
+		// A stakeholder edge may carry no role at all, and a sentence naming
+		// one anyway would invent the fact the rung exists to report.
+		{"a seat with no role recorded", nil, "The deal is live and nothing is scheduled with them. They are a stakeholder on it."},
+		{"a seat whose role is blank", ptr("  "), "The deal is live and nothing is scheduled with them. They are a stakeholder on it."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			page := &crmcontracts.Person360{
+				Commercial: &crmcontracts.Person360Commercial{
+					Deal: &crmcontracts.Person360CommercialDeal{Title: "Expansion"},
+					Role: tc.role,
+				},
+			}
+			got := deriveMoment(readerCtx(), now, page)
+			if got.Rule != crmcontracts.PersonMomentRuleMissingNextStep {
+				t.Fatalf("rule = %q, want missing_next_step", got.Rule)
+			}
+			if got.WhyNow != tc.want {
+				t.Errorf("why now = %q, want %q", got.WhyNow, tc.want)
+			}
+			if strings.Contains(got.WhyNow, "decides it") {
+				t.Error("the sentence still claims this seat decides the deal, which the role vocabulary does not say")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1086.

Both are confident prose over data that does not support it, on the record page — the failure the drafting programme exists to remove. A rep who checks one of these against the thread and finds it wrong stops believing the parts that are right.

## 1. The quiet period was ours

`reEngagedMoment` said **"They replied after N quiet days"**.

The page carries **one timestamp per direction** (`sectionstimeline.go` supplies `max(occurred_at)` per direction and nothing else), so the only interval derivable here runs from our most recent outbound to their most recent inbound. That measures how long **we** have been silent. Every message between the two is invisible to the rule.

A contact who wrote every week for two months while nobody answered produced exactly that sentence with N = 60 — a number specific enough to sound checked, about a quiet period that never happened.

The interval itself is real; only its owner was wrong. So it says whose it is:

> **They wrote — we last wrote 59 days before**
> They are waiting on us, and our last message to them is older than the re-engagement rule allows. The window where a reply is expected is now.

The rung fires on exactly what it fired on before. A gap since our last message is a real signal — more so if they have been writing into it — so the ticket's other branch (widening the timeline section to expose the real interval between consecutive messages) buys nothing this rung needs. The number the page can honestly state is the one it was already computing.

## 2. The seat was not established

`missingNextStepMoment` said **"nothing is scheduled with the person whose seat decides it"**, and fired on **any** recorded stakeholder role. The vocabulary distinguishes the seats that decide (`economic_buyer`, `decision_maker`) from the ones that do not (`champion`, `influencer`, `user`), so telling a rep the deal turns on somebody recorded as an influencer is a claim the row refuses.

It names the seat the record holds:

> The deal is live and nothing is scheduled with them. They are **the recorded influencer** on it.

and falls back to **"a stakeholder"** where the edge carries no role — naming one there would invent the fact the rung exists to report.

**The rung is deliberately not narrowed to the deciding roles.** A deal with no next step is worth saying whoever the seat belongs to; what was wrong was the sentence, not the trigger. Narrowing would have removed real signal to fix a wording defect.

## Neither text was under a test

Which is how both drifted from their data — the existing suite passed unchanged against both the old wording and the new. They are now:

- the re-engagement case drives the fixture the old sentence could not be true about (our last outbound 60 days back, their message yesterday) and asserts the whole headline, plus that neither sentence still claims the silence was theirs;
- the next-step case is a table over four seats — an influencer, an economic buyer, a role-less edge and a blank one — asserting the whole sentence each time.

**Mutation checks:**

| mutation | killed |
|---|---|
| restore "They replied after N quiet days" | the re-engagement case |
| restore "the person whose seat decides it" | three of the four seat cases |
| drop the blank-role trim from the fallback | the blank-role case alone |

`make check-backend` green.