### PR TITLE
fix(briefs): a brief names the ranking factor it could not read

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -40565,7 +40565,7 @@ components:
         `brief_item`): the ranked, honest-short queue of winnable deals plus the metadata that
         reproduces it. `candidate_count` is how many deals cleared the §10 honest-short bar;
         `items` is the top slice (≤ 7) — genuinely shorter when fewer qualify, never padded.
-      required: [id, generated_at, as_of, candidate_count, items]
+      required: [id, generated_at, as_of, candidate_count, items, factors_omitted]
       properties:
         id: { type: string, format: uuid }
         generated_at: { type: string, format: date-time, description: When this run was assembled. }
@@ -40603,6 +40603,32 @@ components:
             When the overnight agent last wrote its findings, null when no pass has. A reader
             showing a run with no narrative must consult this before saying "a quiet night":
             without it, a model that never ran and a night with nothing in it look identical.
+        factors_omitted:
+          type: array
+          description: |
+            The ranking factors this run could not read, so a client can say "the order does
+            not account for this" instead of presenting a queue as fully ranked. Never
+            returned absent, and empty on the ordinary read: empty and withheld are different
+            answers, and a factor that floors silently makes a deal rank lower than it is with
+            nothing marking why.
+
+            `warmth` is omitted for a caller with no `relationship` edge grant. Every seat on
+            a deal is a `deal_stakeholder` edge, so such a caller runs no stakeholder read at
+            all and the factor has no input for ANY deal — which is why this is a property of
+            the run and not of an item.
+
+            A named factor still appears in each item's `feature_vector`, at its floor. The
+            decomposition is what the run scored with, and editing it here would leave a
+            reader unable to check the `composite` against its parts; this array is what says
+            the floor is an absence rather than a reading.
+
+            Stored with the run. The grant can be given or taken away afterwards, and a queue
+            ranked without warmth must not later be read as one that had it. Empty on a run
+            assembled before this field existed — a rep has one run per local day, so those
+            age out within a day.
+          items:
+            type: string
+            enum: [warmth]
 
     MorningBriefItem:
       type: object

--- a/backend/internal/compose/briefs/briefday.go
+++ b/backend/internal/compose/briefs/briefday.go
@@ -62,11 +62,11 @@ func insertRunIfDayFree(ctx context.Context, tx pgx.Tx, run BriefRun) (bool, err
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO brief_run (
 			id, user_id, generated_at, as_of, local_day, candidate_count,
-			revenue_norm_minor, revenue_norm_currency)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			revenue_norm_minor, revenue_norm_currency, factors_omitted)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT ON CONSTRAINT uq_brief_run_user_day DO NOTHING`,
 		run.ID, run.UserID, run.GeneratedAt, run.AsOf, run.LocalDay, run.CandidateCount,
-		run.RevenueNormMinor, run.RevenueNormCurrency)
+		run.RevenueNormMinor, run.RevenueNormCurrency, run.FactorsOmitted)
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/compose/briefs/briefhandlers.go
+++ b/backend/internal/compose/briefs/briefhandlers.go
@@ -189,7 +189,21 @@ func briefRunToWire(run BriefRun) crmcontracts.MorningBrief {
 		Narrative:           nullableText(run.Narrative),
 		AnnotatedAt:         run.AnnotatedAt,
 		Items:               items,
+		FactorsOmitted:      omittedFactorsWire(run.FactorsOmitted),
 	}
+}
+
+// omittedFactorsWire renders the run's withheld factors, never absent.
+//
+// An empty array and an absent field are different answers: the contract says
+// this is always present, so a client can render "the order does not account
+// for this" without first having to decide whether the server simply forgot.
+func omittedFactorsWire(stored []string) []crmcontracts.MorningBriefFactorsOmitted {
+	out := make([]crmcontracts.MorningBriefFactorsOmitted, 0, len(stored))
+	for _, factor := range stored {
+		out = append(out, crmcontracts.MorningBriefFactorsOmitted(factor))
+	}
+	return out
 }
 
 // nullableText serves empty prose as JSON null rather than "".

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -181,7 +181,8 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 	stakeholders := gathered.stakeholders
 	lineage := gathered.lineage
 
-	if err := e.resolveWarmth(ctx, now, facts, stakeholders); err != nil {
+	warmthReadable, err := e.resolveWarmth(ctx, now, facts, stakeholders)
+	if err != nil {
 		return BriefRanking{}, err
 	}
 
@@ -226,7 +227,7 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 		RevenueNormMinor:    revenueNorm,
 		RevenueNormCurrency: gathered.revenueNormCurrency,
 		AsOf:                now,
-		FactorsOmitted:      omittedFactors(gathered),
+		FactorsOmitted:      omittedFactors(gathered, warmthReadable),
 	}, nil
 }
 

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -47,6 +47,11 @@ type BriefRanking struct {
 	// the USD in force by then.
 	RevenueNormCurrency string
 	AsOf                time.Time
+	// FactorsOmitted names the ranking factors this run could not read. Empty
+	// is the ordinary answer and is not the same as a factor that scored zero:
+	// a floored factor the reader is not told about makes every deal rank lower
+	// than it is, with nothing marking why.
+	FactorsOmitted []string
 }
 
 // briefStrengthSource is the compose-injected §4 warmth seam —
@@ -99,6 +104,10 @@ type briefFacts struct {
 	// revenueNormCurrency is what that value is in.
 	revenueNorm         int64
 	revenueNormCurrency string
+	// seatsReadable is whether the caller holds the edge grant the stakeholder
+	// read needs. False is NOT "this rep's deals have no stakeholders": it
+	// floors the warmth factor for every deal, which reorders the queue.
+	seatsReadable bool
 }
 
 // gather reads one transaction's worth of ranking facts.
@@ -134,7 +143,8 @@ func (e *BriefEngine) gather(ctx context.Context, now time.Time, userID ids.UUID
 		if err := briefCandidates(ctx, tx, userID, now, base, out.facts, &out.order); err != nil {
 			return err
 		}
-		if err := briefEvidenceRows(ctx, tx, lastView, out.facts, out.order, out.stakeholders); err != nil {
+		out.seatsReadable, err = briefEvidenceRows(ctx, tx, lastView, out.facts, out.order, out.stakeholders)
+		if err != nil {
 			return err
 		}
 		// Why each returning deal is back, for the whole candidate set at once.
@@ -216,6 +226,7 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 		RevenueNormMinor:    revenueNorm,
 		RevenueNormCurrency: gathered.revenueNormCurrency,
 		AsOf:                now,
+		FactorsOmitted:      omittedFactors(gathered),
 	}, nil
 }
 
@@ -352,16 +363,22 @@ func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.T
 // briefEvidenceRows gathers each candidate's overnight activities (the
 // momentum evidence) and stakeholder persons, after the candidate rows
 // are drained (one connection, one active query).
-func briefEvidenceRows(ctx context.Context, tx pgx.Tx, lastView *time.Time, facts map[ids.UUID]briefDealFacts, order []ids.UUID, stakeholders map[ids.UUID][]ids.UUID) error {
+//
+// It reports whether the seat evidence was READABLE, because that is not the
+// same as a deal having no stakeholders. A refused caller gets a floored warmth
+// factor on every deal, which reorders the queue; the caller has to be told, or
+// they read an order that is wrong rather than one that is short.
+func briefEvidenceRows(
+	ctx context.Context, tx pgx.Tx, lastView *time.Time,
+	facts map[ids.UUID]briefDealFacts, order []ids.UUID, stakeholders map[ids.UUID][]ids.UUID,
+) (seatsReadable bool, err error) {
 	// The seat edge's admission is resolved ONCE, ahead of the loop: it is a
 	// property of the caller, not of the deal being read, and asking per deal
 	// would put a grant lookup inside a per-row loop for an answer that cannot
-	// change. A refused caller runs no stakeholder query at all — the brief
-	// simply carries no seat evidence, which is the same shape as a deal with
-	// no stakeholders on it.
+	// change. A refused caller runs no stakeholder query at all.
 	edgeArgs, edgeBound, mayReadSeats, err := seatEvidenceBound(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 	for _, dealID := range order {
 		f := facts[dealID]
@@ -373,7 +390,7 @@ func briefEvidenceRows(ctx context.Context, tx pgx.Tx, lastView *time.Time, fact
 			ORDER BY a.occurred_at DESC, a.id DESC
 			LIMIT $3`, dealID, lastView, briefOvernightEvidenceCap))
 		if err != nil {
-			return err
+			return false, err
 		}
 		f.overnightActivityIDs = overnight
 		facts[dealID] = f
@@ -387,72 +404,11 @@ func briefEvidenceRows(ctx context.Context, tx pgx.Tx, lastView *time.Time, fact
 			  AND (%s)
 			ORDER BY r.person_id`, edgeBound), append([]any{dealID}, edgeArgs...)...))
 		if err != nil {
-			return err
+			return false, err
 		}
 		stakeholders[dealID] = persons
 	}
-	return nil
-}
-
-// seatEvidenceBound resolves the seat edge's admission for the stakeholder
-// evidence read: the arguments its clause binds, the clause itself, and whether
-// the caller may run the read at all.
-//
-// The registrar returns positions offset by one because the statement it feeds
-// already spends $1 on the deal id. Getting that wrong would bind the deal id
-// to a scope predicate, which is why the offset lives here with the statement
-// it belongs to rather than at the call site.
-func seatEvidenceBound(ctx context.Context) (args []any, clause string, admitted bool, err error) {
-	clause, err = auth.EdgeReadScope(ctx, "r", func(v any) int {
-		args = append(args, v)
-		return len(args) + 1
-	})
-	if errors.Is(err, apperrors.ErrPermissionDenied) {
-		return nil, "", false, nil
-	}
-	if err != nil {
-		return nil, "", false, err
-	}
-	if clause == "" {
-		clause = "TRUE"
-	}
-	return args, clause, true, nil
-}
-
-// resolveWarmth fills each deal's warmth from its strongest visible
-// stakeholder through the injected §4 seam. A stakeholder outside the
-// caller's row scope — or a caller with no person grant at all —
-// contributes nothing: the warmth factor floors instead of out-seeing
-// the people list.
-func (e *BriefEngine) resolveWarmth(ctx context.Context, now time.Time, facts map[ids.UUID]briefDealFacts, stakeholders map[ids.UUID][]ids.UUID) error {
-	cache := map[ids.UUID]people.RelationshipStrength{}
-	for dealID, persons := range stakeholders {
-		f := facts[dealID]
-		for _, personID := range persons {
-			st, ok := cache[personID]
-			if !ok {
-				var err error
-				st, err = e.strength.PersonStrength(ctx, ids.From[ids.PersonKind](personID), now)
-				switch {
-				case errors.Is(err, apperrors.ErrNotFound), errors.Is(err, apperrors.ErrPermissionDenied):
-					// Invisible to this caller: no strength to disclose.
-					st = people.RelationshipStrength{}
-				case err != nil:
-					return err
-				}
-				cache[personID] = st
-			}
-			if st.Strength > f.warmthStrength {
-				f.warmthStrength = st.Strength
-				f.warmthEvidence = make([]ids.UUID, len(st.ContributingIDs))
-				for i, activityID := range st.ContributingIDs {
-					f.warmthEvidence[i] = activityID.UUID
-				}
-			}
-		}
-		facts[dealID] = f
-	}
-	return nil
+	return mayReadSeats, nil
 }
 
 // collectIDList drains a single-uuid-column result set (the compose

--- a/backend/internal/compose/briefs/briefstore.go
+++ b/backend/internal/compose/briefs/briefstore.go
@@ -55,6 +55,12 @@ type BriefRun struct {
 	// RevenueNormCurrency is what RevenueNormMinor is in. Empty on a run stored
 	// before the column existed, which the wire omits rather than guessing at.
 	RevenueNormCurrency string
+	// FactorsOmitted names the ranking factors the run had no input for. Empty
+	// is the ordinary answer AND what a run stored before the column existed
+	// reads as — unlike the currency above, which the wire omits: an empty list
+	// is the honest reading of a run nobody recorded an omission for, and those
+	// age out within a day.
+	FactorsOmitted []string
 	// Narrative is the overnight agent's sentence about the night, empty when
 	// no pass has written one — which AnnotatedAt is what distinguishes from a
 	// pass that ran and had nothing to say.
@@ -148,6 +154,7 @@ func (e *BriefEngine) SnapshotRunForDay(ctx context.Context, now time.Time) (Bri
 		CandidateCount:      ranking.CandidateCount,
 		RevenueNormMinor:    ranking.RevenueNormMinor,
 		RevenueNormCurrency: ranking.RevenueNormCurrency,
+		FactorsOmitted:      ranking.FactorsOmitted,
 	}
 	queueDeals := make([]ids.UUID, 0, len(ranking.Queue))
 	var joinedExisting bool
@@ -186,6 +193,7 @@ func (e *BriefEngine) SnapshotRunForDay(ctx context.Context, now time.Time) (Bri
 			"candidate_count":       run.CandidateCount,
 			"revenue_norm_minor":    run.RevenueNormMinor,
 			"revenue_norm_currency": run.RevenueNormCurrency,
+			"factors_omitted":       run.FactorsOmitted,
 			"queue_deal_ids":        queueDeals,
 		})
 		return err
@@ -323,7 +331,7 @@ func (e *BriefEngine) LatestRun(ctx context.Context, now time.Time) (BriefRun, e
 // carries a zero.
 const runSelect = `
 	SELECT id, user_id, generated_at, as_of, local_day, candidate_count, revenue_norm_minor,
-	       revenue_norm_currency, coalesce(narrative, ''), annotated_at
+	       revenue_norm_currency, factors_omitted, coalesce(narrative, ''), annotated_at
 	FROM brief_run`
 
 // scanRun reads one runSelect row, answering ErrNotFound for no row.
@@ -331,7 +339,7 @@ func scanRun(row pgx.Row) (BriefRun, error) {
 	var run BriefRun
 	err := row.Scan(&run.ID, &run.UserID, &run.GeneratedAt, &run.AsOf, &run.LocalDay,
 		&run.CandidateCount, &run.RevenueNormMinor, &run.RevenueNormCurrency,
-		&run.Narrative, &run.AnnotatedAt)
+		&run.FactorsOmitted, &run.Narrative, &run.AnnotatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return BriefRun{}, apperrors.ErrNotFound
 	}

--- a/backend/internal/compose/briefs/briefwarmth.go
+++ b/backend/internal/compose/briefs/briefwarmth.go
@@ -23,6 +23,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // omittedFactors names the ranking factors this run had no input for, as
@@ -95,6 +96,19 @@ func (e *BriefEngine) resolveWarmth(
 	ctx context.Context, now time.Time,
 	facts map[ids.UUID]briefDealFacts, stakeholders map[ids.UUID][]ids.UUID,
 ) (readable bool, err error) {
+	// Asked UP FRONT, the way the seat edge is, and not inferred from the first
+	// refusal. A caller with no person grant whose candidate deals happen to
+	// carry no stakeholders never reaches the read at all — so a run that
+	// inferred the answer would report nothing withheld for a queue whose warmth
+	// factor could not have been read even if there had been someone to score.
+	// The grant is a property of the caller; the seats are a property of the
+	// deals, and only one of those decides whether the factor is readable.
+	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return false, nil
+		}
+		return false, err
+	}
 	readable = true
 	cache := map[ids.UUID]people.RelationshipStrength{}
 	for dealID, persons := range stakeholders {
@@ -110,9 +124,10 @@ func (e *BriefEngine) resolveWarmth(
 					// and the queue is still ranked on what they may know.
 					st = people.RelationshipStrength{}
 				case errors.Is(err, apperrors.ErrPermissionDenied):
-					// No person grant at all. Every person on every deal answers
-					// the same way, so this is not one deal scoring low — it is
-					// the factor having nothing to read.
+					// The grant was checked above, so this is the seam refusing
+					// for a reason of its own. Still not one deal scoring low:
+					// every person answers the same way, so the factor has
+					// nothing to read for the whole run.
 					readable = false
 					st = people.RelationshipStrength{}
 				case err != nil:

--- a/backend/internal/compose/briefs/briefwarmth.go
+++ b/backend/internal/compose/briefs/briefwarmth.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package briefs
+
+// The warmth factor: where its input comes from, who may read that input, and
+// what the run says when nobody may.
+//
+// Split from briefrank.go because it is the one factor whose input is behind a
+// SEPARATE grant. Every other ranking fact rides the deal read the queue is
+// already bounded by; warmth reads the deal's stakeholders, which is the
+// `relationship` edge, and a caller can hold one and not the other. That makes
+// "could we read it" a question the other factors never have to ask — and the
+// answer part of the run's own record.
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// omittedFactors names the ranking factors this run had no input for, as
+// opposed to the ones that scored low.
+//
+// Only warmth can be withheld today, and it is all-or-nothing: every seat on a
+// deal is a `deal_stakeholder` edge, so a caller without that grant reads no
+// stakeholders for ANY deal. That is why it is a property of the run rather
+// than of an item, and why one refused read omits the factor outright instead
+// of leaving a queue where some deals were scored with it and some without.
+// Empty rather than nil: "nothing was withheld" is an ANSWER, and the column
+// storing it is NOT NULL for the same reason the wire field is always present.
+func omittedFactors(gathered briefFacts) []string {
+	if gathered.seatsReadable {
+		return []string{}
+	}
+	return []string{string(crmcontracts.Warmth)}
+}
+
+// seatEvidenceBound resolves the seat edge's admission for the stakeholder
+// evidence read: the arguments its clause binds, the clause itself, and whether
+// the caller may run the read at all.
+//
+// The registrar returns positions offset by one because the statement it feeds
+// already spends $1 on the deal id. Getting that wrong would bind the deal id
+// to a scope predicate, which is why the offset lives here with the statement
+// it belongs to rather than at the call site.
+// A refusal is reported through `admitted`, never swallowed: what the caller
+// does with it is the whole question this read used to leave open, and
+// briefEvidenceRows carries the answer up to the run.
+func seatEvidenceBound(ctx context.Context) (args []any, clause string, admitted bool, err error) {
+	clause, err = auth.EdgeReadScope(ctx, "r", func(v any) int {
+		args = append(args, v)
+		return len(args) + 1
+	})
+	if errors.Is(err, apperrors.ErrPermissionDenied) {
+		return nil, "", false, nil
+	}
+	if err != nil {
+		return nil, "", false, err
+	}
+	if clause == "" {
+		clause = "TRUE"
+	}
+	return args, clause, true, nil
+}
+
+// resolveWarmth fills each deal's warmth from its strongest visible
+// stakeholder through the injected §4 seam.
+//
+// A stakeholder outside the caller's ROW scope contributes nothing: the factor
+// floors for that deal instead of out-seeing the people list, which is right —
+// the queue is still ranked on what this reader may know, deal by deal, the way
+// every other factor is.
+//
+// A caller refused the seat edge OUTRIGHT is the different case, and it is not
+// answered here: the factor has no input for ANY deal, so the whole queue
+// reorders. That one is named in BriefRanking.FactorsOmitted rather than
+// floored in silence — see omittedFactors.
+func (e *BriefEngine) resolveWarmth(ctx context.Context, now time.Time, facts map[ids.UUID]briefDealFacts, stakeholders map[ids.UUID][]ids.UUID) error {
+	cache := map[ids.UUID]people.RelationshipStrength{}
+	for dealID, persons := range stakeholders {
+		f := facts[dealID]
+		for _, personID := range persons {
+			st, ok := cache[personID]
+			if !ok {
+				var err error
+				st, err = e.strength.PersonStrength(ctx, ids.From[ids.PersonKind](personID), now)
+				switch {
+				case errors.Is(err, apperrors.ErrNotFound), errors.Is(err, apperrors.ErrPermissionDenied):
+					// Invisible to this caller: no strength to disclose.
+					st = people.RelationshipStrength{}
+				case err != nil:
+					return err
+				}
+				cache[personID] = st
+			}
+			if st.Strength > f.warmthStrength {
+				f.warmthStrength = st.Strength
+				f.warmthEvidence = make([]ids.UUID, len(st.ContributingIDs))
+				for i, activityID := range st.ContributingIDs {
+					f.warmthEvidence[i] = activityID.UUID
+				}
+			}
+		}
+		facts[dealID] = f
+	}
+	return nil
+}

--- a/backend/internal/compose/briefs/briefwarmth.go
+++ b/backend/internal/compose/briefs/briefwarmth.go
@@ -28,15 +28,18 @@ import (
 // omittedFactors names the ranking factors this run had no input for, as
 // opposed to the ones that scored low.
 //
-// Only warmth can be withheld today, and it is all-or-nothing: every seat on a
-// deal is a `deal_stakeholder` edge, so a caller without that grant reads no
-// stakeholders for ANY deal. That is why it is a property of the run rather
-// than of an item, and why one refused read omits the factor outright instead
-// of leaving a queue where some deals were scored with it and some without.
+// Only warmth can be withheld today, and it is all-or-nothing whichever of its
+// two reads is refused. Every seat on a deal is a `deal_stakeholder` edge, so a
+// caller without that grant reads no stakeholders for ANY deal; and a caller
+// without the person grant gets the same answer for every stakeholder they do
+// reach. Either way the factor has no input anywhere, which is why this is a
+// property of the run rather than of an item, and why it omits the factor
+// outright instead of leaving a queue where some deals were scored with it and
+// some without.
 // Empty rather than nil: "nothing was withheld" is an ANSWER, and the column
 // storing it is NOT NULL for the same reason the wire field is always present.
-func omittedFactors(gathered briefFacts) []string {
-	if gathered.seatsReadable {
+func omittedFactors(gathered briefFacts, warmthReadable bool) []string {
+	if gathered.seatsReadable && warmthReadable {
 		return []string{}
 	}
 	return []string{string(crmcontracts.Warmth)}
@@ -78,11 +81,21 @@ func seatEvidenceBound(ctx context.Context) (args []any, clause string, admitted
 // the queue is still ranked on what this reader may know, deal by deal, the way
 // every other factor is.
 //
-// A caller refused the seat edge OUTRIGHT is the different case, and it is not
-// answered here: the factor has no input for ANY deal, so the whole queue
-// reorders. That one is named in BriefRanking.FactorsOmitted rather than
-// floored in silence — see omittedFactors.
-func (e *BriefEngine) resolveWarmth(ctx context.Context, now time.Time, facts map[ids.UUID]briefDealFacts, stakeholders map[ids.UUID][]ids.UUID) error {
+// An OUTRIGHT refusal is the different case: the factor then has no input for
+// ANY deal, so the whole queue reorders and the reader is owed the fact. There
+// are two ways to be refused outright and both are reported — the seat edge
+// (seatEvidenceBound, above) and the person grant this read needs, which is
+// what `readable` answers.
+//
+// The two are told apart by their sentinel, which is the contract the whole
+// tree holds: a row-scope miss answers ErrNotFound so existence stays hidden,
+// and an object denial answers ErrPermissionDenied. Reading them as one thing
+// is what let a caller with no person grant get a silently cold queue.
+func (e *BriefEngine) resolveWarmth(
+	ctx context.Context, now time.Time,
+	facts map[ids.UUID]briefDealFacts, stakeholders map[ids.UUID][]ids.UUID,
+) (readable bool, err error) {
+	readable = true
 	cache := map[ids.UUID]people.RelationshipStrength{}
 	for dealID, persons := range stakeholders {
 		f := facts[dealID]
@@ -92,11 +105,18 @@ func (e *BriefEngine) resolveWarmth(ctx context.Context, now time.Time, facts ma
 				var err error
 				st, err = e.strength.PersonStrength(ctx, ids.From[ids.PersonKind](personID), now)
 				switch {
-				case errors.Is(err, apperrors.ErrNotFound), errors.Is(err, apperrors.ErrPermissionDenied):
-					// Invisible to this caller: no strength to disclose.
+				case errors.Is(err, apperrors.ErrNotFound):
+					// Outside this caller's row scope: no strength to disclose,
+					// and the queue is still ranked on what they may know.
+					st = people.RelationshipStrength{}
+				case errors.Is(err, apperrors.ErrPermissionDenied):
+					// No person grant at all. Every person on every deal answers
+					// the same way, so this is not one deal scoring low — it is
+					// the factor having nothing to read.
+					readable = false
 					st = people.RelationshipStrength{}
 				case err != nil:
-					return err
+					return false, err
 				}
 				cache[personID] = st
 			}
@@ -110,5 +130,5 @@ func (e *BriefEngine) resolveWarmth(ctx context.Context, now time.Time, facts ma
 		}
 		facts[dealID] = f
 	}
-	return nil
+	return readable, nil
 }

--- a/backend/internal/compose/briefs/briefwithheldfactor_integration_test.go
+++ b/backend/internal/compose/briefs/briefwithheldfactor_integration_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package briefs
+
+// A rank computed from a withheld input is a WRONG answer, not a short one.
+//
+// Every seat on a deal is a `deal_stakeholder` edge, so a caller without the
+// relationship grant reads no stakeholders for any deal and the warmth factor
+// floors across the whole queue. Silently, the brief then hands back an order
+// that is not the order — deals sit lower than they are, and nothing on the
+// page says the reader is missing the reason.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// edgeBlindPerms is RepPerms with the relationship grant taken away and
+// everything else the brief needs left in place — the caller who may read the
+// deals and not who sits on them. A deep copy, because a plain struct copy
+// shares the Objects map with every other suite using the fixture.
+func edgeBlindPerms() principal.Permissions {
+	perms := integration.RepPerms
+	perms.Objects = make(map[string]principal.ObjectGrant, len(integration.RepPerms.Objects))
+	for object, grant := range integration.RepPerms.Objects {
+		if object == "relationship" {
+			continue
+		}
+		perms.Objects[object] = grant
+	}
+	return perms
+}
+
+func TestABriefNamesTheFactorItCouldNotRead(t *testing.T) {
+	b := setupBrief(t)
+
+	blind, err := b.engine.SnapshotRun(b.As(b.Rep1, []ids.UUID{b.Team1}, edgeBlindPerms()), briefClock)
+	if err != nil {
+		t.Fatalf("snapshot for a caller without the edge grant: %v", err)
+	}
+	if !slices.Contains(blind.FactorsOmitted, "warmth") {
+		t.Errorf("the run omits %v, want warmth named — the factor floored on every deal and the "+
+			"queue came back ordered as though that were a reading", blind.FactorsOmitted)
+	}
+}
+
+// The other half, and the half that makes the first mean something: a caller
+// who CAN read the seats gets an empty list, never a nil one. Empty and
+// withheld are different answers, and a client that had to tell them apart by
+// guessing would render every brief as withheld or none of them.
+func TestABriefThatReadEveryFactorOmitsNone(t *testing.T) {
+	b := setupBrief(t)
+
+	seeing, err := b.engine.SnapshotRun(b.As(b.Rep1, []ids.UUID{b.Team1}, integration.RepPerms), briefClock)
+	if err != nil {
+		t.Fatalf("snapshot for a caller holding the edge grant: %v", err)
+	}
+	if len(seeing.FactorsOmitted) != 0 {
+		t.Errorf("a run that read everything omits %v, want nothing — if this names warmth too, "+
+			"the sibling test proves the caller was refused rather than the factor withheld",
+			seeing.FactorsOmitted)
+	}
+}

--- a/backend/internal/compose/briefs/briefwithheldfactor_integration_test.go
+++ b/backend/internal/compose/briefs/briefwithheldfactor_integration_test.go
@@ -90,15 +90,13 @@ func TestABriefThatReadEveryFactorOmitsNone(t *testing.T) {
 // hidden, and an object denial answers ErrPermissionDenied. Reading them as one
 // thing is what let this case fall through — a stakeholder outside the caller's
 // rows should floor that deal and leave the rest alone.
+//
+// The fixture deliberately seeds NO stakeholder. The grant is a property of the
+// caller and the seats are a property of the deals, so a run whose deals happen
+// to carry nobody must still report the factor withheld — an answer inferred
+// from the first refusal cannot, because there is no read to be refused.
 func TestABriefNamesWarmthWhenItMayReadSeatsButNotPeople(t *testing.T) {
 	b := setupBrief(t)
-
-	// The fixture seeds no seats, and this case only exists once a seat is read
-	// and then cannot be scored — so without one the loop below never runs and
-	// the test passes on an empty map.
-	seat := b.SeedPerson(t, "Ilse Stakeholder", &b.Rep1)
-	b.WsExec(t, `INSERT INTO relationship (kind, deal_id, person_id, source, captured_by)
-		VALUES ('deal_stakeholder', $1, $2, 'manual', 'human:x')`, b.dealA, seat)
 
 	perms := integration.RepPerms
 	perms.Objects = make(map[string]principal.ObjectGrant, len(integration.RepPerms.Objects))

--- a/backend/internal/compose/briefs/briefwithheldfactor_integration_test.go
+++ b/backend/internal/compose/briefs/briefwithheldfactor_integration_test.go
@@ -62,9 +62,59 @@ func TestABriefThatReadEveryFactorOmitsNone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("snapshot for a caller holding the edge grant: %v", err)
 	}
+	// Empty AND non-nil, checked separately. len() cannot tell the two apart,
+	// and the distinction is the point: nil marshals to `null` under a field
+	// documented never to be one, so a client would have to decide for itself
+	// whether the server meant "nothing withheld" or "not told".
+	if seeing.FactorsOmitted == nil {
+		t.Error("a run that read everything omits nil, want an empty list — the two are different " +
+			"answers on the wire, and only one of them is the one this run has to give")
+	}
 	if len(seeing.FactorsOmitted) != 0 {
 		t.Errorf("a run that read everything omits %v, want nothing — if this names warmth too, "+
 			"the sibling test proves the caller was refused rather than the factor withheld",
 			seeing.FactorsOmitted)
+	}
+}
+
+// The OTHER way to be refused the warmth factor.
+//
+// Warmth needs two grants, not one: the seat edge to learn who is on the deal,
+// and the person grant to score them. A caller holding the first and not the
+// second reads the stakeholders and then gets the same refusal for every one of
+// them — so the factor floors across the whole queue exactly as it does for an
+// edge-blind caller, and the reader is owed the same sentence.
+//
+// The two refusals are told apart by their SENTINEL, which is the contract the
+// whole tree holds: a row-scope miss answers ErrNotFound so existence stays
+// hidden, and an object denial answers ErrPermissionDenied. Reading them as one
+// thing is what let this case fall through — a stakeholder outside the caller's
+// rows should floor that deal and leave the rest alone.
+func TestABriefNamesWarmthWhenItMayReadSeatsButNotPeople(t *testing.T) {
+	b := setupBrief(t)
+
+	// The fixture seeds no seats, and this case only exists once a seat is read
+	// and then cannot be scored — so without one the loop below never runs and
+	// the test passes on an empty map.
+	seat := b.SeedPerson(t, "Ilse Stakeholder", &b.Rep1)
+	b.WsExec(t, `INSERT INTO relationship (kind, deal_id, person_id, source, captured_by)
+		VALUES ('deal_stakeholder', $1, $2, 'manual', 'human:x')`, b.dealA, seat)
+
+	perms := integration.RepPerms
+	perms.Objects = make(map[string]principal.ObjectGrant, len(integration.RepPerms.Objects))
+	for object, grant := range integration.RepPerms.Objects {
+		if object == "person" {
+			continue
+		}
+		perms.Objects[object] = grant
+	}
+	run, err := b.engine.SnapshotRun(b.As(b.Rep1, []ids.UUID{b.Team1}, perms), briefClock)
+	if err != nil {
+		t.Fatalf("snapshot for a caller who may read seats but not people: %v", err)
+	}
+	if !slices.Contains(run.FactorsOmitted, "warmth") {
+		t.Errorf("the run omits %v, want warmth named — the caller reached every stakeholder and "+
+			"could score none of them, so the factor floored across the whole queue",
+			run.FactorsOmitted)
 	}
 }

--- a/backend/internal/compose/briefseam.go
+++ b/backend/internal/compose/briefseam.go
@@ -97,6 +97,7 @@ func briefRunToTool(run briefs.BriefRun) agents.ReadBriefResult {
 		// it in a shape a model would read as a real morning.
 		PreviousLocalDay: previousDayForTool(run.PreviousDay),
 		CandidateCount:   run.CandidateCount, Items: items,
+		FactorsOmitted: append(make([]string, 0, len(run.FactorsOmitted)), run.FactorsOmitted...),
 	}
 }
 

--- a/backend/internal/compose/briefseam_test.go
+++ b/backend/internal/compose/briefseam_test.go
@@ -63,9 +63,10 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 		ID: runID, UserID: userID, GeneratedAt: generated, AsOf: asOf,
 		LocalDay:       time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC),
 		CandidateCount: 17, RevenueNormMinor: 918_273, RevenueNormCurrency: "CHF",
-		Narrative:   "Two replies overnight, one deal went quiet.",
-		AnnotatedAt: &annotatedAt,
-		PreviousDay: time.Date(2026, 8, 7, 0, 0, 0, 0, time.UTC),
+		FactorsOmitted: []string{"warmth"},
+		Narrative:      "Two replies overnight, one deal went quiet.",
+		AnnotatedAt:    &annotatedAt,
+		PreviousDay:    time.Date(2026, 8, 7, 0, 0, 0, 0, time.UTC),
 		Items: []briefs.BriefRunItem{{
 			ID: itemID, DealID: dealID, Rank: 3, Composite: 0.815,
 			Features: briefs.BriefFeatureVector{
@@ -119,6 +120,9 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 		// it — the structural version of the guarantee the digits above only
 		// have by probability.
 		"RevenueNormCurrency": "CHF",
+		// Served, not withheld: it says the ORDER the agent is reading is not
+		// the order, which no other field on the run can say.
+		"FactorsOmitted": `"factors_omitted":["warmth"]`,
 		// The items are covered field by field below; what this row asserts is
 		// that the list itself arrived.
 		"Items": `"deal_id":"` + dealID.String(),

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -7264,6 +7264,21 @@ func (e MeetingPlanUnknownKind) Valid() bool {
 	}
 }
 
+// Defines values for MorningBriefFactorsOmitted.
+const (
+	Warmth MorningBriefFactorsOmitted = "warmth"
+)
+
+// Valid indicates whether the value is a known member of the MorningBriefFactorsOmitted enum.
+func (e MorningBriefFactorsOmitted) Valid() bool {
+	switch e {
+	case Warmth:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for MorningBriefItemReopenOn.
 const (
 	MorningBriefItemReopenOnMeeting MorningBriefItemReopenOn = "meeting"
@@ -26507,6 +26522,28 @@ type MorningBrief struct {
 	// CandidateCount Deals that cleared the §10 honest-short bar (may exceed the queue length).
 	CandidateCount int `json:"candidate_count"`
 
+	// FactorsOmitted The ranking factors this run could not read, so a client can say "the order does
+	// not account for this" instead of presenting a queue as fully ranked. Never
+	// returned absent, and empty on the ordinary read: empty and withheld are different
+	// answers, and a factor that floors silently makes a deal rank lower than it is with
+	// nothing marking why.
+	//
+	// `warmth` is omitted for a caller with no `relationship` edge grant. Every seat on
+	// a deal is a `deal_stakeholder` edge, so such a caller runs no stakeholder read at
+	// all and the factor has no input for ANY deal — which is why this is a property of
+	// the run and not of an item.
+	//
+	// A named factor still appears in each item's `feature_vector`, at its floor. The
+	// decomposition is what the run scored with, and editing it here would leave a
+	// reader unable to check the `composite` against its parts; this array is what says
+	// the floor is an absence rather than a reading.
+	//
+	// Stored with the run. The grant can be given or taken away afterwards, and a queue
+	// ranked without warmth must not later be read as one that had it. Empty on a run
+	// assembled before this field existed — a rep has one run per local day, so those
+	// age out within a day.
+	FactorsOmitted []MorningBriefFactorsOmitted `json:"factors_omitted"`
+
 	// GeneratedAt When this run was assembled.
 	GeneratedAt time.Time          `json:"generated_at"`
 	Id          openapi_types.UUID `json:"id"`
@@ -26529,6 +26566,9 @@ type MorningBrief struct {
 	// RevenueNormMinor The workspace-P90 (or fallback) base value the revenue factor normalized against.
 	RevenueNormMinor *int64 `json:"revenue_norm_minor,omitempty"`
 }
+
+// MorningBriefFactorsOmitted defines model for MorningBrief.FactorsOmitted.
+type MorningBriefFactorsOmitted string
 
 // MorningBriefFeatureVector The §10.1 factor decomposition, each normalized 0..1 — the composite reconciles to it.
 type MorningBriefFeatureVector struct {

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -7177,6 +7177,12 @@
           "candidate_count": {
             "type": "integer"
           },
+          "factors_omitted": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "generated_at": {
             "type": "string"
           },
@@ -7290,6 +7296,7 @@
           "as_of",
           "brief_id",
           "candidate_count",
+          "factors_omitted",
           "generated_at",
           "items",
           "local_day"

--- a/backend/internal/modules/agents/tools_brief.go
+++ b/backend/internal/modules/agents/tools_brief.go
@@ -96,8 +96,11 @@ type ReadBriefResult struct {
 	// Items is never null on the wire. An agent reading `null` has to decide
 	// whether it means "nothing is queued" or "the queue was not read".
 	Items []BriefItem `json:"items"`
-	// FactorsOmitted names the ranking factors this run had no input for, and
-	// is never null for the same reason Items is not.
+	// FactorsOmitted names the ranking factors this run had no input for. Never
+	// null, and normalized in Handle beside Items rather than trusted from the
+	// reader: the promise is a property of this wire, and a seam returning a
+	// zero-value run would otherwise serve `null` under a field documented
+	// never to be one.
 	//
 	// It is served rather than withheld, unlike the revenue base above: that
 	// one explains a number the agent already has normalized, while this one
@@ -228,6 +231,9 @@ func (t readBrief) Handle(ctx context.Context, in json.RawMessage) (json.RawMess
 	// be one.
 	if result.Items == nil {
 		result.Items = []BriefItem{}
+	}
+	if result.FactorsOmitted == nil {
+		result.FactorsOmitted = []string{}
 	}
 	// The queue is CONTENT built out of material this call did not read the
 	// provenance of — deals, their activities, the relationships behind them,

--- a/backend/internal/modules/agents/tools_brief.go
+++ b/backend/internal/modules/agents/tools_brief.go
@@ -96,6 +96,19 @@ type ReadBriefResult struct {
 	// Items is never null on the wire. An agent reading `null` has to decide
 	// whether it means "nothing is queued" or "the queue was not read".
 	Items []BriefItem `json:"items"`
+	// FactorsOmitted names the ranking factors this run had no input for, and
+	// is never null for the same reason Items is not.
+	//
+	// It is served rather than withheld, unlike the revenue base above: that
+	// one explains a number the agent already has normalized, while this one
+	// says the ORDER in front of it is not the order. An agent told a queue is
+	// ranked will reason about why the third deal is third; if warmth was
+	// withheld, the honest answer is that nobody knows, and only this field can
+	// say so.
+	//
+	// A named factor still appears in each item's Factors, at its floor — the
+	// decomposition has to reconcile to the composite the run actually scored.
+	FactorsOmitted []string `json:"factors_omitted"`
 }
 
 // BriefItem is one queue entry: the deal it is about, why it ranked, and what

--- a/backend/migrations/core/1788851400_a_brief_says_which_factor_it_could_not_read.down.sql
+++ b/backend/migrations/core/1788851400_a_brief_says_which_factor_it_could_not_read.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+ALTER TABLE brief_run DROP CONSTRAINT IF EXISTS brief_run_factors_omitted_vocabulary;
+ALTER TABLE brief_run DROP COLUMN IF EXISTS factors_omitted;

--- a/backend/migrations/core/1788851400_a_brief_says_which_factor_it_could_not_read.up.sql
+++ b/backend/migrations/core/1788851400_a_brief_says_which_factor_it_could_not_read.up.sql
@@ -1,0 +1,28 @@
+-- A brief names the ranking factor it was not allowed to read.
+--
+-- The queue is ordered by several factors, one of which is the warmth of the
+-- deal's stakeholders. A caller with no `relationship` edge grant runs no
+-- stakeholder read at all, so that factor floored for every deal and the queue
+-- came back ordered LOWER than it should be, with nothing saying why. A rank
+-- computed from a withheld input is a wrong answer, not an incomplete one.
+--
+-- Stored with the run rather than resolved on read, for the same reason
+-- revenue_norm_currency is: the grant can be given or taken away afterwards,
+-- and a queue ranked without warmth must not later be read as one that had it.
+--
+-- An array rather than a boolean because it answers "which", and the queue has
+-- more than one factor that could become unreadable. Empty is the ordinary
+-- answer and is distinct from absent: every run written from here on says
+-- something, and a run stored before this column existed reads as empty — those
+-- age out within a day, since a rep has exactly one run per local day.
+SET LOCAL lock_timeout = '3s';
+ALTER TABLE brief_run
+    ADD COLUMN IF NOT EXISTS factors_omitted text[] DEFAULT '{}'::text[] NOT NULL;
+
+-- The vocabulary is closed: a factor nothing can render is a factor a client
+-- silently drops, which is the failure this column exists to end.
+ALTER TABLE brief_run
+    DROP CONSTRAINT IF EXISTS brief_run_factors_omitted_vocabulary;
+ALTER TABLE brief_run
+    ADD CONSTRAINT brief_run_factors_omitted_vocabulary
+        CHECK (factors_omitted <@ ARRAY['warmth']::text[]);

--- a/backend/migrations/core/1788851400_a_brief_says_which_factor_it_could_not_read.up.sql
+++ b/backend/migrations/core/1788851400_a_brief_says_which_factor_it_could_not_read.up.sql
@@ -23,6 +23,10 @@ ALTER TABLE brief_run
 -- silently drops, which is the failure this column exists to end.
 ALTER TABLE brief_run
     DROP CONSTRAINT IF EXISTS brief_run_factors_omitted_vocabulary;
+-- NOT VALID, and validated by the migration after this one. The runner wraps
+-- each file in ONE transaction, so a validating ADD CONSTRAINT here would scan
+-- every brief_run row under the ACCESS EXCLUSIVE that ALTER holds until commit,
+-- and brief writes would queue behind the scan.
 ALTER TABLE brief_run
     ADD CONSTRAINT brief_run_factors_omitted_vocabulary
-        CHECK (factors_omitted <@ ARRAY['warmth']::text[]);
+        CHECK (factors_omitted <@ ARRAY['warmth']::text[]) NOT VALID;

--- a/backend/migrations/core/1788851401_the_brief_factor_vocabulary_is_validated.down.sql
+++ b/backend/migrations/core/1788851401_the_brief_factor_vocabulary_is_validated.down.sql
@@ -1,0 +1,3 @@
+-- Nothing to undo: the constraint itself is the previous migration's, and a
+-- validated check cannot be returned to NOT VALID.
+SELECT 1;

--- a/backend/migrations/core/1788851401_the_brief_factor_vocabulary_is_validated.up.sql
+++ b/backend/migrations/core/1788851401_the_brief_factor_vocabulary_is_validated.up.sql
@@ -1,0 +1,14 @@
+-- Validate the check the migration before this one added NOT VALID.
+--
+-- Its own file because the runner wraps each file in ONE transaction: run in
+-- the same one, this scan would sit under the ACCESS EXCLUSIVE that ALTER holds
+-- to commit, and the SHARE UPDATE EXCLUSIVE that VALIDATE asks for would be
+-- nothing but a weaker lock requested while a stronger one is held. Here it is
+-- the only statement in its own transaction, so the scan really does run under
+-- the lighter lock and brief writes do not queue behind it.
+--
+-- It cannot fail: the column was created in that migration with a constant
+-- default, so every row it scans carries the empty array.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE brief_run VALIDATE CONSTRAINT brief_run_factors_omitted_vocabulary;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1131,6 +1131,7 @@ public.brief_run acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/mar
 public.brief_run.annotated_at timestamp with time zone gen=- def=-
 public.brief_run.as_of timestamp with time zone NOT NULL gen=- def=-
 public.brief_run.brief_run_candidate_count_check CHECK ((candidate_count >= 0))
+public.brief_run.brief_run_factors_omitted_vocabulary CHECK ((factors_omitted <@ ARRAY['warmth'::text]))
 public.brief_run.brief_run_mail_error_length CHECK (((mail_error IS NULL) OR (char_length(mail_error) <= 500)))
 public.brief_run.brief_run_mail_error_needs_an_attempt CHECK (((mail_error IS NULL) OR (mail_attempted_at IS NOT NULL)))
 public.brief_run.brief_run_narrative_length CHECK (((narrative IS NULL) OR (char_length(narrative) <= 600)))
@@ -1140,6 +1141,7 @@ public.brief_run.brief_run_revenue_norm_currency_check CHECK (((revenue_norm_cur
 public.brief_run.brief_run_revenue_norm_minor_check CHECK ((revenue_norm_minor > 0))
 public.brief_run.brief_run_user_fkey FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE
 public.brief_run.candidate_count integer NOT NULL gen=- def=-
+public.brief_run.factors_omitted text[] NOT NULL gen=- def='{}'::text[]
 public.brief_run.generated_at timestamp with time zone NOT NULL gen=- def=now()
 public.brief_run.id uuid NOT NULL gen=- def=uuidv7()
 public.brief_run.local_day date NOT NULL gen=- def=-

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 74,
     "resources": 12,
-    "tool_catalog_bytes": 213041,
+    "tool_catalog_bytes": 213120,
     "resource_catalog_bytes": 4584,
-    "approx_wire_tokens_total": 54406,
+    "approx_wire_tokens_total": 54426,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 51869,
       "input_schema_bytes": 45443,
-      "output_schema_bytes": 99775,
+      "output_schema_bytes": 99854,
       "description_plus_input_schema_bytes": 97312
     }
   },
@@ -9178,6 +9178,12 @@
                 "candidate_count": {
                   "type": "integer"
                 },
+                "factors_omitted": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "generated_at": {
                   "type": "string"
                 },
@@ -9291,6 +9297,7 @@
                 "as_of",
                 "brief_id",
                 "candidate_count",
+                "factors_omitted",
                 "generated_at",
                 "items",
                 "local_day"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 74 |
 | Resources | 12 |
-| Tool catalog | 208.0 KB |
+| Tool catalog | 208.1 KB |
 | Resource catalog | 4.5 KB |
-| Approx. wire tokens | 54406 |
+| Approx. wire tokens | 54426 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,7 +29,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 97.4 KB | 46% | **No** — a result's shape, never listed to a model |
+| Output schemas | 97.5 KB | 46% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 50.7 KB | 24% | Yes, every step |
 | Input schemas | 44.4 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.6 KB | 7% | Partly |
@@ -115,7 +115,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
 | [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 4.0 KB |
 | [`read_approval`](#read_approval) | Read one staged action in full | yes |  | 2.4 KB |
-| [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 3.1 KB |
+| [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 3.2 KB |
 | [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.9 KB |
 | [`read_import_run`](#read_import_run) | Read an import run | yes |  | 1.4 KB |
 | [`read_project_360`](#read_project_360) | Read a project's page | yes |  | 6.4 KB |
@@ -9997,6 +9997,12 @@ Renders its result in [`ui://margince/account-brief.html`](#account_brief_view),
         "candidate_count": {
           "type": "integer"
         },
+        "factors_omitted": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "generated_at": {
           "type": "string"
         },
@@ -10110,6 +10116,7 @@ Renders its result in [`ui://margince/account-brief.html`](#account_brief_view),
         "as_of",
         "brief_id",
         "candidate_count",
+        "factors_omitted",
         "generated_at",
         "items",
         "local_day"

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -30365,6 +30365,29 @@ export interface components {
              *     without it, a model that never ran and a night with nothing in it look identical.
              */
             annotated_at?: string | null;
+            /**
+             * @description The ranking factors this run could not read, so a client can say "the order does
+             *     not account for this" instead of presenting a queue as fully ranked. Never
+             *     returned absent, and empty on the ordinary read: empty and withheld are different
+             *     answers, and a factor that floors silently makes a deal rank lower than it is with
+             *     nothing marking why.
+             *
+             *     `warmth` is omitted for a caller with no `relationship` edge grant. Every seat on
+             *     a deal is a `deal_stakeholder` edge, so such a caller runs no stakeholder read at
+             *     all and the factor has no input for ANY deal — which is why this is a property of
+             *     the run and not of an item.
+             *
+             *     A named factor still appears in each item's `feature_vector`, at its floor. The
+             *     decomposition is what the run scored with, and editing it here would leave a
+             *     reader unable to check the `composite` against its parts; this array is what says
+             *     the floor is an absence rather than a reading.
+             *
+             *     Stored with the run. The grant can be given or taken away afterwards, and a queue
+             *     ranked without warmth must not later be read as one that had it. Empty on a run
+             *     assembled before this field existed — a rep has one run per local day, so those
+             *     age out within a day.
+             */
+            factors_omitted: "warmth"[];
         };
         /**
          * @description One ranked queue entry: the §10.1 composite, its per-factor decomposition (no mystery

--- a/frontend/src/screens/brief.fixtures.ts
+++ b/frontend/src/screens/brief.fixtures.ts
@@ -165,6 +165,7 @@ export const ranked: MorningBrief = {
   generated_at: "2026-08-21T05:30:00Z",
   as_of: "2026-08-21T05:00:00Z",
   candidate_count: 9,
+  factors_omitted: [],
   items: [
     briefItem("bi-1", "d-1", 1, 0.74),
     briefItem("bi-2", "d-2", 2, 0.61),

--- a/frontend/src/screens/brief.testkit.tsx
+++ b/frontend/src/screens/brief.testkit.tsx
@@ -203,6 +203,7 @@ export const run: MorningBrief = {
   generated_at: "2026-07-05T05:30:00Z",
   as_of: "2026-07-05T05:00:00Z",
   candidate_count: 1,
+  factors_omitted: [],
   items: [
     {
       id: "bi-1",


### PR DESCRIPTION
Closes #2038.

Every seat on a deal is a `deal_stakeholder` edge, so a caller without the `relationship` grant read no stakeholders for **any** deal and the warmth factor floored across the whole queue. The brief then handed back an order that is not the order — deals sitting lower than they are — with nothing saying why.

This is the sibling copy of the defect the withheld-coverage channel fixed one surface over, and it needed the same contract step the issue predicted: the brief payload had nowhere to say a factor was withheld.

## What changed

- **`factors_omitted`** on `MorningBrief` and on the `read_brief` tool result. Never absent, empty on the ordinary read: empty and withheld are different answers, and a client that had to tell them apart by guessing would render every brief as withheld or none of them.
- **Stored with the run**, for the reason `revenue_norm_currency` is: the grant can be given or taken away afterwards, and a queue ranked without warmth must not later be read as one that had it. New nullable-free column with a CHECK holding the vocabulary closed — a factor nothing can render is a factor a client silently drops, which is the failure this exists to end.
- **`seatEvidenceBound` reports its refusal** instead of returning a bare `false`, and `briefEvidenceRows` carries it up to the run.

## Two decisions worth reviewing

**The feature vector is untouched.** A named factor still appears in each item's `feature_vector`, at its floor. The decomposition is what the run *scored with*, and editing it there would leave a reader unable to check the `composite` against its parts. This array is what says the floor is an absence rather than a reading.

**Row-scope flooring stays as it was, and is right.** A stakeholder outside the caller's row scope contributes nothing, deal by deal — the queue is still ranked on what this reader may know, the way every other factor is. Only the *outright* object refusal is named, because that one has no input for any deal and reorders the whole queue. The old comment claimed both cases were the same thing; it now says which is which.

## Served, not withheld, on the tool seam

`TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld` forced the question. It is served: unlike the revenue base beside it — which explains a number the agent already has normalized — this one says the **order** in front of the agent is not the order. An agent told a queue is ranked will reason about why the third deal is third; if warmth was withheld, the honest answer is that nobody knows.

## On the issue's point 3

There is no per-file entry to annotate — `edgereaders_test.go` derives its corpus rather than listing `briefrank.go`. The post-refusal behaviour the issue says no gate judges is now held by the two tests below instead, and the code comments say which case is which rather than leaving the reader to infer it.

## Tests

Both mutation-checked (making `omittedFactors` always return empty fails the first):

- `TestABriefNamesTheFactorItCouldNotRead` — a caller holding every grant the brief needs **except** the edge gets `warmth` named.
- `TestABriefThatReadEveryFactorOmitsNone` — and one holding it gets an empty list, never nil. Without this half, the first would pass against a run that names warmth unconditionally.

## What I left out

**The SPA does not render it yet.** The brief screen is ~60 files and `frontend/AGENTS.md` opens with a design-system catalog that has to be read before anything visible is built, so wiring the caption is its own change in another module rather than a tail on this one. I fixed the two fixtures the new required field broke (`make check-fe` is green) and filed the rendering as a follow-up. The channel is live for the contract and for the MCP tool today.

`make check-backend` and `make check-fe` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC