### PR TITLE
A red main is claimed once, so parallel sessions stop racing it

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -103,6 +103,23 @@
   description: "Unactionable until someone rules on it - 'decide or decline X'"
 
 # ---------------------------------------------------------------------------
+# Claim — a lock one session takes so the others do not race it.
+#
+# The only axis that lives on a PULL REQUEST rather than an issue, and the only
+# one that is about who is working rather than about what the work is. `main`
+# goes red often here on purpose — merging past a red check is a standing
+# decision — and every session that notices reaches for the same fix at the
+# same time. A draft pull request wearing this label is how the first one says
+# so, and the rulebook is what makes the others look before they start.
+#
+# It is not a `status:`: those mark an issue nobody should pick up, and this
+# marks work somebody already did pick up.
+# ---------------------------------------------------------------------------
+- name: "claim: main-red"
+  color: "5319E7"
+  description: "A session is fixing this red on main - check before you start, do not open a second"
+
+# ---------------------------------------------------------------------------
 # Provenance — why the issue exists, which is the one thing nobody can
 # reconstruct later. Additive and independent of the three axes above.
 # ---------------------------------------------------------------------------

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,9 @@ each names the tests it covers. Covered: somebody is on it, so do not diagnose
 it, do not open a second fix, and do not poll it. Your red is inherited; carry on
 with your own work and look again at merge time. Not covered: you are first, even
 while another claim is open for a different cause — open a DRAFT pull request
-labelled `claim: main-red` naming the tests you take, BEFORE you start.
+labelled `claim: main-red` naming the tests you take, BEFORE you start. Listing
+then creating is not atomic, so two claims can cover one test: the LOWER number
+wins and the other session closes its own, pointing at the winner.
 [docs/how-to/claim-a-red-main.md](docs/how-to/claim-a-red-main.md) has stale
 claims, releasing one, and why two half-fixes both stay red.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,16 @@ written for you as much as for a human. The code is still the authority on
 current behaviour, so check the code before you rely on a doc for anything a
 patch depends on.
 
+**A red `main` is claimed once.** Before diagnosing a failure you did not cause,
+run `gh pr list --state open --label "claim: main-red"` and read the bodies —
+each names the tests it covers. Covered: somebody is on it, so do not diagnose
+it, do not open a second fix, and do not poll it. Your red is inherited; carry on
+with your own work and look again at merge time. Not covered: you are first, even
+while another claim is open for a different cause — open a DRAFT pull request
+labelled `claim: main-red` naming the tests you take, BEFORE you start.
+[docs/how-to/claim-a-red-main.md](docs/how-to/claim-a-red-main.md) has stale
+claims, releasing one, and why two half-fixes both stay red.
+
 **A security hole is never a public issue.** [SECURITY.md](SECURITY.md) routes an
 exploitable weakness to a private advisory. The test: if you can write the
 reproduction, it belongs in an advisory, not here.

--- a/backend/gates/issuelabels_test.go
+++ b/backend/gates/issuelabels_test.go
@@ -86,13 +86,14 @@ var labelSections = []struct {
 	{heading: "## Priority", prefix: "priority: "},
 	{heading: "## Area", prefix: "area: ", bare: true},
 	{heading: "## Status", prefix: "status: "},
+	{heading: "## Claim", prefix: "claim: "},
 	{heading: "## Provenance", prefix: "", bare: true},
 }
 
 // labelSpan matches a label name as the page writes one: a fenced span holding
 // only the name, so `gh issue list --label "area: <x>"` — which has spaces — is
 // prose about a label rather than a listing of one.
-var labelSpan = regexp.MustCompile("`((?:priority: |area: |status: )?[a-z][a-z-]*)`")
+var labelSpan = regexp.MustCompile("`((?:priority: |area: |status: |claim: )?[a-z][a-z-]*)`")
 
 func TestEachSectionOfTheReferencePageListsExactlyItsLabels(t *testing.T) {
 	t.Parallel()

--- a/backend/gates/redmainclaim_test.go
+++ b/backend/gates/redmainclaim_test.go
@@ -45,25 +45,22 @@ var claimSpan = regexp.MustCompile("`(claim: [a-z][a-z-]*)`")
 // the file every session reads before it does anything.
 var rulebookPath = filepath.Join(repoRoot, "AGENTS.md")
 
+// lookupCommand matches the search the rulebook tells a session to run, inside
+// one fenced span, with the label it searches for captured.
+//
+// The command and not a bare mention of the label: a rulebook that discusses
+// claims in prose while no longer telling anyone what to RUN leaves every
+// session to invent the query or skip it, and a gate satisfied by the words
+// `claim: main-red` appearing somewhere would call that fine. `[^`+"`"+`]*` keeps the
+// match inside a single span so two unrelated sentences cannot combine into
+// one, and `(?s)` lets the span wrap a line, which prose of this width does.
+var lookupCommand = regexp.MustCompile("(?s)`(gh pr list[^`]*--label \"(claim: [a-z][a-z-]*)\"[^`]*)`")
+
 func TestEveryClaimLabelTheProseNamesIsDeclared(t *testing.T) {
 	t.Parallel()
 
 	declared := declaredLabels(t)
-	named := map[string][]string{}
-	for _, file := range trackedFiles(t) {
-		if file.symlink || !strings.HasSuffix(file.path, ".md") {
-			continue
-		}
-		body, err := os.ReadFile(filepath.Join(repoRoot, file.path))
-		if err != nil {
-			t.Fatalf("reading %s: %v", file.path, err)
-		}
-		for _, match := range claimSpan.FindAllStringSubmatch(string(body), -1) {
-			if !slices.Contains(named[match[1]], file.path) {
-				named[match[1]] = append(named[match[1]], file.path)
-			}
-		}
-	}
+	named := claimLabelsNamedInProse(t)
 
 	if len(named) == 0 {
 		t.Fatal("no page names a `claim:` label, so this gate measures nothing — " +
@@ -82,18 +79,81 @@ func TestEveryClaimLabelTheProseNamesIsDeclared(t *testing.T) {
 	}
 }
 
-func TestTheRulebookStillTellsSessionsToCheckForAClaim(t *testing.T) {
+func TestTheRulebookStillTellsSessionsToRunTheClaimLookup(t *testing.T) {
 	t.Parallel()
 
 	body, err := os.ReadFile(rulebookPath)
 	if err != nil {
 		t.Fatalf("reading the rulebook: %v", err)
 	}
-	if !claimSpan.MatchString(string(body)) {
-		t.Error("AGENTS.md names no `claim:` label.\n" +
+	found := lookupCommand.FindStringSubmatch(string(body))
+	if found == nil {
+		t.Fatal("AGENTS.md carries no `gh pr list ... --label \"claim: ...\"` command.\n" +
 			"\tThe label can exist and the draft pull requests can be opened, and it " +
-			"still buys nothing: a session only stands down if the rulebook it reads " +
-			"first tells it to look. Removing the instruction retires the mechanism, " +
-			"so retire the label and this gate in the same change.")
+			"still buys nothing: a session stands down only if the rulebook it reads " +
+			"first tells it what to RUN. Prose about claims with no command left in it " +
+			"is the shape this misses — so if the mechanism is being retired, retire " +
+			"the label and this gate in the same change.")
 	}
+	if declared := declaredLabels(t); !slices.Contains(declared, found[2]) {
+		t.Errorf("the rulebook's lookup searches for %q, which .github/labels.yml does not declare.\n"+
+			"\tIt exits 0 and returns nothing, which reads as 'nobody is fixing this'.",
+			found[2])
+	}
+}
+
+// TestEveryDeclaredClaimLabelIsOneSomethingTellsSessionsToLookFor is the other
+// direction, and the one this file's own docstring promised before it held it:
+// a label declared and searched for by nobody is a lock nobody takes. The
+// source is the corpus, so a second claim label added tomorrow is covered
+// without this file learning its name.
+func TestEveryDeclaredClaimLabelIsOneSomethingTellsSessionsToLookFor(t *testing.T) {
+	t.Parallel()
+
+	var claims []string
+	for _, label := range declaredLabels(t) {
+		if strings.HasPrefix(label, "claim: ") {
+			claims = append(claims, label)
+		}
+	}
+	if len(claims) == 0 {
+		t.Fatal("the source declares no `claim:` label, so this gate measures nothing — " +
+			"if the mechanism was retired, this file should have gone with it")
+	}
+	named := claimLabelsNamedInProse(t)
+	for _, label := range claims {
+		if len(named[label]) == 0 {
+			t.Errorf("%q is declared and no tracked page tells a session to look for it.\n"+
+				"\tA claim label nobody searches for is a lock nobody takes: the session "+
+				"holding it believes it has said so, and every other session starts "+
+				"the same diagnosis. Name it in AGENTS.md, or retire it from the source.",
+				label)
+		}
+	}
+}
+
+// claimLabelsNamedInProse maps each `claim:` label the tree's Markdown names to
+// the pages naming it. Both directions read it: one asks whether every name is
+// declared, the other whether every declaration is named.
+//
+// Held by: TestEveryClaimLabelTheProseNamesIsDeclared,
+// TestEveryDeclaredClaimLabelIsOneSomethingTellsSessionsToLookFor
+func claimLabelsNamedInProse(t *testing.T) map[string][]string {
+	t.Helper()
+	named := map[string][]string{}
+	for _, file := range trackedFiles(t) {
+		if file.symlink || !strings.HasSuffix(file.path, ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(repoRoot, file.path))
+		if err != nil {
+			t.Fatalf("reading %s: %v", file.path, err)
+		}
+		for _, match := range claimSpan.FindAllStringSubmatch(string(body), -1) {
+			if !slices.Contains(named[match[1]], file.path) {
+				named[match[1]] = append(named[match[1]], file.path)
+			}
+		}
+	}
+	return named
 }

--- a/backend/gates/redmainclaim_test.go
+++ b/backend/gates/redmainclaim_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+//go:build !integration
+
+package gates
+
+// Every `claim:` label the prose tells a session to search for is one
+// `.github/labels.yml` declares.
+//
+// THIS ONE FAILS OPEN, which is why it is worth a gate. The rulebook tells a
+// session to run `gh pr list --label "claim: main-red"` before it starts fixing
+// a red `main`. Rename the label in the source and leave the prose behind — or
+// the reverse — and that command still exits 0. It returns an empty list, which
+// reads exactly like "nobody is fixing this", so every session concludes it is
+// the first and they all diagnose the same failure at once. The mechanism does
+// not break loudly; it silently becomes the race it was built to remove.
+//
+// The corpus is derived rather than listed: any tracked Markdown file naming a
+// `claim:` label is a subject. So a third page that starts telling sessions to
+// search for one is covered the day it is written, without this file learning
+// its name — and a page naming a label that does not exist fails here rather
+// than at 3am in somebody's session.
+//
+// The second case is the other direction, and it is the one a rename gets
+// right by accident: the rulebook must go on carrying the instruction at all. A
+// claim label nothing tells anyone to look for is a lock nobody takes.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// claimSpan matches a claim label as prose writes one — inside a fenced span,
+// so a sentence merely discussing claims is not read as naming a label.
+var claimSpan = regexp.MustCompile("`(claim: [a-z][a-z-]*)`")
+
+// rulebookPath is the one file that must carry the instruction, because it is
+// the file every session reads before it does anything.
+var rulebookPath = filepath.Join(repoRoot, "AGENTS.md")
+
+func TestEveryClaimLabelTheProseNamesIsDeclared(t *testing.T) {
+	t.Parallel()
+
+	declared := declaredLabels(t)
+	named := map[string][]string{}
+	for _, file := range trackedFiles(t) {
+		if file.symlink || !strings.HasSuffix(file.path, ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(repoRoot, file.path))
+		if err != nil {
+			t.Fatalf("reading %s: %v", file.path, err)
+		}
+		for _, match := range claimSpan.FindAllStringSubmatch(string(body), -1) {
+			if !slices.Contains(named[match[1]], file.path) {
+				named[match[1]] = append(named[match[1]], file.path)
+			}
+		}
+	}
+
+	if len(named) == 0 {
+		t.Fatal("no page names a `claim:` label, so this gate measures nothing — " +
+			"either the claim mechanism was removed and this file should go with it, " +
+			"or the prose stopped spelling the label in a fenced span and the search " +
+			"instruction no longer says what to search for")
+	}
+	for label, pages := range named {
+		if !slices.Contains(declared, label) {
+			t.Errorf("%s tells a session to look for %q, which .github/labels.yml does not declare.\n"+
+				"\tThe search still exits 0 and returns nothing, which reads as "+
+				"'nobody is fixing this' — so every session starts diagnosing the same "+
+				"failure. Add the label to the source, or fix the spelling here.",
+				strings.Join(pages, ", "), label)
+		}
+	}
+}
+
+func TestTheRulebookStillTellsSessionsToCheckForAClaim(t *testing.T) {
+	t.Parallel()
+
+	body, err := os.ReadFile(rulebookPath)
+	if err != nil {
+		t.Fatalf("reading the rulebook: %v", err)
+	}
+	if !claimSpan.MatchString(string(body)) {
+		t.Error("AGENTS.md names no `claim:` label.\n" +
+			"\tThe label can exist and the draft pull requests can be opened, and it " +
+			"still buys nothing: a session only stands down if the rulebook it reads " +
+			"first tells it to look. Removing the instruction retires the mechanism, " +
+			"so retire the label and this gate in the same change.")
+	}
+}

--- a/backend/gates/rulebooklength_test.go
+++ b/backend/gates/rulebooklength_test.go
@@ -51,7 +51,16 @@ var ceilings = map[string]int{
 	// paragraph is a running SAVING rather than a running cost: without it the
 	// rulebook names only `make check`, so every iteration of every session pays
 	// the whole gate to learn about one lane.
-	"AGENTS.md": 330,
+	//
+	// +10 for the red-`main` claim rule. It is a running SAVING for the same
+	// reason: `main` is red often here by design, every open pull request
+	// inherits it, and without this rule each session pays a rebase and a local
+	// lane to learn that a failure is not its own — then several of them
+	// diagnose the same one at once. Nine lines here replace that. It cannot
+	// live only in `docs/`: a session that has not read the rule has no reason
+	// to go looking for the page, and by the time it would, it has already spent
+	// what the rule saves.
+	"AGENTS.md": 340,
 	// Raised from 160 for the AI-hue rule: indigo marks agent-authored content,
 	// and a reader who does not know that paints the meaning onto a decoration.
 	// The reasoning lives in the design-system README; what is here is the twelve

--- a/backend/gates/rulebooklength_test.go
+++ b/backend/gates/rulebooklength_test.go
@@ -60,7 +60,14 @@ var ceilings = map[string]int{
 	// live only in `docs/`: a session that has not read the rule has no reason
 	// to go looking for the page, and by the time it would, it has already spent
 	// what the rule saves.
-	"AGENTS.md": 340,
+	//
+	// +2 more for the collision tie-break. Listing claims and then creating one
+	// is not atomic, and two sessions reaching the same red within the same few
+	// seconds both find nothing and both claim it — which is the race the rule
+	// exists to end, arriving through the rule itself. The tie-break has to be
+	// in the rulebook rather than only in the how-to, because the session that
+	// has to stand down is the one that never opened the page.
+	"AGENTS.md": 342,
 	// Raised from 160 for the AI-hue rule: indigo marks agent-authored content,
 	// and a reader who does not know that paints the meaning onto a decoration.
 	// The reasoning lives in the design-system README; what is here is the twelve

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ decision rather than an omission.
 - [add-an-rbac-object.md](how-to/add-an-rbac-object.md) — add a new RBAC object across the policy, the contract enum, the backfill migration, and the published matrix.
 - [create-a-workflow.md](how-to/create-a-workflow.md) — scaffold and wire a new automation starter workflow into the closed catalog.
 - [apply-migrations.md](how-to/apply-migrations.md) — write and apply a database migration.
+- [claim-a-red-main.md](how-to/claim-a-red-main.md) — say you are fixing a red `main` before you start, so parallel sessions do not all diagnose it.
 - [mint-a-passport.md](how-to/mint-a-passport.md) — issue an agent passport token.
 - [connect-an-mcp-client.md](how-to/connect-an-mcp-client.md) — connect a client to the governed MCP tool surface.
 - [run-the-frontend.md](how-to/run-the-frontend.md) — run the SPA in dev.

--- a/docs/how-to/claim-a-red-main.md
+++ b/docs/how-to/claim-a-red-main.md
@@ -56,9 +56,16 @@ commit provides — so the claim opens before a single line is written, which is
 the whole point of it. Do not talk yourself out of the empty commit and wait
 until you have a fix to show: by then the second session has already started.
 
-It is close to free. Measured on a zero-diff draft: fourteen of the sixteen
-checks skip, because the change classifier sees no files and every lane it gates
-skips with it. Only the `ci` fan-in and the review bot run.
+It is close to free, and for a reason worth knowing: `ci.yml` guards the
+`changes` classifier itself on `draft == false`, so on a draft it never runs and
+every lane gated on its output skips with it. Measured on a zero-diff draft,
+fourteen of sixteen checks skipped and only the `ci` fan-in reported. CodeRabbit
+does not review a draft either — `.coderabbit.yaml` sets `drafts: false`.
+
+**The cheapness comes from being a draft, not from the diff being empty.** That
+is what makes the claim usable once you start work: push your investigation to
+it, and it stays as cheap as it was while it was empty. It gets expensive at the
+moment you mark it ready, which is the moment it should.
 
 An empty commit is also the honest first state — you are claiming the work, not
 reporting a fix.
@@ -85,6 +92,26 @@ otherwise pay to rediscover.
   next session starts from your evidence rather than from nothing.
 - **Not actually broken** — close it and say why the verdict was wrong. A claim
   left open over a green `main` stops somebody looking at a real failure later.
+
+## When two sessions claim the same thing
+
+Listing the open claims and then creating one is not atomic. Two sessions
+reaching the same red within the same few seconds both find nothing and both
+open a claim — the race arriving through the mechanism built to end it.
+
+**The lower pull request number wins.** It is the one that existed first, every
+session can see it, and no clock has to agree. If yours is the higher number and
+its covered tests overlap:
+
+- close yours, with a comment pointing at the winner;
+- if you had already found something, say it on the winner's claim before you
+  go — that is the part they would otherwise pay to rediscover;
+- carry on with your own work.
+
+Overlap is per test, not per pull request. If your claim covers three tests and
+only one is also on the winner's list, drop that one from your body and keep
+going: the other two are still unclaimed, and dropping them would leave them
+owned by nobody.
 
 ## Taking over a stale claim
 

--- a/docs/how-to/claim-a-red-main.md
+++ b/docs/how-to/claim-a-red-main.md
@@ -1,0 +1,101 @@
+# Claim a red `main`
+
+`main` goes red here often, and on purpose: merging past a red required check is
+a standing decision, so a break reaches the tip and every open pull request
+inherits it through its merge commit. At the number of sessions this repository
+runs at once, that means several of them notice the same failure within minutes
+and all reach for the same fix.
+
+That race is the thing this page removes. It costs a session its whole context
+window to diagnose a red lane, and the second and third session to do it produce
+nothing — one duplicate pull request, or two, and the original author's fix
+lands anyway.
+
+**The claim is a draft pull request wearing `claim: main-red`.** One command
+finds it, and it exists before the fix does.
+
+## Before you investigate a failure you did not cause
+
+```sh
+gh pr list --state open --label "claim: main-red" \
+  --json number,title,body,updatedAt,author
+```
+
+Read the bodies, not just the titles. Each claim lists the lanes and tests it
+covers, and **that list is what you match against** — not "is `main` red", which
+is nearly always yes.
+
+**If a claim covers your failure** — stop. Do not investigate it, do not open a
+second fix, and do not sit and poll it either: waiting burns the tokens this
+page exists to save. Your own pull request is red for a reason that is not
+yours, so carry on with your own work and look again when you are ready to
+merge.
+
+**If nothing covers it** you are first for this cause, even when another claim
+is open for a different one. `main` is regularly red for two unrelated reasons
+at once — on 2026-09-08 it was red for three — and a claim naming one of them
+says nothing about the others.
+
+## Opening a claim
+
+Do this **before** you start diagnosing, not after you have a fix. The whole
+value is in the minutes it saves the next session.
+
+```sh
+git switch -c red/<lane-or-test-slug> origin/main
+git commit --allow-empty -m "claim: <lane> is red on main"
+git push -u origin red/<lane-or-test-slug>
+gh pr create --draft --label "claim: main-red" \
+  --title "main is red: <lane>" \
+  --body "$(printf 'Claiming:\n- TestOne\n- TestTwo\n\nCause: unknown so far.\n')"
+```
+
+An empty commit is the honest first state: you are claiming the work, not
+reporting a fix. Draft is not decoration either — `ci.yml` gates the frontend
+and UAT lanes on `draft == false`, so a claim costs a fraction of a full run.
+
+If `main-health` has already filed a `main is red:` issue, assign yourself to it
+in the same breath. Unassigned reads as unclaimed, and the issue is where anyone
+not watching pull requests will look.
+
+## Keeping it honest
+
+**The body is the interface.** Another session decides whether to stand down by
+reading your list, so keep it current: add a test when you find the failure is
+wider than you thought, and say so if it turns out narrower. A claim that quietly
+covers less than it lists is how a real failure ends up owned by nobody.
+
+**Say what you learn.** A comment naming the cause, or naming what you ruled
+out, is worth more to the next session than the diff — it is the part they would
+otherwise pay to rediscover.
+
+## Releasing it
+
+- **Fixed** — mark the pull request ready and merge it. The claim goes with it.
+- **Abandoned** — close the draft, and say in a comment what you found, so the
+  next session starts from your evidence rather than from nothing.
+- **Not actually broken** — close it and say why the verdict was wrong. A claim
+  left open over a green `main` stops somebody looking at a real failure later.
+
+## Taking over a stale claim
+
+A session can die, and a claim it left behind would otherwise block the repository
+for good. **A claim with no commit and no comment for 90 minutes may be taken
+over.** Say so in a comment on it first, so the original session sees what
+happened if it wakes up, then carry on in your own branch.
+
+Ninety minutes rather than ten: diagnosing a red integration lane genuinely takes
+that long, and a threshold short enough to catch a dead session is short enough
+to steal work from a live one.
+
+## When several causes are in flight
+
+Each cause gets its own claim, and they land in whatever order they are ready.
+Be aware of the trap that follows: because required checks run against the merge
+commit, **two pull requests each fixing half of a red `main` are both red, and
+neither can go green while the other is unmerged.** Branch protection then
+refuses both.
+
+The way out is one branch merging both fixes — its merge commit carries the
+whole repair, so it is green and needs no administrator bypass. This happened on
+2026-09-08 and cost several hours; the record is issue #4852.

--- a/docs/how-to/claim-a-red-main.md
+++ b/docs/how-to/claim-a-red-main.md
@@ -50,9 +50,18 @@ gh pr create --draft --label "claim: main-red" \
   --body "$(printf 'Claiming:\n- TestOne\n- TestTwo\n\nCause: unknown so far.\n')"
 ```
 
-An empty commit is the honest first state: you are claiming the work, not
-reporting a fix. Draft is not decoration either — `ci.yml` gates the frontend
-and UAT lanes on `draft == false`, so a claim costs a fraction of a full run.
+**A pull request with no diff is allowed, and this one has none.** GitHub asks
+only that the head branch carry a commit the base does not, which the empty
+commit provides — so the claim opens before a single line is written, which is
+the whole point of it. Do not talk yourself out of the empty commit and wait
+until you have a fix to show: by then the second session has already started.
+
+It is close to free. Measured on a zero-diff draft: fourteen of the sixteen
+checks skip, because the change classifier sees no files and every lane it gates
+skips with it. Only the `ci` fan-in and the review bot run.
+
+An empty commit is also the honest first state — you are claiming the work, not
+reporting a fix.
 
 If `main-health` has already filed a `main is red:` issue, assign yourself to it
 in the same breath. Unassigned reads as unclaimed, and the issue is where anyone

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (98)
+## Parity (99)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -105,6 +105,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `providername_test.go` | H2 | The rule a REGISTERED NAME must satisfy is the contract's, on both surfaces that have one. |
 | `publicevents_test.go` | H3 | The public-events contract as a cross-cutting fitness function (A15): the outbound-webhook surface has three moving parts that must stay in lock-step, and nothing in the build forces them to. |
 | `rbacvocabulary_test.go` | H3 | The RBAC vocabulary is DECLARED in the contract and restated in Go, and the two must not drift. |
+| `redmainclaim_test.go` | H2 | Every `claim:` label the prose tells a session to search for is one `.github/labels.yml` declares. |
 | `reopenconditionparity_test.go` | H3 | What a snooze may wait for is spelled in four places, and all four must agree. |
 | `rowscopetables_test.go` | H2 | WHICH table a row-scope call bounds, and which column names a reference to one. |
 | `runneractivityparity_test.go` | H3 | The runner's own status vocabulary must be TOTAL over the column it reads. |

--- a/docs/reference/issue-labels.md
+++ b/docs/reference/issue-labels.md
@@ -69,6 +69,23 @@ work. Leaving one off puts that issue in somebody's queue:
   in the issue what it is waiting for, so the reader who filters it back in
   knows what changed.
 
+## Claim
+
+The one axis that goes on a **pull request** rather than an issue, and the one
+that says who is working rather than what the work is.
+
+- `claim: main-red` — a session is already fixing this red on `main`. It rides a
+  DRAFT pull request whose body lists the failing lanes and tests it covers, and
+  that list is the point: `main` is regularly red for two unrelated reasons at
+  once, so a claim naming one of them leaves the other unclaimed and free to
+  take. Check for one before you investigate a failure you did not cause, and
+  open one before you start fixing if none covers yours. The procedure, and when
+  a stale claim may be taken over, is
+  [../how-to/claim-a-red-main.md](../how-to/claim-a-red-main.md).
+
+  Not a `status:` label: those mark an issue nobody should pick up, and this
+  marks work somebody already has.
+
 ## Provenance
 
 **Provenance**, additive and independent of the three axes: `bug`,


### PR DESCRIPTION
`main` is red often here on purpose — merging past a red required check is a standing decision — and every open pull request inherits it through its merge commit. With this many sessions running at once, several notice the same failure within minutes and all reach for the same fix.

That happened on 2026-09-08 and is what this is built from: two duplicate pull requests against one breakage (https://github.com/margince/margince/pull/4943 duplicating https://github.com/margince/margince/pull/4942), and each duplicate had first paid a rebase and a full local lane just to learn its red was somebody else's.

## The mechanism

A **draft pull request labelled `claim: main-red`**, found in one command, opened *before* the diagnosis rather than after it:

```sh
gh pr list --state open --label "claim: main-red" --json number,title,body,updatedAt
```

Draft is load-bearing, not decoration: `ci.yml` gates the frontend and UAT lanes on `draft == false`, so a claim costs a fraction of a run.

The binding rule is nine lines in `AGENTS.md`; the procedure, stale claims and release are in `docs/how-to/claim-a-red-main.md`.

## Three things the obvious version gets wrong

**A claim names the tests it covers, and that list is the interface.** `main` is regularly red for two unrelated reasons at once — it was red for **three** that morning. A single global "somebody is fixing main" would have stood down the session that found the third cause, which nobody was on and which was failing `deterministic-gates`, `extension-reference` and the coverage job on *every open pull request in the repository*.

**A blocked session does not wait.** Polling a claim spends exactly what the claim exists to save. The rule is: your red is inherited, carry on with your own work, look again at merge time.

**A claim goes stale after ninety minutes** without a commit or comment and may then be taken over, with a comment saying so. Without that, one dead session locks the repository. Ninety rather than ten because diagnosing a red integration lane genuinely takes that long.

The list also doubles as a **known-failures registry**: match your red against it and you get "not mine" from one API call instead of a local reproduction. That saves every session, not only the second and third to attempt a fix.

## Why a gate

**This mechanism fails OPEN.** Rename the label on one side only and `gh pr list --label "claim: main-red"` still exits 0 — it returns an empty list, which reads exactly like *"nobody is fixing this"*, so every session concludes it is first and the race is back with no symptom.

`redmainclaim_test.go` holds both directions: a `claim:` label named in any tracked Markdown that `.github/labels.yml` does not declare, and a rulebook that has stopped naming one at all. The corpus is derived from the tree, so a third page that starts telling sessions to search is covered the day it is written. Both cases are mutation-tested — renaming the label in `AGENTS.md` alone fails the first; deleting the rule fails the second.

`claim:` is a new axis rather than a reused one. It is the only label that lives on a pull request, and it says who is working rather than what the work is — it is emphatically not a `status:`, which marks an issue nobody should pick up.

## The rulebook ceiling moves 330 → 340

Deliberately, with the reason in the gate beside the number, which is what that ratchet asks for. The rule cannot live only in `docs/`: a session that has not read it has no reason to open the page, and by the time it would, it has already spent what the rule saves. It is a running *saving*, not a running cost.

## Verified

`go test ./gates` passes apart from `TestPublicTreeCitesNoDocumentGitIgnores`, which fails on this machine only — a `.superpowers` entry in the local `.git/info/exclude`, not in the repository — and is green in CI.

**One follow-up this does not do:** it treats the symptom, not the cause. The standard fix for a frequently-red `main` is a merge queue, which tests the merge commit before it lands. That trade was made deliberately for speed; worth revisiting when the cost is felt, and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `claim: main-red` label for tracking work addressing a failing main branch.
  * Added guidance for creating, monitoring, taking over, and releasing claims through draft pull requests.

* **Documentation**
  * Documented the new claim workflow and label in the how-to and issue-label references.

* **Tests**
  * Added validation ensuring claim labels are consistently declared and documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->