### PR TITLE
fix(deals): archiving a deal pins the row it archives

### DIFF
--- a/frontend/src/api/if-match-coverage.test.ts
+++ b/frontend/src/api/if-match-coverage.test.ts
@@ -37,17 +37,20 @@ const srcRoot = join(apiDir, "..");
 // here is deleted. Nothing keeps a stale entry alive.
 const UNPINNED_WRITES: readonly string[] = [
   "screens/automations.tsx PATCH /automations/{id}",
-  // The six archive screens. They join this list because the ENDPOINTS learned
+  // The archive screens. They joined this list because the ENDPOINTS learned
   // the precondition, not because the screens changed: the archive routes
   // declared no If-Match at all until an approved agent archive needed to
   // carry the version a human released it against, so these calls were outside
   // this gate's subject set rather than inside it and passing. Threading a
-  // version through six screens is its own change with its own proof; what
+  // version through each screen is its own change with its own proof; what
   // matters here is that the class is now visible and the count can only fall.
+  //
+  // Four left. The two DEAL archives are gone: the deals table has bulk
+  // actions, so its archive is the one gesture in the product that removes a
+  // screenful of rows at once, and it was the verb of three in that bar that
+  // could not lose a race it should lose.
   "screens/companyheader.tsx DELETE /organizations/{id}",
   "screens/contacts.tsx DELETE /people/{id}",
-  "screens/dealbulk.tsx DELETE /deals/{id}",
-  "screens/deals.tsx DELETE /deals/{id}",
   "screens/personrail.tsx DELETE /relationships/{id}",
   "screens/relationships.tsx DELETE /relationships/{id}",
   "screens/contractform.tsx PATCH /contracts/{id}",

--- a/frontend/src/screens/dealbulk.test.tsx
+++ b/frontend/src/screens/dealbulk.test.tsx
@@ -2,7 +2,14 @@
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
@@ -45,6 +52,15 @@ const STAGE: Stage = {
   position: 1,
   semantic: "open",
   win_probability: 40,
+};
+
+// A stage the fixture deal is NOT in: the bar leaves a row alone when the move
+// would not move it, so a one-stage fixture proves nothing about the move verb.
+const OTHER_STAGE: Stage = {
+  ...STAGE,
+  id: "s-2",
+  name: "Proposal",
+  position: 2,
 };
 
 function json(body: unknown) {
@@ -97,7 +113,13 @@ afterEach(() => {
 describe("the bulk bar's roster caveat", () => {
   it("comes after every verb, never between the owner picker and the button that applies it", async () => {
     stubTruncatedRoster();
-    render(<DealBulkBar deals={[DEAL]} stages={[STAGE]} onDone={() => {}} />);
+    render(
+      <DealBulkBar
+        deals={[DEAL]}
+        stages={[STAGE, OTHER_STAGE]}
+        onDone={() => {}}
+      />,
+    );
 
     const note = await screen.findByText(en["state.partial"]);
     for (const label of [
@@ -117,7 +139,13 @@ describe("the bulk bar's roster caveat", () => {
 
   it("stays attached to the picker it is about, through the picker's description", async () => {
     stubTruncatedRoster();
-    render(<DealBulkBar deals={[DEAL]} stages={[STAGE]} onDone={() => {}} />);
+    render(
+      <DealBulkBar
+        deals={[DEAL]}
+        stages={[STAGE, OTHER_STAGE]}
+        onDone={() => {}}
+      />,
+    );
 
     const note = await screen.findByText(en["state.partial"]);
     const picker = screen.getByRole("combobox", {
@@ -130,7 +158,13 @@ describe("the bulk bar's roster caveat", () => {
 
   it("does not announce itself as news inside the bar's live region", async () => {
     stubTruncatedRoster();
-    render(<DealBulkBar deals={[DEAL]} stages={[STAGE]} onDone={() => {}} />);
+    render(
+      <DealBulkBar
+        deals={[DEAL]}
+        stages={[STAGE, OTHER_STAGE]}
+        onDone={() => {}}
+      />,
+    );
 
     // The bar is `aria-live="polite"`, so the caveat arriving when the walk
     // finishes would be read out mid-interaction — a fact about a list the
@@ -139,5 +173,128 @@ describe("the bulk bar's roster caveat", () => {
       "aria-live",
       "off",
     );
+  });
+});
+
+// Every verb in the bar sends the row's own version guard.
+//
+// The bar's promise is that each row carries its own guard, and archive was the
+// verb that did not: a deal edited between the moment the list was drawn and the
+// moment the archive reached the server was archived anyway, and the edit went
+// with it. Bulk archive is the gesture most likely to race somebody else's edit,
+// and it was the one verb of three that could not lose the race.
+//
+// All three are asserted, not archive alone: a test naming only the verb that
+// was broken passes just as well after a refactor drops the header from its
+// neighbours.
+describe("the bulk bar's version guards", () => {
+  // One page of owners, so the roster caveat never appears and cannot collide
+  // with the button lookups below.
+  function stubDealWrites(): Request[] {
+    const sent: Request[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const request = input instanceof Request ? input : null;
+        if (request && request.method !== "GET") {
+          sent.push(request);
+          return json(DEAL);
+        }
+        return json({
+          data: [{ id: "u-1", display_name: "Member" }],
+          page: { has_more: false },
+        });
+      }),
+    );
+    return sent;
+  }
+
+  // The row's OWN version, not merely a header that is present: a guard pinned
+  // to the wrong revision refuses a write nobody raced.
+  function expectGuarded(request: Request, method: string, path: string) {
+    expect(request.method).toBe(method);
+    expect(new URL(request.url, "https://test.local").pathname).toBe(path);
+    expect(request.headers.get("If-Match")).toBe(String(DEAL.version));
+  }
+
+  it("pins the row's version when assigning an owner", async () => {
+    const sent = stubDealWrites();
+    const user = userEvent.setup();
+    render(
+      <DealBulkBar
+        deals={[DEAL]}
+        stages={[STAGE, OTHER_STAGE]}
+        onDone={() => {}}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("combobox", { name: en["deals.bulkOwner"] }),
+    );
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: "Member",
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: en["deals.bulkAssign"] }),
+    );
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    expectGuarded(sent[0], "PATCH", "/v1/deals/d-1");
+  });
+
+  it("pins the row's version when moving a stage", async () => {
+    const sent = stubDealWrites();
+    const user = userEvent.setup();
+    render(
+      <DealBulkBar
+        deals={[DEAL]}
+        stages={[STAGE, OTHER_STAGE]}
+        onDone={() => {}}
+      />,
+    );
+
+    // The deal is in s-1 already, and the bar skips a row that would not move —
+    // so the fixture needs a SECOND stage for the move to be a move at all.
+    await user.click(
+      screen.getByRole("combobox", { name: en["deals.bulkStage"] }),
+    );
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: OTHER_STAGE.name,
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: en["deals.bulkMove"] }),
+    );
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    expectGuarded(sent[0], "POST", "/v1/deals/d-1/advance");
+  });
+
+  it("pins the row's version when archiving", async () => {
+    const sent = stubDealWrites();
+    const user = userEvent.setup();
+    render(
+      <DealBulkBar
+        deals={[DEAL]}
+        stages={[STAGE, OTHER_STAGE]}
+        onDone={() => {}}
+      />,
+    );
+
+    // Archiving asks first, so the verb is two gestures: the bar's button opens
+    // the confirmation, and the modal's button is the one that writes.
+    await user.click(
+      screen.getByRole("button", { name: en["deals.bulkArchive"] }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: en["deals.bulkArchive"] }),
+    );
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    expectGuarded(sent[0], "DELETE", "/v1/deals/d-1");
   });
 });

--- a/frontend/src/screens/dealbulk.tsx
+++ b/frontend/src/screens/dealbulk.tsx
@@ -187,7 +187,10 @@ export function DealBulkBar({
       rows: [...deals],
       write: async (deal) => {
         const { error } = await api.DELETE("/deals/{id}", {
-          params: { path: { id: deal.id } },
+          params: {
+            path: { id: deal.id },
+            ...ifMatch(requireVersion(deal.version)),
+          },
         });
         if (error) {
           throwProblem(error, t);

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3454,7 +3454,10 @@ function DealActions({
           archivedMessage={t("record.archiveDone", { name: deal.name })}
           archive={async () => {
             const { data, error } = await api.DELETE("/deals/{id}", {
-              params: { path: { id: deal.id } },
+              params: {
+                path: { id: deal.id },
+                ...ifMatch(requireVersion(deal.version)),
+              },
             });
             if (error) {
               throwProblem(error);


### PR DESCRIPTION
Closes #2031.

The bulk bar documents that each row sends its own version guard. Archive was the verb of three that did not: a deal edited between the moment the list was drawn and the moment the archive reached the server was archived anyway, and the edit went with it.

## The backend was already done

The issue says `DELETE /deals/{id}` "accepts no `If-Match` and applies none". That has since changed — `archiveDeal` declares the parameter, `ArchiveDeal` takes an `ifVersion`, and the store applies `applyDealPatchGuarded` as a compare-and-set **before** the dependent cleanup (relationships, list memberships, tags) runs, which is exactly the ordering the issue asks for. Only the two callers never sent it, so the guard was live and nothing used it.

## The decision the issue flagged

`If-Match` stays **optional**. An agent reaching this through `archive_record` holds no version to send, so requiring one would refuse a call that works today — and whether an agent archive must carry the version a human released it against is a product decision rather than part of this fix. The parameter was already optional in the contract, so nothing here is a contract change at all.

## The census caught the rest

`src/api/if-match-coverage.test.ts` already tracks writes that do not pin their row, and it failed the moment these two started to — its second test exists precisely to refuse a stale allowlist entry. Both lines are gone. Four archive screens remain on the list (organizations, people, and two relationship screens); the comment now says how many are left instead of saying "the six" while listing four.

## Tests

Three, in `dealbulk.test.tsx`, one per verb — not archive alone, because a test naming only the broken verb passes just as well after a refactor drops the header from its neighbours. Each drives the real controls (the owner and stage pickers are a custom listbox, so they are opened and clicked rather than `selectOptions`-ed) and asserts the method, the path, and that `If-Match` carries **the row's own version** — a guard pinned to the wrong revision refuses a write nobody raced.

Mutation-checked: removing the header from the archive call fails the archive test with `expected null to be '1'`.

## What is not covered

The **record page's** archive action (`deals.tsx`) gets the same one-line change, beside three call sites in that file that already send the guard, but has no direct test — covering it means rendering the whole deal record screen, and the gesture the issue calls out as most at risk is the bulk one. The census above holds both call sites either way, which is what stops the pair drifting apart again.

`make check-fe` and `make check-backend` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC