### PR TITLE
fix: the worker serves its own AI counters, and an abnormal finish reason survives

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -152,11 +152,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 
-	// The api serves the write, this role only ever reads — so without this it
-	// would keep serving whatever binding it resolved at boot while the api
-	// served the new one, which is the two-roles-disagree failure moving
-	// routing into the database was meant to end (compose/routingwatcher).
-	go compose.NewRoutingWatcher(pool, &modelPath, config.FromOS, logger).Run(ctx)
+	serveResolvedModelPath(ctx, observe, pool, &modelPath, logger)
 
 	// The lanes' lifetime is created and DEFERRED HERE, before anything can
 	// start on it. That ordering used to live inside startEventLanes and be
@@ -209,6 +205,30 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 
 	relayUntilSignal(ctx, cfg, pool, rdb, logger, stdout)
 	return releaseSkewRefusal(releaseSkewErr)
+}
+
+// serveResolvedModelPath hands the resolved path to both things that read it
+// for the rest of the process's life, which is why they sit together: the
+// operator surface renders this process's AI counters from it, and the watcher
+// keeps it current.
+//
+// The counters belong to the process that routed the call, so the api cannot
+// answer for what the lanes here dispatched — while this was unpublished, an
+// AI error rate computed from the api's exposition alone described a minority
+// of the installation's calls while appearing to describe all of them.
+//
+// The watcher rebinds INSIDE the *ai.Router the path holds rather than
+// replacing the value, so publishing once is enough: a routing change is
+// picked up through the same path the section already renders.
+//
+// The api serves the routing write and this role only ever reads it — without
+// the watcher this process would keep serving whatever binding it resolved at
+// boot while the api served the new one, which is the two-roles-disagree
+// failure that moving routing into the database was meant to end
+// (compose/routingwatcher).
+func serveResolvedModelPath(ctx context.Context, observe observeListener, pool *pgxpool.Pool, path *compose.ModelPath, log *slog.Logger) {
+	observe.PublishAIMetrics(path.WriteMetrics)
+	go compose.NewRoutingWatcher(pool, path, config.FromOS, log).Run(ctx)
 }
 
 // releaseSkewRefusal is why the relay returned: a signal, or the release guard.

--- a/backend/cmd/worker/observe.go
+++ b/backend/cmd/worker/observe.go
@@ -14,17 +14,23 @@
 //
 // So this listener carries only what is PROCESS-LOCAL and therefore differs
 // per target — the Go runtime, this process's own pool, this process's relay
-// counter. It re-serves no job-table gauge, and passes a nil outbox backlog
-// for the same reason: that read is the api's, and a second copy of a
-// fleet-wide number is a worse operator surface than one copy. It carries no
-// workspace id and no tenant data at all, which is what makes it a NARROWER
-// surface than the api's /metrics rather than a second copy of it.
+// counter, and the AI counters of the Router this process routes through. It
+// re-serves no job-table gauge, and passes a nil outbox backlog for the same
+// reason: that read is the api's, and a second copy of a fleet-wide number is
+// a worse operator surface than one copy. It carries no workspace id and no
+// tenant data at all, which is what makes it a NARROWER surface than the
+// api's /metrics rather than a second copy of it.
+//
+// The AI counters are not an exception to that rule but an instance of it: a
+// call is routed by ONE process, so the counter is a property of the process
+// that made it, and the api cannot report what the lanes here dispatched.
 package main
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -98,6 +104,18 @@ func (g *bootGate) check(context.Context) error {
 type observeListener struct {
 	Stop func()
 	Addr string
+
+	// PublishAIMetrics installs the /metrics AI section, and exists because
+	// this listener is started BEFORE the model path is resolved — that
+	// ordering is deliberate (a listener started later reports nothing during
+	// exactly the window a slow boot needs explaining), so the section has to
+	// arrive afterwards. Until it does, a scrape omits the family rather than
+	// serving one reading zero calls, which a rate would render as a healthy
+	// tier instead of an absent one.
+	//
+	// Always non-nil, including when the surface is off, so a caller publishes
+	// unconditionally rather than guarding a call it cannot see the shape of.
+	PublishAIMetrics func(func(io.Writer))
 }
 
 // startObserveListener serves the worker's probes and metrics on cfg.observeAddr.
@@ -114,19 +132,35 @@ type observeListener struct {
 // logged into a process that carries on looking healthy.
 func startObserveListener(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, boot *bootGate, log *slog.Logger) (observeListener, error) {
 	if cfg.observeAddr == "" {
-		return observeListener{Stop: func() {}}, nil
+		return observeListener{Stop: func() {}, PublishAIMetrics: func(func(io.Writer)) {}}, nil
 	}
+
+	// Held atomically because the scrape goroutine reads what this process's
+	// boot writes, and a plain field would be a data race the detector fails.
+	var aiSection atomic.Value
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", httpserver.Healthz)
 	mux.HandleFunc("/readyz", httpserver.Readyz("", nil, workerReadyChecks(pool, rdb, boot)...))
 	// nil backlog: the outbox backlog is a fleet-wide read the api already
 	// serves. nil jobStats and nil overlay for the same reason — both are
-	// projections of shared tables, not of this process. nil `extra` because
-	// this process now keeps no metric of its own: the extension-job dispatcher
-	// enqueues every live workspace unconditionally, so there is no per-tenant
-	// precondition left for it to count.
-	mux.HandleFunc("/metrics", httpserver.Metrics(pool, nil, events.PublishedTotal, nil, nil, nil))
+	// projections of shared tables, not of this process.
+	//
+	// `extra` carries the AI counters, and they belong here by the same test
+	// everything else on this listener passes: they count what THIS process
+	// routed through its own Router, so they differ per target and no other
+	// role can answer them. The api's exposition covers the api's calls only,
+	// so while this was nil every call the enrichment lanes made was missing
+	// from the AI panels entirely — and because the lanes are where the bulk
+	// of the routing happens, a per-tier error rate read from the api alone
+	// describes a small minority of the traffic while appearing to describe
+	// all of it. Undercounting a denominator is the failure mode that reports
+	// a healthy tier as broken.
+	mux.HandleFunc("/metrics", httpserver.Metrics(pool, nil, events.PublishedTotal, func(w io.Writer) {
+		if write, ok := aiSection.Load().(func(io.Writer)); ok && write != nil {
+			write(w)
+		}
+	}, nil, nil))
 
 	srv := &http.Server{
 		Addr: cfg.observeAddr,
@@ -155,7 +189,9 @@ func startObserveListener(ctx context.Context, cfg workerConfig, pool *pgxpool.P
 		}
 	}()
 
-	return observeListener{Addr: bound, Stop: func() {
+	return observeListener{Addr: bound, PublishAIMetrics: func(write func(io.Writer)) {
+		aiSection.Store(write)
+	}, Stop: func() {
 		// Its own window, detached from the run context: at shutdown that
 		// context is already cancelled, and passing it would turn every
 		// graceful drain into an immediate close.

--- a/backend/cmd/worker/observe_test.go
+++ b/backend/cmd/worker/observe_test.go
@@ -207,3 +207,63 @@ func TestTheWorkerMetricsOmitThePoolSectionRatherThanZeroingIt(t *testing.T) {
 		t.Errorf("a nil pool produced pool gauges, which read as an idle pool rather than as no pool\ngot:\n%s", body)
 	}
 }
+
+// TestTheWorkerServesItsOwnAICounters — an AI call is routed by ONE process,
+// so its counter is a property of that process and no other role can report
+// it. With this section absent the api's exposition is the only one, and a
+// per-tier error rate computed over it describes api traffic while appearing
+// to describe the installation's: the lanes in this binary do the bulk of the
+// routing, so the denominator is short by most of its calls.
+func TestTheWorkerServesItsOwnAICounters(t *testing.T) {
+	const family = `margince_ai_calls_total{provider="gemini",task="site_extract",tier="premium"} 7`
+	observe, err := startObserveListener(t.Context(), workerConfig{observeAddr: "127.0.0.1:0"},
+		nil, nil, &bootGate{}, quietLog())
+	if err != nil {
+		t.Fatalf("startObserveListener: %v", err)
+	}
+	t.Cleanup(observe.Stop)
+
+	// Published AFTER the listener is already serving, which is the ordering
+	// run() has: the surface comes up before the model path is resolved.
+	observe.PublishAIMetrics(func(w io.Writer) { _, _ = io.WriteString(w, family+"\n") })
+
+	status, body := get(t, "http://"+observe.Addr+"/metrics")
+	if status != http.StatusOK {
+		t.Fatalf("GET /metrics = %d, want 200", status)
+	}
+	if !strings.Contains(body, family) {
+		t.Errorf("the published AI section never reached the exposition\ngot:\n%s", body)
+	}
+	// Additive, not a replacement: the process section this listener exists
+	// for still has to be there beside it.
+	if !strings.Contains(body, "margince_process_heap_sys_bytes") {
+		t.Errorf("the process section went missing once an AI section was published\ngot:\n%s", body)
+	}
+}
+
+// TestTheWorkerMetricsOmitTheAISectionUntilItIsPublished — the same "declared
+// or absent" posture the pool section takes, and it has to hold for the whole
+// boot window: the listener is serving before the model path is resolved, so
+// a scrape landing in between must omit the family rather than serve one
+// reading zero calls, which a rate renders as a healthy tier instead of none.
+func TestTheWorkerMetricsOmitTheAISectionUntilItIsPublished(t *testing.T) {
+	_, body := get(t, startForTest(t)+"/metrics")
+	if strings.Contains(body, "margince_ai_calls_total") {
+		t.Errorf("an unpublished model path produced AI counters, which read as a healthy tier rather than as no tier\ngot:\n%s", body)
+	}
+}
+
+// TestPublishAIMetricsIsSafeWhenTheSurfaceIsOff — off is the default, and
+// run() publishes unconditionally, so a nil seam here would panic every
+// worker that never enabled the listener.
+func TestPublishAIMetricsIsSafeWhenTheSurfaceIsOff(t *testing.T) {
+	observe, err := startObserveListener(t.Context(), workerConfig{}, nil, nil, &bootGate{}, quietLog())
+	if err != nil {
+		t.Fatalf("an empty --observe-addr must be a legitimate configuration, got: %v", err)
+	}
+	t.Cleanup(observe.Stop)
+	if observe.PublishAIMetrics == nil {
+		t.Fatal("no publish seam returned; run() calls it unconditionally and would panic")
+	}
+	observe.PublishAIMetrics(func(io.Writer) { t.Fatal("an off surface must never render a section") })
+}

--- a/backend/internal/modules/ai/gemini.go
+++ b/backend/internal/modules/ai/gemini.go
@@ -389,11 +389,33 @@ func geminiResponseError(out geminiResponse) error {
 	}
 	for _, cand := range out.Candidates {
 		if cand.FinishReason != "" && cand.FinishReason != "STOP" {
-			return fmt.Errorf("ai: gemini: generation stopped: %s", cand.FinishReason)
+			return stoppedError{reason: cand.FinishReason}
 		}
 	}
 	return nil
 }
+
+// stoppedError is an abnormal finishReason as an error that still NAMES the
+// terminal.
+//
+// Carrying it as data is what keeps the distinction recoverable: every
+// abnormal terminal classifies to the one `provider_error` sentinel, so a
+// truncated answer (MAX_TOKENS), a refused one (SAFETY) and a recited one
+// (RECITATION) are indistinguishable in a stored call unless the reason
+// itself survives. They call for opposite responses — retry smaller, do not
+// retry, change the prompt — so a row that cannot separate them cannot be
+// acted on.
+//
+// The message is byte-identical to the plain error it replaces: callers and
+// tests match on the text, so the reason is additive rather than a reword.
+type stoppedError struct{ reason string }
+
+func (e stoppedError) Error() string { return "ai: gemini: generation stopped: " + e.reason }
+
+// FinishReason satisfies the accessor tracing.go probes for with errors.As,
+// so the terminal reaches the trace without this package's error type
+// leaking into the tracing path's imports.
+func (e stoppedError) FinishReason() string { return e.reason }
 
 // geminiSawStop reports whether any candidate finished with the clean STOP
 // terminal. Intermediate stream chunks legitimately carry no finishReason —

--- a/backend/internal/modules/ai/gemini_test.go
+++ b/backend/internal/modules/ai/gemini_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -322,6 +323,36 @@ func TestGeminiAbnormalFinishReasonIsAnError(t *testing.T) {
 	_, err := client.Complete(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "q"}}})
 	if err == nil || !strings.Contains(err.Error(), "MAX_TOKENS") {
 		t.Fatalf("want error naming MAX_TOKENS, got %v", err)
+	}
+}
+
+// The terminal has to survive as DATA, not only inside the message: every
+// abnormal finishReason classifies to the one `provider_error` sentinel, so
+// without an accessor the stored row cannot separate a truncated answer
+// (MAX_TOKENS — retry smaller) from a refused one (SAFETY — retrying is
+// pointless). The message is asserted byte-for-byte because callers and the
+// test above match on its text, so carrying the reason must not reword it.
+func TestGeminiAbnormalFinishReasonCarriesTheTerminalAsData(t *testing.T) {
+	for _, reason := range []string{"MAX_TOKENS", "SAFETY", "RECITATION"} {
+		t.Run(reason, func(t *testing.T) {
+			client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"x"}]},"finishReason":"` + reason + `"}]}`))
+			})
+			_, err := client.Complete(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "q"}}})
+			if err == nil {
+				t.Fatal("want an error for an abnormal finishReason")
+			}
+			if want := "ai: gemini: generation stopped: " + reason; err.Error() != want {
+				t.Fatalf("message changed:\n got %q\nwant %q", err.Error(), want)
+			}
+			var stopped interface{ FinishReason() string }
+			if !errors.As(err, &stopped) {
+				t.Fatalf("error does not expose FinishReason(), so the trace cannot record it: %T", err)
+			}
+			if got := stopped.FinishReason(); got != reason {
+				t.Fatalf("FinishReason() = %q, want %q", got, reason)
+			}
+		})
 	}
 }
 

--- a/backend/internal/modules/ai/router_tracing_test.go
+++ b/backend/internal/modules/ai/router_tracing_test.go
@@ -208,6 +208,44 @@ func TestCompleteRecordsFailure(t *testing.T) {
 	}
 }
 
+// A failed attempt has no Response to read the terminal off, so an abnormal
+// finishReason reaches the trace only from the error. MAX_TOKENS, SAFETY and
+// RECITATION share the single `provider_error` sentinel, so a blank
+// finish_reason leaves the stored row unable to say which occurred.
+func TestCompleteRecordsFinishReasonCarriedByTheError(t *testing.T) {
+	fcs := &fakeCallStore{}
+	r := newTracingRouter(t, stubClient{err: stoppedError{reason: "MAX_TOKENS"}}, fcs)
+	if _, _, err := r.serveCompletion(wsCtx(), TaskColdStart, []Tier{TierCheapCloud}, model.Request{}); err == nil {
+		t.Fatal("expected error when the only tier fails")
+	}
+	if len(fcs.recorded) != 1 {
+		t.Fatalf("want exactly one traced attempt, got %+v", fcs.recorded)
+	}
+	got := fcs.recorded[0]
+	if got.FinishReason != "MAX_TOKENS" {
+		t.Fatalf("finish_reason lost on the failure path: %+v", got)
+	}
+	// The sentinel stays put: carrying the terminal is additive, and moving
+	// an abnormal finish out of `provider_error` would change what every
+	// error rate over this counter means.
+	if got.ErrorSentinel != "provider_error" {
+		t.Fatalf("classification moved, which would change every error rate: %q", got.ErrorSentinel)
+	}
+}
+
+// The Response's own report wins whenever there is one, so a successful call
+// that reports its terminal is never overwritten by a stale error accessor.
+func TestCompleteKeepsTheResponsesOwnFinishReason(t *testing.T) {
+	fcs := &fakeCallStore{}
+	r := newTracingRouter(t, stubClient{resp: model.Response{Text: "ok", FinishReason: "stop"}}, fcs)
+	if _, _, err := r.serveCompletion(wsCtx(), TaskColdStart, []Tier{TierCheapCloud}, model.Request{}); err != nil {
+		t.Fatalf("serveCompletion: %v", err)
+	}
+	if len(fcs.recorded) != 1 || fcs.recorded[0].FinishReason != "stop" {
+		t.Fatalf("want the response's own finish reason, got %+v", fcs.recorded)
+	}
+}
+
 // TestCompleteEmitsSlog verifies that the router's observeCall emits an
 // "ai.call" slog line with the expected attributes (task, tier, provider,
 // tokens_in, tokens_out, latency_ms, cache_hit, degraded, error).

--- a/backend/internal/modules/ai/router_tracing_test.go
+++ b/backend/internal/modules/ai/router_tracing_test.go
@@ -233,6 +233,46 @@ func TestCompleteRecordsFinishReasonCarriedByTheError(t *testing.T) {
 	}
 }
 
+// A rung the walk FELL BACK from is stored through traceForFailedRung, not
+// through finalizeAttempt, and it is the row most likely to carry a terminal:
+// an abnormal finish is exactly what sends the walk to the next rung. Both
+// writers derive the reason from one helper, so neither can be the blank one.
+func TestAFallenBackRungRecordsItsFinishReason(t *testing.T) {
+	fcs := &fakeCallStore{}
+	r := assembleRouter(
+		map[Tier]model.Client{
+			TierCheapCloud: stubClient{err: stoppedError{reason: "MAX_TOKENS"}},
+			TierPremium:    stubClient{resp: model.Response{Text: "served"}},
+		},
+		stubClient{}, ProfileCloudFrontier, stubMeter{}, unlimitedBudget{}, fcs,
+		map[Tier]routeMeta{
+			TierCheapCloud: {provider: "gemini", model: "flash-lite"},
+			TierPremium:    {provider: "gemini", model: "flash"},
+		},
+		false, nil,
+	)
+	r.now = func() time.Time { return time.Unix(0, 0) }
+
+	if _, _, err := r.serveCompletion(wsCtx(), TaskColdStart, []Tier{TierCheapCloud, TierPremium}, model.Request{}); err != nil {
+		t.Fatalf("the ladder should have escalated and served: %v", err)
+	}
+	if len(fcs.recorded) != 2 {
+		t.Fatalf("want the failed rung and the served one, got %d: %+v", len(fcs.recorded), fcs.recorded)
+	}
+	fell := fcs.recorded[0]
+	if fell.Tier != TierCheapCloud || fell.IsTerminal {
+		t.Fatalf("first row is not the fallen-back rung: %+v", fell)
+	}
+	if fell.FinishReason != "MAX_TOKENS" {
+		t.Errorf("the fallen-back rung lost its terminal, which is the row that explains WHY it fell back: %+v", fell)
+	}
+	// The rung that answered reported no terminal of its own, and nothing
+	// should have leaked the failed rung's onto it.
+	if served := fcs.recorded[1]; served.FinishReason != "" {
+		t.Errorf("the served rung carries a terminal it never reported: %+v", served)
+	}
+}
+
 // The Response's own report wins whenever there is one, so a successful call
 // that reports its terminal is never overwritten by a stale error accessor.
 func TestCompleteKeepsTheResponsesOwnFinishReason(t *testing.T) {

--- a/backend/internal/modules/ai/tracing.go
+++ b/backend/internal/modules/ai/tracing.go
@@ -102,20 +102,7 @@ func (r *Router) finalizeAttempt(ctx context.Context, b *binding, lc *logicalCal
 	// both are reports or they are nothing. An absent ServedProvider
 	// means no broker named an upstream, and substituting the configured
 	// provider would turn "nobody told us" into a claim about who served.
-	trace.ServedProvider, trace.FinishReason = resp.ServedProvider, resp.FinishReason
-	// A failed attempt has no Response to read the terminal off, so an
-	// abnormal one arrives on the error instead (gemini.go's stoppedError).
-	// The stored row is otherwise blank on exactly the calls finish_reason
-	// describes: MAX_TOKENS, SAFETY and RECITATION share the one
-	// `provider_error` sentinel and are separable only by this field. The
-	// Response's own report wins whenever there is one, because a provider
-	// that stated its terminal outranks an inference from an error value.
-	if trace.FinishReason == "" && callErr != nil {
-		var stopped interface{ FinishReason() string }
-		if errors.As(callErr, &stopped) {
-			trace.FinishReason = stopped.FinishReason()
-		}
-	}
+	trace.ServedProvider, trace.FinishReason = resp.ServedProvider, finishReasonFor(resp.FinishReason, callErr)
 	// Payload capture is best-effort and, like the trace write itself, must
 	// not become a new way for a working model call to fail (contrast the
 	// meter, which fails loudly to protect the budget guardrail). flush()
@@ -255,7 +242,38 @@ func (r *Router) traceForFailedRung(b *binding, base Call, t Tier, callErr error
 	c.ServedModel, c.ServedIdentitySource = servedIdentity(c.Provider, c.ModelID, "")
 	c.LatencyMS = r.now().Sub(start).Milliseconds()
 	c.AttemptReason = attemptReasonProviderError
+	// A rung that fell back is stored too, so it needs the terminal for the
+	// same reason the finalized attempt does — and it is the row most likely
+	// to carry one, since an abnormal finish is exactly what sends the walk
+	// to the next rung. There is no Response on this path at all: the rung
+	// failed, so the reason can only have come from the error.
+	c.FinishReason = finishReasonFor("", callErr)
 	return c
+}
+
+// finishReasonFor derives the terminal for one stored attempt, and is the ONE
+// place it is derived because both writers above record one — a finalized
+// attempt and a rung the walk fell back from — and two derivations of the
+// same field would drift.
+//
+// `reported` is what the Response said, and it wins whenever it is set: a
+// provider that stated its terminal outranks anything inferred from an error
+// value. A failed attempt has no Response to read, so an abnormal terminal
+// arrives on the error instead (gemini.go's stoppedError).
+//
+// Without this the stored row is blank on exactly the calls finish_reason
+// exists to describe: MAX_TOKENS, SAFETY and RECITATION all classify to the
+// single `provider_error` sentinel and are separable only by this field,
+// though they call for opposite responses.
+func finishReasonFor(reported string, callErr error) string {
+	if reported != "" {
+		return reported
+	}
+	var stopped interface{ FinishReason() string }
+	if errors.As(callErr, &stopped) {
+		return stopped.FinishReason()
+	}
+	return ""
 }
 
 // tierOnLadder reports whether t survives on the budget- and

--- a/backend/internal/modules/ai/tracing.go
+++ b/backend/internal/modules/ai/tracing.go
@@ -103,6 +103,19 @@ func (r *Router) finalizeAttempt(ctx context.Context, b *binding, lc *logicalCal
 	// means no broker named an upstream, and substituting the configured
 	// provider would turn "nobody told us" into a claim about who served.
 	trace.ServedProvider, trace.FinishReason = resp.ServedProvider, resp.FinishReason
+	// A failed attempt has no Response to read the terminal off, so an
+	// abnormal one arrives on the error instead (gemini.go's stoppedError).
+	// The stored row is otherwise blank on exactly the calls finish_reason
+	// describes: MAX_TOKENS, SAFETY and RECITATION share the one
+	// `provider_error` sentinel and are separable only by this field. The
+	// Response's own report wins whenever there is one, because a provider
+	// that stated its terminal outranks an inference from an error value.
+	if trace.FinishReason == "" && callErr != nil {
+		var stopped interface{ FinishReason() string }
+		if errors.As(callErr, &stopped) {
+			trace.FinishReason = stopped.FinishReason()
+		}
+	}
 	// Payload capture is best-effort and, like the trace write itself, must
 	// not become a new way for a working model call to fail (contrast the
 	// meter, which fails loudly to protect the budget guardrail). flush()


### PR DESCRIPTION
Two independent defects found while investigating an AI error-rate panel that read **133%** for a tier whose real lifetime error rate was **1.7%**. One PR, two commits, because the rulebook asks for one PR per piece of work.

## 1. The worker published no AI counters at all

`margince_ai_calls_total` and `margince_ai_call_errors_total` count what **one** process routed through **its own** `ai.Router`. They are process-local by exactly the test every other section on the worker's listener already passes — and no other role can answer for them. `cmd/worker` passed `nil` for the `extra` renderer, so every call its enrichment lanes made was missing from the exposition.

Since those lanes do the bulk of the routing, an error rate over the api's exposition alone describes a small minority of an installation's calls while appearing to describe all of them:

| source | premium attempts seen |
|---|---|
| `ai_call` in Postgres (every role writes it) | **293** — 286 of them the worker's `site_extract` |
| the metrics | **5** |

Strip out the healthy 97% and what's left is five escalations with three failures in them. **An undercounted denominator is the failure mode that reports a healthy tier as broken.**

### Why a publish seam and not a constructor argument

The listener is started *before* the model path is resolved, and that ordering is deliberate — the file's own comment: a listener started later "reports nothing during exactly the window a slow boot needs explaining." So the section has to arrive afterwards.

`PublishAIMetrics` holds it in an `atomic.Value`, because the scrape goroutine reads what the boot writes. Until it's published a scrape **omits** the family rather than serving one reading zero calls, which a rate renders as a healthy tier instead of an absent one — the same "declared or absent" posture the pool section already takes. The seam is non-nil even when the surface is off, so `run()` publishes unconditionally rather than guarding a shape it can't see.

`serveResolvedModelPath` puts the path's two long-lived readers together: the operator surface renders the counters from it, the routing watcher keeps it current. The watcher rebinds *inside* the `*ai.Router` the path holds rather than replacing the value, so publishing once is enough.

Sizing note, since it shaped the diff: `run()` sat exactly at the craft gate's 80-code-line ceiling, and the first version of this blocked at 86. Folding the publish in beside the watcher — both consumers of the resolved path — costs `run()` **zero net lines**, needs no signature change, and leaves every existing test call site untouched.

## 2. An abnormal finish reason was discarded

`ai_call.finish_reason` exists to separate a truncated answer from a refused one, and it was stored **empty on exactly the calls that ended abnormally**: `geminiResponseError` formatted the terminal into an error string, `classifyError` flattened it to the one `provider_error` sentinel, and `finalizeAttempt` read the reason off a `Response` that a failed attempt never produced.

So `MAX_TOKENS`, `SAFETY` and `RECITATION` are indistinguishable in a stored call, though they call for opposite responses — retry smaller, do not retry, change the prompt.

`stoppedError` carries the reason behind a `FinishReason()` accessor that `finalizeAttempt` probes with `errors.As`, so the tracing path gains no import of the error type. The `Response`'s own report still wins whenever there is one: a provider that stated its terminal outranks an inference from an error value.

**Deliberately behaviour-preserving.** The message is byte-identical, so callers and the existing test that match on its text are unaffected; the sentinel stays `provider_error`, because moving it would change what every error rate over that counter means. A test asserts both.

### One thing I did not change

`openaicompat.go` answers the same wire condition by returning the `Response` with `FinishReason` set and letting schema validation reject it, so "the rejection carries the text that was paid for." Its comment argues that case well and it may be the better posture for Gemini too — but adopting it would move these calls out of `provider_error`, which is a routing decision rather than a diagnostic one. Happy to open an issue if you want it considered.

## Verification

- `go test ./cmd/worker/ ./internal/modules/ai/` — both pass; `-race` clean on the worker (new atomic seam).
- `go vet -tags=integration ./cmd/worker/` — the integration-tagged file still compiles.
- `craft static --strict` diff-scoped vs `origin/main` — **0 blocker, 0 major, 0 minor**.
- **The `finish_reason` test was proven to catch the bug**: reverting only `tracing.go` reproduces the exact production row, `FinishReason:` empty beside `ErrorSentinel:provider_error`.
- `make check-go` locally: `internal/modules/ai` ok, `cmd/worker` ok, and `backend/gates` **hit its 600s package timeout** on this machine. That is a budget, not an assertion — the test named in the goroutine dump passes alone in 0.459s, and it was simply parked in the panic listing. CI is the arbiter; flagging it rather than claiming a green local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)