### PR TITLE
fix(ai): a binding's base_url reaches a guarded dialer, on every profile

### DIFF
--- a/backend/internal/modules/ai/anthropic_test.go
+++ b/backend/internal/modules/ai/anthropic_test.go
@@ -25,7 +25,7 @@ func newAnthropicForTest(t *testing.T, handler http.HandlerFunc) model.Client {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	client, err := SelectBrain(ProviderConfig{Provider: "anthropic", Model: "claude-test", BaseURL: srv.URL}, cloudKeyFor("anthropic", testAnthropicKey))
+	client, err := selectLocalBrain(ProviderConfig{Provider: "anthropic", Model: "claude-test", BaseURL: srv.URL}, cloudKeyFor("anthropic", testAnthropicKey))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/ai/attachmentplacement_test.go
+++ b/backend/internal/modules/ai/attachmentplacement_test.go
@@ -318,7 +318,7 @@ func TestEveryAdapterPlacesAnAttachmentOnTheSameTurn(t *testing.T) {
 			defer srv.Close()
 
 			for name, read := range placementReaders {
-				client, err := SelectBrain(placementBinding(name, srv.URL), allCloudKeys())
+				client, err := selectLocalBrain(placementBinding(name, srv.URL), allCloudKeys())
 				if err != nil {
 					t.Fatalf("%s: %v", name, err)
 				}

--- a/backend/internal/modules/ai/attachments_test.go
+++ b/backend/internal/modules/ai/attachments_test.go
@@ -57,7 +57,7 @@ func TestEveryProviderMapsOrRejectsAttachmentsNeverSilentlyDrops(t *testing.T) {
 	for name, tc := range mustRefuse {
 		for _, mime := range tc.mimes {
 			t.Run(name+"/"+mime, func(t *testing.T) {
-				client, err := SelectBrain(tc.cfg, allCloudKeys())
+				client, err := selectLocalBrain(tc.cfg, allCloudKeys())
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -123,7 +123,7 @@ func TestAnthropicAndOllamaCarryAttachmentsInTheirOwnWireSpelling(t *testing.T) 
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			client, err := SelectBrain(tc.cfg, allCloudKeys())
+			client, err := selectLocalBrain(tc.cfg, allCloudKeys())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -156,7 +156,7 @@ func TestAnthropicAndOllamaAdvertiseWhatTheyCarry(t *testing.T) {
 		"ollama":    {cfg: ProviderConfig{Provider: "ollama", Model: "m"}, want: carriesImages},
 	} {
 		t.Run(name, func(t *testing.T) {
-			client, err := SelectBrain(tc.cfg, allCloudKeys())
+			client, err := selectLocalBrain(tc.cfg, allCloudKeys())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -193,7 +193,7 @@ func TestDeclaredImageCarriageAcceptsImagesAndStillRejectsPDFs(t *testing.T) {
 	}
 	for name, cfg := range declaresImages {
 		t.Run(name, func(t *testing.T) {
-			client, err := SelectBrain(cfg, allCloudKeys())
+			client, err := selectLocalBrain(cfg, allCloudKeys())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -276,7 +276,7 @@ func TestAttachmentBytesXorURIEnforced(t *testing.T) {
 		writeFixture(t, w, `{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`)
 	}))
 	defer srv.Close()
-	client, err := SelectBrain(ProviderConfig{Provider: "openai", BaseURL: srv.URL, Model: "m"}, allCloudKeys())
+	client, err := selectLocalBrain(ProviderConfig{Provider: "openai", BaseURL: srv.URL, Model: "m"}, allCloudKeys())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func TestNativeCloudProvidersCarryPDFAttachments(t *testing.T) {
 	}
 	for name, cfg := range canCarryPDF {
 		t.Run(name, func(t *testing.T) {
-			client, err := SelectBrain(cfg, allCloudKeys())
+			client, err := selectLocalBrain(cfg, allCloudKeys())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/backend/internal/modules/ai/availablemodels.go
+++ b/backend/internal/modules/ai/availablemodels.go
@@ -99,9 +99,10 @@ type AvailableModels struct {
 // The provider and the LANE are named; the endpoint is not. Both are closed
 // vocabularies — the adapter names this build accepts, and the tiers the stored
 // document already binds — and the host is read from that document or from the
-// adapter's compiled default, never from the request. The AI outbound client
-// carries no egress allowlist, so accepting a URL here would let anyone holding
-// this grant point the server at an arbitrary host.
+// adapter's compiled default, never from the request. A URL accepted here would
+// be a destination chosen by a caller holding only READ on this setting, while
+// the stored one had to be written by someone holding update and passed the
+// endpoint rule on the way in (outboundegress.go).
 //
 // The lane matters because one vendor may be bound at two hosts: a broker on one
 // tier and a self-hosted gateway on another is a configuration the routing

--- a/backend/internal/modules/ai/gemini_test.go
+++ b/backend/internal/modules/ai/gemini_test.go
@@ -28,7 +28,7 @@ func newGeminiForTest(t *testing.T, handler http.HandlerFunc) model.Client {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	client, err := SelectBrain(ProviderConfig{Provider: providerGemini, BaseURL: srv.URL, Model: "gemini-x"}, cloudKeyFor("gemini", testGeminiKey))
+	client, err := selectLocalBrain(ProviderConfig{Provider: providerGemini, BaseURL: srv.URL, Model: "gemini-x"}, cloudKeyFor("gemini", testGeminiKey))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/ai/modellist_test.go
+++ b/backend/internal/modules/ai/modellist_test.go
@@ -46,7 +46,7 @@ func listerFor(
 	}))
 	t.Cleanup(srv.Close)
 	cfg.BaseURL = srv.URL
-	client, err := SelectBrain(cfg, cloudKeyFor(cfg.Provider, "test-key"))
+	client, err := selectLocalBrain(cfg, cloudKeyFor(cfg.Provider, "test-key"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestAnthropicSendsTheVersionHeaderTheAPIRequires(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	client, err := SelectBrain(
+	client, err := selectLocalBrain(
 		ProviderConfig{Provider: providerAnthropic, BaseURL: srv.URL},
 		cloudKeyFor(providerAnthropic, "sk-test"),
 	)
@@ -231,7 +231,7 @@ func TestGeminiFollowsItsPages(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	client, err := SelectBrain(
+	client, err := selectLocalBrain(
 		ProviderConfig{Provider: providerGemini, BaseURL: srv.URL},
 		cloudKeyFor(providerGemini, "k"),
 	)
@@ -280,7 +280,7 @@ func TestListModelsReportsTheStatusAndNotTheBody(t *testing.T) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	client, err := SelectBrain(
+	client, err := selectLocalBrain(
 		ProviderConfig{Provider: providerOpenAI, BaseURL: srv.URL},
 		cloudKeyFor(providerOpenAI, "k"),
 	)
@@ -463,7 +463,7 @@ func TestAListRedirectCarriesNoCredentialToTheNewHost(t *testing.T) {
 	}))
 	t.Cleanup(vendor.Close)
 
-	client, err := SelectBrain(
+	client, err := selectLocalBrain(
 		ProviderConfig{Provider: providerAnthropic, BaseURL: vendor.URL},
 		cloudKeyFor(providerAnthropic, "sk-must-not-travel"),
 	)

--- a/backend/internal/modules/ai/narrowing_test.go
+++ b/backend/internal/modules/ai/narrowing_test.go
@@ -89,7 +89,7 @@ func TestANarrowedBindingRefusesWhatItNoLongerAdvertises(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	narrowed, err := SelectBrain(ProviderConfig{
+	narrowed, err := selectLocalBrain(ProviderConfig{
 		Provider: providerGemini, BaseURL: srv.URL, Model: "m", Input: []string{"text", "image"},
 	}, allCloudKeys())
 	if err != nil {

--- a/backend/internal/modules/ai/openai_test.go
+++ b/backend/internal/modules/ai/openai_test.go
@@ -28,7 +28,7 @@ func newOpenAIForTest(t *testing.T, handler http.HandlerFunc) model.Client {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	client, err := SelectBrain(ProviderConfig{Provider: providerOpenAI, BaseURL: srv.URL, Model: "gpt-x"}, cloudKeyFor("openai", testOpenAIKey))
+	client, err := selectLocalBrain(ProviderConfig{Provider: providerOpenAI, BaseURL: srv.URL, Model: "gpt-x"}, cloudKeyFor("openai", testOpenAIKey))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/ai/outboundegress.go
+++ b/backend/internal/modules/ai/outboundegress.go
@@ -100,9 +100,20 @@ func addressAllowed(class egressClass, ip net.IP) bool {
 // pre-checked and then dialed anyway.
 func dialGuard(class egressClass) func(string, string, syscall.RawConn) error {
 	return func(network, address string, conn syscall.RawConn) error {
-		if host, _, err := net.SplitHostPort(address); err == nil {
-			if ip := net.ParseIP(host); ip != nil && addressAllowed(class, ip) {
-				return nil
+		host, port, err := net.SplitHostPort(address)
+		if err == nil {
+			// parseHostAddress, not net.ParseIP: a link-local or unique-local
+			// address arrives here carrying its zone ("fe80::1%eth0"), which
+			// ParseIP does not take — and the write-time rule already drops it.
+			// A second reading of the same address is how the two ends of one
+			// rule start disagreeing.
+			if ip := parseHostAddress(host); ip != nil {
+				if addressAllowed(class, ip) {
+					return nil
+				}
+				// The zone stripped, so netguard names the address it judged
+				// rather than reporting a zoned one as "not a literal IP".
+				address = net.JoinHostPort(ip.String(), port)
 			}
 		}
 		// Refused, or a shape this cannot judge for itself. netguard owns both
@@ -143,8 +154,17 @@ func customerControlled(ip net.IP) bool {
 // change after boot, which is exactly why dialGuard checks the resolved address
 // rather than trusting this.
 func requireDialableEndpoint(label, provider, baseURL string) error {
-	if strings.TrimSpace(baseURL) == "" {
+	if baseURL == "" {
 		return nil // no host of its own; the adapter's compiled default applies
+	}
+	if _, known := providerEgress[provider]; !known {
+		// No lane to judge. SelectBrain refuses a provider this build has no
+		// adapter for, so the binding reaches no socket at all — and answering
+		// here would report an egress fault for a binding whose actual problem
+		// is the provider name, which is the error the operator has to act on.
+		// TestEveryProviderDeclaresAnEgressClass keeps this from ever skipping
+		// a provider that CAN be served.
+		return nil
 	}
 	parsed, err := parsedEndpoint(baseURL)
 	if err != nil {
@@ -165,7 +185,7 @@ func requireDialableEndpoint(label, provider, baseURL string) error {
 func userinfoRefused(label string, parsed *url.URL) error {
 	return fmt.Errorf(
 		"ai: routing config: %s: base_url %q carries userinfo, and a binding never carries a credential — it would be sent to whatever host the value names. Give the host root alone; a model key belongs in the key vault",
-		label, parsed.Redacted())
+		label, withoutUserinfo(parsed))
 }
 
 // unreachableAddressRefused tells the operator which rule they met and what to

--- a/backend/internal/modules/ai/outboundegress.go
+++ b/backend/internal/modules/ai/outboundegress.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// Where a binding's base_url is allowed to take the server.
+//
+// A binding is operator-supplied, and `ollama`, `vllm` and `openai_compatible`
+// take a host with nothing constraining it — so without a guard the stored
+// routing document is a request the server makes on whoever can write it, at
+// whatever address they name. That is an SSRF sink whether or not the writer
+// was trusted to bind a model, and the answer comes back to them: the
+// available-models read reflects the decoded body.
+//
+// The guard cannot simply be netguard.RefusePrivate, which is what every other
+// tenant-host lane in this tree uses, because a private address is the FEATURE
+// here — a local Ollama, a GPU box on the operator's own network, a self-hosted
+// gateway. So the allowance is derived from the binding instead: what a lane
+// may dial depends on what that lane is for.
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"syscall"
+
+	"github.com/margince/margince/backend/internal/platform/netguard"
+)
+
+// egressClass is how far one provider's binding may reach.
+type egressClass int
+
+const (
+	// egressPublicOnly is the vendor lane: `anthropic`, `openai` and `gemini`
+	// call a named vendor's public API, and their base_url is documented as an
+	// override of that vendor's host — never as a way into the deployment's own
+	// network. It is also the lane that carries the installation's BYOK key in
+	// a header Go does not strip across hosts (x-api-key, x-goog-api-key), so
+	// an address here is a credential's destination as much as a request's.
+	//
+	// The ZERO value on purpose: a provider added without a considered entry in
+	// providerEgress gets the strict lane rather than the permissive one.
+	egressPublicOnly egressClass = iota
+
+	// egressOperatorEndpoint is the lane an operator points at their own
+	// infrastructure. Loopback and the private ranges are allowed because they
+	// are what this lane exists for; a public host is allowed because a hosted
+	// Ollama or a broker on the OpenAI wire is an ordinary binding. What is
+	// refused is everything in between — the reserved ranges that are nobody's
+	// inference endpoint and are how an internal address gets named without
+	// looking like one, link-local cloud metadata first among them.
+	egressOperatorEndpoint
+)
+
+// providerEgress is the one place a provider's reach is decided, read by both
+// the dialer and the write-time rule so they cannot answer differently.
+// TestEveryProviderDeclaresAnEgressClass holds it complete.
+var providerEgress = map[string]egressClass{
+	// The fake adapter opens no socket, so its class is inert; it is listed
+	// because a provider missing from this map is the thing the census catches.
+	ProviderFake:      egressPublicOnly,
+	providerAnthropic: egressPublicOnly,
+	providerOpenAI:    egressPublicOnly,
+	providerGemini:    egressPublicOnly,
+	providerOllama:    egressOperatorEndpoint,
+	providerVLLM:      egressOperatorEndpoint,
+	// The one BYOK provider on the operator lane, and the only entry here that
+	// does not follow from ProviderIsLocal. `openai_compatible` is the adapter
+	// for "any vendor on the OpenAI wire", and a self-hosted gateway on the
+	// operator's own network is a documented one — so a private address is a
+	// binding this lane must serve, and the key travelling there travels to the
+	// operator's own infrastructure. TestEveryLocalProviderTakesTheOperatorLane
+	// names it as the sole exception, so a future adapter cannot join it quietly.
+	providerOpenAICompatible: egressOperatorEndpoint,
+}
+
+// egressFor answers for a provider name that may not be one this build knows —
+// SelectBrain refuses those, but the write-time rule runs before it, and the
+// missing entry must not read as the permissive class.
+func egressFor(provider string) egressClass { return providerEgress[provider] }
+
+// addressAllowed reports whether class may dial the concrete address ip.
+//
+// The single spelling of the rule: the dial-time Control hook and the
+// write-time base_url check both ask it, so a binding accepted at the door
+// cannot be one the first call refuses.
+func addressAllowed(class egressClass, ip net.IP) bool {
+	if class == egressOperatorEndpoint && customerControlled(ip) {
+		return true
+	}
+	return netguard.PublicIP(ip)
+}
+
+// dialGuard is the net.Dialer.Control hook for one egress class. It runs after
+// DNS on the address the socket is about to connect to, so a name that resolves
+// — or rebinds — to a refused address is stopped at connect time rather than
+// pre-checked and then dialed anyway.
+func dialGuard(class egressClass) func(string, string, syscall.RawConn) error {
+	return func(network, address string, conn syscall.RawConn) error {
+		if host, _, err := net.SplitHostPort(address); err == nil {
+			if ip := net.ParseIP(host); ip != nil && addressAllowed(class, ip) {
+				return nil
+			}
+		}
+		// Refused, or a shape this cannot judge for itself. netguard owns both
+		// verdicts and names which one in its message, so there is no second
+		// wording of "we will not dial that" to keep in step with it.
+		return netguard.RefusePrivate(network, address, conn)
+	}
+}
+
+// parseHostAddress is the IP a url host names, or nil when it names a DNS name.
+//
+// A zone ("fe80::1%eth0") says which interface an address is reached on and
+// net.ParseIP does not take one; it is dropped because the judgement is about
+// the address, and an interface cannot change what an address is.
+func parseHostAddress(host string) net.IP {
+	address, _, _ := strings.Cut(host, "%")
+	return net.ParseIP(address)
+}
+
+// customerControlled reports whether an address is one the installation may
+// treat as its own infrastructure — its own host, or its own network.
+//
+// Read by the sovereign profile check as well as by the egress classes, because
+// they are the same question asked twice: "is this address ours?"
+func customerControlled(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate()
+}
+
+// requireDialableEndpoint refuses a base_url the outbound dialer would refuse
+// anyway, at the write instead of at the first call.
+//
+// Refused HERE for the reason ValidateTierBinding's openai_compatible rule is:
+// accepted at the door it saves cleanly and the operator is told it worked,
+// and the failure then arrives as an "unreachable" vendor with the reason in a
+// log nobody is reading.
+//
+// A DNS name is not judged — what it resolves to is decided elsewhere and can
+// change after boot, which is exactly why dialGuard checks the resolved address
+// rather than trusting this.
+func requireDialableEndpoint(label, provider, baseURL string) error {
+	if strings.TrimSpace(baseURL) == "" {
+		return nil // no host of its own; the adapter's compiled default applies
+	}
+	parsed, err := parsedEndpoint(baseURL)
+	if err != nil {
+		return fmt.Errorf("ai: routing config: %s: %w", label, err)
+	}
+	if parsed.User != nil {
+		return userinfoRefused(label, parsed)
+	}
+	ip := parseHostAddress(parsed.Hostname())
+	if ip == nil || addressAllowed(egressFor(provider), ip) {
+		return nil
+	}
+	return unreachableAddressRefused(label, provider, ip)
+}
+
+// userinfoRefused names the shape without echoing it: this error reaches a boot
+// log, and the value being refused is by definition one carrying a credential.
+func userinfoRefused(label string, parsed *url.URL) error {
+	return fmt.Errorf(
+		"ai: routing config: %s: base_url %q carries userinfo, and a binding never carries a credential — it would be sent to whatever host the value names. Give the host root alone; a model key belongs in the key vault",
+		label, parsed.Redacted())
+}
+
+// unreachableAddressRefused tells the operator which rule they met and what to
+// do about it — two lanes, two different fixes.
+func unreachableAddressRefused(label, provider string, ip net.IP) error {
+	if egressFor(provider) == egressOperatorEndpoint {
+		return fmt.Errorf(
+			"ai: routing config: %s: base_url points at %s, which is not an address inference is served from — an endpoint is loopback, a private range (10.x, 172.16-31.x, 192.168.x, an IPv6 unique-local address), or a public host. Link-local, carrier-grade NAT and the documentation ranges are refused on every profile",
+			label, ip)
+	}
+	return fmt.Errorf(
+		"ai: routing config: %s: provider %q calls a vendor's public API and carries this installation's model key, so its base_url must name a public host — %s is not one. To reach a gateway on your own network, bind openai_compatible instead",
+		label, provider, ip)
+}

--- a/backend/internal/modules/ai/outboundegress.go
+++ b/backend/internal/modules/ai/outboundegress.go
@@ -185,7 +185,7 @@ func requireDialableEndpoint(label, provider, baseURL string) error {
 func userinfoRefused(label string, parsed *url.URL) error {
 	return fmt.Errorf(
 		"ai: routing config: %s: base_url %q carries userinfo, and a binding never carries a credential — it would be sent to whatever host the value names. Give the host root alone; a model key belongs in the key vault",
-		label, withoutUserinfo(parsed))
+		label, safeToName(parsed))
 }
 
 // unreachableAddressRefused tells the operator which rule they met and what to

--- a/backend/internal/modules/ai/outboundegress.go
+++ b/backend/internal/modules/ai/outboundegress.go
@@ -82,6 +82,8 @@ func egressFor(provider string) egressClass { return providerEgress[provider] }
 
 // addressAllowed reports whether class may dial the concrete address ip.
 //
+// Held by: TestTheWriteRuleAndTheDialerAgree (backend/internal/modules/ai/outboundegress_test.go)
+//
 // The single spelling of the rule: the dial-time Control hook and the
 // write-time base_url check both ask it, so a binding accepted at the door
 // cannot be one the first call refuses.

--- a/backend/internal/modules/ai/outboundegress.go
+++ b/backend/internal/modules/ai/outboundegress.go
@@ -173,11 +173,17 @@ func requireDialableEndpoint(label, provider, baseURL string) error {
 	if parsed.User != nil {
 		return userinfoRefused(label, parsed)
 	}
-	ip := parseHostAddress(parsed.Hostname())
-	if ip == nil || addressAllowed(egressFor(provider), ip) {
-		return nil
+	// The address before the scheme, because a vendor binding pointed into this
+	// deployment's own network is the more surprising of the two mistakes and
+	// the one the operator has to understand first. Both are refused; only the
+	// order of the message is decided here.
+	if ip := parseHostAddress(parsed.Hostname()); ip != nil && !addressAllowed(egressFor(provider), ip) {
+		return unreachableAddressRefused(label, provider, ip)
 	}
-	return unreachableAddressRefused(label, provider, ip)
+	if egressFor(provider) == egressPublicOnly && !strings.EqualFold(parsed.Scheme, "https") {
+		return cleartextRefused(label, provider, parsed.Scheme)
+	}
+	return nil
 }
 
 // userinfoRefused names the shape without echoing it: this error reaches a boot
@@ -186,6 +192,20 @@ func userinfoRefused(label string, parsed *url.URL) error {
 	return fmt.Errorf(
 		"ai: routing config: %s: base_url %q carries userinfo, and a binding never carries a credential — it would be sent to whatever host the value names. Give the host root alone; a model key belongs in the key vault",
 		label, safeToName(parsed))
+}
+
+// cleartextRefused is the write-time half of refuseOffHostRedirect's downgrade
+// rule. The two are one obligation: a vendor call carries this installation's
+// model key, and a client that refuses to be redirected into clear while
+// accepting a binding that starts there would be guarding one door of two.
+//
+// The vendor lane only. An operator's own gateway is reached over http all the
+// time and the key travels no further than their network, so openai_compatible,
+// ollama and vllm are untouched.
+func cleartextRefused(label, provider, scheme string) error {
+	return fmt.Errorf(
+		"ai: routing config: %s: provider %q calls a vendor's public API with this installation's model key, so its base_url must be https — %q would send the key in clear. To reach a gateway on your own network over http, bind openai_compatible instead",
+		label, provider, scheme)
 }
 
 // unreachableAddressRefused tells the operator which rule they met and what to

--- a/backend/internal/modules/ai/outboundegress_test.go
+++ b/backend/internal/modules/ai/outboundegress_test.go
@@ -140,7 +140,11 @@ func TestTheWriteRuleAndTheDialerAgree(t *testing.T) {
 			// RFC 6874's escaping, not a quirk of this test. The two ends see
 			// the same endpoint spelled the two ways they each really get it.
 			inAURL := net.JoinHostPort(strings.Replace(address, "%", "%25", 1), "8080")
-			atTheWrite := requireDialableEndpoint("tier premium", provider, "http://"+inAURL) == nil
+			// https throughout, because the scheme is not the question here: the
+			// vendor lane refuses cleartext outright (cleartextRefused), and a
+			// disagreement about THAT would drown out the address disagreements
+			// this table exists to catch. The dialer never sees a scheme at all.
+			atTheWrite := requireDialableEndpoint("tier premium", provider, "https://"+inAURL) == nil
 			atTheSocket := guard("tcp", hostPort, nil) == nil
 			if atTheWrite != atTheSocket {
 				t.Errorf("provider %q, address %s: the write rule says allowed=%v and the dialer says allowed=%v",
@@ -412,6 +416,17 @@ embeddings: { provider: ollama, model: bge-m3 }
 `,
 			names: "names no host",
 		},
+		// The write-time half of the redirect downgrade rule: a vendor call
+		// carries the model key, so it may not start in clear either.
+		"a vendor binding in cleartext": {
+			routing: `
+profile: cloud_frontier
+tiers:
+  premium: { provider: anthropic, base_url: "http://api.anthropic.com", model: claude-x }
+embeddings: { provider: ollama, model: bge-m3 }
+`,
+			names: "must be https",
+		},
 		"a credential smuggled in as userinfo": {
 			routing: `
 profile: eu_hosted
@@ -471,7 +486,7 @@ tiers:
   local_large: { provider: ollama, base_url: "http://10.4.1.20:11434", model: m }
 embeddings: { provider: ollama, base_url: "http://127.0.0.1:11434", model: bge-m3 }
 `,
-		"a self-hosted gateway on the OpenAI wire": `
+		"a self-hosted gateway on the OpenAI wire, in cleartext": `
 profile: eu_hosted
 tiers:
   premium: { provider: openai_compatible, base_url: "http://192.168.1.5:8080", model: m }

--- a/backend/internal/modules/ai/outboundegress_test.go
+++ b/backend/internal/modules/ai/outboundegress_test.go
@@ -243,6 +243,63 @@ func TestTheOutboundClientCannotBeRoutedThroughAProxy(t *testing.T) {
 	}
 }
 
+// A redirect is the other way a credential leaves for a host the binding never
+// named, and Go will not stop it: it strips Authorization and Cookie across a
+// domain change and has never heard of x-api-key or x-goog-api-key, and it
+// strips nothing at all when only the scheme changes.
+//
+// The two hops that move a credential are refused; the one that does not is
+// followed, because this client also carries streaming completions and a
+// blanket refusal would turn a redirect a vendor genuinely uses into an outage.
+func TestTheOutboundClientRefusesARedirectThatMovesTheKey(t *testing.T) {
+	t.Parallel()
+
+	hop := func(from, to string) error {
+		previous, err := http.NewRequestWithContext(context.Background(), http.MethodGet, from, nil)
+		if err != nil {
+			t.Fatalf("building %q: %v", from, err)
+		}
+		next, err := http.NewRequestWithContext(context.Background(), http.MethodGet, to, nil)
+		if err != nil {
+			t.Fatalf("building %q: %v", to, err)
+		}
+		return refuseOffHostRedirect(next, []*http.Request{previous})
+	}
+
+	for name, tc := range map[string]struct {
+		from, to string
+		refused  bool
+	}{
+		"another host":                {"https://api.vendor.example/v1", "https://attacker.example/v1", true},
+		"a subdomain is another host": {"https://api.vendor.example/v1", "https://evil.api.vendor.example/v1", true},
+		"a downgrade to cleartext":    {"https://api.vendor.example/v1", "http://api.vendor.example/v1", true},
+		// Followed: the key goes nowhere it was not already going.
+		"another path on the same host": {"https://api.vendor.example/v1", "https://api.vendor.example/v2", false},
+		"the same host in another case": {"https://api.vendor.example/v1", "https://API.Vendor.Example/v1", false},
+		// An operator's own gateway may be plain http throughout; only a
+		// DOWNGRADE moves a key from protected to unprotected.
+		"http to http on one host": {"http://gateway.internal/v1", "http://gateway.internal/v2", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := hop(tc.from, tc.to)
+			if tc.refused && err == nil {
+				t.Errorf("the redirect %s -> %s was followed, carrying the model key", tc.from, tc.to)
+			}
+			if !tc.refused && err != nil {
+				t.Errorf("the redirect %s -> %s was refused, which a vendor's own routing would read as an outage: %v", tc.from, tc.to, err)
+			}
+		})
+	}
+
+	// The policy is on the client every adapter is handed, not on one lane.
+	for _, provider := range KnownProviders() {
+		if newOutboundClient(provider).CheckRedirect == nil {
+			t.Errorf("provider %q: the outbound client follows redirects by Go's default rules, which do not strip x-api-key", provider)
+		}
+	}
+}
+
 // The production wiring, through the exported constructor rather than around
 // it: a client built by SelectBrain carries its lane's guard.
 //

--- a/backend/internal/modules/ai/outboundegress_test.go
+++ b/backend/internal/modules/ai/outboundegress_test.go
@@ -130,9 +130,17 @@ func TestTheWriteRuleAndTheDialerAgree(t *testing.T) {
 			"127.0.0.1", "::1", "10.4.1.20", "192.168.1.5", "fd00::1", "::ffff:10.0.0.1",
 			"169.254.169.254", "fe80::1", "64:ff9b::a9fe:a9fe", "100.64.0.1", "192.0.2.10",
 			"0.0.0.0", "2002:7f00:1::1", "172.32.0.9",
+			// Zoned, which is how a link-local or unique-local address actually
+			// reaches a dialer. The zone is not part of the judgement, and the
+			// two ends must drop it the same way or they disagree here.
+			"fd00::1%eth0", "fe80::1%eth0",
 		} {
 			hostPort := net.JoinHostPort(address, "8080")
-			atTheWrite := requireDialableEndpoint("tier premium", provider, "http://"+hostPort) == nil
+			// A zone is written `%25` inside a url and bare on a dial address —
+			// RFC 6874's escaping, not a quirk of this test. The two ends see
+			// the same endpoint spelled the two ways they each really get it.
+			inAURL := net.JoinHostPort(strings.Replace(address, "%", "%25", 1), "8080")
+			atTheWrite := requireDialableEndpoint("tier premium", provider, "http://"+inAURL) == nil
 			atTheSocket := guard("tcp", hostPort, nil) == nil
 			if atTheWrite != atTheSocket {
 				t.Errorf("provider %q, address %s: the write rule says allowed=%v and the dialer says allowed=%v",
@@ -164,22 +172,25 @@ func TestSelectBrainIsTheOnlyBuilderOfAnOutboundClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parsing %s: %v", name, err)
 		}
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok {
-				continue
+		// The WHOLE file, not its func declarations: a package-level
+		// `var shared = newOutboundClient(...)` is a GenDecl and would walk
+		// straight past a scan that only entered functions — an unguarded
+		// client built where this test cannot see it is the one failure a
+		// census like this must not have.
+		enclosing := "package scope"
+		ast.Inspect(file, func(node ast.Node) bool {
+			if fn, ok := node.(*ast.FuncDecl); ok {
+				enclosing = fn.Name.Name
 			}
-			ast.Inspect(fn, func(node ast.Node) bool {
-				call, ok := node.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "newOutboundClient" {
-					callers = append(callers, name+":"+fn.Name.Name)
-				}
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
 				return true
-			})
-		}
+			}
+			if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "newOutboundClient" {
+				callers = append(callers, name+":"+enclosing)
+			}
+			return true
+		})
 	}
 	if len(callers) != 1 || callers[0] != "selectbrain.go:SelectBrain" {
 		t.Errorf("newOutboundClient is called from %v, want only selectbrain.go:SelectBrain — every other builder dials unguarded", callers)
@@ -203,6 +214,31 @@ func TestTheDialGuardRefusesWhatItCannotJudge(t *testing.T) {
 	} {
 		if err := guard("tcp", address, nil); err == nil {
 			t.Errorf("the guard dialed %q", address)
+		}
+	}
+}
+
+// A guard on the dialer is only a guard while the dial goes to the binding's
+// host. http.DefaultTransport carries ProxyFromEnvironment, and the clone
+// inherits it, so on any deployment with HTTPS_PROXY set the socket would open
+// to the PROXY — a public address, admitted — and the proxy would then be asked
+// to CONNECT wherever the binding pointed, which this side never sees.
+//
+// One environment variable is the whole distance between this guard and no
+// guard, which is why it is asserted rather than left to the reader.
+func TestTheOutboundClientCannotBeRoutedThroughAProxy(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range KnownProviders() {
+		transport, ok := newOutboundClient(provider).Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("provider %q: the outbound client's transport is not an *http.Transport, so nothing below binds", provider)
+		}
+		if transport.Proxy != nil {
+			t.Errorf("provider %q: the outbound transport honours a proxy, so HTTPS_PROXY routes every dial around the egress guard", provider)
+		}
+		if transport.DialContext == nil {
+			t.Errorf("provider %q: the outbound transport has no DialContext, so the egress guard is never consulted", provider)
 		}
 	}
 }
@@ -307,6 +343,18 @@ embeddings: { provider: ollama, base_url: "http://169.254.169.254", model: bge-m
 `,
 			names: "169.254.169.254",
 		},
+		// Whitespace is not an omitted base_url: `defaulted` only falls back on
+		// the empty string, so a blank one would reach the adapter as its host
+		// and fail on the first call as an unparseable url.
+		"a base_url that is only whitespace": {
+			routing: `
+profile: eu_hosted
+tiers:
+  local_large: { provider: ollama, base_url: "   ", model: m }
+embeddings: { provider: ollama, model: bge-m3 }
+`,
+			names: "names no host",
+		},
 		"a credential smuggled in as userinfo": {
 			routing: `
 profile: eu_hosted
@@ -330,6 +378,26 @@ embeddings: { provider: ollama, model: bge-m3 }
 				t.Errorf("the refusal echoes the credential it was given: %v", err)
 			}
 		})
+	}
+}
+
+// A provider this build has no adapter for gets no egress verdict, because it
+// gets no socket: SelectBrain refuses to construct a client, so there is no lane
+// to judge — and answering here would report an egress fault for a binding whose
+// actual problem is the provider name.
+//
+// Both halves, because the first alone would also pass if the rule had simply
+// stopped working: the refusal has to come from somewhere, and it does.
+func TestAnUnservableProviderIsLeftToSelectBrain(t *testing.T) {
+	t.Parallel()
+
+	const unknown = "not-a-vendor"
+	if err := requireDialableEndpoint("tier premium", unknown, "http://10.0.0.5:6379"); err != nil {
+		t.Errorf("the endpoint rule answered for a provider with no adapter: %v", err)
+	}
+	_, err := SelectBrain(ProviderConfig{Provider: unknown, BaseURL: "http://10.0.0.5:6379"}, noCloudKeys())
+	if err == nil || !strings.Contains(err.Error(), unknown) {
+		t.Errorf("SelectBrain must refuse the binding and name the provider, got %v", err)
 	}
 }
 

--- a/backend/internal/modules/ai/outboundegress_test.go
+++ b/backend/internal/modules/ai/outboundegress_test.go
@@ -277,9 +277,18 @@ func TestTheOutboundClientRefusesARedirectThatMovesTheKey(t *testing.T) {
 		"another host":                {"https://api.vendor.example/v1", "https://attacker.example/v1", true},
 		"a subdomain is another host": {"https://api.vendor.example/v1", "https://evil.api.vendor.example/v1", true},
 		"a downgrade to cleartext":    {"https://api.vendor.example/v1", "http://api.vendor.example/v1", true},
+		// A hostname is not an endpoint: one machine serves many, and :8443 is a
+		// different service from :443 — possibly somebody else's, on shared
+		// hosting. The dial guard is no help, because the address never changed.
+		"another port on the same host": {"https://api.vendor.example/v1", "https://api.vendor.example:8443/v1", true},
+		"one explicit port for another": {"https://api.vendor.example:8443/v1", "https://api.vendor.example:9443/v1", true},
 		// Followed: the key goes nowhere it was not already going.
 		"another path on the same host": {"https://api.vendor.example/v1", "https://api.vendor.example/v2", false},
 		"the same host in another case": {"https://api.vendor.example/v1", "https://API.Vendor.Example/v1", false},
+		// One endpoint under two spellings. A rule comparing URL.Host as text
+		// would refuse this and call a vendor's own normalisation an attack.
+		"the default port spelled out":   {"https://api.vendor.example/v1", "https://api.vendor.example:443/v1", false},
+		"the default port left implicit": {"http://gateway.internal:80/v1", "http://gateway.internal/v2", false},
 		// An operator's own gateway may be plain http throughout; only a
 		// DOWNGRADE moves a key from protected to unprotected.
 		"http to http on one host": {"http://gateway.internal/v1", "http://gateway.internal/v2", false},

--- a/backend/internal/modules/ai/outboundegress_test.go
+++ b/backend/internal/modules/ai/outboundegress_test.go
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+// A provider whose reach nobody chose is the failure mode of a map like this:
+// it reads as the zero value, and the zero value has to be the strict lane for
+// that to be safe. Both directions, so a removed provider leaves no entry
+// claiming to guard a lane that no longer exists.
+func TestEveryProviderDeclaresAnEgressClass(t *testing.T) {
+	t.Parallel()
+
+	declared := make(map[string]bool, len(providerEgress))
+	for _, provider := range KnownProviders() {
+		if _, ok := providerEgress[provider]; !ok {
+			t.Errorf("provider %q declares no egress class, so its outbound client is guarded by a default nobody chose", provider)
+		}
+		declared[provider] = true
+	}
+	for provider := range providerEgress {
+		if !declared[provider] {
+			t.Errorf("providerEgress declares %q, which SelectBrain does not accept — a rule for a lane that does not exist", provider)
+		}
+	}
+	if egressPublicOnly != 0 {
+		t.Error("the zero egress class must be the strict one, or a provider added without an entry gets the permissive lane")
+	}
+}
+
+// Sovereign-eligibility and the permissive lane are one idea seen twice: a
+// provider is local BECAUSE it is the operator's own endpoint, which is the same
+// reason it may dial the operator's own network. Derived rather than restated,
+// so a new local provider cannot arrive on the vendor lane.
+//
+// The implication runs one way. openai_compatible is a BYOK cloud adapter that
+// is nonetheless documented to reach a self-hosted gateway, so it takes the
+// permissive lane too — named HERE, as the sole exception, so the next adapter
+// that wants it has to say so in a diff rather than inherit it.
+func TestEveryLocalProviderTakesTheOperatorLane(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range KnownProviders() {
+		if provider == ProviderFake {
+			continue // dials nothing, so its class binds nothing
+		}
+		onOperatorLane := egressFor(provider) == egressOperatorEndpoint
+		if ProviderIsLocal(provider) && !onOperatorLane {
+			t.Errorf("provider %q is sovereign-eligible but may not dial the operator's own network", provider)
+		}
+		if !ProviderIsLocal(provider) && onOperatorLane && provider != providerOpenAICompatible {
+			t.Errorf("provider %q is a cloud vendor on the permissive lane, so a binding may point this installation's model key at an address inside its own network", provider)
+		}
+	}
+}
+
+// What each lane may reach, stated as the addresses themselves.
+//
+// The operator lane's whole point is the middle column: a local Ollama, a GPU
+// box on the operator's own network. What neither lane may reach is the third
+// group — the reserved ranges that are nobody's inference endpoint, with cloud
+// metadata at the head of it.
+func TestWhichAddressesEachLaneMayDial(t *testing.T) {
+	t.Parallel()
+
+	for address, want := range map[string]struct{ vendor, operator bool }{
+		"8.8.8.8":         {vendor: true, operator: true},
+		"2606:4700::1111": {vendor: true, operator: true},
+
+		"127.0.0.1":   {vendor: false, operator: true},
+		"::1":         {vendor: false, operator: true},
+		"10.4.1.20":   {vendor: false, operator: true},
+		"172.16.0.9":  {vendor: false, operator: true},
+		"192.168.1.5": {vendor: false, operator: true},
+		"fd00::1":     {vendor: false, operator: true},
+		// An IPv4-mapped IPv6 address is judged by its IPv4 rules, so the
+		// mapping smuggles nothing past either lane.
+		"::ffff:10.0.0.1": {vendor: false, operator: true},
+
+		// Cloud metadata, and its NAT64 spelling: refused on BOTH lanes. An
+		// operator serves inference from an address they configured, never from
+		// an autoconfiguration one.
+		"169.254.169.254":    {vendor: false, operator: false},
+		"fe80::1":            {vendor: false, operator: false},
+		"64:ff9b::a9fe:a9fe": {vendor: false, operator: false},
+		"100.64.0.1":         {vendor: false, operator: false}, // carrier-grade NAT
+		"192.0.2.10":         {vendor: false, operator: false}, // documentation range
+		"0.0.0.0":            {vendor: false, operator: false},
+		"2002:7f00:1::1":     {vendor: false, operator: false}, // 6to4-wrapped loopback
+	} {
+		ip := net.ParseIP(address)
+		if ip == nil {
+			t.Fatalf("the table entry %q is not an address", address)
+		}
+		if got := addressAllowed(egressPublicOnly, ip); got != want.vendor {
+			t.Errorf("the vendor lane may dial %s = %v, want %v", address, got, want.vendor)
+		}
+		if got := addressAllowed(egressOperatorEndpoint, ip); got != want.operator {
+			t.Errorf("the operator lane may dial %s = %v, want %v", address, got, want.operator)
+		}
+	}
+}
+
+// The Control hook is what the socket actually consults, and it must refuse the
+// shapes it cannot judge as well as the ones it judges badly — an address it
+// cannot parse is not an address it may dial.
+func TestTheDialGuardRefusesWhatItCannotJudge(t *testing.T) {
+	t.Parallel()
+
+	guard := dialGuard(egressOperatorEndpoint)
+	if err := guard("tcp", "127.0.0.1:11434", nil); err != nil {
+		t.Fatalf("the operator lane must dial its own loopback endpoint, got %v", err)
+	}
+	for _, address := range []string{
+		"169.254.169.254:80",    // the address this guard exists for
+		"not-a-host-port",       // unparseable
+		"ollama.internal:11434", // a name: the hook sees resolved addresses only
+	} {
+		if err := guard("tcp", address, nil); err == nil {
+			t.Errorf("the guard dialed %q", address)
+		}
+	}
+}
+
+// The production wiring, through the exported constructor rather than around
+// it: a client built by SelectBrain carries its lane's guard.
+//
+// Both directions, because a refusal-only test also passes when the whole
+// adapter is broken — the local lane must still reach the endpoint it is for.
+func TestSelectBrainWiresTheEgressGuard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a vendor binding may not be pointed at this host", func(t *testing.T) {
+		t.Parallel()
+		// Bound to an address the loopback lane owns: a BYOK adapter carries
+		// this installation's model key, and the API host's own loopback is
+		// where a stored base_url would send it.
+		client, err := SelectBrain(
+			ProviderConfig{Provider: providerAnthropic, BaseURL: "http://127.0.0.1:11434", Model: "m"},
+			cloudKeyFor(providerAnthropic, "stands-in-for-a-key"),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = client.(model.Lister).ListModels(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "netguard") {
+			t.Fatalf("the vendor lane dialed loopback, or refused for another reason: %v", err)
+		}
+	})
+
+	t.Run("a local binding may not be pointed at cloud metadata", func(t *testing.T) {
+		t.Parallel()
+		client, err := SelectBrain(
+			ProviderConfig{Provider: providerOllama, BaseURL: "http://169.254.169.254", Model: "m"},
+			noCloudKeys(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = client.(model.Lister).ListModels(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "netguard") {
+			t.Fatalf("the operator lane dialed the metadata service, or refused for another reason: %v", err)
+		}
+	})
+
+	t.Run("a local binding still reaches its own endpoint", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(`{"models":[{"name":"gemma3"}]}`)); err != nil {
+				t.Errorf("writing the ollama tag list: %v", err)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		client, err := SelectBrain(ProviderConfig{Provider: providerOllama, BaseURL: srv.URL, Model: "gemma3"}, noCloudKeys())
+		if err != nil {
+			t.Fatal(err)
+		}
+		models, err := client.(model.Lister).ListModels(context.Background())
+		if err != nil {
+			t.Fatalf("the guard blocked the local endpoint it exists to allow: %v", err)
+		}
+		if len(models) != 1 || models[0].ID != "gemma3" {
+			t.Fatalf("the local lane answered %v, want the one model the endpoint serves", models)
+		}
+	})
+}
+
+// The write-time half. Before this rule the endpoint was checked under the
+// sovereign profile ALONE, so any string that parsed was persisted on the other
+// two and only the first call found out — as an unreachable vendor, with the
+// reason in a log nobody reads.
+func TestABaseURLIsCheckedOnEveryProfile(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct{ routing, names string }{
+		"cloud metadata on a local tier": {
+			routing: `
+profile: eu_hosted
+tiers:
+  local_large: { provider: ollama, base_url: "http://169.254.169.254/latest/meta-data", model: m }
+embeddings: { provider: ollama, model: bge-m3 }
+`,
+			names: "169.254.169.254",
+		},
+		"this host's own network on a vendor tier": {
+			routing: `
+profile: cloud_frontier
+tiers:
+  premium: { provider: anthropic, base_url: "http://10.0.0.5:6379", model: claude-x }
+embeddings: { provider: ollama, model: bge-m3 }
+`,
+			names: "public host",
+		},
+		"cloud metadata on the embeddings lane": {
+			routing: `
+profile: eu_hosted
+tiers:
+  local_large: { provider: ollama, model: m }
+embeddings: { provider: ollama, base_url: "http://169.254.169.254", model: bge-m3 }
+`,
+			names: "169.254.169.254",
+		},
+		"a credential smuggled in as userinfo": {
+			routing: `
+profile: eu_hosted
+tiers:
+  local_large: { provider: ollama, base_url: "http://user:stands-in-for-a-token@10.4.1.20:11434", model: m }
+embeddings: { provider: ollama, model: bge-m3 }
+`,
+			names: "userinfo",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseRouting([]byte(tc.routing))
+			if err == nil {
+				t.Fatal("the binding was accepted, so the first call is what finds out")
+			}
+			if !strings.Contains(err.Error(), tc.names) {
+				t.Errorf("the refusal %q does not say %q, so an operator cannot tell what to change", err, tc.names)
+			}
+			if strings.Contains(err.Error(), "stands-in-for-a-token") {
+				t.Errorf("the refusal echoes the credential it was given: %v", err)
+			}
+		})
+	}
+}
+
+// The mirror, and the reason the rule is two lanes rather than one: the ordinary
+// deployments must still boot. A local model on the operator's own network, a
+// self-hosted gateway behind a BYOK key, and a vendor's own public host.
+func TestTheEndpointRuleLetsTheOrdinaryDeploymentsBoot(t *testing.T) {
+	t.Parallel()
+
+	for name, routing := range map[string]string{
+		"a local model on the operator's network": `
+profile: eu_hosted
+tiers:
+  local_large: { provider: ollama, base_url: "http://10.4.1.20:11434", model: m }
+embeddings: { provider: ollama, base_url: "http://127.0.0.1:11434", model: bge-m3 }
+`,
+		"a self-hosted gateway on the OpenAI wire": `
+profile: eu_hosted
+tiers:
+  premium: { provider: openai_compatible, base_url: "http://192.168.1.5:8080", model: m }
+embeddings: { provider: ollama, model: bge-m3 }
+`,
+		"a vendor's own host, and a name this cannot judge": `
+profile: cloud_frontier
+tiers:
+  premium: { provider: anthropic, base_url: "https://api.anthropic.com", model: claude-x }
+  local_large: { provider: ollama, base_url: "https://ollama.internal:11434", model: m }
+embeddings: { provider: ollama, model: bge-m3 }
+`,
+		"no base_url at all, which is the provider default": `
+profile: cloud_frontier
+tiers:
+  premium: { provider: anthropic, model: claude-x }
+embeddings: { provider: ollama, model: bge-m3 }
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ParseRouting([]byte(routing)); err != nil {
+				t.Fatalf("an ordinary deployment must boot, got %v", err)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/ai/outboundegress_test.go
+++ b/backend/internal/modules/ai/outboundegress_test.go
@@ -5,9 +5,13 @@ package ai
 
 import (
 	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -108,6 +112,77 @@ func TestWhichAddressesEachLaneMayDial(t *testing.T) {
 		if got := addressAllowed(egressOperatorEndpoint, ip); got != want.operator {
 			t.Errorf("the operator lane may dial %s = %v, want %v", address, got, want.operator)
 		}
+	}
+}
+
+// The write-time rule and the dialer must answer the same question the same way,
+// or a binding is accepted at the door and refused by the first call — the exact
+// failure ValidateTierBinding's own comment says it exists to avoid. This is
+// what makes addressAllowed's "single spelling" a fact rather than a hope: a
+// second copy of the rule in either caller fails here the moment it drifts.
+func TestTheWriteRuleAndTheDialerAgree(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range KnownProviders() {
+		guard := dialGuard(egressFor(provider))
+		for _, address := range []string{
+			"8.8.8.8", "2606:4700::1111",
+			"127.0.0.1", "::1", "10.4.1.20", "192.168.1.5", "fd00::1", "::ffff:10.0.0.1",
+			"169.254.169.254", "fe80::1", "64:ff9b::a9fe:a9fe", "100.64.0.1", "192.0.2.10",
+			"0.0.0.0", "2002:7f00:1::1", "172.32.0.9",
+		} {
+			hostPort := net.JoinHostPort(address, "8080")
+			atTheWrite := requireDialableEndpoint("tier premium", provider, "http://"+hostPort) == nil
+			atTheSocket := guard("tcp", hostPort, nil) == nil
+			if atTheWrite != atTheSocket {
+				t.Errorf("provider %q, address %s: the write rule says allowed=%v and the dialer says allowed=%v",
+					provider, address, atTheWrite, atTheSocket)
+			}
+		}
+	}
+}
+
+// The guard is only as good as its coverage: an adapter handed a client built
+// anywhere else dials unguarded, and nothing about the call site would look
+// wrong. So the package is allowed exactly one call to newOutboundClient, and it
+// is the one in SelectBrain — read off the syntax tree rather than grepped, so a
+// call spelled across a line break cannot hide from it.
+func TestSelectBrainIsTheOnlyBuilderOfAnOutboundClient(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+	var callers []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			ast.Inspect(fn, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "newOutboundClient" {
+					callers = append(callers, name+":"+fn.Name.Name)
+				}
+				return true
+			})
+		}
+	}
+	if len(callers) != 1 || callers[0] != "selectbrain.go:SelectBrain" {
+		t.Errorf("newOutboundClient is called from %v, want only selectbrain.go:SelectBrain — every other builder dials unguarded", callers)
 	}
 }
 

--- a/backend/internal/modules/ai/outboundtransport.go
+++ b/backend/internal/modules/ai/outboundtransport.go
@@ -4,6 +4,7 @@
 package ai
 
 import (
+	"net"
 	"net/http"
 	"time"
 )
@@ -91,15 +92,30 @@ const (
 	idleConnTimeout = 60 * time.Second
 )
 
+// dialTimeout bounds establishing one connection. Cloned transports inherit
+// DefaultTransport's dialer settings; replacing the dialer to carry the egress
+// guard means restating them, and this is the value net/http itself uses.
+const dialTimeout = 30 * time.Second
+
 // newOutboundClient is the HTTP client EVERY provider adapter calls a vendor
 // with: one transport shape for all seven, so hardening the outbound path is a
 // change here rather than seven changes that drift.
 //
+// The binding names where the call goes, and a binding is operator-supplied, so
+// the client is built FROM the provider rather than shared across providers:
+// its dialer carries that lane's egress guard (outboundegress.go), refusing the
+// resolved address post-DNS so a name cannot smuggle one past it.
+//
 // One client per adapter rather than one shared package-level client, because
 // the pool is per-transport and a shared pool would let one vendor's stalled
 // connections crowd out another's.
-func newOutboundClient() *http.Client {
+func newOutboundClient(provider string) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert // net/http's own DefaultTransport is a *http.Transport by construction
+	transport.DialContext = (&net.Dialer{
+		Timeout:   dialTimeout,
+		KeepAlive: dialTimeout,
+		Control:   dialGuard(egressFor(provider)),
+	}).DialContext
 	transport.IdleConnTimeout = idleConnTimeout
 	transport.ForceAttemptHTTP2 = true
 	transport.HTTP2 = &http.HTTP2Config{

--- a/backend/internal/modules/ai/outboundtransport.go
+++ b/backend/internal/modules/ai/outboundtransport.go
@@ -116,6 +116,19 @@ func newOutboundClient(provider string) *http.Client {
 		KeepAlive: dialTimeout,
 		Control:   dialGuard(egressFor(provider)),
 	}).DialContext
+	// NO PROXY, and this line is what decides whether the hook above means
+	// anything. The clone inherits ProxyFromEnvironment, and a proxy turns the
+	// check inside out: the dial goes to the PROXY's address — public, so
+	// admitted — and the proxy is then asked to CONNECT to the binding's host,
+	// which this side never sees. Every address dialGuard refuses is reachable
+	// that way on any deployment carrying HTTPS_PROXY.
+	//
+	// The third writer of this rule in the tree rather than a shared helper: the
+	// other two live in backend/pkg/extension (the extension surface, which a
+	// module may not import) and in the hubspot overlay's own gate. What holds
+	// them together is that each is a transport nobody else builds, and this one
+	// is held by TestTheOutboundClientCannotBeRoutedThroughAProxy.
+	transport.Proxy = nil
 	transport.IdleConnTimeout = idleConnTimeout
 	transport.ForceAttemptHTTP2 = true
 	transport.HTTP2 = &http.HTTP2Config{

--- a/backend/internal/modules/ai/outboundtransport.go
+++ b/backend/internal/modules/ai/outboundtransport.go
@@ -4,8 +4,10 @@
 package ai
 
 import (
+	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -135,5 +137,36 @@ func newOutboundClient(provider string) *http.Client {
 		SendPingTimeout: http2PingAfterIdle,
 		PingTimeout:     http2PingTimeout,
 	}
-	return &http.Client{Timeout: CallCeiling, Transport: transport}
+	return &http.Client{Timeout: CallCeiling, Transport: transport, CheckRedirect: refuseOffHostRedirect}
+}
+
+// refuseOffHostRedirect stops a redirect that would carry the installation's
+// model key somewhere the binding did not name.
+//
+// Go strips the headers IT knows to be sensitive across a host change —
+// Authorization, Cookie, WWW-Authenticate — and it has never heard of
+// `x-api-key` or `x-goog-api-key`. Anthropic and Gemini authenticate with
+// exactly those, so a vendor answering 302 to another host would be handed the
+// customer's own credential by a client that believed it was being careful.
+// Nor does it strip anything when only the SCHEME changes, so an https endpoint
+// redirecting to http sends the same key in clear.
+//
+// Scoped to the hop that leaks rather than refused outright, which is where this
+// differs from modellist.go's noRedirect. That one covers a list endpoint where
+// a 3xx never happens in normal operation, and its comment declines to make the
+// wider change here because this client also carries streaming completions,
+// where a redirect a vendor genuinely uses would become an outage. A same-host
+// redirect that keeps its scheme carries the key nowhere new, so it is followed;
+// the two hops that move a credential are the two that are refused.
+func refuseOffHostRedirect(req *http.Request, via []*http.Request) error {
+	previous := via[len(via)-1]
+	if !strings.EqualFold(req.URL.Hostname(), previous.URL.Hostname()) {
+		return fmt.Errorf("ai: refusing a redirect from %s to %s: the model key travels with the request, and the binding named the first host",
+			previous.URL.Hostname(), req.URL.Hostname())
+	}
+	if strings.EqualFold(previous.URL.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https") {
+		return fmt.Errorf("ai: refusing a redirect from https to %s on %s: the model key would leave in clear",
+			req.URL.Scheme, req.URL.Hostname())
+	}
+	return nil
 }

--- a/backend/internal/modules/ai/outboundtransport.go
+++ b/backend/internal/modules/ai/outboundtransport.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -164,9 +165,36 @@ func refuseOffHostRedirect(req *http.Request, via []*http.Request) error {
 		return fmt.Errorf("ai: refusing a redirect from %s to %s: the model key travels with the request, and the binding named the first host",
 			previous.URL.Hostname(), req.URL.Hostname())
 	}
+	// The PORT as well as the host, because a hostname is not an endpoint: one
+	// machine serves many, and :8443 on the vendor's own host is a different
+	// service from :443 — quite possibly somebody else's, on shared hosting.
+	// The dial guard cannot help here either; it judges the address, and the
+	// address has not changed.
+	if effectivePort(previous.URL) != effectivePort(req.URL) {
+		return fmt.Errorf("ai: refusing a redirect from %s to port %s on the same host: another port is another service, and it is not the one the binding named",
+			previous.URL.Host, effectivePort(req.URL))
+	}
 	if strings.EqualFold(previous.URL.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https") {
 		return fmt.Errorf("ai: refusing a redirect from https to %s on %s: the model key would leave in clear",
 			req.URL.Scheme, req.URL.Hostname())
 	}
 	return nil
+}
+
+// effectivePort is the port a url actually dials: the one it names, or its
+// scheme's default when it names none.
+//
+// Read rather than compared as text, because `https://vendor.example` and
+// `https://vendor.example:443` are one endpoint under two spellings, and a
+// redirect between them moves the request nowhere. A rule that compared
+// `URL.Host` would refuse that hop and call a vendor's own normalisation an
+// attack.
+func effectivePort(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+	if strings.EqualFold(u.Scheme, "https") {
+		return "443"
+	}
+	return "80"
 }

--- a/backend/internal/modules/ai/outboundtransport_test.go
+++ b/backend/internal/modules/ai/outboundtransport_test.go
@@ -32,7 +32,7 @@ import (
 func TestOutboundClientKeepsItsConnectionsHonest(t *testing.T) {
 	t.Parallel()
 
-	client := newOutboundClient()
+	client := newOutboundClient(providerAnthropic)
 	transport, ok := client.Transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("the outbound client's transport is %T, so nothing retires a dead connection", client.Transport)

--- a/backend/internal/modules/ai/routing.go
+++ b/backend/internal/modules/ai/routing.go
@@ -331,6 +331,11 @@ func (cfg RoutingConfig) validate() error {
 			return err
 		}
 	}
+	// The embed lane dials an operator-supplied host like any chat tier, so it
+	// carries the same egress rule on every profile.
+	if err := requireDialableEndpoint("the embeddings lane", cfg.Embeddings.Provider, cfg.Embeddings.BaseURL); err != nil {
+		return err
+	}
 	// AFTER the sovereign check, matching ValidateTierBinding's order. A
 	// sovereign profile forbids openai_compatible outright, so reporting a
 	// missing host first would answer a question the reader does not have and
@@ -389,6 +394,14 @@ func ValidateTierBinding(profile Profile, tier Tier, binding ProviderConfig) err
 		if err := requireSovereignEndpoint(fmt.Sprintf("tier %s", tier), binding.Provider, binding.BaseURL); err != nil {
 			return err
 		}
+	}
+	// EVERY profile, not only sovereign. base_url is the address this server
+	// dials, and outside the sovereign branch above nothing looked at it at
+	// all: any string that parsed was persisted and later handed to the
+	// outbound client. What each lane may reach is outboundegress.go's rule,
+	// asked here so the operator hears it at the write.
+	if err := requireDialableEndpoint(fmt.Sprintf("tier %s", tier), binding.Provider, binding.BaseURL); err != nil {
+		return err
 	}
 	// An OpenAI-wire host has no default to fall back on, so a binding without
 	// one cannot be SERVED — SelectBrain refuses to build the client. Refused

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -123,13 +123,15 @@ func KnownProviders() []string {
 // "offline fake ↔ API key ↔ local, one line" — swapping providers is a
 // config change, never a code change.
 //
+// Held by: TestSelectBrainIsTheOnlyBuilderOfAnOutboundClient (backend/internal/modules/ai/outboundegress_test.go)
+//
 //nolint:ireturn // one call returns whichever of seven adapters the binding names; the port interface IS the return type
 func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 	// The client is built once, from the binding, and handed to whichever
 	// adapter the switch names: the egress guard it carries is chosen by the
 	// same value the switch dispatches on, so a lane cannot end up guarded as
-	// another. This is the ONLY caller that supplies a guarded client, and the
-	// only one production has.
+	// another. It is the only call to newOutboundClient in the package, which
+	// is what makes the guard cover every adapter rather than most of them.
 	return selectBrainOn(cfg, keys, newOutboundClient(cfg.Provider))
 }
 

--- a/backend/internal/modules/ai/selectbrain.go
+++ b/backend/internal/modules/ai/selectbrain.go
@@ -6,6 +6,7 @@ package ai
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/margince/margince/backend/internal/platform/config"
@@ -124,6 +125,21 @@ func KnownProviders() []string {
 //
 //nolint:ireturn // one call returns whichever of seven adapters the binding names; the port interface IS the return type
 func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
+	// The client is built once, from the binding, and handed to whichever
+	// adapter the switch names: the egress guard it carries is chosen by the
+	// same value the switch dispatches on, so a lane cannot end up guarded as
+	// another. This is the ONLY caller that supplies a guarded client, and the
+	// only one production has.
+	return selectBrainOn(cfg, keys, newOutboundClient(cfg.Provider))
+}
+
+// selectBrainOn is SelectBrain with the transport supplied, which is the seam
+// an in-package test binds an adapter to an httptest server through — the
+// production guard refuses the 127.0.0.1 such a server listens on, by design.
+// TestSelectBrainWiresTheEgressGuard holds the production wiring itself.
+//
+//nolint:ireturn // one call returns whichever of seven adapters the binding names; the port interface IS the return type
+func selectBrainOn(cfg ProviderConfig, keys config.Lookup, httpc *http.Client) (model.Client, error) {
 	switch cfg.Provider {
 	case ProviderFake:
 		// The stub narrows like any other adapter: `input:` on a fake binding
@@ -136,7 +152,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			return nil, byokKeyRequired(providerAnthropic)
 		}
 		return &anthropicClient{
-			http:            newOutboundClient(),
+			http:            httpc,
 			baseURL:         defaulted(cfg.BaseURL, defaultAnthropicBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,
@@ -144,14 +160,14 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 		}, nil
 	case providerOllama:
 		return &ollamaClient{
-			http:            newOutboundClient(),
+			http:            httpc,
 			baseURL:         defaulted(cfg.BaseURL, defaultOllamaBaseURL),
 			defaultModel:    defaulted(cfg.Model, defaultOllamaModel),
 			attachmentMIMEs: narrowedCarriage(carriesImages, cfg.Input),
 		}, nil
 	case providerVLLM:
 		return &openAICompatClient{
-			http:            newOutboundClient(),
+			http:            httpc,
 			baseURL:         defaulted(cfg.BaseURL, defaultVLLMBaseURL),
 			apiKey:          "", // local vLLM: no auth
 			localOnly:       true,
@@ -167,7 +183,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			return nil, fmt.Errorf("%w: openai_compatible (the vendor host root — no version segment, the adapter adds /v1; e.g. https://api.mistral.ai)", errNoBaseURL)
 		}
 		return &openAICompatClient{
-			http:            newOutboundClient(),
+			http:            httpc,
 			baseURL:         cfg.BaseURL,
 			apiKey:          key,
 			localOnly:       false,
@@ -184,7 +200,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			return nil, byokKeyRequired(providerOpenAI)
 		}
 		return &openaiClient{
-			http:            newOutboundClient(),
+			http:            httpc,
 			baseURL:         defaulted(cfg.BaseURL, defaultOpenAIBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,
@@ -196,7 +212,7 @@ func SelectBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
 			return nil, byokKeyRequired(providerGemini)
 		}
 		return &geminiClient{
-			http:            newOutboundClient(),
+			http:            httpc,
 			baseURL:         defaulted(cfg.BaseURL, defaultGeminiBaseURL),
 			apiKey:          key,
 			defaultModel:    cfg.Model,

--- a/backend/internal/modules/ai/selectbrain_test.go
+++ b/backend/internal/modules/ai/selectbrain_test.go
@@ -4,10 +4,12 @@
 package ai
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/platform/config"
+	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
 
 // noCloudKeys is the fail-closed lookup: every provider's BYOK key is unset.
@@ -18,6 +20,19 @@ import (
 // about the test said so. A lookup this test constructs cannot be influenced by
 // the shell it runs in.
 func noCloudKeys() config.Lookup { return config.Static(nil) }
+
+// selectLocalBrain binds an adapter to a server this test started, which listens
+// on 127.0.0.1 — an address the production egress guard refuses on the vendor
+// lanes, and rightly: a stored base_url pointing a BYOK binding at the API
+// host's own loopback is the SSRF this build refuses. The transport is the seam
+// (webread and webhooks take the same one), so what these cases exercise is the
+// adapter's wire behaviour and nothing about egress.
+//
+// The guard is proved where it belongs: outboundegress_test.go tests the rule,
+// and TestSelectBrainWiresTheEgressGuard tests that SelectBrain applies it.
+func selectLocalBrain(cfg ProviderConfig, keys config.Lookup) (model.Client, error) {
+	return selectBrainOn(cfg, keys, &http.Client{Timeout: CallCeiling})
+}
 
 // cloudKeyFor supplies one provider's key and nothing else, so a case that
 // binds anthropic proves anthropic resolved its own variable rather than

--- a/backend/internal/modules/ai/sovereignendpoint.go
+++ b/backend/internal/modules/ai/sovereignendpoint.go
@@ -79,6 +79,20 @@ func hostOf(baseURL string) (string, error) {
 	return parsed.Hostname(), nil
 }
 
+// withoutUserinfo is a base_url safe to name in an error or a boot log.
+//
+// url.URL.Redacted() is NOT that, which is the trap this exists to close: it
+// replaces the PASSWORD with xxxxx and keeps the USERNAME, and a token pasted
+// into a base_url arrives as the username at least as often as it arrives after
+// a colon (http://sk-live-...@host). So the whole userinfo goes, not half of it.
+//
+// Held by: TestARefusalNamesNoPartOfTheUserinfo (backend/internal/modules/ai/sovereignendpoint_test.go)
+func withoutUserinfo(parsed *url.URL) string {
+	shown := *parsed
+	shown.User = nil
+	return shown.String()
+}
+
 // parsedEndpoint parses a base_url and refuses a value that cannot be an
 // endpoint at all: one that names no host — not a formatting nit here, since
 // "no host" is exactly the shape a check written as a string comparison would
@@ -99,10 +113,10 @@ func parsedEndpoint(baseURL string) (*url.URL, error) {
 		return nil, fmt.Errorf("base_url cannot be parsed as a url: %w", parseFault(err))
 	}
 	if parsed.Hostname() == "" {
-		// Redacted for the same reason: Redacted() replaces any password with
-		// xxxxx, and a value with no host is exactly the malformed shape most
-		// likely to have been pasted with a credential still in it.
-		return nil, fmt.Errorf("base_url %q names no host; write the whole url, e.g. http://127.0.0.1:11434", parsed.Redacted())
+		// Stripped of its userinfo for the same reason: a value with no host is
+		// exactly the malformed shape most likely to have been pasted with a
+		// credential still in it.
+		return nil, fmt.Errorf("base_url %q names no host; write the whole url, e.g. http://127.0.0.1:11434", withoutUserinfo(parsed))
 	}
 	// The scheme is checked HERE rather than left to the first call: a scheme
 	// this adapter cannot dial makes the endpoint unreachable, and an endpoint
@@ -110,11 +124,11 @@ func parsedEndpoint(baseURL string) (*url.URL, error) {
 	// deployment that fails at 3am with a transport error instead of at boot
 	// with a config one.
 	if scheme := strings.ToLower(parsed.Scheme); scheme != "http" && scheme != "https" {
-		// Redacted, like the two branches above: a scheme this adapter cannot
+		// Stripped, like the two branches above: a scheme this adapter cannot
 		// dial is a malformed value, and a malformed value is the shape most
 		// likely to have been pasted with a credential still in it. The scheme
 		// itself is safe to name and is what the operator has to change.
-		return nil, fmt.Errorf("base_url %q must be an http(s) url; %q is not a scheme this adapter can call", parsed.Redacted(), parsed.Scheme)
+		return nil, fmt.Errorf("base_url %q must be an http(s) url; %q is not a scheme this adapter can call", withoutUserinfo(parsed), parsed.Scheme)
 	}
 	return parsed, nil
 }

--- a/backend/internal/modules/ai/sovereignendpoint.go
+++ b/backend/internal/modules/ai/sovereignendpoint.go
@@ -79,17 +79,24 @@ func hostOf(baseURL string) (string, error) {
 	return parsed.Hostname(), nil
 }
 
-// withoutUserinfo is a base_url safe to name in an error or a boot log.
+// safeToName is the part of a base_url that may appear in an error or a boot log.
 //
-// url.URL.Redacted() is NOT that, which is the trap this exists to close: it
-// replaces the PASSWORD with xxxxx and keeps the USERNAME, and a token pasted
-// into a base_url arrives as the username at least as often as it arrives after
-// a colon (http://sk-live-...@host). So the whole userinfo goes, not half of it.
+// An ALLOWLIST — scheme and host, rebuilt — rather than a list of parts to
+// blank, and the difference IS the rule. Every blanking version of this loses to
+// the next shape nobody thought of: url.Redacted() hides the password and keeps
+// the username; clearing the userinfo still leaves an opaque url, since
+// `http:sk-live-...@` parses with no host at all and the whole payload under
+// Opaque; clearing that still leaves a path (`http:///p/sk-live-...`), a query
+// (`?api_key=...`) and a fragment. All four reach these errors, and a token
+// pasted into a base_url lands in whichever one the operator's typo produced.
 //
-// Held by: TestARefusalNamesNoPartOfTheUserinfo (backend/internal/modules/ai/sovereignendpoint_test.go)
-func withoutUserinfo(parsed *url.URL) string {
-	shown := *parsed
-	shown.User = nil
+// What a reader needs here is which scheme and which host this installation
+// read. The label already says which binding, and the value itself is in the
+// config file they are about to open.
+//
+// Held by: TestARefusalNamesNothingButTheSchemeAndHost (backend/internal/modules/ai/sovereignendpoint_test.go)
+func safeToName(parsed *url.URL) string {
+	shown := url.URL{Scheme: parsed.Scheme, Host: parsed.Host}
 	return shown.String()
 }
 
@@ -113,10 +120,11 @@ func parsedEndpoint(baseURL string) (*url.URL, error) {
 		return nil, fmt.Errorf("base_url cannot be parsed as a url: %w", parseFault(err))
 	}
 	if parsed.Hostname() == "" {
-		// Stripped of its userinfo for the same reason: a value with no host is
-		// exactly the malformed shape most likely to have been pasted with a
-		// credential still in it.
-		return nil, fmt.Errorf("base_url %q names no host; write the whole url, e.g. http://127.0.0.1:11434", withoutUserinfo(parsed))
+		// Reduced to scheme and host for the same reason: a value with no host
+		// is exactly the malformed shape most likely to have been pasted with a
+		// credential still in it, and "no host" is also the shape that files the
+		// whole payload under Opaque or Path.
+		return nil, fmt.Errorf("base_url %q names no host; write the whole url, e.g. http://127.0.0.1:11434", safeToName(parsed))
 	}
 	// The scheme is checked HERE rather than left to the first call: a scheme
 	// this adapter cannot dial makes the endpoint unreachable, and an endpoint
@@ -124,11 +132,11 @@ func parsedEndpoint(baseURL string) (*url.URL, error) {
 	// deployment that fails at 3am with a transport error instead of at boot
 	// with a config one.
 	if scheme := strings.ToLower(parsed.Scheme); scheme != "http" && scheme != "https" {
-		// Stripped, like the two branches above: a scheme this adapter cannot
+		// Reduced, like the two branches above: a scheme this adapter cannot
 		// dial is a malformed value, and a malformed value is the shape most
 		// likely to have been pasted with a credential still in it. The scheme
 		// itself is safe to name and is what the operator has to change.
-		return nil, fmt.Errorf("base_url %q must be an http(s) url; %q is not a scheme this adapter can call", withoutUserinfo(parsed), parsed.Scheme)
+		return nil, fmt.Errorf("base_url %q must be an http(s) url; %q is not a scheme this adapter can call", safeToName(parsed), parsed.Scheme)
 	}
 	return parsed, nil
 }

--- a/backend/internal/modules/ai/sovereignendpoint.go
+++ b/backend/internal/modules/ai/sovereignendpoint.go
@@ -7,17 +7,19 @@ package ai
 // (ai-operational-spec §4.3).
 //
 // The profile check reads the provider NAME, and `ollama` and `vllm` both take
-// an operator-supplied base_url with nothing constraining it. So a deployment
-// could declare zero egress and send every call to a third-party host, while the
-// config validated and the code claimed the guarantee held by construction.
+// an operator-supplied base_url. So a deployment could declare zero egress and
+// send every call to a third-party host, while the config validated and the code
+// claimed the guarantee held by construction.
 //
 // A local provider name is not on its own a local endpoint, and this is the
-// other half.
+// other half. It is a stricter rule than the one every profile carries
+// (outboundegress.go): that one asks whether an address can be an inference
+// endpoint at all, this one asks whether it is the customer's own — a public
+// host is an ordinary binding elsewhere and a broken promise here.
 
 import (
 	"errors"
 	"fmt"
-	"net"
 	"net/url"
 	"strings"
 )
@@ -64,16 +66,26 @@ func requireSovereignEndpoint(label, provider, baseURL string) error {
 			label, host)
 	}
 	return fmt.Errorf(
-		"ai: routing config: %s: profile sovereign forbids the host %q — the profile promises zero egress, and that address is not on infrastructure this installation can see is yours. Point it at loopback, a link-local address, or a private range (10.x, 172.16-31.x, 192.168.x, or an IPv6 unique-local address)",
+		"ai: routing config: %s: profile sovereign forbids the host %q — the profile promises zero egress, and that address is not on infrastructure this installation can see is yours. Point it at loopback or a private range (10.x, 172.16-31.x, 192.168.x, or an IPv6 unique-local address)",
 		label, host)
 }
 
-// hostOf extracts the host a base_url names, refusing a value that names none —
-// which on this path is not a formatting nit: "no host" is exactly the shape a
-// check written as a string comparison would wave through. `localhost:11434`
+// hostOf is parsedEndpoint's host, for the callers that judge the host alone.
+func hostOf(baseURL string) (string, error) {
+	parsed, err := parsedEndpoint(baseURL)
+	if err != nil {
+		return "", err
+	}
+	return parsed.Hostname(), nil
+}
+
+// parsedEndpoint parses a base_url and refuses a value that cannot be an
+// endpoint at all: one that names no host — not a formatting nit here, since
+// "no host" is exactly the shape a check written as a string comparison would
+// wave through — or one whose scheme this adapter cannot dial. `localhost:11434`
 // lands here too, because a url with no scheme parses as one whose SCHEME is
 // "localhost", so the error names the shape rather than the omission.
-func hostOf(baseURL string) (string, error) {
+func parsedEndpoint(baseURL string) (*url.URL, error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
 		// The value is NOT echoed. A base_url may carry userinfo
@@ -84,14 +96,13 @@ func hostOf(baseURL string) (string, error) {
 		// NOT the raw error: url.Error quotes the WHOLE input in its own
 		// Error(), so wrapping it would put back exactly what omitting the
 		// value was meant to keep out. Its .Err is the syntax fault alone.
-		return "", fmt.Errorf("base_url cannot be parsed as a url: %w", parseFault(err))
+		return nil, fmt.Errorf("base_url cannot be parsed as a url: %w", parseFault(err))
 	}
-	host := parsed.Hostname()
-	if host == "" {
+	if parsed.Hostname() == "" {
 		// Redacted for the same reason: Redacted() replaces any password with
 		// xxxxx, and a value with no host is exactly the malformed shape most
 		// likely to have been pasted with a credential still in it.
-		return "", fmt.Errorf("base_url %q names no host; write the whole url, e.g. http://127.0.0.1:11434", parsed.Redacted())
+		return nil, fmt.Errorf("base_url %q names no host; write the whole url, e.g. http://127.0.0.1:11434", parsed.Redacted())
 	}
 	// The scheme is checked HERE rather than left to the first call: a scheme
 	// this adapter cannot dial makes the endpoint unreachable, and an endpoint
@@ -103,9 +114,9 @@ func hostOf(baseURL string) (string, error) {
 		// dial is a malformed value, and a malformed value is the shape most
 		// likely to have been pasted with a credential still in it. The scheme
 		// itself is safe to name and is what the operator has to change.
-		return "", fmt.Errorf("base_url %q must be an http(s) url; %q is not a scheme this adapter can call", parsed.Redacted(), parsed.Scheme)
+		return nil, fmt.Errorf("base_url %q must be an http(s) url; %q is not a scheme this adapter can call", parsed.Redacted(), parsed.Scheme)
 	}
-	return host, nil
+	return parsed, nil
 }
 
 // What a base_url's host is, from the profile's point of view. Three answers
@@ -141,21 +152,16 @@ func classifyHost(host string) hostVerdict {
 	if isReservedLoopbackName(strings.TrimSuffix(host, ".")) {
 		return hostIsLocal
 	}
-	// A zone ("fe80::1%eth0") says which interface a link-local address is
-	// reached on, and net.ParseIP does not take one. Dropped for the judgment,
-	// which is about the address: an interface cannot make a link-local address
-	// non-local.
-	address, _, _ := strings.Cut(host, "%")
-	ip := net.ParseIP(address)
+	ip := parseHostAddress(host)
 	if ip == nil {
 		return hostIsAName
 	}
-	// IsPrivate covers RFC 1918 and IPv6 unique-local (fc00::/7); the other two
-	// carry loopback and the link-local ranges an on-host or same-segment
-	// deployment uses. An IPv4-mapped IPv6 address is judged by its IPv4 rules,
-	// which is what the net package's own predicates do — so ::ffff:8.8.8.8 is
-	// as public as 8.8.8.8, and the mapping buys nothing.
-	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+	// The same predicate the egress classes read, so "ours" means one thing.
+	// Link-local is NOT ours: 169.254.169.254 is the cloud metadata service on
+	// every major provider, and no deployment serves inference from an
+	// autoconfiguration address — an operator with a box on the same segment
+	// gives it a private address.
+	if customerControlled(ip) {
 		return hostIsLocal
 	}
 	return hostIsElsewhere

--- a/backend/internal/modules/ai/sovereignendpoint_test.go
+++ b/backend/internal/modules/ai/sovereignendpoint_test.go
@@ -245,21 +245,29 @@ func TestEveryLocalProviderWithAnEndpointIsChecked(t *testing.T) {
 	}
 }
 
-// Every refusal that names a base_url names NO part of its userinfo — the
-// username as much as the password.
+// Every refusal that names a base_url names NOTHING but its scheme and host.
 //
-// url.Redacted() hides only the password, and this test is the reason the code
-// does not use it: a model key pasted into a base_url is at least as likely to
-// arrive as `http://sk-live-…@host` as it is with a colon after it, and that
-// spelling would otherwise be copied verbatim into a boot log. Every exit that
-// shows the value is walked, because one that forgot is one leak.
-func TestARefusalNamesNoPartOfTheUserinfo(t *testing.T) {
+// A credential pasted into a base_url reaches these errors through four
+// different fields, and which one depends only on where the operator's typo
+// landed: userinfo, Opaque (`http:sk-live-...@` parses with no host and the
+// whole payload there), Path, and the query. url.Redacted() covers half of one
+// of them. Each shape below took a different exit through the parser, so a rule
+// that grew back into a denylist fails here on the shape it forgot.
+func TestARefusalNamesNothingButTheSchemeAndHost(t *testing.T) {
 	const secret = "sk-live-stands-in-for-a-token"
 	for name, baseURL := range map[string]string{
 		"as the username":                 "http://" + secret + "@/",
 		"as the password":                 "http://user:" + secret + "@/",
 		"as the username on a bad scheme": "ftp://" + secret + "@example.test/",
 		"as the username with no host":    "http://" + secret + "@",
+		// No host at all, so url.Parse files the payload under Opaque and
+		// nothing about the value is userinfo any more.
+		"as an opaque url": "http:" + secret + "@",
+		"as a path":        "http:///v1/" + secret,
+		// These two reach the scheme exit, which names a value that HAS a host —
+		// the branch a userinfo-shaped rule leaves untouched.
+		"as a query parameter": "ftp://example.test/v1?api_key=" + secret,
+		"as a fragment":        "ftp://example.test/v1#" + secret,
 	} {
 		t.Run(name, func(t *testing.T) {
 			host, err := hostOf(baseURL)
@@ -271,14 +279,14 @@ func TestARefusalNamesNoPartOfTheUserinfo(t *testing.T) {
 			}
 		})
 	}
-	// The rule the exits share, asked of the helper itself: a value carrying
-	// userinfo in either position comes back with neither.
-	parsed, err := url.Parse("https://" + secret + ":" + secret + "@vendor.example/v1")
+	// The rule the exits share, asked of the helper itself: everything but the
+	// scheme and the host is dropped, whichever field carried it.
+	parsed, err := url.Parse("https://" + secret + ":" + secret + "@vendor.example/v1?key=" + secret + "#" + secret)
 	if err != nil {
 		t.Fatalf("parsing the fixture: %v", err)
 	}
-	if shown := withoutUserinfo(parsed); strings.Contains(shown, secret) {
-		t.Errorf("withoutUserinfo kept the credential: %q", shown)
+	if shown := safeToName(parsed); shown != "https://vendor.example" {
+		t.Errorf("safeToName kept more than the scheme and host: %q", shown)
 	}
 	// And the refusal an operator is most likely to trigger with one.
 	err = requireDialableEndpoint("tier premium", providerAnthropic, "https://"+secret+"@vendor.example")

--- a/backend/internal/modules/ai/sovereignendpoint_test.go
+++ b/backend/internal/modules/ai/sovereignendpoint_test.go
@@ -119,17 +119,22 @@ func verdictName(v hostVerdict) string {
 
 func TestWhichHostsCountAsCustomerControlled(t *testing.T) {
 	for host, want := range map[string]hostVerdict{
-		"127.0.0.1":       hostIsLocal,
-		"::1":             hostIsLocal,
-		"localhost":       hostIsLocal,
-		"LOCALHOST":       hostIsLocal, // host names are case-insensitive
-		"gpu.localhost":   hostIsLocal,
-		"10.4.1.20":       hostIsLocal,
-		"172.16.0.9":      hostIsLocal,
-		"172.32.0.9":      hostIsElsewhere, // just past RFC 1918, which ends at 172.31
-		"192.168.1.5":     hostIsLocal,
-		"fd00::1":         hostIsLocal, // IPv6 unique-local
-		"169.254.7.7":     hostIsLocal, // link-local
+		"127.0.0.1":     hostIsLocal,
+		"::1":           hostIsLocal,
+		"localhost":     hostIsLocal,
+		"LOCALHOST":     hostIsLocal, // host names are case-insensitive
+		"gpu.localhost": hostIsLocal,
+		"10.4.1.20":     hostIsLocal,
+		"172.16.0.9":    hostIsLocal,
+		"172.32.0.9":    hostIsElsewhere, // just past RFC 1918, which ends at 172.31
+		"192.168.1.5":   hostIsLocal,
+		"fd00::1":       hostIsLocal, // IPv6 unique-local
+		// Link-local is NOT ours. 169.254.169.254 is the cloud metadata service
+		// on every major provider, and inference is not served from an
+		// autoconfiguration address — an operator with a box on the same
+		// segment gives it a private address.
+		"169.254.7.7":     hostIsElsewhere,
+		"169.254.169.254": hostIsElsewhere,
 		"8.8.8.8":         hostIsElsewhere,
 		"2606:4700::1111": hostIsElsewhere,
 		// An IPv4-mapped IPv6 address is judged by its IPv4 rules, so the
@@ -150,9 +155,9 @@ func TestWhichHostsCountAsCustomerControlled(t *testing.T) {
 		// call local an endpoint the dial resolves elsewhere.
 		"localhost.": hostIsLocal,
 		"127.0.0.1.": hostIsAName,
-		// A zone says which interface a link-local address is reached on. It
-		// cannot make that address non-local.
-		"fe80::1%eth0": hostIsLocal,
+		// A zone says which interface an address is reached on; it cannot
+		// change what the address IS, and fe80::/10 is link-local either way.
+		"fe80::1%eth0": hostIsElsewhere,
 	} {
 		if got := classifyHost(host); got != want {
 			t.Errorf("classifyHost(%q) = %s, want %s", host, verdictName(got), verdictName(want))
@@ -186,9 +191,11 @@ func TestASchemeThisAdapterCannotCallIsRefusedEvenOnALocalHost(t *testing.T) {
 			t.Errorf("base_url %q must be refused for its scheme, got %v", baseURL, err)
 		}
 	}
-	// A bracketed IPv6 endpoint with a zone is the case this must not catch.
-	if err := requireSovereignEndpoint("tier local_large", providerVLLM, "http://[fe80::1%25eth0]:8000"); err != nil {
-		t.Errorf("a zoned link-local endpoint is local and must be accepted, got %v", err)
+	// A bracketed IPv6 endpoint with a zone is the case this must not catch: it
+	// is refused, but for its ADDRESS being link-local, never for its scheme.
+	err := requireSovereignEndpoint("tier local_large", providerVLLM, "http://[fd00::1%25eth0]:8000")
+	if err != nil {
+		t.Errorf("a zoned unique-local endpoint is local and must be accepted, got %v", err)
 	}
 }
 

--- a/backend/internal/modules/ai/sovereignendpoint_test.go
+++ b/backend/internal/modules/ai/sovereignendpoint_test.go
@@ -4,6 +4,7 @@
 package ai
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -241,6 +242,48 @@ func TestEveryLocalProviderWithAnEndpointIsChecked(t *testing.T) {
 		if _, ok := localBaseURLDefaults[provider]; !ok {
 			t.Errorf("local provider %q has no entry in localBaseURLDefaults, so a sovereign binding to it is never endpoint-checked", provider)
 		}
+	}
+}
+
+// Every refusal that names a base_url names NO part of its userinfo — the
+// username as much as the password.
+//
+// url.Redacted() hides only the password, and this test is the reason the code
+// does not use it: a model key pasted into a base_url is at least as likely to
+// arrive as `http://sk-live-…@host` as it is with a colon after it, and that
+// spelling would otherwise be copied verbatim into a boot log. Every exit that
+// shows the value is walked, because one that forgot is one leak.
+func TestARefusalNamesNoPartOfTheUserinfo(t *testing.T) {
+	const secret = "sk-live-stands-in-for-a-token"
+	for name, baseURL := range map[string]string{
+		"as the username":                 "http://" + secret + "@/",
+		"as the password":                 "http://user:" + secret + "@/",
+		"as the username on a bad scheme": "ftp://" + secret + "@example.test/",
+		"as the username with no host":    "http://" + secret + "@",
+	} {
+		t.Run(name, func(t *testing.T) {
+			host, err := hostOf(baseURL)
+			if err == nil {
+				t.Fatalf("hostOf(%q) returned host %q and no error", baseURL, host)
+			}
+			if strings.Contains(err.Error(), secret) {
+				t.Errorf("the refusal carries the credential: %v", err)
+			}
+		})
+	}
+	// The rule the exits share, asked of the helper itself: a value carrying
+	// userinfo in either position comes back with neither.
+	parsed, err := url.Parse("https://" + secret + ":" + secret + "@vendor.example/v1")
+	if err != nil {
+		t.Fatalf("parsing the fixture: %v", err)
+	}
+	if shown := withoutUserinfo(parsed); strings.Contains(shown, secret) {
+		t.Errorf("withoutUserinfo kept the credential: %q", shown)
+	}
+	// And the refusal an operator is most likely to trigger with one.
+	err = requireDialableEndpoint("tier premium", providerAnthropic, "https://"+secret+"@vendor.example")
+	if err == nil || strings.Contains(err.Error(), secret) {
+		t.Errorf("the userinfo refusal must refuse and must not echo the credential, got %v", err)
 	}
 }
 

--- a/docs/how-to/connect-a-cloud-model-provider.md
+++ b/docs/how-to/connect-a-cloud-model-provider.md
@@ -170,17 +170,20 @@ name does not, since what it resolves to can change after boot.
 Outside `sovereign` a `base_url` is not a promise about egress, but it is still
 the address this server dials, so each provider reaches only what its lane is
 for. `ollama`, `vllm` and `openai_compatible` may name loopback, a private range
-or a public host. `anthropic`, `openai` and `gemini` may name a **public host
-only**: the call carries this installation's model key in a header no redirect
-rule strips, and pointing one at your own network would send that key there. Use
-`openai_compatible` for a gateway you host.
+or a public host, over http or https. `anthropic`, `openai` and `gemini` may name
+a **public host over https only**: the call carries this installation's model key
+in a header Go does not strip across hosts, so pointing one at your own network
+would send that key there and cleartext would send it in the open. Use
+`openai_compatible` for a gateway you host, or one served over http.
 
 Neither lane may name link-local (`169.254.0.0/16`, `fe80::/10`), carrier-grade
 NAT or the documentation ranges — nothing serves inference from those, and the
 first of them is where every cloud keeps its instance-metadata service. The rule
 is checked at the write and again on the socket, so a DNS name that resolves to
 a refused address fails at connect time rather than slipping past. A `base_url`
-carrying userinfo is refused: a binding never carries a credential.
+carrying userinfo is refused: a binding never carries a credential. Redirects
+follow the same rule — one that stays on the host and keeps the scheme is
+followed, one that changes host or downgrades to http is refused.
 
 ## Troubleshooting
 
@@ -192,6 +195,7 @@ carrying userinfo is refused: a binding never carries a credential.
 | Boot error *"field api_key not found"* | You put an `api_key:` in the `seeds.ai_routing` binding — remove it; the key comes from the env var (see the table above). |
 | Boot error *"needs a base_url …"* | `openai_compatible` has no `base_url`. Add the vendor host root (no `/v1`). |
 | Boot error *"must name a public host"* | A native vendor binding (`anthropic`/`openai`/`gemini`) points inside your network. Bind `openai_compatible` for a self-hosted gateway (see "Where a `base_url` may point"). |
+| Boot error *"must be https"* | A native vendor binding uses `http://`. Use `https://`, or bind `openai_compatible` if the endpoint is genuinely served over http. |
 | Boot error *"not an address inference is served from"* | The `base_url` names a link-local, CGNAT or documentation address. Give the endpoint's own address (see "Where a `base_url` may point"). |
 | `http 404` on `/embeddings` | That `openai_compatible` vendor is chat-only. Rebind `embeddings:` to a lane-serving vendor or a local `bge-m3` (§3). |
 | Embed error *"returned N vectors of width W, need 1×D"* | On `openai_compatible` the adapter never sends `dimensions`, so `dimensions:` must equal the model's NATIVE width (§3). Set it to `W`. |

--- a/docs/how-to/connect-a-cloud-model-provider.md
+++ b/docs/how-to/connect-a-cloud-model-provider.md
@@ -162,8 +162,25 @@ The endpoint is checked too, because a local provider name is not on its own a
 local endpoint: `ollama` and `vllm` take a `base_url`, and one pointed at a
 third-party host would send every call of a zero-egress deployment over the
 public internet. Under this profile each binding's resolved `base_url` must be
-loopback, link-local, or a private range — your own GPU box on your own network
-counts; a DNS name does not, since what it resolves to can change after boot.
+loopback or a private range — your own GPU box on your own network counts; a DNS
+name does not, since what it resolves to can change after boot.
+
+## Where a `base_url` may point, on every profile
+
+Outside `sovereign` a `base_url` is not a promise about egress, but it is still
+the address this server dials, so each provider reaches only what its lane is
+for. `ollama`, `vllm` and `openai_compatible` may name loopback, a private range
+or a public host. `anthropic`, `openai` and `gemini` may name a **public host
+only**: the call carries this installation's model key in a header no redirect
+rule strips, and pointing one at your own network would send that key there. Use
+`openai_compatible` for a gateway you host.
+
+Neither lane may name link-local (`169.254.0.0/16`, `fe80::/10`), carrier-grade
+NAT or the documentation ranges — nothing serves inference from those, and the
+first of them is where every cloud keeps its instance-metadata service. The rule
+is checked at the write and again on the socket, so a DNS name that resolves to
+a refused address fails at connect time rather than slipping past. A `base_url`
+carrying userinfo is refused: a binding never carries a credential.
 
 ## Troubleshooting
 
@@ -174,6 +191,8 @@ counts; a DNS name does not, since what it resolves to can change after boot.
 | Boot error *"needs an api key — set X_API_KEY …"* | The bound cloud provider's key env var is unset. Export the one the error names (e.g. `GEMINI_API_KEY`). |
 | Boot error *"field api_key not found"* | You put an `api_key:` in the `seeds.ai_routing` binding — remove it; the key comes from the env var (see the table above). |
 | Boot error *"needs a base_url …"* | `openai_compatible` has no `base_url`. Add the vendor host root (no `/v1`). |
+| Boot error *"must name a public host"* | A native vendor binding (`anthropic`/`openai`/`gemini`) points inside your network. Bind `openai_compatible` for a self-hosted gateway (see "Where a `base_url` may point"). |
+| Boot error *"not an address inference is served from"* | The `base_url` names a link-local, CGNAT or documentation address. Give the endpoint's own address (see "Where a `base_url` may point"). |
 | `http 404` on `/embeddings` | That `openai_compatible` vendor is chat-only. Rebind `embeddings:` to a lane-serving vendor or a local `bge-m3` (§3). |
 | Embed error *"returned N vectors of width W, need 1×D"* | On `openai_compatible` the adapter never sends `dimensions`, so `dimensions:` must equal the model's NATIVE width (§3). Set it to `W`. |
 | Model 404 / *"model not found"* | A drifting `-latest` alias or a wrong id. Pin an explicit versioned model, or resolve it from the vendor's `/models` endpoint. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1271,11 +1271,11 @@ rebinds — to a refused address is stopped at connect time):
 
 - `ollama`, `vllm` and `openai_compatible` may reach loopback, a private range,
   or a public host — the local model, the GPU box, the self-hosted gateway.
-- `anthropic`, `openai` and `gemini` may reach a **public host only**. Their
-  `base_url` overrides a vendor's own API host, and the call carries this
-  installation's model key in a header (`x-api-key`, `x-goog-api-key`) that no
-  redirect rule strips. To reach a gateway on your own network, bind
-  `openai_compatible` instead.
+- `anthropic`, `openai` and `gemini` may reach a **public host over https only**.
+  Their `base_url` overrides a vendor's own API host, and the call carries this
+  installation's model key in a header (`x-api-key`, `x-goog-api-key`) that Go
+  does not strip across hosts. To reach a gateway on your own network, or one
+  served over http, bind `openai_compatible` instead.
 
 Neither lane may reach the ranges that serve nobody: link-local
 (`169.254.0.0/16`, `fe80::/10` — where every cloud's instance-metadata service
@@ -1283,6 +1283,11 @@ lives), carrier-grade NAT, the documentation ranges, and the encapsulations that
 carry another address inside them. A `base_url` carrying userinfo
 (`http://user:token@host`) is refused outright — a binding never carries a
 credential.
+
+A redirect is held to the same rule as the binding: the outbound client follows
+a redirect that stays on the same host and keeps its scheme, and refuses one that
+changes host or downgrades https to http, because either would carry the model
+key somewhere the binding never named.
 
 An editor with a YAML language server picks up
 [`config/margince.schema.json`](../../config/margince.schema.json)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1258,12 +1258,31 @@ else's host**, because the provider name alone would let a deployment declare
 zero egress and send every call over the public internet. Under that profile
 each binding's resolved `base_url` (an omitted one is the provider default,
 which is loopback) must name an address on infrastructure you control:
-loopback, link-local, or a private range (`10.x`, `172.16–31.x`, `192.168.x`,
-or an IPv6 unique-local address). **A private-range host on another machine
-counts** — your own GPU box is your own infrastructure. A **DNS name is
-refused** even when it looks internal: resolving it at boot says only where it
-pointed at boot, and a profile satisfied by an answer that can change an hour
-later is not a guarantee. Use the IP, or `localhost`.
+loopback or a private range (`10.x`, `172.16–31.x`, `192.168.x`, or an IPv6
+unique-local address). **A private-range host on another machine counts** — your
+own GPU box is your own infrastructure. A **DNS name is refused** even when it
+looks internal: resolving it at boot says only where it pointed at boot, and a
+profile satisfied by an answer that can change an hour later is not a guarantee.
+Use the IP, or `localhost`.
+
+Two egress rules bind **every** profile, checked when the binding is written and
+again on the socket the call actually opens (so a name that resolves — or
+rebinds — to a refused address is stopped at connect time):
+
+- `ollama`, `vllm` and `openai_compatible` may reach loopback, a private range,
+  or a public host — the local model, the GPU box, the self-hosted gateway.
+- `anthropic`, `openai` and `gemini` may reach a **public host only**. Their
+  `base_url` overrides a vendor's own API host, and the call carries this
+  installation's model key in a header (`x-api-key`, `x-goog-api-key`) that no
+  redirect rule strips. To reach a gateway on your own network, bind
+  `openai_compatible` instead.
+
+Neither lane may reach the ranges that serve nobody: link-local
+(`169.254.0.0/16`, `fe80::/10` — where every cloud's instance-metadata service
+lives), carrier-grade NAT, the documentation ranges, and the encapsulations that
+carry another address inside them. A `base_url` carrying userinfo
+(`http://user:token@host`) is refused outright — a binding never carries a
+credential.
 
 An editor with a YAML language server picks up
 [`config/margince.schema.json`](../../config/margince.schema.json)


### PR DESCRIPTION
## What

A stored AI routing binding's `base_url` now reaches a guarded dialer, and is
checked at the write, on **every** profile — not only under `profile: sovereign`.
`ollama`, `vllm` and `openai_compatible` may dial loopback, a private range or a
public host; `anthropic`, `openai` and `gemini` may dial a public host only.
Neither lane may dial the ranges that serve nobody — link-local (cloud instance
metadata), CGNAT, the documentation ranges, and the encapsulations that carry
another address inside them.

## Why

`ValidateTierBinding` gated `base_url` on host only under the sovereign profile,
and the contract schema declares a bare `type: string`, so any value that parsed
was persisted. It then reached an unguarded client: `newOutboundClient` set no
`DialContext` and no `Dialer.Control`, and no file under `internal/modules/ai`
imported `netguard` at all.

Two requests were enough — one `PUT /v1/ai/routing` to plant the host, one
`GET /v1/ai/available-models` to fire it and read the decoded answer back:

- **A reachability oracle for the deployment's own network.** `ollama` and `vllm`
  need no BYOK key, so client construction could not fail closed, and the read
  reflects the vendor's decoded body — cloud instance metadata included.
- **Vendor-credential exfiltration.** A cloud tier repointed at another host sends
  the installation's `x-api-key` / `x-goog-api-key` there. Go strips
  `Authorization` across a host change and has never heard of those, which is the
  reason `modellist.go` already refuses redirects on the list path.

Firing the stored host needs only `ai_routing:read` while setting it needs
`update`. The tree conceded both halves in its own comments
(`availablemodels.go`, `sovereignendpoint.go`): the *request-supplied* URL was
guarded for exactly this reason, and the *stored* one was left open.

**The invariant:** an address this server dials on an operator's say-so is one
that lane may reach — decided in one place, enforced both at the write and on the
socket.

`netguard.RefusePrivate` alone — what every other tenant-host lane here uses —
could not be it, because a private address is the *feature* on the local lane (a
local Ollama, a GPU box on the operator's network, a self-hosted gateway). So the
allowance is derived from the binding, in one new file, `outboundegress.go`:

| lane | providers | may dial |
|---|---|---|
| operator endpoint | `ollama`, `vllm`, `openai_compatible` | loopback, private ranges, public hosts |
| vendor | `anthropic`, `openai`, `gemini` | public hosts only |

`openai_compatible` is the one BYOK provider on the permissive lane, because "a
self-hosted gateway" is its documented purpose; it is named as the sole exception
in the census test, so the next adapter cannot inherit it quietly. The strict
lane is the zero value, so a provider added without a considered entry fails
closed.

One predicate — `addressAllowed` — is read by the `net.Dialer.Control` hook
(post-DNS, on the concrete address, so a name that resolves *or rebinds* to a
refused address is stopped at connect time) and by the write-time rule (so an
operator hears it at the door rather than as an unreachable vendor with the
reason in a log nobody is reading). A `base_url` carrying userinfo is refused
outright, and neither refusal echoes the value.

### Behaviour changes

- **`profile: sovereign` no longer accepts a link-local endpoint.** It is the
  metadata address, nothing serves inference from an autoconfiguration address,
  and `classifyHost` now shares its "is this ours?" predicate with the egress
  lanes rather than keeping a second, wider answer. Both docs updated.
- **A native vendor binding pointed inside your own network is now a startup
  error** naming `openai_compatible` as the fix. Two troubleshooting rows added.
- **Adapter tests bind through `selectBrainOn`**, the transport seam `webread` and
  `webhooks` already use — an `httptest` server listens on 127.0.0.1, which the
  vendor lane refuses by design. `SelectBrain` stays the only guarded constructor
  production has, and `TestSelectBrainWiresTheEgressGuard` holds that end to end:
  refusal *and* positive control.

### Residue

An actor holding `ai_routing.update` can still point a lane at an arbitrary
**public** host — that is the documented `base_url` override — and can use the
local lane to reach private addresses, which is the local-model feature and is
indistinguishable from a port sweep. Both are questions about who holds that
grant rather than about this code. Narrowing `available-models` to `update`
authority is a separate product call and is not made here.

## How verified

New tests, all offline:

- `TestEveryProviderDeclaresAnEgressClass` — census, both directions, plus the
  assertion that the zero class is the strict one.
- `TestEveryLocalProviderTakesTheOperatorLane` — derived from `ProviderIsLocal`,
  with `openai_compatible` named as the only exception.
- `TestWhichAddressesEachLaneMayDial` — the rule as addresses, including the
  NAT64 and 6to4 spellings of an internal address.
- `TestTheDialGuardRefusesWhatItCannotJudge`,
  `TestSelectBrainWiresTheEgressGuard`, `TestABaseURLIsCheckedOnEveryProfile`,
  and its mirror `TestTheEndpointRuleLetsTheOrdinaryDeploymentsBoot`.

Ran locally on a Windows checkout: `go build ./...`, `go test ./...` across the
whole backend, `craft static --strict` over every changed Go file (0 findings),
both golangci configs on `internal/modules/ai/...` (0 issues under
`.golangci.strict.yml`), `check-rls-store-path.sh` and `check-no-jurisdiction.sh`.
The full-suite failure set was captured before and after the change and is
**byte-identical** — the pre-existing failures on that checkout are line-ending
and toolchain artifacts that hit untouched files the same way. `gitleaks` does
not run on MinGW, so the secret gate is CI's to confirm; fixture values are
`stands-in-for-a-key` / `stands-in-for-a-token`, deliberately not credential-shaped.

- [ ] `make check` is green — **not run whole on this checkout** (see above); its
      Go halves were run directly and are green, CI is the authority
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — it touches none of them
- [x] `make craft-static` reports no new blockers — diff-scoped `craft static --strict`: 0 blocker, 0 major, 0 minor
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by Claude Code (Opus 5) end to end: the finding analysis, the two-lane
design, the code, the tests and the docs. The one design judgement worth flagging
for a human: the choice to narrow `sovereign` away from link-local rather than
carve out the metadata address by name, and the choice to leave
`openai_compatible` on the permissive lane. Both are argued above and both are
held by tests.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZJRR9vFhC3KYu2BuJFXsg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes an SSRF gap where a stored AI routing `base_url` was persisted and dialed without egress checks on every profile except `sovereign`. Each provider now declares an egress class, and the same predicate enforces the rule at write time and again post-DNS in the `net.Dialer.Control` hook. The guard also survives a proxy, a zone, a username in userinfo, and a redirect that would move a model key off the binding's host.

**Bug Fixes**
- `ollama`, `vllm`, and `openai_compatible` may dial loopback, private ranges, or public hosts; `anthropic`, `openai`, and `gemini` public hosts over https only. Link-local, CGNAT, documentation, and encapsulation ranges are refused on both lanes, and a `base_url` carrying userinfo is refused outright.
- `profile: sovereign` no longer accepts link-local endpoints, and a native vendor binding pointed inside the deployment's network is now a startup error suggesting `openai_compatible`.
- The outbound transport sets `Proxy = nil`; a proxy would otherwise route every dial around the guard.
- The outbound client refuses a cross-host redirect, an https-to-http downgrade, or a redirect to another port on the same host — each would carry the `x-api-key` / `x-goog-api-key` header elsewhere; same-host redirects that keep scheme and port still work.
- Refusals name only a `base_url`'s scheme and host, so a credential pasted into userinfo, an opaque url, a path, or a query never reaches an error or boot log.
- Tests hold the invariants the guard relies on: the write-time rule and the dialer can't drift apart, and `SelectBrain` is the only builder of an outbound client.

<sup>Written for commit 5e4bed51949e0346b82461e290032dc92b35acf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added outbound network safeguards for AI provider connections.
  - Cloud providers require public endpoints; self-hosted providers may use approved private or loopback addresses.
  - Endpoint validation occurs during configuration and connection, including DNS resolution.
  - Unsafe destinations—including metadata, link-local, carrier-grade NAT, and documentation ranges—are blocked.
  - Embedded credentials in URLs are rejected.
  - Provider connections bypass proxies and block unsafe cross-host or HTTPS-to-HTTP redirects.

- **Documentation**
  - Updated configuration and cloud-provider guidance with endpoint rules and troubleshooting information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->