### PR TITLE
fix(agents): a refusal that changed something does not give the key back

### DIFF
--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -264,6 +264,11 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 		buffered.flushTo(w)
 		return
 	}
+	// From here on this request HAS changed the record, and anything it answers
+	// after this line is a failure rather than a refusal. The idempotency layer
+	// reads this to decide whether the key goes back: released, the retry would
+	// re-run the half that just committed under the same key.
+	markWriteCommitted(r.Context())
 	// UseNumber keeps integers exact: a plain interface{} decode renders
 	// every JSON number as float64, silently truncating any value past
 	// 2^53 on this re-encode path (money-minor fields, version).
@@ -271,9 +276,7 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 	dec := json.NewDecoder(bytes.NewReader(buffered.body.Bytes()))
 	dec.UseNumber()
 	if uErr := dec.Decode(&record); uErr != nil {
-		httperr.Write(w, r, fmt.Errorf(
-			"agent gate: %s applied the permitted fields, but its response cannot carry the staging note for the withheld human-edited fields (%s): %w",
-			pol.Op, strings.Join(split.Conflicts, ", "), uErr))
+		httperr.Write(w, r, partiallyApplied(split.Conflicts, uErr))
 		return
 	}
 	// No version pin travels from here, and the residue is still staged against
@@ -299,8 +302,7 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 			restSummary(pol, r, split.Staged),
 	})
 	if sErr != nil {
-		httperr.Write(w, r, fmt.Errorf("the other fields were updated, but staging the human-edited fields (%s) failed: %w",
-			strings.Join(split.Conflicts, ", "), sErr))
+		httperr.Write(w, r, partiallyApplied(split.Conflicts, sErr))
 		return
 	}
 	record["staged_approval"] = map[string]any{
@@ -395,4 +397,37 @@ func copyHeaders(w http.ResponseWriter, headers http.Header) {
 	}
 	// The buffered body may be re-encoded; a stale length would truncate.
 	w.Header().Del("Content-Length")
+}
+
+// partiallyApplied is what a caller is told when this door wrote and then could
+// not finish.
+//
+// It is a CLASSIFIED refusal rather than a bare error, and that is the whole of
+// it: an unclassified one reaches httperr.Write's unhandled path, which logs the
+// sentence and answers `{"code":"internal"}` with no detail at all. The message
+// naming the applied half went to the operator's log and the caller — the one
+// party who has to decide what to do next — got nothing. A partial write is
+// precisely the outcome nobody can discover from the outside.
+//
+// It says DO NOT RETRY UNCHANGED, and that is not advice this call can leave
+// out. The idempotency key is recorded rather than released for exactly this
+// answer (settleClaim), so a retry under it meets the claimFailed refusal
+// instead of running the applied half again — and a caller who reads only the
+// status would otherwise take a 5xx as the invitation to retry that it usually
+// is.
+//
+// The cause is WRAPPED rather than carried on the wire: Classify matches the
+// DetailedError first, so the caller reads the sentence above while the
+// operator gets the staging engine's own through the wrapped chain.
+func partiallyApplied(conflicts []string, cause error) error {
+	return fmt.Errorf("%w: staging the withheld fields (%s) failed: %w",
+		&httperr.DetailedError{
+			Status: http.StatusInternalServerError,
+			Code:   "partially_applied",
+			Detail: "the fields this agent may write were updated; the human-edited fields (" +
+				strings.Join(conflicts, ", ") + ") could not be staged for approval and were NOT written. " +
+				"Do not retry this request unchanged — the applied half would run a second time. " +
+				"Read the record back, then send only the withheld fields under a new idempotency key.",
+		},
+		strings.Join(conflicts, ", "), cause)
 }

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -11,6 +11,7 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -343,5 +344,98 @@ func TestASubResourcePatchProbesTheRecordItWrites(t *testing.T) {
 	if rec.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want %d (approval_required) — an agent silently overwriting a human-typed "+
 			"to-do is the §2.1 protection this test exists to hold", rec.Code, http.StatusForbidden)
+	}
+}
+
+// failingApprovals is the staging seam refusing after the auto-execute half has
+// already committed — the race the split cannot design away, because approvals
+// resolves its own target version inside the staging transaction and that
+// transaction can only run after the write it is staged against.
+type failingApprovals struct{ capturingApprovals }
+
+var errStagingRefused = errors.New("the record's authority moved between the two writes")
+
+func (failingApprovals) StageCall(context.Context, agents.StageRequest) (ids.ApprovalID, bool, error) {
+	return ids.ApprovalID{}, false, errStagingRefused
+}
+
+// A refusal that follows a committed write says so, so the key is not given
+// back.
+//
+// The split writes the agent-owned fields and then stages the human-owned
+// residue. A staging failure answers a refusal for a request that already
+// wrote, and the idempotency middleware reads every non-2xx the same way: it
+// releases the claim. The retry the caller is entitled to make then runs the
+// applied half a second time under the same key, which is the one thing the key
+// exists to prevent.
+//
+// So the handler reports the write, and this asserts the report — the middleware
+// is a layer up and settleClaim's own case covers what it does with it.
+func TestARefusalAfterTheAppliedHalfReportsThatItWrote(t *testing.T) {
+	orgID := ids.NewV7()
+	pol := agentPolicy{Op: "updateOrganization", Access: accessTool, Tool: "update_record", RecordType: recordTypeOrganization}
+	body := []byte(`{"display_name":"Renamed GmbH","industry":"software"}`)
+	req := patchRequest("/v1/organizations", orgID, body)
+	ctx, effect := withWriteEffect(req.Context())
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	// The agent-owned half commits, exactly as the real handler does.
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`{"id":"` + orgID.String() + `","version":2}`)); err != nil {
+			t.Fatalf("writing the applied half: %v", err)
+		}
+	})
+
+	admitAgentCall(rec, req, next, admissionOutcome{
+		staging: &failingApprovals{}, ownership: mixedHumanOwned{conflict: "display_name"},
+		commands: restCommandDeps{records: seamRecord{}}, pol: pol, body: body,
+		registry: agents.NewRegistry(nil, auth.NewGate(fullSeat{})),
+	})
+
+	if rec.Code >= 200 && rec.Code <= 299 {
+		t.Fatalf("a failed staging answered %d — the caller is told the whole patch landed", rec.Code)
+	}
+	if !effect.committed {
+		t.Error("the refusal did not report that it had written, so the idempotency layer gives the key back " +
+			"and the retry runs the applied half a second time under it")
+	}
+	// And the sentence still names what did land, which is the half a caller
+	// cannot discover any other way.
+	if !strings.Contains(rec.Body.String(), "display_name") {
+		t.Errorf("the refusal reads %q and does not name the withheld fields", rec.Body.String())
+	}
+}
+
+// The control, one outcome apart. Without it the case above would pass against
+// a door that reported a write on every path, which would strand the key of
+// every ordinary refusal — a caller unable to retry a call that changed nothing.
+func TestARefusalBeforeAnythingIsWrittenReportsNoWrite(t *testing.T) {
+	orgID := ids.NewV7()
+	pol := agentPolicy{Op: "updateOrganization", Access: accessTool, Tool: "update_record", RecordType: recordTypeOrganization}
+	body := []byte(`{"display_name":"Renamed GmbH","industry":"software"}`)
+	req := patchRequest("/v1/organizations", orgID, body)
+	ctx, effect := withWriteEffect(req.Context())
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("the handler ran for a call this door refuses before the write")
+	})
+
+	// An externally-held record: refused by the target resolver, ahead of the
+	// auto-execute half.
+	admitAgentCall(rec, req, next, admissionOutcome{
+		staging: &capturingApprovals{}, ownership: mixedHumanOwned{conflict: "display_name"},
+		commands: restCommandDeps{records: mirroredRecord{}}, pol: pol, body: body,
+		registry: agents.NewRegistry(nil, auth.NewGate(fullSeat{})),
+	})
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+	if effect.committed {
+		t.Error("a refusal that wrote nothing reported a write, which strands the caller's idempotency key " +
+			"on a call they are entitled to retry unchanged")
 	}
 }

--- a/backend/internal/compose/idempotency.go
+++ b/backend/internal/compose/idempotency.go
@@ -120,12 +120,16 @@ func idempotency(pool *pgxpool.Pool, probes map[string]replayProbe) func(http.Ha
 			}
 
 			rec := &replayRecorder{ResponseWriter: w, status: http.StatusOK}
-			next.ServeHTTP(rec, r)
+			// The handler is given somewhere to say that it wrote before it
+			// refused. Read after it returns, because a refusal that changed
+			// something must not give the key back — see settleClaim.
+			ctx, effect := withWriteEffect(r.Context())
+			next.ServeHTTP(rec, r.WithContext(ctx))
 			// Zero records: this door charges no read bound, so its claims carry
 			// no cost to record (0198).
-			if err := settleClaim(r.Context(), pool, actor.ID, key, endpoint,
-				rec.status, rec.buf.String(), rec.Header().Get("Content-Type"), 0); err != nil {
-				slog.ErrorContext(r.Context(), "idempotency claim settlement failed", "err", err)
+			if err := settleClaim(ctx, pool, actor.ID, key, endpoint,
+				rec.status, rec.buf.String(), rec.Header().Get("Content-Type"), 0, effect.committed); err != nil {
+				slog.ErrorContext(ctx, "idempotency claim settlement failed", "err", err)
 			}
 		})
 	}
@@ -168,13 +172,12 @@ func writeClaimOutcome(w http.ResponseWriter, r *http.Request, pool *pgxpool.Poo
 	case claimFresh:
 		// Unreachable: the caller returns early only for a non-fresh claim.
 	case claimFailed:
-		// The tool surface records a run that produced no result
-		// (agentidempotency.go); this middleware releases the claim instead, so
-		// REST does not write one today. It ANSWERS anyway rather than falling
-		// through: an empty case here returns without writing, and net/http
-		// then sends a bare 200 with no body — a silent success for a call that
-		// failed. The table is shared, so "no door writes this yet" is a fact
-		// about today, not a guarantee.
+		// Reached by two writers now: the tool surface records a run that
+		// produced no result (agentidempotency.go), and this middleware records
+		// a refusal whose handler had already committed (settleClaim). It
+		// ANSWERS rather than falling through: an empty case here returns
+		// without writing, and net/http then sends a bare 200 with no body — a
+		// silent success for a call that failed.
 		httperr.Write(w, r, &httperr.DetailedError{
 			Status: http.StatusConflict,
 			Code:   "idempotency_key_conflict",
@@ -320,9 +323,10 @@ func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint,
 	case status == nil:
 		return claimInProgress, storedResponse{}, nil
 	case *status < 200 || *status >= 300:
-		// A RECORDED failure — the attempt reached its handler and produced no
-		// result. Only the tool surface writes one (failClaim); the middleware
-		// releases instead, so a REST row is never in this state. It is not a
+		// A RECORDED failure — the attempt reached its handler and answered a
+		// refusal it could not take back. The tool surface writes one for a run
+		// that produced no result; REST writes one when a handler reported that
+		// it had already committed before refusing (settleClaim). It is not a
 		// replay and not a free key: whether the effect landed is exactly what
 		// the recording could not determine, so the body carries the reason and
 		// the caller decides.
@@ -334,16 +338,37 @@ func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint,
 	}
 }
 
-// settleClaim records a 2xx outcome for replay and releases the claim on
-// anything else (see the package comment for why failures are not
-// replayed).
+// settleClaim records a 2xx outcome for replay, and decides what a refusal
+// means from whether the request WROTE before it answered one.
+//
+// A refusal that changed nothing gives the key back: the caller fixes the call
+// and retries, which is the whole point of releasing it. A refusal that changed
+// something must not — the retry would run the applied half a second time under
+// the same key, which is precisely what the key exists to prevent. Such a claim
+// is RECORDED instead, and the next attempt under it meets the claimFailed
+// answer: this request failed after it had already started, check whether it
+// took effect before retrying under a new key. That is the honest sentence,
+// because whether the effect landed is exactly what nobody here can determine.
+//
+// Only one door reports a write today (the per-field split's staging half), so
+// the released path is still what every other refusal takes.
 func settleClaim(ctx context.Context, pool *pgxpool.Pool, principalID, key, endpoint string,
-	status int, body, contentType string, records int,
+	status int, body, contentType string, records int, wrote bool,
 ) error {
-	if status < 200 || status >= 300 {
+	if claimIsReleased(status, wrote) {
 		return releaseClaim(ctx, pool, principalID, key, endpoint)
 	}
 	return recordClaimOutcome(ctx, pool, principalID, key, endpoint, status, body, contentType, records)
+}
+
+// claimIsReleased is the rule a refusal is judged by: a key goes back only for
+// one that changed nothing.
+//
+// A function rather than an inline condition because it is the whole of what
+// settleClaim decides, and a case can then state it without a database — the
+// two arms it chooses between are each already held.
+func claimIsReleased(status int, wrote bool) bool {
+	return (status < 200 || status >= 300) && !wrote
 }
 
 // recordClaimOutcome writes a settled response onto a held claim, whatever that

--- a/backend/internal/compose/idempotency.go
+++ b/backend/internal/compose/idempotency.go
@@ -11,10 +11,22 @@ package compose
 // a silent replay of mismatched intent). The claim row is written
 // insert-first, so two concurrent attempts under one key can never both
 // execute: the loser sees the claim and answers 409 while the first is
-// in flight. Only a 2xx outcome is recorded; a failed attempt releases
-// the claim so the client may retry the same key — replaying stored
-// failures would pin transient faults for 24h and would break the
-// stage-then-redeem approval flow, whose retry is the same request.
+// in flight.
+//
+// A 2xx outcome is recorded for replay. A refusal is judged by whether it
+// CHANGED anything, which is not one answer:
+//
+//   - A refusal that wrote nothing releases the claim, so the client may retry
+//     the same key. Replaying stored failures would pin transient faults for
+//     24h and would break the stage-then-redeem approval flow, whose retry is
+//     the same request.
+//   - A refusal that had already written is recorded instead. Releasing it
+//     hands back a key whose retry re-runs the committed half — the one thing
+//     the key exists to prevent — so the next attempt meets the claimFailed
+//     answer: this request failed after it had already started, check whether
+//     it took effect before retrying under a new key. Handlers report a write
+//     through markWriteCommitted (partialwrite.go); the per-field split's
+//     staging half is the only door that does today.
 
 import (
 	"bytes"

--- a/backend/internal/compose/idempotency.go
+++ b/backend/internal/compose/idempotency.go
@@ -139,9 +139,9 @@ func idempotency(pool *pgxpool.Pool, probes map[string]replayProbe) func(http.Ha
 			next.ServeHTTP(rec, r.WithContext(ctx))
 			// Zero records: this door charges no read bound, so its claims carry
 			// no cost to record (0198).
-			if err := settleClaim(ctx, pool, actor.ID, key, endpoint,
+			if err := settleClaim(r.Context(), pool, actor.ID, key, endpoint,
 				rec.status, rec.buf.String(), rec.Header().Get("Content-Type"), 0, effect.committed); err != nil {
-				slog.ErrorContext(ctx, "idempotency claim settlement failed", "err", err)
+				slog.ErrorContext(r.Context(), "idempotency claim settlement failed", "err", err)
 			}
 		})
 	}

--- a/backend/internal/compose/idempotency_test.go
+++ b/backend/internal/compose/idempotency_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a refusal means for the caller's key, which is not one answer.
+
+import "testing"
+
+// A refusal that changed nothing gives the key back; one that changed something
+// does not.
+//
+// The distinction is the whole of #1073. Every non-2xx released the claim, so
+// the per-field split — which applies the agent-owned fields and then stages the
+// human-owned residue — handed the key back after a staging failure that
+// followed a committed write. The retry the caller is entitled to make then ran
+// the applied half a second time under the same key, which is precisely what
+// the key exists to prevent.
+//
+// Asserted on the DECISION rather than on the database, because the database
+// half is recordClaimOutcome and releaseClaim, each already held: what was
+// wrong was which of the two a refusal reached.
+func TestARefusalReleasesTheKeyOnlyIfItChangedNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		status  int
+		wrote   bool
+		release bool
+	}{
+		{"a refusal that wrote nothing", 422, false, true},
+		{"a refusal that had already written", 500, true, false},
+		{"a success", 200, false, false},
+		// A success is recorded whatever it reports, so the marker cannot make
+		// a completed call retryable by accident.
+		{"a success that wrote", 200, true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claimIsReleased(tc.status, tc.wrote); got != tc.release {
+				t.Errorf("released = %v, want %v", got, tc.release)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/partialwrite.go
+++ b/backend/internal/compose/partialwrite.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Whether a request that answered a refusal changed anything.
+//
+// A refusal normally means nothing happened, and every layer above a handler
+// reads it that way — the idempotency middleware most of all, which gives a
+// key back so the caller may retry it. That is right for a request refused
+// before it wrote, and wrong for one refused after: the retry runs the applied
+// half a second time under the same key, which is exactly what the key exists
+// to prevent.
+//
+// One door reaches that state today. The per-field split applies the
+// agent-owned fields and then stages the human-owned residue, and the staging
+// call runs after the first half has committed — so a failure there answers a
+// refusal for a request that already wrote. Everything the split can refuse on
+// BEFORE the write is settled before the write (agentsplit.go); this is the
+// remainder, which is a genuine failure rather than a refusal.
+//
+// The signal travels DOWN as a pointer and is read on the way back up, because
+// a context value set by a handler is invisible to the middleware that
+// dispatched it — the request's context is the one the middleware built.
+
+import "context"
+
+// writeEffect records whether the handler under it committed anything.
+//
+// A plain bool behind a pointer, with no mutex: a request is served on one
+// goroutine, and a handler that fanned out and wrote from another would be
+// outside every other assumption on this path too.
+type writeEffect struct{ committed bool }
+
+type writeEffectKey struct{}
+
+// withWriteEffect gives a request a place for its handler to say that it wrote.
+// Called by the layer that will read the answer, so a door with nobody above it
+// to care simply has no marker and costs nothing.
+func withWriteEffect(ctx context.Context) (context.Context, *writeEffect) {
+	effect := &writeEffect{}
+	return context.WithValue(ctx, writeEffectKey{}, effect), effect
+}
+
+// markWriteCommitted records that this request has already changed the record,
+// whatever it answers next.
+//
+// Silent when nothing is listening: the marker exists only under a layer that
+// asked for one, and a handler that reports its own writes honestly should not
+// have to know which of its callers did.
+func markWriteCommitted(ctx context.Context) {
+	if effect, ok := ctx.Value(writeEffectKey{}).(*writeEffect); ok {
+		effect.committed = true
+	}
+}


### PR DESCRIPTION
Closes #1073.

The per-field split applies the agent-owned fields and then stages the human-owned residue. The staging call can only run **after** the first half commits — approvals resolves its own target version inside the staging transaction — so a failure there answers a refusal for a request that already wrote.

Two things followed from that, and both are worse than the failure itself.

## 1. The key went back, so the retry ran the applied half again

`settleClaim` read every non-2xx the same way and released the claim. That is right for a request refused **before** it wrote, and exactly wrong for one refused after: the retry the caller is entitled to make runs the committed half a second time under the same key — the one thing the key exists to prevent.

The handler reports the write now, and a refusal that reports one is **recorded** rather than released. The next attempt under that key meets the `claimFailed` answer, which was already built and had no writer on this door:

> an earlier request with this idempotency key failed after it had already started; check whether it took effect before retrying under a new key

That is the honest sentence, because whether the effect landed is exactly what nobody at that layer can determine.

The signal travels **down as a pointer and is read on the way back up**, because a context value a handler sets is invisible to the middleware that dispatched it — the request's context is the one the middleware built.

## 2. The caller was told nothing at all

The ticket says the pre-existing path "carries a message telling the caller the other fields already applied". It does not. That sentence was wrapped in a plain `fmt.Errorf`, which reaches `httperr.Write`'s **unhandled** path: logged for the operator, answered to the caller as `{"code":"internal"}` with no detail at all.

A partial write is precisely the outcome nobody can discover from the outside, and the one party who has to decide what to do next got the one answer that says nothing. It is a classified refusal now — it names the withheld fields, says the other half landed, and says not to retry unchanged, which matters because a caller reading only the status would take a 5xx as the invitation to retry it usually is.

## What the ticket asked for, and what this does instead

The ticket offered two fixes: a second return shape out of the staging seam, or making the two writes atomic — and said neither belonged in the change that found it. Both are still true, and neither is needed for the defect as it stands:

- **The framing gap is closed at the source.** Both post-write exits go through one refusal now, so there is no path that reports a partial write as a plain one. The seam does not need a new shape for that.
- **The Guards path the ticket describes is already gone.** Everything the split can refuse on before the write is now settled before the write (the comment on `applyAutoExecuteAndStageResidue` cites this issue). What remains is the genuine race the ticket names: the record's system of record or its visibility changing between the two writes.

What was left unfixed by both of those, and is fixed here, is the idempotency half — which is the part that turns one bad request into two writes.

## Tests

`claimIsReleased` is the rule as a function, so a case states it without a database — the two arms it chooses between (`recordClaimOutcome`, `releaseClaim`) are each already held. Four rows: a refusal that wrote nothing releases; one that wrote does not; a success is recorded either way, so the marker cannot make a completed call retryable by accident.

Beside it, the split's own pair: a staging failure after the applied half reports that it wrote and still names the withheld fields, and — the control — a refusal that happens **before** the write reports no write, so an ordinary refusal still hands the key back.

**Mutation checks:**

| mutation | killed |
|---|---|
| release on every non-2xx | the "had already written" row |
| drop `markWriteCommitted` | the after-the-applied-half case |
| answer the staging failure as a plain error | the same case, on the detail |

`make check-backend` green; the `compose/integration` idempotency and human-precedence lanes green.