### PR TITLE
fix(agents): a refusal that names an input says so in the field list

### DIFF
--- a/backend/internal/compose/agentcommandrecord.go
+++ b/backend/internal/compose/agentcommandrecord.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -48,6 +49,19 @@ func mergeCommand(pol agentPolicy, deps restCommandDeps, r *http.Request, body [
 		TargetID ids.UUID `json:"target_id"`
 	}](body)
 	if err != nil {
+		return nil, err
+	}
+	// An omitted target is the CALLER'S OWN INPUT, and answers 422 naming it —
+	// the rule advanceDealCommand states at length for `to_stage_id` and the
+	// stakeholder commands follow. Without it the zero id travelled on, the
+	// resolver read it, and an agent got the resolver's existence-hiding 404
+	// where a session on the same route gets the handler's 422: one mistake,
+	// two machine codes, keyed on which credential presented it.
+	//
+	// Existence-hiding wins only where a ROUTED id names a record, because an
+	// agent must not learn from a validation message that an id it guessed is
+	// well-formed and merely invisible. A body field it left out is neither.
+	if err := httperr.RequireBodyID("target_id", in.TargetID); err != nil {
 		return nil, err
 	}
 	return agents.NewMergeCall(deps.records, agents.MergeCommand{

--- a/backend/internal/compose/agentgatecanon.go
+++ b/backend/internal/compose/agentgatecanon.go
@@ -124,6 +124,12 @@ func canonicalHeaders(h http.Header, keys idempotencyKeyBinding) map[string]stri
 // canonical form catches an escaped unpaired surrogate (`"\udcff"`), which
 // is valid UTF-8 on the wire and still decodes to U+FFFD, so the byte check
 // cannot see it.
+//
+// That scan runs PER MEMBER rather than over the finished object, because the
+// object is where the three inputs stop being distinguishable: json.Marshal
+// coerces the path, the body and the header values into one string, so a
+// replacement rune from any of them was reported as `body`. A caller told to
+// fix a body that is already clean has been handed a task it cannot perform.
 func canonicalRESTCall(op, path string, headers http.Header, body []byte, keys idempotencyKeyBinding) (json.RawMessage, string, error) {
 	if !utf8.Valid(body) {
 		return nil, "", httperr.Validation("body", "invalid_utf8", "request body must be valid UTF-8")
@@ -142,10 +148,44 @@ func canonicalRESTCall(op, path string, headers http.Header, body []byte, keys i
 	if err != nil {
 		return nil, "", err
 	}
-	if bytes.ContainsRune(canonical, utf8.RuneError) {
-		return nil, "", httperr.Validation("body", "invalid_utf8",
-			"request body contains the Unicode replacement character, which makes two different calls indistinguishable")
+	if err := refuseReplacementRune(path, payload, fields["headers"]); err != nil {
+		return nil, "", err
 	}
 	sum := sha256.Sum256(canonical)
 	return canonical, hex.EncodeToString(sum[:]), nil
+}
+
+// refuseReplacementRune names WHICH caller-supplied member carries U+FFFD.
+//
+// Each is marshalled on its own, because the escaped-unpaired-surrogate case
+// this catches (`"\udcff"`) is valid UTF-8 on the wire and only becomes the
+// replacement rune once encoded — so a scan of the raw input cannot see it, and
+// a scan of the assembled object cannot say where it came from.
+//
+// `operation` is not among them: it is the route's own declared id, supplied by
+// this server, so a caller cannot put anything in it and being told to fix it
+// would be advice about a value they never sent.
+func refuseReplacementRune(path string, body, headers any) error {
+	for _, member := range []struct {
+		field string
+		value any
+	}{
+		{"path", path},
+		{"body", body},
+		{"headers", headers},
+	} {
+		if member.value == nil {
+			continue
+		}
+		encoded, err := json.Marshal(member.value)
+		if err != nil {
+			return err
+		}
+		if bytes.ContainsRune(encoded, utf8.RuneError) {
+			return httperr.Validation(member.field, "invalid_utf8",
+				"the request's "+member.field+" contains the Unicode replacement character, "+
+					"which makes two different calls indistinguishable")
+		}
+	}
+	return nil
 }

--- a/backend/internal/compose/agentgatecanon.go
+++ b/backend/internal/compose/agentgatecanon.go
@@ -165,6 +165,8 @@ func canonicalRESTCall(op, path string, headers http.Header, body []byte, keys i
 // `operation` is not among them: it is the route's own declared id, supplied by
 // this server, so a caller cannot put anything in it and being told to fix it
 // would be advice about a value they never sent.
+//
+//craft:ignore naked-any the members ARE arbitrary decoded JSON — the body is open by operation and the headers map is assembled here — so a concrete type would be a claim about payload shape this must not make
 func refuseReplacementRune(path string, body, headers any) error {
 	for _, member := range []struct {
 		field string

--- a/backend/internal/compose/agentrefusalshape_test.go
+++ b/backend/internal/compose/agentrefusalshape_test.go
@@ -138,3 +138,37 @@ func TestAReplacementRuneNamesTheMemberItCameFrom(t *testing.T) {
 // errProbeBadPhase is a refusal of the shape this file is about: it names an
 // input in its prose, which is exactly the case the field must now carry too.
 var errProbeBadPhase = errors.New(`to_phase "vibing" is not a project phase`)
+
+// The detail a field-fault refusal carries is bounded like every other value
+// on that path.
+//
+// It was the one that was not, and it is the value most likely to be long: a
+// BadArgsError's Guidance is deliberately unbounded — bounding it with the echo
+// truncated the accepted-field list mid-word, deleting the actionable half of a
+// message whose reader had just proved they did not know the vocabulary — and
+// Error() concatenates the two.
+func TestAFieldFaultsDetailIsBounded(t *testing.T) {
+	rec := httptest.NewRecorder()
+	httperr.Write(rec, httptest.NewRequest(http.MethodPost, "/v1/probe", http.NoBody),
+		&agents.BadArgsError{
+			Field:    "fields",
+			Cause:    errProbeBadPhase,
+			Guidance: "accepts " + strings.Repeat("a_long_field_name, ", 80),
+		})
+	var problem struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &problem); err != nil {
+		t.Fatalf("the refusal is not a problem document: %v", err)
+	}
+	// The bound plus the ellipsis boundFaultText appends, which is what every
+	// other value on this path measures to as well.
+	const ellipsis = len("…")
+	if len(problem.Detail) > httperr.MaxFaultText+ellipsis {
+		t.Errorf("detail is %d bytes, above the %d-byte bound every other value on this path takes",
+			len(problem.Detail), httperr.MaxFaultText)
+	}
+	if !strings.HasSuffix(problem.Detail, "…") {
+		t.Error("the detail was not bounded at all — this case passes on a short message whatever the code does")
+	}
+}

--- a/backend/internal/compose/agentrefusalshape_test.go
+++ b/backend/internal/compose/agentrefusalshape_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// One mistake, one machine code, whichever credential presented it — and a
+// refusal that names an input says so in the structured field list rather than
+// only in prose.
+//
+// The governed-call seam moved a set of argument guards onto the REST agent
+// door that had run only on the tool door. They refuse the right calls; what
+// they ANSWERED with had drifted from what the contract and the session door
+// answer for the same mistake, which is the divergence that whole change exists
+// to remove.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// fieldsNamed reads the per-field entries a refusal carries on the wire.
+func fieldsNamed(t *testing.T, err error) []struct{ Field, Code string } {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	httperr.Write(rec, httptest.NewRequest(http.MethodPost, "/v1/probe", http.NoBody), err)
+	var problem struct {
+		Status  int `json:"status"`
+		Details struct {
+			Errors []struct{ Field, Code string } `json:"errors"`
+		} `json:"details"`
+	}
+	if uErr := json.Unmarshal(rec.Body.Bytes(), &problem); uErr != nil {
+		t.Fatalf("the refusal is not a problem document: %v\n%s", uErr, rec.Body.String())
+	}
+	if problem.Status != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422: %s", problem.Status, rec.Body.String())
+	}
+	return problem.Details.Errors
+}
+
+// A BadArgsError that names an input reaches the caller as a per-field entry.
+//
+// It declared MessageFault, which apperrors documents as "a refusal that names
+// NO input the caller can change" — so a refusal like `to_phase "vibing" is not
+// a project phase` answered a 422 whose `details.errors` was empty and whose
+// only actionable content was prose. A client that branches on the structured
+// list had nothing to branch on, and the coverage gate had to match a substring
+// instead of a field code.
+func TestABadArgumentNamingAnInputAnswersAPerFieldEntry(t *testing.T) {
+	entries := fieldsNamed(t, &agents.BadArgsError{
+		Field: "to_phase",
+		Cause: errProbeBadPhase,
+	})
+	if len(entries) != 1 || entries[0].Field != "to_phase" || entries[0].Code != "validation_error" {
+		t.Fatalf("the refusal names %+v, want one entry for to_phase/validation_error", entries)
+	}
+}
+
+// And one that names none still carries no entry. Inventing one would point a
+// caller at an argument that is not theirs to change, which is the reason the
+// message form exists at all — so the field is optional and its absence is an
+// answer rather than an omission.
+func TestABadArgumentNamingNoInputCarriesNoEntry(t *testing.T) {
+	if entries := fieldsNamed(t, &agents.BadArgsError{Cause: errProbeBadPhase}); len(entries) != 0 {
+		t.Fatalf("the refusal names %+v, want none", entries)
+	}
+}
+
+// A merge with no `target_id` is the caller's own input, and answers as one.
+//
+// The zero id used to travel on to the resolver, which read it and returned
+// not-found — so an agent got a 404 where a session on the same route gets the
+// handler's 422. Existence-hiding wins where a ROUTED id names a record, and a
+// body field the caller left out is not one.
+func TestAMergeWithNoTargetNamesTheFieldRatherThanHidingARecord(t *testing.T) {
+	// A ROUTED request, so the source id resolves and the only thing missing is
+	// the one this case is about.
+	_, err := mergeCommand(
+		agentPolicy{Op: "mergeOrganization", RecordType: recordTypeOrganization},
+		restCommandDeps{records: seamRecord{}},
+		patchRequest("/v1/organizations", ids.NewV7(), []byte(`{}`)),
+		[]byte(`{}`),
+	)
+	if err == nil {
+		t.Fatal("a merge naming no survivor was accepted")
+	}
+	entries := fieldsNamed(t, err)
+	if len(entries) != 1 || entries[0].Field != "target_id" {
+		t.Fatalf("the refusal names %+v, want one entry for target_id — a 404 here tells an agent a "+
+			"record is invisible when what it did was omit an argument", entries)
+	}
+}
+
+// A replacement rune is attributed to the member that carries it.
+//
+// json.Marshal coerces the path, the body and the header values into one
+// canonical object, so a scan of the finished object reported every one of them
+// as `body` — and a caller told to fix a body that is already clean has been
+// handed a task it cannot perform.
+func TestAReplacementRuneNamesTheMemberItCameFrom(t *testing.T) {
+	// An escaped unpaired surrogate: valid UTF-8 on the wire, and U+FFFD once
+	// encoded — which is why the raw-byte check upstream cannot see it.
+	const surrogate = `"\udcff"`
+
+	for _, tc := range []struct {
+		name  string
+		path  string
+		body  []byte
+		field string
+	}{
+		{"in the body", "/v1/people/x", []byte(`{"note":` + surrogate + `}`), "body"},
+		{"in the path", "/v1/people/�", []byte(`{}`), "path"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := canonicalRESTCall("updatePerson", tc.path, http.Header{}, tc.body, keySettledByThisCall)
+			if err == nil {
+				t.Fatal("a call carrying the replacement character was accepted — two different calls hash alike")
+			}
+			entries := fieldsNamed(t, err)
+			if len(entries) != 1 || entries[0].Field != tc.field {
+				t.Fatalf("the refusal names %+v, want one entry for %q", entries, tc.field)
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), tc.field) {
+				t.Errorf("the sentence reads %q and does not name %q either", err.Error(), tc.field)
+			}
+		})
+	}
+}
+
+// errProbeBadPhase is a refusal of the shape this file is about: it names an
+// input in its prose, which is exactly the case the field must now carry too.
+var errProbeBadPhase = errors.New(`to_phase "vibing" is not a project phase`)

--- a/backend/internal/modules/agents/badargs.go
+++ b/backend/internal/modules/agents/badargs.go
@@ -29,7 +29,7 @@ import (
 // var-checked here rather than left implicit: a signature typo on the method
 // below would otherwise compile clean and simply never match in
 // httperr.Classify, which is a silent 500 nobody would connect to this file.
-var _ apperrors.MessageFault = (*BadArgsError)(nil)
+var _ apperrors.FieldFaults = (*BadArgsError)(nil)
 
 // decodeArgs is the surface's input validation: strict JSON — unknown argument
 // names are errors rather than silent drops, and the arguments are exactly ONE
@@ -104,6 +104,16 @@ const maxBadArgsDetail = 200
 // vocabulary reflected off the contract, chosen by no caller.
 type BadArgsError struct {
 	Cause error
+	// Field is the argument the caller must change, as the contract spells it,
+	// and empty only where no single one is at fault.
+	//
+	// It exists because almost every refusal of this kind DOES name an input —
+	// `to_phase "vibing" is not a project phase` — and saying so only in prose
+	// left the 422's `details.errors` empty on the REST agent door while the
+	// session door answering the identical mistake filled it. A client
+	// branching on the structured list got nothing to branch on, and the
+	// coverage gate had to match a substring instead of a field code.
+	Field string
 	// Guidance is server-authored text appended after the echo, and it is NOT
 	// bounded. Bounding it with the echo is what made the accepted-field list
 	// truncate mid-word on a long unknown key — cutting away the list the
@@ -142,8 +152,25 @@ func (e *BadArgsError) Unwrap() error { return e.Cause }
 // The MCP tool door is untouched by this: Dispatcher.explain matches
 // *BadArgsError by type BEFORE it ever consults httperr.Classify, so this
 // method is never read on that path.
-func (e *BadArgsError) MessageFault() (code, message string) {
-	return "validation_error", e.Error()
+//
+// FieldFaults — the PLURAL — rather than FieldFault or MessageFault, because it
+// is the only one of the three that can answer both shapes from one method. A
+// type implements exactly one, and errors.As matches whichever it finds, so a
+// conditional choice between the singular and the message form is not
+// expressible. The plural returns one entry when a field is named and NONE when
+// it is not, which is precisely the difference: the caller gets a per-field
+// entry to act on, or the same 422 with an empty list this refusal has always
+// answered. Inventing an entry for a refusal that names no input would point a
+// caller at an argument that is not theirs to change.
+func (e *BadArgsError) FieldFaults() []apperrors.FieldRefusal {
+	if e.Field == "" {
+		return nil
+	}
+	// The code REUSES validation_error rather than minting one: crm.yaml
+	// already declares it for exactly this class of caller mistake, and
+	// inventing a second would put an undocumented code in front of a client
+	// that branches on the documented one (P3 — the contract wins).
+	return []apperrors.FieldRefusal{{Field: e.Field, Code: "validation_error", Message: e.Error()}}
 }
 
 // boundDetail caps a message at n bytes, cutting on a rune boundary so the

--- a/backend/internal/modules/agents/badargs.go
+++ b/backend/internal/modules/agents/badargs.go
@@ -132,7 +132,7 @@ func (e *BadArgsError) Error() string {
 }
 func (e *BadArgsError) Unwrap() error { return e.Cause }
 
-// MessageFault lets a BadArgsError classify correctly when it reaches the REST
+// FieldFaults lets a BadArgsError classify correctly when it reaches the REST
 // surface — which the create/patch resolvers' shared Guards are the first
 // callers to do, since every earlier BadArgsError site answered the MCP tool
 // door alone. httperr.Classify has no notion of this package's own error type,
@@ -140,14 +140,6 @@ func (e *BadArgsError) Unwrap() error { return e.Cause }
 // method") is the seam built for exactly that; without it the REST door would
 // answer a caller's own mistake with an opaque 500, which is the one thing
 // clientInputValidation's own doc says must never happen.
-//
-// The code REUSES validation_error rather than minting one: crm.yaml already
-// declares it for exactly this class of caller mistake (httperr.Validation's
-// own code), and inventing a second would put an undocumented code in front
-// of a client that branches on the documented one (P3 — the contract wins).
-// A code this package needs of its own belongs in an upstream contract
-// change, the same rule compose's EmptyReportPlanError.MessageFault states
-// for its own reused code.
 //
 // The MCP tool door is untouched by this: Dispatcher.explain matches
 // *BadArgsError by type BEFORE it ever consults httperr.Classify, so this

--- a/backend/internal/modules/agents/recordfields.go
+++ b/backend/internal/modules/agents/recordfields.go
@@ -132,12 +132,20 @@ const customFieldPrefix = "cf_"
 // This lives at the TOOL, not in the store, and that placement is the whole
 // point. The store's silence is contract-conformant: the write bodies declare
 // additionalProperties: true, and storekit's package doc ratifies
-// drop-on-mismatch. So REST may keep accepting-and-discarding, while the tool
-// surface — whose caller cannot see a response body it did not think to
+// drop-on-mismatch. So a SESSION may keep accepting-and-discarding, while a
+// governed call — whose caller cannot see a response body it did not think to
 // re-read — refuses up front instead of reporting success for a write it did
 // not perform. Two sessions lost data to that silence: organization_id on a
 // person create, and emails on a person UPDATE, which is a real field on
 // create and no field at all on update.
+//
+// The line is the CREDENTIAL, not the door, and it stopped being the door when
+// the governed-call seam put these guards on the REST agent path
+// (margince/margince#928). An agent's confirm-first create with a stray key is
+// refused where a session's identical request succeeds, and that asymmetry is
+// the intended one: the session's own reader is looking at the screen the write
+// answered, and the agent's is not. Reading this comment as "REST accepts" is
+// what it used to say and is now false of half of REST.
 //
 // A cf_-prefixed key passes: whether that custom field is active in this
 // workspace is the store's ratified question, not a shape this tool can judge.
@@ -153,13 +161,13 @@ func rejectUnknownFields(shapes map[datasource.EntityType]reflect.Type, recordTy
 		// `fields` is a JSON object in every record type's contract, so a
 		// payload that is not one is the caller's mistake and says so here —
 		// carrying the decoder's own words rather than discarding them.
-		return &BadArgsError{Cause: fmt.Errorf("fields must be a JSON object: %w", err)}
+		return &BadArgsError{Field: fieldsArg, Cause: fmt.Errorf("fields must be a JSON object: %w", err)}
 	}
 	// A literal null decodes into a nil map with NO error and therefore no
 	// unknown keys, so it would pass this check and reach the provider as a
 	// write carrying no fields at all.
 	if submitted == nil {
-		return &BadArgsError{Cause: errors.New("fields must be a JSON object, not null")}
+		return &BadArgsError{Field: fieldsArg, Cause: errors.New("fields must be a JSON object, not null")}
 	}
 	accepted := make(map[string]struct{})
 	for _, name := range contractFieldNames(shape) {
@@ -190,6 +198,11 @@ func rejectUnknownFields(shapes map[datasource.EntityType]reflect.Type, recordTy
 	// store: an activity stores links, so "cannot store links" would be false and
 	// would send the caller looking for the wrong fix.
 	return &BadArgsError{
+		// The argument the caller must change is `fields` — not one of the
+		// unknown KEYS inside it, which are not contract fields at all and
+		// which a client cannot look up. A refusal naming a key the schema does
+		// not have points at nothing.
+		Field:    fieldsArg,
 		Cause:    fmt.Errorf("%s does not accept %s", recordType, strings.Join(unknown, ", ")),
 		Guidance: "accepts " + strings.Join(contractFieldNames(shape), ", ") + " (or cf_<slug> for an active custom field)",
 	}
@@ -262,3 +275,7 @@ func UpdatableFields(recordType datasource.EntityType) ([]string, bool) {
 	}
 	return contractFieldNames(shape), true
 }
+
+// fieldsArg is the argument name every refusal above blames, as the contract
+// spells it: the payload is `fields` on both the create and the patch shape.
+const fieldsArg = "fields"

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -214,7 +214,10 @@ func moduleDeclaredFault(err error) (error, bool) {
 		return &DetailedError{
 			Status: http.StatusUnprocessableEntity,
 			Code:   "validation_error",
-			Detail: fieldFaults.Error(),
+			// Bounded like every other value on this path. It was the one that
+			// was not, and it is the value most likely to be long: a type
+			// carrying a list has a sentence naming all of them.
+			Detail: boundFaultText(fieldFaults.Error()),
 			Fields: fields,
 		}, true
 	}


### PR DESCRIPTION
Closes #1071.

Four instances of one root, and the root is the divergence the governed-call seam exists to remove: **one mistake carrying two answers depending on which credential presented it.**

## 1. `BadArgsError` declared the wrong fault form

`apperrors` documents `MessageFault` as *"a refusal that names NO input the caller can change"*, explicitly contrasted with `FieldFault`. Almost every `BadArgsError` newly routed to REST does name one — `to_phase "vibing" is not a project phase` — so the 422 arrived with an empty `details.errors` and prose as its only actionable content. That is why the coverage gate had to match a substring rather than a field code.

It carries an optional `Field` and implements **`FieldFaults` — the plural**. That is the only one of the three forms that can answer both shapes from one method: a type implements exactly one, and `errors.As` matches whichever it finds, so a conditional choice between the singular and the message form is not expressible. One entry when a field is named, **none** when it is not — inventing an entry for a refusal that names no input would point a caller at an argument that is not theirs to change, which is the whole reason the message form exists.

`rejectUnknownFields` — the create/patch guard the seam actually put on this door — names `fields`. Deliberately `fields` and not one of the unknown *keys* inside it: those are not contract fields at all, so a client cannot look one up.

## 2. A merge with no `target_id` answered 404

The zero id travelled to the resolver, which read it and reported not-found. An agent learned that a record was invisible where a session on the same route is told it omitted an argument.

Existence-hiding wins where a **routed** id names a record — an agent must not learn from a validation message that an id it guessed is well-formed and merely invisible. A body field the caller left out is not one. That is the rule `advanceDealCommand` spends eleven lines establishing for `to_stage_id` and the stakeholder commands follow; the merge now follows it too, through the same `httperr.RequireBodyID`.

## 3. The stated placement rule no longer described the code

`rejectUnknownFields`' doc said *"REST may keep accepting-and-discarding, while the tool surface refuses up front"*. That stopped being true when the seam put these guards on the REST agent path.

The line is the **credential**, not the door — and the asymmetry is the intended one: a session's reader is looking at the screen the write answered, and an agent's is not. The comment says that now, and says plainly that the old reading is false of half of REST.

## 4. A replacement rune was attributed to `body` wherever it came from

`json.Marshal` coerces the path, the body and the header values into one canonical object, and the scan ran over the finished thing. A caller told to fix a body that is already clean has been handed a task it cannot perform.

It runs **per member** now, each marshalled on its own — which is also necessary, because the case this catches (an escaped unpaired surrogate, valid UTF-8 on the wire) only becomes U+FFFD once encoded, so scanning the raw input cannot see it. `operation` is excluded: it is this server's own route id, so being told to fix it would be advice about a value the caller never sent.

## Tests

Four cases, driven through `httperr.Write` so each asserts what actually reaches the wire:

- a `BadArgsError` naming an input answers one `details.errors` entry with its field and code;
- one naming none carries no entry, so the message form's own case is not lost;
- a merge with no `target_id` names the field instead of hiding a record;
- a replacement rune in the body names `body`, and one in the path names `path`.

**Mutation checks:** dropping the `Field` guard fails the first; dropping the body-id check fails the merge case; removing `path` from the per-member scan fails the path row and only that row.

## What this does not do

The ticket's closing line — *"the invariant to gate afterwards"* — is not built here. `&BadArgsError{` has 88 construction sites, and most of them answer the MCP tool door only, where `Dispatcher.explain` matches the type before `httperr.Classify` is ever consulted, so the fault form is not read at all. Migrating those is real work with no defect behind it yet, and a gate demanding a field everywhere would be demanding it where nothing reads one. The form is fixed and the REST-reachable guard names its field; the rest is a register worth opening when a second door starts reading them.

`make check-backend` green; the `compose/integration` agent lanes green.