### PR TITLE
fix(capture): the auto-enrich sweep drains oldest first, so none waits forever

### DIFF
--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -10,7 +10,8 @@ package compose
 // The anchor is excluded; cold start has already read it. Per workspace, when
 // the capture_auto_enrich flag is on, it enqueues a deep read
 // (system:capture_auto_enrich, auto-applied on completion) for each due org —
-// newest first, under an atomically-reserved daily cap. It is the
+// oldest first, under an atomically-reserved daily cap, so a company behind a
+// day's worth of arrivals is still reached (ListDueOrgs says why). It is the
 // self-healing reconciler: the prompt trigger is the organization-event
 // consumer (orgautoenrich.go), which queues this same workspace pass the
 // moment a company appears, and anything that slips through — the worker

--- a/backend/internal/compose/captureautoenrich_integration_test.go
+++ b/backend/internal/compose/captureautoenrich_integration_test.go
@@ -255,3 +255,62 @@ func TestAutoEnrichExpireExhausted(t *testing.T) {
 		t.Fatalf("cursor = (%q, %v), want (exhausted, <nil>)", outcome, nextAttempt)
 	}
 }
+
+// A company waiting behind a day's worth of newer arrivals is still reached.
+//
+// The pass takes ONE page, bounded by the daily cap, and queues what it takes —
+// which writes a cursor row that drops that company out of the due set until its
+// next attempt falls due. So the set shrinks by exactly what was worked, and
+// which END the page comes from decides whether it drains.
+//
+// Taking the newest end starves: in a workspace gaining more eligible companies
+// between passes than the cap, arrivals keep landing in front of a company that
+// has never been reached, and it waits forever — not retried, not exhausted, not
+// visible as skipped, so nothing anywhere says it was missed.
+//
+// A page of one against three eligible companies is the same shape as 500
+// against a day's arrivals, and it is the shape the assertion can actually read.
+func TestTheOldestCompanyIsSweptFirstSoNoneWaitsForever(t *testing.T) {
+	e := integration.Setup(t)
+	store := capture.NewAutoEnrichStore(e.DB())
+	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
+
+	// Inserted oldest first. The id is a uuidv7, so this is also id order —
+	// which is what the query sorts on, and why it does.
+	oldest := insertDomainOrg(t, e, "waiting.example")
+	insertDomainOrg(t, e, "newer.example")
+	insertDomainOrg(t, e, "newest.example")
+
+	page, err := store.ListDueOrgs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ListDueOrgs: %v", err)
+	}
+	if len(page) != 1 {
+		t.Fatalf("a page of 1 returned %d companies", len(page))
+	}
+	if page[0].Domain != "waiting.example" {
+		t.Errorf("the pass takes %q, want waiting.example — the company that has been due "+
+			"longest. Taking the newest end leaves it behind every arrival, and nothing "+
+			"retries it or reports it skipped", page[0].Domain)
+	}
+	if page[0].OrganizationID != oldest {
+		t.Errorf("the pass takes org %s, want %s", page[0].OrganizationID, oldest)
+	}
+
+	// And the set really does shrink by what was worked: once the oldest holds a
+	// dossier it leaves, and the next pass takes the one behind it rather than
+	// the same row again. Without this the ordering above would be a queue that
+	// never advances.
+	if _, _, err := e.People.StartSiteRead(ctx, oldest, "https://waiting.example",
+		"human:"+e.Rep1.String()); err != nil {
+		t.Fatalf("seed the oldest company's dossier: %v", err)
+	}
+	next, err := store.ListDueOrgs(ctx, 1)
+	if err != nil {
+		t.Fatalf("ListDueOrgs after the first company was worked: %v", err)
+	}
+	if len(next) != 1 || next[0].Domain != "newer.example" {
+		t.Errorf("the next pass takes %v, want newer.example — the queue has to advance, "+
+			"or oldest-first is a company that blocks every other one", next)
+	}
+}

--- a/backend/internal/modules/capture/autoenrich.go
+++ b/backend/internal/modules/capture/autoenrich.go
@@ -92,7 +92,15 @@ func NewAutoEnrichStore(db *database.DB) *AutoEnrichStore { return &AutoEnrichSt
 // The order is on the ID rather than created_at because it must be TOTAL: two
 // companies captured in the same statement share an instant, and a tie under a
 // LIMIT is a coin toss that can seat the same row at the boundary every pass.
-// The id is a uuidv7, so ordering by it is ordering by arrival anyway.
+//
+// TOTAL and STABLE is all the argument above needs. A uuidv7 sorts by its
+// millisecond and then by bits that are process-local or random, so ids minted
+// on two app instances inside one millisecond can interleave — it is very
+// nearly arrival order, not exactly it. That costs nothing here: a company can
+// be overtaken only by rows sharing its millisecond, which is a bounded
+// reordering and not a queue it can sit behind. What would break the argument
+// is an order that is not total, or one a new row can enter arbitrarily far
+// ahead in — and the id is neither.
 //
 // The org-name sweep pages this same set to exhaustion instead
 // (people/orgnamepromotion.go). It can: its per-candidate work is one in-memory

--- a/backend/internal/modules/capture/autoenrich.go
+++ b/backend/internal/modules/capture/autoenrich.go
@@ -49,9 +49,9 @@ type AutoEnrichStore struct {
 func NewAutoEnrichStore(db *database.DB) *AutoEnrichStore { return &AutoEnrichStore{db: db} }
 
 // ListDueOrgs returns up to limit captured organizations that need a dossier,
-// newest first (ADR-0072): with a live primary domain, no dossier, and either
-// no cursor row or a due one under the attempt bound. The query's own
-// workspace predicate scopes it to the bound workspace.
+// OLDEST first: with a live primary domain, no dossier, and either no cursor
+// row or a due one under the attempt bound. The query's own workspace predicate
+// scopes it to the bound workspace.
 //
 // The population is every company with a live primary domain and no dossier,
 // however it was named. ADR-0072 scoped this lane to auto-created companies
@@ -76,6 +76,29 @@ func NewAutoEnrichStore(db *database.DB) *AutoEnrichStore { return &AutoEnrichSt
 // refresh compares every proposal against confirmed truth and asks the human to
 // resolve each conflict (ADR-0065 §8); offering it here would write machine
 // values onto the one company the installation IS, outside that comparison.
+//
+// Oldest first, and that ordering is the whole termination argument.
+//
+// It used to take the NEWEST prefix, which starves. A pass queues what it takes
+// — writing a cursor row that drops the company out of this set until its next
+// attempt is due — so the set shrinks by exactly what was worked. Taking the
+// oldest end therefore drains it in arrival order: every company ahead of a
+// given one is consumed before it, and nothing new can be inserted ahead of it
+// because nothing new is older. Taking the NEWEST end reverses that: in a
+// workspace gaining more eligible companies between passes than the daily cap,
+// arrivals keep landing in front of a company that has never been reached, and
+// it waits forever — not retried, not exhausted, not visible as skipped.
+//
+// The order is on the ID rather than created_at because it must be TOTAL: two
+// companies captured in the same statement share an instant, and a tie under a
+// LIMIT is a coin toss that can seat the same row at the boundary every pass.
+// The id is a uuidv7, so ordering by it is ordering by arrival anyway.
+//
+// The org-name sweep pages this same set to exhaustion instead
+// (people/orgnamepromotion.go). It can: its per-candidate work is one in-memory
+// decision. This lane's is a model-backed site read under a daily cap, so a
+// pass takes one page by construction — which is why the ordering has to be the
+// thing that guarantees progress.
 //
 // The site-read clause excludes a company whose dossier exists or is still
 // coming. A read that ended with NO dossier is not one: a failure, and a
@@ -102,7 +125,7 @@ func (s *AutoEnrichStore) ListDueOrgs(ctx context.Context, limit int) ([]DueOrg,
 				s.organization_id IS NULL
 				OR (s.next_attempt_at IS NOT NULL AND s.next_attempt_at <= now()
 				    AND s.attempts < $1))
-			ORDER BY o.created_at DESC
+			ORDER BY o.id
 			LIMIT $2`, autoEnrichMaxAttempts, limit)
 		if err != nil {
 			return err


### PR DESCRIPTION
Closes #2021 (the starvation half — see **What I did not decide** below).

The pass took the **newest** page of companies due for a dossier. It queues what it takes — writing a cursor row that drops that company out of the due set until its next attempt falls due — so the set shrinks by exactly what was worked, and which end the page comes from decides whether it drains at all.

In a workspace gaining more eligible companies between passes than the daily cap, arrivals keep landing in front of a company that has never been reached. It waits indefinitely: not retried, not exhausted, not visible as skipped, so nothing anywhere says it was missed.

## Ordering, not paging

The issue suggests following the org-name sweep's keyset paging. That sweep pages **to exhaustion in one pass**, and it can: its per-candidate work is one in-memory decision, no model call. This lane's is a model-backed site read under a daily cap, so a pass takes exactly one page by construction — a cursor parameter would have no second page to fetch.

What actually guarantees progress here is the **ordering**, because the due set shrinks by what the pass worked. Oldest first drains in arrival order: everything ahead of a given company is consumed before it, and nothing new can be inserted ahead of it, because nothing new is older.

So this is a one-line query change with the argument written beside it, rather than a paging parameter nothing would page with.

**Ordered on the id, not `created_at`.** The order has to be TOTAL: two companies captured in one statement share an instant, and a tie under a `LIMIT` is a coin toss that can seat the same row at the boundary every pass — starvation again, by a different route. The id is a uuidv7, so ordering by it *is* ordering by arrival. The due rows sit at the head of that order by construction, so the walk stops early rather than sorting the table; `idx_org_created_keyset` no longer serves this query and the primary key does.

## Test

`TestTheOldestCompanyIsSweptFirstSoNoneWaitsForever` — a page of one against three eligible companies is the same shape as 500 against a day's arrivals, and it is the shape an assertion can read.

It asserts **both** halves, because oldest-first is only progress if the queue advances: the pass takes the company that has been due longest, and once that one holds a dossier the next pass takes the one behind it rather than the same row again. Mutation-checked — restoring `ORDER BY o.created_at DESC` fails both, taking `newest.example` twice.

## What I did not decide

The issue's second item: whether auto-enrich may consume the **whole** daily allowance it shares with domain triage, or should take a share. That is a product call about which lane matters more on a busy first boot, and there is already a test showing a newly captured domain goes unprocessed once the counter is full. I have left the split exactly as it is and not touched `sweepDomainTriage`; the issue should stay open on that point, or move to its own with the ruling named.

`make check-backend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC