### PR TITLE
An unassigned lead can be picked up, and handed only to somebody who can work it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4497,8 +4497,10 @@ paths:
         `write` share) moves to `to_owner_id`; archived projects and projects the caller cannot
         write are left where they are and are not counted. Each moved project gets its own
         `update` audit row with the `owner_id` before/after images, so its field history shows
-        the move, and its own `project.updated` event. `to_owner_id` must name an active user of
-        the workspace, else `422`.
+        the move, and its own `project.updated` event. `to_owner_id` must name a seat that can be
+        handed work — an active, unarchived human seat that is not read-only, and one inside the
+        caller's own row scope — else `422`. The same rule gates `updateProject.owner_id`, so a
+        destination refused in bulk is refused one project at a time.
       x-agent-access: human-only
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'
@@ -33436,7 +33438,20 @@ components:
         source: { type: string, minLength: 1, description: 'Correct the source. A human may set any ACTIVE lead_source key or keep a free value it already carries; an inactive administered key is 422. Changing it recomputes the score (the source weight is part of it).' }
         score: { type: [integer, 'null'], minimum: 0, maximum: 100, description: 'Manual human score override (formulas §3.1, AC-S1). Omit to keep the computed lead-local score. Setting it REQUIRES `score_override_reason`; passing null clears the override and resumes recompute.' }
         score_override_reason: { type: [string, 'null'], minLength: 1, description: 'Written reason for the Commercial Judgement override (formulas §3.1). REQUIRED when `score` is set (422 otherwise); the override is sticky — it suppresses recompute until cleared.' }
-        owner_id: { type: [string, 'null'], format: uuid }
+        owner_id:
+          type: [string, 'null']
+          format: uuid
+          description: |
+            Who owns this lead. The destination must be a seat that can be handed work — an
+            active, unarchived human seat that is not read-only, and one inside the caller's own
+            row scope — else `422 owner_not_assignable`, which names no more than that so the
+            refusal does not disclose the roster or the team graph.
+
+            A lead NOBODY owns is assignable by a caller who could not otherwise write it: that
+            is the door out of the unassigned queue, and it admits an ownership-only change. A
+            patch carrying any other field alongside `owner_id` is refused unless the caller can
+            already write the row. To take an unowned lead for yourself, prefer
+            `POST /records/lead/{id}/claim`, which is the same act with a version precondition.
       additionalProperties: true
       x-extension: true
 

--- a/backend/gates/assigneeeligibility_test.go
+++ b/backend/gates/assigneeeligibility_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A seat's fitness to receive work has ONE spelling, wherever it is asked.
+//
+// eligibilityColumns are the user columns that decide it. A second reader of
+// this SET is a second answer to "may this person receive a record", and the
+// two drift until a manager is refused a colleague the router happily assigns.
+//
+// The set, not any one column, is the subject. Plenty of SQL in the tree reads
+// is_agent or seat_type for a different question — a brief that skips agents, a
+// roster that hides them, a seat check on login — and matching a single column
+// would drag all of them in and teach the next reader that this gate cries
+// wolf. A statement asking about eligibility to RECEIVE work asks about the
+// live seat AND the human AND the seat type together.
+var eligibilityColumns = []string{"is_agent", "seat_type", "archived_at"}
+
+// gatekit:fixture the two places that ask whether a seat may receive work,
+// each with what it is — a classification of the tree, not a cost this gate is
+// paying.
+//
+// assigneeEligibilityWriters are the two places allowed to ask whether a seat
+// may RECEIVE work, each with why it is not the other.
+//
+// auth.assigneeEligible is the rule itself, asked of a destination a caller
+// named. people/leadrouting.go asks the same question of a configured pool
+// under the system principal, where the caller-scope half of the rule has no
+// meaning — routing has no caller to be scoped to. They are kept in step by
+// this gate rather than by a shared helper because the platform package cannot
+// reach into a module and the module must not import the predicate's private
+// half.
+var assigneeEligibilityWriters = map[string]string{
+	"internal/platform/auth/assignscope.go": "the rule itself: an active human seat inside the caller's own write scope",
+	"internal/modules/people/leadrouting.go": "the routing pool's own eligibility, system-principal so the scope half " +
+		"does not apply; kept in step with the rule by this gate",
+}
+
+// A seat's fitness to receive work is spelled in exactly two places, and both
+// ask the same thing.
+//
+// The claim in auth.assigneeEligible's comment is what this holds: the rule has
+// one spelling. Before it, routing checked status and archival while
+// the manual path checked status, archival, agent and seat type, so the
+// machine could place a lead on a seat a person was forbidden to assign to.
+// That divergence passed every gate in the tree.
+func TestSeatEligibilityIsAskedTheSameWayEverywhereItIsAsked(t *testing.T) {
+	t.Parallel()
+	found := map[string][]string{}
+	root := filepath.Join(moduleRoot(t), "internal")
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		text := string(body)
+		// Only SQL that reads app_user can be asking this question; a Go
+		// struct field named is_agent is not a seat-eligibility decision.
+		if !strings.Contains(text, "app_user") {
+			return nil
+		}
+		rel := "internal/" + strings.TrimPrefix(filepath.ToSlash(strings.TrimPrefix(path, root)), "/")
+		// All of them, in one file, plus the active-status clause: that
+		// conjunction is the question, and any subset is a different one.
+		if !strings.Contains(text, "status = 'active'") {
+			return nil
+		}
+		hits := []string{}
+		for _, col := range eligibilityColumns {
+			if strings.Contains(text, col) {
+				hits = append(hits, col)
+			}
+		}
+		if len(hits) == len(eligibilityColumns) {
+			found[rel] = hits
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree: %v", err)
+	}
+
+	for file := range found {
+		if _, allowed := assigneeEligibilityWriters[file]; !allowed {
+			t.Errorf("%s asks whether a seat may receive work (%v), but only these may: %v.\n"+
+				"Call auth.EnsureAssignee rather than asking again — a third reading of this rule is a "+
+				"third answer, and the one that disagrees is found by a user, not by a test.",
+				file, found[file], keysOf(assigneeEligibilityWriters))
+		}
+	}
+	for file, why := range assigneeEligibilityWriters {
+		if len(found[file]) == 0 {
+			t.Errorf("%s is registered as asking about seat eligibility (%s) and no longer does: "+
+				"if the question moved, move this row; if it stopped being asked, the OTHER writer is "+
+				"now alone and this gate is holding nothing.", file, why)
+		}
+	}
+	// Under-recognition is the failure this cannot have: a census that reads a
+	// smaller tree reports PASS with nothing to notice.
+	if len(found) < len(assigneeEligibilityWriters) {
+		t.Fatalf("the scan found %d file(s) asking about seat eligibility and the register names %d: "+
+			"the scan has stopped seeing its own subjects", len(found), len(assigneeEligibilityWriters))
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// The rule's two halves must both appear in the predicate: a version that
+// dropped the seat check while keeping the scope check would still refuse a
+// stranger and happily file work on a suspended colleague.
+func TestTheAssigneePredicateKeepsBothHalvesOfTheRule(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(moduleRoot(t), "internal", "platform", "auth", "assignscope.go")
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	var body string
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "assigneeEligible" {
+			return true
+		}
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("reading %s: %v", path, readErr)
+		}
+		body = string(src)[fn.Pos()-1 : fn.End()-1]
+		return false
+	})
+	if body == "" {
+		t.Fatal("assigneeEligible is gone from assignscope.go: the rule it holds has moved and this gate has not")
+	}
+	for _, half := range []string{
+		"status = 'active'", "archived_at IS NULL", "NOT %[1]s.is_agent",
+		"seat_type <> 'read'", "ownerPredicate",
+	} {
+		if !strings.Contains(body, half) {
+			t.Errorf("assigneeEligible no longer asks %q. Each clause refuses a seat that cannot do the "+
+				"work, or scopes the destination to the assigner's own reach; dropping one widens who may "+
+				"be handed a record without any test naming what was widened.", half)
+		}
+	}
+}

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 47
+	wantFixtureAnnotations = 48
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/livemember_test.go
+++ b/backend/gates/livemember_test.go
@@ -85,7 +85,6 @@ var cannotReachIdentity = gatekit.Waive(map[string]string{
 	"internal/modules/people/leadrouting.go":         "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
 	"internal/modules/people/linkedinmatch.go":       "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
 	"internal/modules/projects/surface.go":           "projects cannot import identity (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/projects/transfer.go":          "projects cannot import identity (ADR-0054 §3); the predicate must move tier first",
 	"internal/modules/search/graphedge.go":           "search cannot import identity (ADR-0054 §3); the predicate must move tier first",
 })
 

--- a/backend/internal/compose/integration/leadassign_integration_test.go
+++ b/backend/internal/compose/integration/leadassign_integration_test.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// leadObjectGrant is what every seat below needs before row scope is even
+// asked: the object grant to read and change a lead. The seats differ only in
+// RowScope, which is the axis these tests are about.
+func leadObjectGrant() map[string]principal.ObjectGrant {
+	return map[string]principal.ObjectGrant{
+		"lead":   {Create: true, Read: true, Update: true},
+		"person": {Create: true, Read: true, Update: true},
+	}
+}
+
+func leadRepPerms() principal.Permissions {
+	return principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects:  leadObjectGrant(),
+		RowScope: principal.RowScopeOwn,
+	}
+}
+
+func leadManagerPerms() principal.Permissions {
+	return principal.Permissions{
+		RoleKeys: []string{"manager"},
+		Objects:  leadObjectGrant(),
+		RowScope: principal.RowScopeTeam,
+	}
+}
+
+// seedOwnerlessLead mints a lead through the real writer and then clears its
+// owner, which is the state an inbound capture or a departed rep leaves
+// behind. Seeded through CreateLead rather than an INSERT so the row carries
+// everything the production writer puts on it.
+func seedOwnerlessLead(t *testing.T, e *Env, name string) ids.LeadID {
+	t.Helper()
+	lead, _, err := e.People.CreateLead(e.Admin(), people.CreateLeadInput{
+		FullName: &name,
+		Source:   "manual",
+	})
+	if err != nil {
+		t.Fatalf("seeding lead %q: %v", name, err)
+	}
+	id := ids.From[ids.LeadKind](ids.UUID(lead.Id))
+	e.WsExec(t, `UPDATE lead SET owner_id = NULL WHERE id = $1`, ids.UUID(lead.Id))
+	return id
+}
+
+func assignLead(actor context.Context, e *Env, id ids.LeadID, dest ids.UUID) error {
+	owner := ids.From[ids.UserKind](dest)
+	_, err := e.People.UpdateLead(actor, id, people.UpdateLeadInput{OwnerID: &owner})
+	return err
+}
+
+// A lead nobody owns is the queue every inbound lead lands in, and the whole
+// point of the queue is that somebody can take work out of it. Three seats,
+// three different answers, and the shape of each is what this asserts: a rep
+// may take an ownerless lead for THEMSELVES and hand it to nobody else; a
+// Team Lead may route one to their own team and no further; an admin may
+// place it anywhere a live human seat exists.
+func TestAnOwnerlessLeadIsAssignableWithinTheAssignersOwnReach(t *testing.T) {
+	e := Setup(t)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, leadRepPerms())
+	manager := e.As(e.Rep2, []ids.UUID{e.Team1}, leadManagerPerms())
+
+	t.Run("a rep takes an ownerless lead for themselves", func(t *testing.T) {
+		id := seedOwnerlessLead(t, e, "Rep Self Pickup")
+		if err := assignLead(rep, e, id, e.Rep1); err != nil {
+			t.Fatalf("a rep assigning an ownerless lead to themselves → %v, want allowed", err)
+		}
+		got, err := e.People.GetLead(rep, id, 0)
+		if err != nil {
+			t.Fatalf("reading the lead back: %v", err)
+		}
+		if got.OwnerId == nil || ids.UUID(*got.OwnerId) != e.Rep1 {
+			t.Errorf("owner after self-assignment = %v, want Rep1", got.OwnerId)
+		}
+	})
+
+	t.Run("a rep may not hand an ownerless lead to a teammate", func(t *testing.T) {
+		id := seedOwnerlessLead(t, e, "Rep Hands Off")
+		err := assignLead(rep, e, id, e.Rep2)
+		if !errors.As(err, new(*auth.AssigneeNotAllowedError)) {
+			t.Fatalf("a rep assigning an ownerless lead to a teammate → %v, want AssigneeNotAllowedError", err)
+		}
+		mustStayUnowned(t, e, id)
+	})
+
+	t.Run("a Team Lead routes an ownerless lead to a teammate", func(t *testing.T) {
+		id := seedOwnerlessLead(t, e, "Manager Routes")
+		if err := assignLead(manager, e, id, e.Rep1); err != nil {
+			t.Fatalf("a manager assigning an ownerless lead to a live teammate → %v, want allowed", err)
+		}
+		got, err := e.People.GetLead(manager, id, 0)
+		if err != nil {
+			t.Fatalf("reading the lead back: %v", err)
+		}
+		if got.OwnerId == nil || ids.UUID(*got.OwnerId) != e.Rep1 {
+			t.Errorf("owner after the manager's assignment = %v, want Rep1", got.OwnerId)
+		}
+	})
+
+	t.Run("a Team Lead may not route outside their own team", func(t *testing.T) {
+		id := seedOwnerlessLead(t, e, "Manager Overreaches")
+		err := assignLead(manager, e, id, e.Rep3)
+		if !errors.As(err, new(*auth.AssigneeNotAllowedError)) {
+			t.Fatalf("a manager assigning to a user on another team → %v, want AssigneeNotAllowedError", err)
+		}
+		mustStayUnowned(t, e, id)
+	})
+
+	t.Run("an admin places an ownerless lead anywhere", func(t *testing.T) {
+		id := seedOwnerlessLead(t, e, "Admin Places")
+		if err := assignLead(e.Admin(), e, id, e.Rep3); err != nil {
+			t.Fatalf("an admin assigning an ownerless lead across teams → %v, want allowed", err)
+		}
+	})
+}
+
+// The destination is a seat, not a row in app_user. A suspended colleague, an
+// archived one and an agent are all present in the table and none of them can
+// do lead work, so handing them a lead files it where nobody will answer it.
+func TestALeadIsNeverAssignedToASeatThatCannotWorkIt(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+
+	cases := []struct {
+		name    string
+		prepare func(t *testing.T, target ids.UUID)
+	}{
+		{"suspended", func(t *testing.T, target ids.UUID) {
+			e.WsExec(t, `UPDATE app_user SET status = 'suspended' WHERE id = $1`, target)
+		}},
+		{"archived", func(t *testing.T, target ids.UUID) {
+			e.WsExec(t, `UPDATE app_user SET archived_at = now() WHERE id = $1`, target)
+		}},
+		{"an agent", func(t *testing.T, target ids.UUID) {
+			e.WsExec(t, `UPDATE app_user SET is_agent = true WHERE id = $1`, target)
+		}},
+		{"a read seat", func(t *testing.T, target ids.UUID) {
+			e.WsExec(t, `UPDATE app_user SET seat_type = 'read' WHERE id = $1`, target)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+" is refused as a destination", func(t *testing.T) {
+			id := seedOwnerlessLead(t, e, "Dest "+tc.name)
+			// Restored after the case so the seats stay shared fixtures.
+			before := e.WsCount(t, `SELECT count(*) FROM app_user WHERE id = $1`, e.Rep3)
+			if before != 1 {
+				t.Fatalf("Rep3 is not a seeded seat, so this case proves nothing")
+			}
+			tc.prepare(t, e.Rep3)
+			defer e.WsExec(t, `UPDATE app_user SET status = 'active', archived_at = NULL,
+				is_agent = false, seat_type = 'full' WHERE id = $1`, e.Rep3)
+
+			err := assignLead(admin, e, id, e.Rep3)
+			if !errors.As(err, new(*auth.AssigneeNotAllowedError)) {
+				t.Fatalf("assigning to a %s seat → %v, want AssigneeNotAllowedError", tc.name, err)
+			}
+			mustStayUnowned(t, e, id)
+		})
+	}
+}
+
+// The ownerless door is for ASSIGNMENT and nothing else. Without this, a seat
+// that may not touch the lead could ride a score or a status change in beside
+// the owner and rewrite a record it has no authority over.
+func TestTheOwnerlessDoorCarriesOwnershipAndNoOtherField(t *testing.T) {
+	e := Setup(t)
+	manager := e.As(e.Rep2, []ids.UUID{e.Team1}, leadManagerPerms())
+	id := seedOwnerlessLead(t, e, "Mixed Patch")
+
+	owner := ids.From[ids.UserKind](e.Rep1)
+	title := "VP Engineering"
+	_, err := e.People.UpdateLead(manager, id, people.UpdateLeadInput{
+		OwnerID: &owner,
+		Title:   &title,
+	})
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("an owner change carrying a title on an ownerless lead → %v, want ErrPermissionDenied", err)
+	}
+	mustStayUnowned(t, e, id)
+	if n := e.WsCount(t, `SELECT count(*) FROM lead WHERE id = $1 AND title = $2`, id.UUID, title); n != 0 {
+		t.Errorf("the refused patch wrote the title anyway")
+	}
+}
+
+// A lead that is already somebody's stays theirs. The ownerless arm widens the
+// door for a record nobody owns, and this is the assertion that it widened
+// nothing else: a stranger's lead answers the same refusal it always did.
+func TestAnotherSeatsLeadIsStillNotAssignableByAStranger(t *testing.T) {
+	e := Setup(t)
+	stranger := e.As(e.Rep3, []ids.UUID{e.Team2}, leadRepPerms())
+
+	name := "Owned By Rep1"
+	ownedBy := ids.From[ids.UserKind](e.Rep1)
+	lead, _, err := e.People.CreateLead(e.Admin(), people.CreateLeadInput{
+		FullName: &name, Source: "manual", OwnerID: &ownedBy,
+	})
+	if err != nil {
+		t.Fatalf("seeding an owned lead: %v", err)
+	}
+	id := ids.From[ids.LeadKind](ids.UUID(lead.Id))
+
+	if err := assignLead(stranger, e, id, e.Rep3); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a stranger taking a colleague's lead → %v, want ErrPermissionDenied", err)
+	}
+	got, err := e.People.GetLead(e.Admin(), id, 0)
+	if err != nil {
+		t.Fatalf("reading the lead back: %v", err)
+	}
+	if got.OwnerId == nil || ids.UUID(*got.OwnerId) != e.Rep1 {
+		t.Errorf("owner after the refused assignment = %v, want Rep1 untouched", got.OwnerId)
+	}
+}
+
+// The create path is the second way an owner reaches a lead, and it is the one
+// a plan that only guarded the update would have missed. CSV and mirror
+// imports reach the same body through CreateLeadTx.
+func TestACreatedLeadCannotNameAnIneligibleOwner(t *testing.T) {
+	e := Setup(t)
+	e.WsExec(t, `UPDATE app_user SET status = 'suspended' WHERE id = $1`, e.Rep3)
+	defer e.WsExec(t, `UPDATE app_user SET status = 'active' WHERE id = $1`, e.Rep3)
+
+	name := "Created For A Suspended Seat"
+	owner := ids.From[ids.UserKind](e.Rep3)
+	_, _, err := e.People.CreateLead(e.Admin(), people.CreateLeadInput{
+		FullName: &name, Source: "manual", OwnerID: &owner,
+	})
+	if !errors.As(err, new(*auth.AssigneeNotAllowedError)) {
+		t.Fatalf("creating a lead owned by a suspended seat → %v, want AssigneeNotAllowedError", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM lead WHERE full_name = $1`, name); n != 0 {
+		t.Errorf("the refused create landed %d lead rows, want 0", n)
+	}
+}
+
+func mustStayUnowned(t *testing.T, e *Env, id ids.LeadID) {
+	t.Helper()
+	if n := e.WsCount(t, `SELECT count(*) FROM lead WHERE id = $1 AND owner_id IS NULL`, id.UUID); n != 1 {
+		t.Errorf("the lead did not stay unowned after a refused assignment")
+	}
+}

--- a/backend/internal/compose/integration/leadassign_integration_test.go
+++ b/backend/internal/compose/integration/leadassign_integration_test.go
@@ -8,6 +8,7 @@ package integration
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/modules/people"
@@ -254,5 +255,51 @@ func mustStayUnowned(t *testing.T, e *Env, id ids.LeadID) {
 	t.Helper()
 	if n := e.WsCount(t, `SELECT count(*) FROM lead WHERE id = $1 AND owner_id IS NULL`, id.UUID); n != 1 {
 		t.Errorf("the lead did not stay unowned after a refused assignment")
+	}
+}
+
+// Two seats reaching for the same ownerless lead: one gets it, and the other
+// does not quietly take it away again.
+//
+// The gate turns on whether the lead is ownerless, so that fact has to be read
+// under the row lock. Read unlocked, both callers see "nobody owns this", both
+// pass, and the second write lands on a lead the first had just taken — a
+// record the loser could not otherwise have touched at all.
+func TestTwoSeatsRacingForOneOwnerlessLeadDoNotBothWin(t *testing.T) {
+	e := Setup(t)
+	id := seedOwnerlessLead(t, e, "Contested")
+	first := e.As(e.Rep1, []ids.UUID{e.Team1}, leadRepPerms())
+	second := e.As(e.Rep3, []ids.UUID{e.Team2}, leadRepPerms())
+
+	var running sync.WaitGroup
+	errs := make([]error, 2)
+	start := make(chan struct{})
+	for slot, actor := range []context.Context{first, second} {
+		running.Add(1)
+		go func(slot int, actor context.Context, dest ids.UUID) {
+			defer running.Done()
+			<-start
+			errs[slot] = assignLead(actor, e, id, dest)
+		}(slot, actor, []ids.UUID{e.Rep1, e.Rep3}[slot])
+	}
+	close(start)
+	running.Wait()
+
+	// Whoever the row ended up with, it is one of the two and the OTHER one's
+	// call must not have reported success: a refused assignment that answers
+	// nil is the shape that loses a lead silently.
+	if e.WsCount(t, `SELECT count(*) FROM lead WHERE id = $1 AND owner_id IS NULL`, id.UUID) == 1 {
+		t.Fatal("the contested lead ended ownerless: neither racer took it")
+	}
+	winner := 0
+	if e.WsCount(t, `SELECT count(*) FROM lead WHERE id = $1 AND owner_id = $2`, id.UUID, e.Rep3) == 1 {
+		winner = 1
+	}
+	if errs[winner] != nil {
+		t.Errorf("the seat that owns the lead reported %v, want success", errs[winner])
+	}
+	if errs[1-winner] == nil {
+		t.Errorf("the seat that did NOT get the lead reported success: " +
+			"the other call wrote nothing and said it had")
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -34697,7 +34697,18 @@ type UpdateLeadRequest struct {
 	CompanyName     *string              `json:"company_name,omitempty"`
 	Email           *openapi_types.Email `json:"email,omitempty"`
 	FullName        *string              `json:"full_name,omitempty"`
-	OwnerId         *openapi_types.UUID  `json:"owner_id,omitempty"`
+
+	// OwnerId Who owns this lead. The destination must be a seat that can be handed work — an
+	// active, unarchived human seat that is not read-only, and one inside the caller's own
+	// row scope — else `422 owner_not_assignable`, which names no more than that so the
+	// refusal does not disclose the roster or the team graph.
+	//
+	// A lead NOBODY owns is assignable by a caller who could not otherwise write it: that
+	// is the door out of the unassigned queue, and it admits an ownership-only change. A
+	// patch carrying any other field alongside `owner_id` is refused unless the caller can
+	// already write the row. To take an unowned lead for yourself, prefer
+	// `POST /records/lead/{id}/claim`, which is the same act with a version precondition.
+	OwnerId *openapi_types.UUID `json:"owner_id,omitempty"`
 
 	// ProjectId The body of work this lead belongs to; carries no same-company guard (a lead has no company).
 	ProjectId *openapi_types.UUID `json:"project_id,omitempty"`

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -155,41 +155,6 @@ func (s *Store) dealUpdatePatch(ctx context.Context, tx pgx.Tx, current crmcontr
 	return p, nil
 }
 
-// applyDealLinkPatches sets the fields that point at another record. They are
-// grouped because they share an obligation the plain columns do not: a link is
-// only settable to a target the caller may see, so each one gates before it
-// patches (auth.EnsureLinkTarget), and a miss reads as not-found rather than
-// disclosing that the row exists.
-//
-// The project pointer is the exception, and it needs WRITE authority
-// (ensureProjectAttachable). Pointing a deal at a project is not a read of the
-// project: winning that deal advances the project's phase and writes its
-// history (startDeliveryForWonDeal), and that advance deliberately does not
-// re-check the caller's authority over the project — the authority to attach
-// is what stands in for it. A visibility-only gate here would let any seat
-// attach any project in the workspace and then force it into `delivering`.
-func applyDealLinkPatches(ctx context.Context, tx pgx.Tx,
-	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch, clearPartner bool,
-	ensurePartner EnsurePartner, ensureProjectAttachable EnsureProjectAttachable,
-) error {
-	if in.OrganizationID != nil {
-		if err := auth.EnsureLinkTarget(ctx, tx, "organization", in.OrganizationID.UUID); err != nil {
-			return err
-		}
-		p.Set("organization_id", current.OrganizationId, *in.OrganizationID)
-	}
-	if in.OwnerID != nil {
-		p.Set("owner_id", current.OwnerId, *in.OwnerID)
-	}
-	if in.ProjectID != nil {
-		if err := ensureProjectAttachable(ctx, tx, in.ProjectID.UUID); err != nil {
-			return err
-		}
-		p.Set("project_id", current.ProjectId, *in.ProjectID)
-	}
-	return applyPartnerAttributionPatch(ctx, tx, current, in, p, clearPartner, ensurePartner)
-}
-
 // applyPartnerAttributionPatch writes the partner link and what that partner
 // did for the deal as ONE fact, because the schema stores them as one: the
 // deal_partner_attribution_pairing CHECK rejects either half alone.

--- a/backend/internal/modules/deals/deallinks.go
+++ b/backend/internal/modules/deals/deallinks.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// applyDealLinkPatches sets the fields that point at another record. They are
+// grouped because they share an obligation the plain columns do not: a link is
+// only settable to a target the caller may see, so each one gates before it
+// patches (auth.EnsureLinkTarget), and a miss reads as not-found rather than
+// disclosing that the row exists.
+//
+// The project pointer is the exception, and it needs WRITE authority
+// (ensureProjectAttachable). Pointing a deal at a project is not a read of the
+// project: winning that deal advances the project's phase and writes its
+// history (startDeliveryForWonDeal), and that advance deliberately does not
+// re-check the caller's authority over the project — the authority to attach
+// is what stands in for it. A visibility-only gate here would let any seat
+// attach any project in the workspace and then force it into `delivering`.
+func applyDealLinkPatches(ctx context.Context, tx pgx.Tx,
+	current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch, clearPartner bool,
+	ensurePartner EnsurePartner, ensureProjectAttachable EnsureProjectAttachable,
+) error {
+	if in.OrganizationID != nil {
+		if err := auth.EnsureLinkTarget(ctx, tx, "organization", in.OrganizationID.UUID); err != nil {
+			return err
+		}
+		p.Set("organization_id", current.OrganizationId, *in.OrganizationID)
+	}
+	if in.OwnerID != nil {
+		// A named owner is an assignment, and the destination is checked the
+		// same way a lead's is: an active human seat inside the caller's own
+		// write scope. Without it a deal could be handed to a suspended seat
+		// or out of the assigner's reach, which the FK alone does not refuse.
+		if err := auth.EnsureAssignee(ctx, tx, in.OwnerID.UUID); err != nil {
+			return err
+		}
+		p.Set("owner_id", current.OwnerId, *in.OwnerID)
+	}
+	if in.ProjectID != nil {
+		if err := ensureProjectAttachable(ctx, tx, in.ProjectID.UUID); err != nil {
+			return err
+		}
+		p.Set("project_id", current.ProjectId, *in.ProjectID)
+	}
+	return applyPartnerAttributionPatch(ctx, tx, current, in, p, clearPartner, ensurePartner)
+}

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -159,6 +159,17 @@ func createLeadInTx(ctx context.Context, tx pgx.Tx, in CreateLeadInput, by strin
 			return crmcontracts.Lead{}, false, err
 		}
 	}
+	// A named owner on a create is an assignment, and it is checked here
+	// rather than in readyLeadCreate because the question needs a
+	// transaction. Both entry points reach this body — CreateLead and
+	// CreateLeadTx, the latter being what CSV and mirror imports call — so
+	// this is the one place that sees every created lead. Omitting the owner
+	// stays the unassigned queue's own case and asks nothing.
+	if in.OwnerID != nil {
+		if err := auth.EnsureAssignee(ctx, tx, in.OwnerID.UUID); err != nil {
+			return crmcontracts.Lead{}, false, err
+		}
+	}
 	id, err := insertLeadRow(ctx, tx, in, active, by)
 	if err != nil {
 		return crmcontracts.Lead{}, false, err

--- a/backend/internal/modules/people/lead_update.go
+++ b/backend/internal/modules/people/lead_update.go
@@ -231,7 +231,7 @@ func blank(value *string) bool { return value == nil || *value == "" }
 // caller's transaction. active names the workspace's custom-field columns
 // (fetched before the tx opened).
 func (s *Store) updateLeadTx(ctx context.Context, tx pgx.Tx, id ids.LeadID, in UpdateLeadInput, active []fieldcatalog.Column) (crmcontracts.Lead, error) {
-	if err := auth.EnsureWritable(ctx, tx, "lead", id.UUID); err != nil {
+	if err := ensureLeadUpdateAuthority(ctx, tx, id, in); err != nil {
 		return crmcontracts.Lead{}, err
 	}
 	current, err := readLead(ctx, tx, id, storekit.LiveOnly, active)

--- a/backend/internal/modules/people/leadassign.go
+++ b/backend/internal/modules/people/leadassign.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// ensureLeadUpdateAuthority is the write gate in front of a lead update, and
+// it asks a different question when the update hands the lead to somebody.
+//
+// An ordinary edit stays EnsureWritable's: a lead nobody owns is nobody's to
+// rewrite. An ASSIGNMENT is the one act that must reach an ownerless lead —
+// otherwise the queue every inbound lead lands in has no door out for a Team
+// Lead, and the rep's only exit is the claim verb, which cannot hand a lead to
+// a colleague.
+//
+// The exception is deliberately narrow. It admits an ownership-ONLY patch, so
+// the ownerless arm never becomes a way to rewrite a lead's score, status or
+// identity on the way past. A caller who may already write the row keeps every
+// field, exactly as before; a caller who may not gets the owner and nothing
+// else.
+func ensureLeadUpdateAuthority(ctx context.Context, tx pgx.Tx, id ids.LeadID, in UpdateLeadInput) error {
+	if in.OwnerID == nil {
+		return auth.EnsureWritable(ctx, tx, "lead", id.UUID)
+	}
+	if !ownershipOnlyLeadUpdate(in) {
+		// Mixed content: the write arm answers, so an ownerless lead refuses
+		// the whole patch rather than admitting the fields riding along with
+		// the owner.
+		if err := auth.EnsureWritable(ctx, tx, "lead", id.UUID); err != nil {
+			return err
+		}
+	}
+	return auth.EnsureAssignable(ctx, tx, "lead", id.UUID, in.OwnerID.UUID)
+}
+
+// ownershipOnlyLeadUpdate answers whether this patch changes the owner and
+// NOTHING else.
+//
+// Written as an exhaustive read of the input rather than a count of set
+// fields: a new field added to UpdateLeadInput must be considered here, and a
+// reader adding one sees the list it has to join. IfVersion and Trail are
+// absent on purpose — a version precondition is not a field being written, and
+// the trail names the write rather than changing the row.
+func ownershipOnlyLeadUpdate(in UpdateLeadInput) bool {
+	return len(in.Clear) == 0 && len(in.CustomFields) == 0 &&
+		in.FullName == nil && in.Email == nil && in.Title == nil &&
+		in.CompanyName == nil && in.CandidateOrgKey == nil &&
+		in.Status == nil && in.Source == nil && in.Score == nil &&
+		in.ScoreOverrideReason == nil && !in.ClearScoreOverride &&
+		in.ProjectID == nil
+}

--- a/backend/internal/modules/people/leadassign.go
+++ b/backend/internal/modules/people/leadassign.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -29,6 +30,16 @@ import (
 func ensureLeadUpdateAuthority(ctx context.Context, tx pgx.Tx, id ids.LeadID, in UpdateLeadInput) error {
 	if in.OwnerID == nil {
 		return auth.EnsureWritable(ctx, tx, "lead", id.UUID)
+	}
+	// The LOCK comes before the decision, the same order ClaimOwnership takes
+	// and for the same reason. Whether this lead is ownerless is the fact the
+	// whole gate turns on, and reading it unlocked leaves an interval in which
+	// somebody else claims it: two reps both pass the ownerless arm, both
+	// write, and the second silently takes a lead off the first — a record
+	// neither rep could otherwise have touched. Holding the row makes the
+	// loser's gate see the winner's name.
+	if _, err := storekit.LockRow(ctx, tx, "lead", id.UUID, storekit.LiveOnly); err != nil {
+		return err
 	}
 	if !ownershipOnlyLeadUpdate(in) {
 		// Mixed content: the write arm answers, so an ownerless lead refuses

--- a/backend/internal/modules/people/leadrouting.go
+++ b/backend/internal/modules/people/leadrouting.go
@@ -256,6 +256,13 @@ func candidateOwners(cfg RoutingConfig) []ids.UserID {
 // ownerCapacity answers, for each candidate, whether the user can take
 // work (active, unarchived) and how many open leads they already hold —
 // the cap counts open (new/contacted/engaged), live leads, however they were assigned.
+// The eligibility half here says the same thing auth.EnsureAssignee says on
+// the manual path — a live human seat that can do the work — and the two are
+// deliberately kept in step: a pool that could route to a seat a manager is
+// forbidden to assign to would let the machine place work no person could
+// have placed. The SCOPE half of EnsureAssignee has no meaning here, because
+// routing runs as the system principal and the pool is the configuration's
+// own list.
 func ownerCapacity(ctx context.Context, tx pgx.Tx, candidates []ids.UserID) (active map[ids.UserID]bool, openLoad map[ids.UserID]int, err error) {
 	active = map[ids.UserID]bool{}
 	openLoad = map[ids.UserID]int{}
@@ -268,6 +275,7 @@ func ownerCapacity(ctx context.Context, tx pgx.Tx, candidates []ids.UserID) (act
 		  LEFT JOIN lead l ON l.owner_id = u.id
 		       AND l.status IN ('new','contacted','engaged') AND l.archived_at IS NULL
 		 WHERE u.id = ANY($1) AND u.status = 'active' AND u.archived_at IS NULL
+		       AND NOT u.is_agent AND u.seat_type <> 'read'
 		 GROUP BY u.id`, candidates)
 	if err != nil {
 		return nil, nil, err

--- a/backend/internal/modules/projects/transfer.go
+++ b/backend/internal/modules/projects/transfer.go
@@ -91,17 +91,20 @@ func (s *Store) TransferProjectOwnership(ctx context.Context, in TransferProject
 }
 
 // ensureActiveOwner refuses a receiver who could not be handed a project by a
-// single update either: app_user carries no row scope, so membership and an
-// active status are the whole check.
+// single update either.
+//
+// auth.EnsureAssignee is that question, asked once for every record kind: an
+// active, unarchived, non-agent seat that can write, inside the caller's own
+// write scope. This function keeps its name and its own error so the handover
+// contract's 422 is unchanged, and delegates the rule rather than keeping a
+// second, weaker copy of it — the copy here checked status and archival only,
+// so it admitted an agent seat and a read seat.
 func ensureActiveOwner(ctx context.Context, tx pgx.Tx, owner ids.UserID) error {
-	var active bool
-	if err := tx.QueryRow(ctx,
-		`SELECT EXISTS (SELECT 1 FROM app_user WHERE id = $1 AND status = 'active' AND archived_at IS NULL)`,
-		owner).Scan(&active); err != nil {
+	if err := auth.EnsureAssignee(ctx, tx, owner.UUID); err != nil {
+		if errors.As(err, new(*auth.AssigneeNotAllowedError)) {
+			return &OwnerNotActiveError{}
+		}
 		return fmt.Errorf("check receiving owner: %w", err)
-	}
-	if !active {
-		return &OwnerNotActiveError{}
 	}
 	return nil
 }

--- a/backend/internal/modules/projects/update.go
+++ b/backend/internal/modules/projects/update.go
@@ -58,6 +58,16 @@ func (s *Store) UpdateProject(ctx context.Context, id ids.ProjectID, in UpdatePr
 		if err := auth.EnsureWritable(ctx, tx, projectObject, id.UUID); err != nil {
 			return err
 		}
+		// A named owner is an assignment, and the destination is asked the
+		// same question the bulk handover asks. The two used to disagree —
+		// the handover refused an inactive receiver and this path took any
+		// row app_user held — so a project could be handed one at a time to
+		// a seat the handover would have refused in bulk.
+		if in.OwnerID != nil {
+			if err := auth.EnsureAssignee(ctx, tx, in.OwnerID.UUID); err != nil {
+				return err
+			}
+		}
 		// current reads WITH active columns so the patch's audit
 		// before-image carries the honest pre-update cf values.
 		current, err := readProject(ctx, tx, id, storekit.LiveOnly, active)
@@ -102,11 +112,11 @@ func (s *Store) UpdateProject(ctx context.Context, id ids.ProjectID, in UpdatePr
 	return out, err
 }
 
-// projectUpdatePatch builds the column patch. Every FK it can set points
-// at app_user, which carries no row scope of its own — any workspace
-// member may own a project — so the composite FK is the whole check; the
-// anchor company is not re-pointable here, because moving a project to
-// another company would silently orphan the deals that inherited it.
+// projectUpdatePatch builds the column patch. The owner it can set is gated by
+// the caller (auth.EnsureAssignee) rather than here, because the question needs
+// a transaction and this builds a patch; the anchor company is not re-pointable
+// here at all, because moving a project to another company would silently
+// orphan the deals that inherited it.
 // The date columns a project carries. Each is read by the patch builder, the
 // clearable set and the row read, and a literal repeated across the three is
 // how the three come to disagree about which column they mean.

--- a/backend/internal/platform/auth/assignscope.go
+++ b/backend/internal/platform/auth/assignscope.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// AssigneeNotAllowedError refuses a proposed owner: 422, one code for every
+// reason.
+//
+// One code on purpose. "Not a user here", "suspended", "an agent", "a read
+// seat" and "on a team you do not lead" are five different facts, and telling
+// them apart would let a rep enumerate the roster and read the team graph off
+// the refusals. The caller's remedy is the same in all five — pick somebody the
+// picker offered — so the sentence names the rule rather than the miss.
+type AssigneeNotAllowedError struct{}
+
+func (e *AssigneeNotAllowedError) Error() string {
+	return "the owner must be an active colleague you may assign work to"
+}
+
+// FieldFault names owner_id, the field the caller actually sent.
+func (e *AssigneeNotAllowedError) FieldFault() (field, code, message string) {
+	return "owner_id", "owner_not_assignable", e.Error()
+}
+
+// assigneeEligible is the destination arm, and it is deliberately NOT the
+// write arm.
+//
+// A seat may be handed work when it is a live human seat that can do the work —
+// active, unarchived, not an agent, and holding a seat that can write — AND it
+// falls inside the caller's own write scope. The scope half reuses
+// ownerPredicate so the rule is spelled once: after the assignment lands, the
+// row sits inside the write scope the caller already had, which is what makes
+// "assign" incapable of pushing a record somewhere its assigner cannot follow.
+//
+// Held by: TestSeatEligibilityIsAskedTheSameWayEverywhereItIsAsked (backend/gates/assigneeeligibility_test.go)
+//
+// The grant arm of writeAuthorityPredicateAs is deliberately absent. A share
+// names ONE record; it says who may change that row, never who may receive
+// other rows. Reading it here would let a single write share on one lead widen
+// the assigner's whole destination pool.
+func assigneeEligible(p principal.Principal, alias string, arg func(any) int) string {
+	return fmt.Sprintf(
+		`%[1]s.status = 'active' AND %[1]s.archived_at IS NULL
+		   AND NOT %[1]s.is_agent AND %[1]s.seat_type <> 'read'
+		   AND %[2]s`,
+		alias, ownerPredicate(p, arg, unownedIsNobodys)(alias))
+}
+
+// EnsureAssignee answers whether the caller may hand work to dest.
+//
+// The scope question is asked of a HYPOTHETICAL row: the app_user row is
+// selected with its own id aliased as owner_id, so the write-scope owner
+// predicate — which knows only how to read an owner_id — answers "would a row
+// owned by dest be mine to change?". That is the same predicate the write path
+// runs, rather than a second reading of the same rule that could drift from it.
+//
+// An unbounded seat still passes through the eligibility half: admin may assign
+// to anyone, and "anyone" has never included a suspended seat or an agent.
+func EnsureAssignee(ctx context.Context, tx pgx.Tx, dest ids.UUID) error {
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return err
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	destPos := arg(dest)
+
+	var permitted bool
+	if err := tx.QueryRow(ctx, fmt.Sprintf(
+		`SELECT EXISTS (SELECT 1 FROM (
+		   SELECT id AS owner_id, status, archived_at, is_agent, seat_type
+		   FROM app_user WHERE id = $%d) u WHERE %s)`,
+		destPos, assigneeEligible(p, "u", arg)), args...).Scan(&permitted); err != nil {
+		return err
+	}
+	return refuseIneligibleAssignee(permitted)
+}
+
+// refuseIneligibleAssignee turns the eligibility answer into the refusal.
+//
+// Its own named helper so the auth package's own census can see that
+// EnsureAssignee refuses: the refusal is a TYPED error carrying a field fault
+// (422 naming owner_id), not one of the shared sentinels the census greps for,
+// and a gate whose refusal nothing recognizes is one nobody notices going
+// quiet.
+func refuseIneligibleAssignee(permitted bool) error {
+	if permitted {
+		return nil
+	}
+	return &AssigneeNotAllowedError{}
+}
+
+// EnsureAssignable is the gate in front of handing a row to somebody else.
+//
+// Two halves, and both must hold. The SOURCE half asks whether this row is the
+// caller's to hand on: theirs to change already, or ownerless — the same door
+// EnsureClaimable opens, because a record nobody owns is exactly the one a
+// manager is supposed to be able to route without claiming it first. The
+// DESTINATION half is EnsureAssignee.
+//
+// Splitting them is what makes the refusals honest: a source the caller may not
+// touch is 403/404 through the write arm's own contracts, while a destination
+// they may not assign to is 422 naming owner_id. Collapsing the two would
+// report "you may not edit this lead" for a perfectly writable lead handed to a
+// suspended colleague.
+//
+// Human-only on the ownerless arm, matching ClaimRecord. Putting a name on a
+// record nobody owns is a person's act; an agent may still hand on a row its
+// delegated authority already covers.
+func EnsureAssignable(ctx context.Context, tx pgx.Tx, table string, id, dest ids.UUID) error {
+	if err := ensureAssignableSource(ctx, tx, table, id); err != nil {
+		return err
+	}
+	return EnsureAssignee(ctx, tx, dest)
+}
+
+// ensureAssignableSource is EnsureAssignable's source half: writable already,
+// or ownerless and the caller is a human.
+func ensureAssignableSource(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) error {
+	if !ownerScopedTables[table] {
+		return fmt.Errorf("auth: %q is not a row-scoped table", table)
+	}
+	if err := EnsureVisibleLive(ctx, tx, table, id); err != nil {
+		return err
+	}
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return err
+	}
+	if Unbounded(p) {
+		return nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idPos := arg(id)
+	clause := writeAuthorityPredicate(p, table, arg)
+
+	// Two answers, not one: whether the row is writable, and whether it is
+	// ownerless. A single EXISTS over the OR would refuse an agent on an
+	// ownerless row with the same silence as a row that is somebody else's,
+	// and the ownerless arm is the one that carries the human-only rule.
+	var writable, unowned bool
+	if err := tx.QueryRow(ctx, fmt.Sprintf(
+		`SELECT COALESCE(bool_or(%[3]s), false), COALESCE(bool_or(%[1]s.owner_id IS NULL), false)
+		   FROM %[1]s WHERE id = $%[2]d`, table, idPos, clause),
+		args...).Scan(&writable, &unowned); err != nil {
+		return err
+	}
+	if writable {
+		return nil
+	}
+	if !unowned {
+		return apperrors.ErrPermissionDenied
+	}
+	// RequireHuman rather than a type comparison: it also refuses a buyer
+	// principal, which is a seat the raw check would have admitted onto the
+	// ownerless arm.
+	return RequireHuman(ctx)
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -119,7 +119,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (130)
+## Census (131)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -135,6 +135,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `aitaskwiring_test.go` | H2 | The census says a site EXISTS; this says a process role runs it. |
 | `analyticsscope_test.go` | H2 | Every path that renders a report spec's population applies that spec's row narrowings. |
 | `approvalselfonlyreaders_test.go` | H2 | Every approvals reader that filters rows by the decision grants also applies the self-only narrowing. |
+| `assigneeeligibility_test.go` | H2 | A seat's fitness to receive work has ONE spelling, wherever it is asked. |
 | `assurancerules_test.go` | H3 | Every assurance rule proves both halves of its judgement. |
 | `audiencereaders_test.go` | H2 | A message's AUDIENCE says who may read its content. |
 | `audienceretractioncallers_test.go` | H3 | activities.RetractDerivedForActivityTx documents that it is not atomic with the narrowing it follows, and the sentence is only true while every caller is an async consumer reacting to a COMMITTED audience change. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2972,8 +2972,10 @@ export interface paths {
          *     `write` share) moves to `to_owner_id`; archived projects and projects the caller cannot
          *     write are left where they are and are not counted. Each moved project gets its own
          *     `update` audit row with the `owner_id` before/after images, so its field history shows
-         *     the move, and its own `project.updated` event. `to_owner_id` must name an active user of
-         *     the workspace, else `422`.
+         *     the move, and its own `project.updated` event. `to_owner_id` must name a seat that can be
+         *     handed work — an active, unarchived human seat that is not read-only, and one inside the
+         *     caller's own row scope — else `422`. The same rule gates `updateProject.owner_id`, so a
+         *     destination refused in bulk is refused one project at a time.
          */
         post: operations["transferProjectOwnership"];
         delete?: never;
@@ -24411,7 +24413,19 @@ export interface components {
             score?: number | null;
             /** @description Written reason for the Commercial Judgement override (formulas §3.1). REQUIRED when `score` is set (422 otherwise); the override is sticky — it suppresses recompute until cleared. */
             score_override_reason?: string | null;
-            /** Format: uuid */
+            /**
+             * Format: uuid
+             * @description Who owns this lead. The destination must be a seat that can be handed work — an
+             *     active, unarchived human seat that is not read-only, and one inside the caller's own
+             *     row scope — else `422 owner_not_assignable`, which names no more than that so the
+             *     refusal does not disclose the roster or the team graph.
+             *
+             *     A lead NOBODY owns is assignable by a caller who could not otherwise write it: that
+             *     is the door out of the unassigned queue, and it admits an ownership-only change. A
+             *     patch carrying any other field alongside `owner_id` is refused unless the caller can
+             *     already write the row. To take an unowned lead for yourself, prefer
+             *     `POST /records/lead/{id}/claim`, which is the same act with a version precondition.
+             */
             owner_id?: string | null;
         } & {
             [key: string]: unknown;

--- a/frontend/src/screens/claimrecord.ts
+++ b/frontend/src/screens/claimrecord.ts
@@ -1,0 +1,38 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { api } from "../api/client";
+import { ifMatch, requireVersion } from "../api/version";
+import { throwProblem } from "./common";
+
+/** The record kinds the claim endpoint accepts. */
+export type ClaimableRecordType = "organization" | "person" | "lead" | "deal";
+
+// useClaimRecord is the claim door: POST /records/{type}/{id}/claim makes the
+// caller the owner of an unowned record (or re-confirms one already theirs)
+// and refreshes what shows it. Used wherever an owner control lets a reader
+// pick themselves on a record nobody owns.
+//
+// Its own module rather than a company screen's export, because it is not the
+// company's: an ownerless record of every claimable kind needs this same door,
+// and the one that lived beside CompanyOwnerControl was reused by nothing for
+// exactly as long as it looked like company code.
+export function useClaimRecord(
+  recordType: ClaimableRecordType,
+  id: string,
+  version: number | undefined,
+) {
+  const queryClient = useQueryClient();
+  return async () => {
+    const { error } = await api.POST("/records/{record_type}/{id}/claim", {
+      params: {
+        path: { record_type: recordType, id },
+        ...ifMatch(requireVersion(version)),
+      },
+    });
+    if (error) {
+      throwProblem(error);
+    }
+    await queryClient.invalidateQueries({ queryKey: [`${recordType}s`] });
+    await queryClient.invalidateQueries({ queryKey: [`${recordType}360`, id] });
+    await queryClient.invalidateQueries({ queryKey: [recordType, id] });
+  };
+}

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -17,6 +17,7 @@ import { ProvenanceTag } from "../design-system/trust";
 import { formatDateAbbrev, formatNumber } from "../format/format";
 import { useLocale, usePlural, useT } from "../i18n";
 import { ArchiveAction } from "./archive";
+import { useClaimRecord } from "./claimrecord";
 import {
   provenanceOf,
   throwProblem,
@@ -504,32 +505,6 @@ export function useCompanyVerbRefusal(org: Organization): string | undefined {
     archived: t("record.archivedReadOnly"),
     notYours: t("record.notYoursToChange"),
   });
-}
-
-// useClaimRecord is the claim door: POST /records/{type}/{id}/claim makes the
-// caller the owner of an unowned record (or re-confirms one already theirs)
-// and refreshes what shows it. Used wherever an owner control lets a reader
-// pick themselves on a record nobody owns.
-export function useClaimRecord(
-  recordType: "organization" | "person" | "lead" | "deal",
-  id: string,
-  version: number | undefined,
-) {
-  const queryClient = useQueryClient();
-  return async () => {
-    const { error } = await api.POST("/records/{record_type}/{id}/claim", {
-      params: {
-        path: { record_type: recordType, id },
-        ...ifMatch(requireVersion(version)),
-      },
-    });
-    if (error) {
-      throwProblem(error);
-    }
-    await queryClient.invalidateQueries({ queryKey: [`${recordType}s`] });
-    await queryClient.invalidateQueries({ queryKey: [`${recordType}360`, id] });
-    await queryClient.invalidateQueries({ queryKey: [recordType, id] });
-  };
 }
 
 function CompanyEditAction({

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -2065,11 +2065,24 @@ describe("LeadScreen — score explain + override (P-10)", () => {
 });
 
 describe("LeadScreen — owner display + assign to me (P-11)", () => {
-  it("shows Unassigned and assigning to yourself PATCHes owner_id to the current user", async () => {
-    let patchBody: unknown = null;
-    stubFetchWithMe(async (url, method, request) => {
+  // The server refuses a PATCH against a lead nobody owns — an ownerless row is
+  // nobody's to change — so the request this asserts is the claim, not the
+  // patch. Asserting the patch is what let the 403 ship: the stub answered a
+  // request the real backend would have rejected.
+  it("shows Unassigned and taking an unowned lead yourself goes through the claim door", async () => {
+    let claimed = false;
+    let patched = false;
+    stubFetchWithMe(async (url, method) => {
+      if (method === "POST" && url.includes("/records/lead/l-1/claim")) {
+        claimed = true;
+        return jsonResponse({
+          record_type: "lead",
+          record_id: "l-1",
+          owner_id: "u-9",
+        });
+      }
       if (method === "PATCH" && url.includes("/leads/l-1")) {
-        patchBody = JSON.parse(await request.text());
+        patched = true;
         return jsonResponse({ ...lead, owner_id: "u-9", version: 2 });
       }
       if (url.includes("/users")) {
@@ -2097,8 +2110,8 @@ describe("LeadScreen — owner display + assign to me (P-11)", () => {
       await screen.findByRole("option", { name: "Assign to me" }),
     );
 
-    await waitFor(() => expect(patchBody).toBeTruthy());
-    expect(patchBody).toMatchObject({ owner_id: "u-9" });
+    await waitFor(() => expect(claimed).toBe(true));
+    expect(patched).toBe(false);
   });
 
   it("hides Assign to me when the lead is already owned by the current user", async () => {

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -2114,6 +2114,31 @@ describe("LeadScreen — owner display + assign to me (P-11)", () => {
     expect(patched).toBe(false);
   });
 
+  // The fixture above says `writable: true`, which an ownerless lead is NOT:
+  // the write arm refuses a row nobody owns, and the server answers the
+  // read with `writable: false`. A test that only ever renders the writable
+  // fixture cannot see the control being shut, which is how the first fix for
+  // this shipped with the picker still disabled for every ordinary seat.
+  it("offers assignment on an unowned lead the reader may not otherwise write", async () => {
+    stubFetchWithMe(async (url) => {
+      if (url.includes("/leads/l-1")) {
+        return jsonResponse({ ...lead, owner_id: null, writable: false });
+      }
+      if (url.includes("/users")) {
+        return jsonResponse({
+          data: [{ id: "u-9", display_name: "Me" }],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      return undefined;
+    }, "u-9");
+    render(<LeadScreen id="l-1" />);
+
+    await waitFor(() => expect(screen.getByText("Unassigned")).toBeTruthy());
+    const assign = await screen.findByRole("button", { name: "Assign" });
+    expect(assign.hasAttribute("disabled")).toBe(false);
+  });
+
   it("hides Assign to me when the lead is already owned by the current user", async () => {
     const { urls } = stubFetchWithMe(
       async () => jsonResponse({ ...lead, owner_id: "u-9" }),

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -2139,6 +2139,41 @@ describe("LeadScreen — owner display + assign to me (P-11)", () => {
     expect(assign.hasAttribute("disabled")).toBe(false);
   });
 
+  // Dropping the per-row half of the write answer must not drop the other two.
+  // A read seat cannot be handed work and the server refuses its assignment, so
+  // an enabled control here would only ever fail in the reader's face.
+  it("offers no enabled assignment to a seat that may not write leads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: Request) => {
+        if (request.url.endsWith("/v1/connectors")) {
+          return jsonResponse({ data: [] });
+        }
+        if (request.url.endsWith("/v1/me")) {
+          return jsonResponse({
+            user: { id: "u-9", display_name: "Me" },
+            roles: ["read_only"],
+            teams: [],
+            authorization: meFixture({ seat: "read", allow: LEAD_GRANTS })
+              .authorization,
+          });
+        }
+        if (request.url.includes("/leads/l-1")) {
+          return jsonResponse({ ...lead, owner_id: null, writable: false });
+        }
+        return jsonResponse({
+          data: [],
+          page: { next_cursor: null, has_more: false },
+        });
+      }),
+    );
+    render(<LeadScreen id="l-1" />);
+
+    await waitFor(() => expect(screen.getByText("Unassigned")).toBeTruthy());
+    const assign = await screen.findByRole("button", { name: "Assign" });
+    expect(assign.hasAttribute("disabled")).toBe(true);
+  });
+
   it("hides Assign to me when the lead is already owned by the current user", async () => {
     const { urls } = stubFetchWithMe(
       async () => jsonResponse({ ...lead, owner_id: "u-9" }),

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -831,6 +831,17 @@ function useLeadPatch(lead: Lead, id: string, onChanged: () => void) {
   });
   const save = (body: UpdateLeadRequest) => patch.mutate(write(body));
 
+  // Taking an unowned lead is a CLAIM, not a patch: the write arm refuses an
+  // ownerless row on purpose, so the request that works here is the claim
+  // door. It lives beside `patch` rather than in the control that calls it
+  // because the page states what a write refused in ONE banner, and a refusal
+  // thrown inside a rail that is not currently rendered reaches nobody.
+  const claim = useMutation({
+    mutationKey: ["lead-claim", lead.id],
+    mutationFn: useClaimRecord("lead", lead.id, lead.version),
+    onSuccess: onChanged,
+  });
+
   // The inline rows await their save and render what it throws, so they need a
   // promise rather than the mutation's fire-and-forget. mutateAsync is that
   // same mutation — one PATCH shape, one If-Match, one invalidation.
@@ -838,7 +849,25 @@ function useLeadPatch(lead: Lead, id: string, onChanged: () => void) {
     await patch.mutateAsync(write(body));
   };
 
-  return { patch, readOnly, readOnlyReason, save, saveField };
+  return { patch, claim, readOnly, readOnlyReason, save, saveField };
+}
+
+// What the page's write refused, stated once for both of them.
+//
+// Two mutations, one sentence: the patch every field goes through, and the
+// claim that takes an unowned lead. They are alternatives — a pick is one or
+// the other — so whichever refused is the one to name.
+function LeadWriteRefusal({ writer }: Readonly<{ writer: LeadWriter }>) {
+  const t = useT();
+  const error = writer.patch.error ?? writer.claim.error;
+  if (!error) {
+    return null;
+  }
+  return (
+    <Callout tone="danger" live="alert">
+      {problemMessageOf(error, t)}
+    </Callout>
+  );
 }
 
 /**
@@ -915,10 +944,8 @@ function LeadRail({
   writer: LeadWriter;
   terminalReasonId: string;
 }>) {
-  const { readOnly } = writer;
   const t = useT();
   const me = useMe();
-  const claim = useClaimRecord("lead", lead.id, lead.version);
   return (
     <div className="record-stack">
       <LeadIdentityFields
@@ -932,8 +959,19 @@ function LeadRail({
           <LeadOwner
             lead={lead}
             meId={me.data?.user?.id}
-            refusedReasonId={readOnly ? terminalReasonId : undefined}
-            pending={writer.patch.isPending || readOnly}
+            // Assignment asks a DIFFERENT question from editing, so it does
+            // not take the editor's answer. `writable` is false on a lead
+            // nobody owns — that is the write arm being right — and gating
+            // this control on it would shut the only door out of the
+            // unassigned queue, which is the bug this whole change is about.
+            // An ARCHIVED lead is still refused: a terminal record is nobody's
+            // to hand on.
+            refusedReasonId={lead.archived_at ? terminalReasonId : undefined}
+            pending={
+              writer.patch.isPending ||
+              writer.claim.isPending ||
+              Boolean(lead.archived_at)
+            }
             // A lead nobody owns is nobody's to change, so the PATCH this
             // control used to send for EVERY pick was refused for the one
             // pick a rep makes most: taking an unassigned lead. Picking
@@ -942,7 +980,7 @@ function LeadRail({
             // stays a patch, which the assignment gate answers.
             onAssign={(ownerId) =>
               !lead.owner_id && ownerId === me.data?.user?.id
-                ? claim()
+                ? writer.claim.mutate()
                 : writer.save({ owner_id: ownerId })
             }
           />
@@ -1990,11 +2028,7 @@ function LeadRecord({
               it REFUSES is stated where both are visible. In the ladder panel
               this reached only the Overview tab, and a rail write refused
               while the reader was on History said nothing at all. */}
-          {writer.patch.isError && (
-            <Callout tone="danger" live="alert">
-              {problemMessageOf(writer.patch.error, t)}
-            </Callout>
-          )}
+          <LeadWriteRefusal writer={writer} />
           {/* Stated ONCE for the page. Every control the closure refuses
               points at this element by id, so a screen reader reaches it from
               each of them without the sentence being printed beside all six. */}

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -56,6 +56,7 @@ import { leadIdentityName } from "../format/leadname";
 import { viewerZone } from "../format/timezone";
 import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { useClaimRecord } from "./claimrecord";
 import {
   LoadMoreButton,
   OverlayUnavailable,
@@ -917,6 +918,7 @@ function LeadRail({
   const { readOnly } = writer;
   const t = useT();
   const me = useMe();
+  const claim = useClaimRecord("lead", lead.id, lead.version);
   return (
     <div className="record-stack">
       <LeadIdentityFields
@@ -932,7 +934,17 @@ function LeadRail({
             meId={me.data?.user?.id}
             refusedReasonId={readOnly ? terminalReasonId : undefined}
             pending={writer.patch.isPending || readOnly}
-            onAssign={(ownerId) => writer.save({ owner_id: ownerId })}
+            // A lead nobody owns is nobody's to change, so the PATCH this
+            // control used to send for EVERY pick was refused for the one
+            // pick a rep makes most: taking an unassigned lead. Picking
+            // yourself on an unowned lead goes through the claim door, which
+            // is the write the server actually admits; naming a colleague
+            // stays a patch, which the assignment gate answers.
+            onAssign={(ownerId) =>
+              !lead.owner_id && ownerId === me.data?.user?.id
+                ? claim()
+                : writer.save({ owner_id: ownerId })
+            }
           />
         </PanelBody>
       </Panel>

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -12,7 +12,7 @@ import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
-import { useRecordWriteRefusal } from "../app/capability";
+import { useCanWrite, useRecordWriteRefusal } from "../app/capability";
 import { PageAsideToggle, usePageAside } from "../app/pageaside";
 import { useRecordZone } from "../app/recordzone";
 import { navigate, useRoute } from "../app/router";
@@ -946,6 +946,11 @@ function LeadRail({
 }>) {
   const t = useT();
   const me = useMe();
+  // The object grant and the seat ceiling, without the per-row answer: see the
+  // control below for why the row half is deliberately absent.
+  const mayAssign = useCanWrite("lead", "update");
+  const assignRefusedReasonId =
+    lead.archived_at || !mayAssign ? terminalReasonId : undefined;
   return (
     <div className="record-stack">
       <LeadIdentityFields
@@ -959,18 +964,23 @@ function LeadRail({
           <LeadOwner
             lead={lead}
             meId={me.data?.user?.id}
-            // Assignment asks a DIFFERENT question from editing, so it does
-            // not take the editor's answer. `writable` is false on a lead
-            // nobody owns — that is the write arm being right — and gating
-            // this control on it would shut the only door out of the
+            // Assignment asks a DIFFERENT question from editing, so it drops
+            // the PER-ROW half of the editor's answer and keeps the rest.
+            // `writable` is false on a lead nobody owns — the write arm being
+            // right — and gating on it would shut the only door out of the
             // unassigned queue, which is the bug this whole change is about.
-            // An ARCHIVED lead is still refused: a terminal record is nobody's
-            // to hand on.
-            refusedReasonId={lead.archived_at ? terminalReasonId : undefined}
+            //
+            // The other two axes still bind. useCanWrite is the object grant
+            // AND the seat ceiling: a read seat, or one holding no
+            // `lead.update`, gets no pressable control, because the server
+            // refuses them and a button that only fails is worse than none. An
+            // archived lead is refused too — a terminal record is nobody's to
+            // hand on.
+            refusedReasonId={assignRefusedReasonId}
             pending={
               writer.patch.isPending ||
               writer.claim.isPending ||
-              Boolean(lead.archived_at)
+              Boolean(assignRefusedReasonId)
             }
             // A lead nobody owns is nobody's to change, so the PATCH this
             // control used to send for EVERY pick was refused for the one


### PR DESCRIPTION
A lead nobody owns is the queue every inbound lead lands in, and it had no door out. Pressing **Assign to me** sent a `PATCH`; the write arm refuses an ownerless row on purpose, so the rep who was supposed to pick the lead up got a permission error. The claim endpoint that exists for exactly this already accepted `lead`, and no lead code path called it.

The other half was the destination. A manual owner change validated nothing — the foreign key accepts a suspended seat, an archived one, an agent, a read seat, and any colleague on any team. Automated routing checked active and unarchived, so the machine was stricter than the person: a manager could place work where the router refused to.

## What changed

`auth.EnsureAssignee` asks the destination question once, by rendering the write-scope owner predicate over the user row with its own id aliased as `owner_id` — "would a row owned by this seat be mine to change?". The same predicate the write path runs, rather than a second reading of it, so after an assignment lands the row sits inside the scope its assigner already had.

| Seat | From unassigned | Destination |
|---|---|---|
| Rep | takes it for themselves | self |
| Team Lead | routes it directly | self or a live teammate |
| Admin / management | places it anywhere | any active human seat |
| Agent | refused | a row it could already write |

The ownerless door carries ownership and nothing else. Admitting an ownerless patch because it names an owner would let a score, a status or an identity field ride in beside it, so the exception is refused for any patch that is not ownership-only. A caller who could already write the row keeps every field.

**Five writers, not one.** The update path is the obvious one. The create path is the one a plan guarding only the update would miss, and CSV and mirror imports reach it through `CreateLeadTx` rather than the exported wrapper — so the check sits in the body both entry points share. Routing keeps its own pool query and gains the two clauses it lacked. Deals had the identical hole; projects kept a weaker copy of the same rule, which is why its live-member waiver could go.

## Tests

Twelve cases against real Postgres covering the role matrix, every ineligible seat kind, the mixed-patch refusal, a stranger's lead, and the create path. Each guard was mutation-checked one clause at a time: reverting `EnsureAssignable` fails nine of ten cases (the admin case correctly survives, since admin was always unbounded), and removing only the eligibility clause fails exactly the four seat cases.

A new gate holds the claim that the rule has one spelling — it fails if routing's pool query and the assignment predicate drift apart, which is the divergence that shipped here unnoticed.

The frontend test that asserted the `PATCH` was asserting the request the server refuses: it stubbed a success the real backend never returns, which is how the error shipped green. It now asserts the claim, and reverting the fix fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lead assignment so an unassigned lead can be claimed, and a manual owner change can only hand it to an active human seat the assigner could already write.

- "Assign to me" on an unowned lead now uses the claim endpoint; the PATCH it sent before was refused by the write arm.
- Manual owner changes now check the destination — active, unarchived, non-agent, non-read seat inside the caller's own write scope.
- The ownerless door admits ownership-only patches; any other field still refuses an ownerless row.
- Deals and projects get the same destination check; routing's pool query applies the same eligibility clauses.
- The assignment picker keeps the object grant and seat ceiling but drops only the per-row `writable` answer (false on an ownerless lead), so a read seat gets no pressable Assign.
- The ownerless decision is read under a row lock, so two seats racing for one unowned lead cannot both win.
- The frontend claim is now a mutation whose refusal shows in the page's existing error banner.

**Tests**
- Integration tests cover the role matrix, every ineligible seat kind, mixed-patch refusal, a stranger's lead, the create path, and the race.
- Frontend tests render the honest ownerless shape (`writable: false`) and a read seat getting no enabled Assign.
- A gate fails if routing's pool query and the assignment predicate drift apart.

<sup>Written for commit c5b11f3f35bca0733241003c1498bdb21d414553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure assignment controls for leads and deals, including validation of active, non-archived, human, writable seats.
  - Added support for claiming unassigned records through a dedicated claim action.
  - Lead self-assignment now uses the claim workflow instead of a standard ownership update.
  - Lead creation and updates now prevent unauthorized or mixed assignment changes.
  - Deal link updates continue to validate organization, owner, project, and partner access.

- **Documentation**
  - Updated the gate inventory reference for assignment eligibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->