### PR TITLE
fix(approvals): four residues around a staged call's edit scope

### DIFF
--- a/backend/internal/modules/approvals/editscope.go
+++ b/backend/internal/modules/approvals/editscope.go
@@ -169,10 +169,17 @@ func isRESTStaging(payload map[string]json.RawMessage) bool {
 func assertSameCallIdentity(original, edited json.RawMessage) error {
 	var before, after map[string]json.RawMessage
 	if err := json.Unmarshal(original, &before); err != nil {
-		return fmt.Errorf("approvals: decoding a proposed change to compare its call identity: %w", err)
+		// The STAGED payload is not an object. `proposed_change` is jsonb, which
+		// permits an array or a scalar, and nothing this comparison can say
+		// about such a payload is the caller's to fix — but answering a bare
+		// error made it a 500, and a 500 tells a human their approval hit a
+		// server fault when what happened is that the staging is unusable. No
+		// producer stages one today; the column is what makes it reachable.
+		return &InvalidEditError{Cause: fmt.Errorf(
+			"the staged change is not a JSON object, so an edit cannot be compared against it: %w", err)}
 	}
 	if err := json.Unmarshal(edited, &after); err != nil {
-		return fmt.Errorf("approvals: decoding an edited change to compare its call identity: %w", err)
+		return &InvalidEditError{Cause: fmt.Errorf("the edit is not a JSON object: %w", err)}
 	}
 	if !isRESTStaging(before) && !isRESTStaging(after) {
 		return nil
@@ -192,7 +199,11 @@ func assertSameCallIdentity(original, edited json.RawMessage) error {
 	for member := range members {
 		was, had := before[member]
 		now, has := after[member]
-		if had != has || !bytes.Equal(was, now) {
+		same, err := sameJSONValue(was, now)
+		if err != nil {
+			return &InvalidEditError{Cause: err}
+		}
+		if had != has || !same {
 			changed = append(changed, "/"+member)
 		}
 	}
@@ -204,4 +215,48 @@ func assertSameCallIdentity(original, edited json.RawMessage) error {
 	// reviewer cannot diff against the last one.
 	sort.Strings(changed)
 	return &RetargetedEditError{Paths: changed}
+}
+
+// sameJSONValue compares two raw members by what they MEAN rather than by
+// their bytes.
+//
+// The two sides arrive spelled differently by construction. `before` comes back
+// from a jsonb column, which emits `&`, `<` and `>` raw; `after` comes from
+// diffhash.Canonical through json.Marshal, which escapes them as `\u0026` and
+// friends. Compared as bytes, a staged `path` carrying any of those characters
+// made every later body-only edit refuse as a retarget — a legitimate
+// correction the human is entitled to make, refused for a reason nothing in the
+// message could explain.
+//
+// It failed CLOSED, which is why this is a correction rather than a hole: two
+// different decoded values cannot have equal bytes either, so nothing was ever
+// admitted that should not have been.
+//
+// Absent members compare equal here and the caller's own had/has check
+// separates them, so a member present on one side only is reported as changed
+// rather than as a decode failure.
+func sameJSONValue(a, b json.RawMessage) (bool, error) {
+	if len(a) == 0 || len(b) == 0 {
+		return len(a) == len(b), nil
+	}
+	var left, right any
+	if err := json.Unmarshal(a, &left); err != nil {
+		return false, fmt.Errorf("the staged change carries a member that is not JSON: %w", err)
+	}
+	if err := json.Unmarshal(b, &right); err != nil {
+		return false, fmt.Errorf("the edit carries a member that is not JSON: %w", err)
+	}
+	// Re-marshalled rather than reflect.DeepEqual: one encoder decides the
+	// escaping AND the key order for both sides, so two objects that differ
+	// only in how they were written compare equal, and any two that differ in
+	// content do not.
+	leftJSON, err := json.Marshal(left)
+	if err != nil {
+		return false, err
+	}
+	rightJSON, err := json.Marshal(right)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(leftJSON, rightJSON), nil
 }

--- a/backend/internal/modules/approvals/editscope.go
+++ b/backend/internal/modules/approvals/editscope.go
@@ -37,6 +37,7 @@ package approvals
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -165,10 +166,32 @@ func isRESTStaging(payload map[string]json.RawMessage) bool {
 	return hasOp || hasPath
 }
 
+// errJSONNull names the one non-object that decodes into a map without error.
+var errJSONNull = errors.New("it is the JSON literal null")
+
+// jsonObjectMembers narrows one jsonb payload to its members, refusing every
+// shape that is not an object.
+//
+// The nil check is not belt-and-braces: `null` unmarshals into a NIL map and
+// returns no error, so a decode alone answers "object" for it. A null staging
+// that reached the comparison below produced two empty member sets, matched
+// nothing against nothing, and let an edit through the identity guard
+// untouched — the opposite of what a payload nobody can read should get.
+func jsonObjectMembers(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	var members map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &members); err != nil {
+		return nil, err
+	}
+	if members == nil {
+		return nil, errJSONNull
+	}
+	return members, nil
+}
+
 // assertSameCallIdentity refuses an edit that changes which call was staged.
 func assertSameCallIdentity(original, edited json.RawMessage) error {
-	var before, after map[string]json.RawMessage
-	if err := json.Unmarshal(original, &before); err != nil {
+	before, err := jsonObjectMembers(original)
+	if err != nil {
 		// The STAGED payload is not an object. `proposed_change` is jsonb, which
 		// permits an array or a scalar, and nothing this comparison can say
 		// about such a payload is the caller's to fix — but answering a bare
@@ -178,7 +201,8 @@ func assertSameCallIdentity(original, edited json.RawMessage) error {
 		return &InvalidEditError{Cause: fmt.Errorf(
 			"the staged change is not a JSON object, so an edit cannot be compared against it: %w", err)}
 	}
-	if err := json.Unmarshal(edited, &after); err != nil {
+	after, err := jsonObjectMembers(edited)
+	if err != nil {
 		return &InvalidEditError{Cause: fmt.Errorf("the edit is not a JSON object: %w", err)}
 	}
 	if !isRESTStaging(before) && !isRESTStaging(after) {

--- a/backend/internal/modules/approvals/editscope_test.go
+++ b/backend/internal/modules/approvals/editscope_test.go
@@ -71,6 +71,18 @@ func TestAssertSameEntityRefsPinsEveryRecordTheProposalNames(t *testing.T) {
 		// path as one flat key and have the two read as the same location.
 		// They must not: the reference would move out of where the effect
 		// reads it while this check saw nothing change.
+		// THE PREMISE assertSameCallIdentity EXISTS FOR, asserted rather than
+		// assumed. entityRefs collects only strings that parse WHOLLY as a
+		// UUID, so a record id inside a request path is invisible to it and a
+		// re-aimed call reads here as no change at all. If this ever started
+		// failing — entityRefs widened to find ids inside strings — the second
+		// assertion beside it would look redundant and become a candidate for
+		// deletion, with nothing left to say why it is not.
+		{
+			name:     "a record named inside a REST path is invisible here, which is why the call identity is pinned separately",
+			original: `{"operation":"advanceDeal","path":"/v1/deals/` + mine + `/advance","body":{}}`,
+			edited:   `{"operation":"advanceDeal","path":"/v1/deals/` + theirs + `/advance","body":{}}`,
+		},
 		{
 			name:        "a flat key spelling a nested path does not collide with it",
 			original:    `{"link":{"activity_id":"` + alice + `"}}`,
@@ -116,9 +128,9 @@ func TestAnEditMayNotRepointTheRecordNamedInARestPath(t *testing.T) {
 	other := ids.NewV7()
 	// toStageID is fixed across both calls so the ONLY thing that differs
 	// between the staged and edited payload is the record named in the path.
-	// A body id that varied too would let assertSameEntityRefs reject the
-	// edit for catching THAT change, which would prove nothing about
-	// whether it can see the one hidden inside the path.
+	// A body id that varied too would be refused as a changed `/body`, and the
+	// case would pass without ever showing that the PATH is pinned — which is
+	// the whole claim, since the path is where a REST staging keeps its record.
 	toStageID := ids.NewV7().String()
 	rest := func(id ids.UUID) json.RawMessage {
 		return json.RawMessage(`{"operation":"advanceDeal","path":"/v1/deals/` + id.String() +
@@ -246,5 +258,71 @@ func TestRetargetedEditErrorNamesTheOffendingPaths(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("message %q does not name %q", msg, want)
 		}
+	}
+}
+
+// A body-only edit survives a staged path carrying an HTML-significant
+// character.
+//
+// The two sides of the comparison are spelled differently by construction:
+// `before` comes back from a jsonb column, which emits `&`, `<` and `>` raw,
+// and `after` comes from diffhash.Canonical through json.Marshal, which escapes
+// them. Compared as bytes they never matched, so every later correction to the
+// body was refused as a retarget — a legitimate edit the human is entitled to
+// make, refused for a reason nothing in the message could explain.
+//
+// It failed CLOSED, so nothing was admitted that should not have been; what it
+// cost was the edit.
+func TestABodyEditSurvivesAPathPostgresAndGoSpellDifferently(t *testing.T) {
+	// As jsonb hands it back: the ampersand RAW.
+	staged := json.RawMessage(`{"operation":"listDeals","path":"/v1/deals?q=a&b","body":{"note":"first"}}`)
+	// As json.Marshal writes it: the same path, the ampersand ESCAPED. This is
+	// the difference — written raw on both sides the case passes against a
+	// byte comparison and proves nothing.
+	edited := json.RawMessage(`{"operation":"listDeals","path":"/v1/deals?q=a\u0026b","body":{"note":"corrected"}}`)
+
+	if err := assertSameCallIdentity(staged, edited); err != nil {
+		t.Fatalf("a body-only edit was refused as %v — the path is the SAME path, spelled by two encoders", err)
+	}
+}
+
+// And the control, one character apart: a path that genuinely differs is still
+// refused. Without it the case above would pass against a comparison that had
+// stopped comparing.
+func TestAPathThatGenuinelyDiffersIsStillRefused(t *testing.T) {
+	staged := json.RawMessage(`{"operation":"listDeals","path":"/v1/deals?q=a&b","body":{}}`)
+	edited := json.RawMessage(`{"operation":"listDeals","path":"/v1/deals?q=a&c","body":{}}`)
+
+	retargeted := requireRetargeted(t, assertSameCallIdentity(staged, edited),
+		"an edit that changed the path was accepted")
+	if strings.Join(retargeted.Paths, ",") != "/path" {
+		t.Errorf("refused paths = %v, want [/path]", retargeted.Paths)
+	}
+}
+
+// A staged payload that is not an object is the approval's problem, not the
+// server's.
+//
+// `proposed_change` is jsonb, which permits an array or a scalar. No producer
+// stages one today — the column is what makes it reachable — and answering a
+// bare error made it a 500, which tells a human their approval hit a server
+// fault when what happened is that the staging is unusable.
+func TestANonObjectStagedChangeIsRefusedAsAnInvalidEditNotAServerFault(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		staged, editedTo string
+	}{
+		{"an array", `[1,2,3]`, `{"body":{}}`},
+		{"a scalar", `"just a string"`, `{"body":{}}`},
+		{"an edit that is not an object", `{"operation":"x","path":"/v1/y","body":{}}`, `[1,2,3]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := assertSameCallIdentity(json.RawMessage(tc.staged), json.RawMessage(tc.editedTo))
+			var invalid *InvalidEditError
+			if !errors.As(err, &invalid) {
+				t.Fatalf("err = %v (%T), want an *InvalidEditError — anything else reaches writeErr as "+
+					"neither refusal type and answers 500", err, err)
+			}
+		})
 	}
 }

--- a/backend/internal/modules/approvals/editscope_test.go
+++ b/backend/internal/modules/approvals/editscope_test.go
@@ -315,6 +315,18 @@ func TestANonObjectStagedChangeIsRefusedAsAnInvalidEditNotAServerFault(t *testin
 		{"an array", `[1,2,3]`, `{"body":{}}`},
 		{"a scalar", `"just a string"`, `{"body":{}}`},
 		{"an edit that is not an object", `{"operation":"x","path":"/v1/y","body":{}}`, `[1,2,3]`},
+		// The null cases are the ones a decode-only check cannot see: `null`
+		// unmarshals into a NIL map and returns no error, so a decode alone
+		// answers "object" for it. Both wrong answers it produced are here.
+		// Against a REST staging the empty side made every member read as
+		// removed, so an unreadable payload came back as a retarget — a
+		// refusal that names a cause the human cannot act on.
+		{"a null staging", `null`, `{"operation":"x","path":"/v1/y","body":{}}`},
+		{"a null edit", `{"operation":"x","path":"/v1/y","body":{}}`, `null`},
+		// And null on both sides is the silent one: two empty member sets,
+		// isRESTStaging false for each, so the guard returned nil and let the
+		// edit through untouched.
+		{"null on both sides", `null`, `null`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := assertSameCallIdentity(json.RawMessage(tc.staged), json.RawMessage(tc.editedTo))


### PR DESCRIPTION
Closes #1070. One reading of one file, so they land together.

## 1. A body-only edit was refused whenever the staged path carried `&`, `<` or `>`

The two sides are spelled differently **by construction**: `before` comes back from a `jsonb` column, which emits those characters raw, and `after` comes from `diffhash.Canonical` through `json.Marshal`, which escapes them as `&` and friends. Compared as bytes they never matched, so a staged `path` containing one made every later correction to the **body** refuse as a retarget.

It failed **closed** — two different decoded values cannot have equal bytes either, so nothing was ever admitted that should not have been. What it cost was an edit the human is entitled to make, refused for a reason nothing in the message could explain.

Members compare by what they *mean* now: both sides re-marshalled through one encoder, so escaping and key order stop being differences while any difference in content still is.

## 2. A non-object `proposed_change` answered 500

The column is `jsonb`, which permits an array or a scalar, and `assertSameCallIdentity` returned a bare `fmt.Errorf` — which `writeErr` matches as neither `RetargetedEditError` nor `InvalidEditError`. A human was told their approval hit a server fault when what happened is that the staging is unusable.

It is an `InvalidEditError` now, and so is an edit that is not an object. No producer stages one today; the column is what makes it reachable, which is why the ticket listed it last and why it is a small change here.

## 3. The premise the whole function exists for is now asserted

`assertSameCallIdentity` sits beside `assertSameEntityRefs` precisely because `entityRefs` matches only strings that parse **wholly** as a UUID — so a record id inside `"path": "/v1/deals/<uuid>/advance"` is invisible to it, and a re-aimed call reads there as no change at all.

Nothing said so. If `entityRefs` ever widened, the second assertion would look redundant and become a candidate for deletion with nothing left to explain why it is not. One row in `TestAssertSameEntityRefsPinsEveryRecordTheProposalNames` — a path-only edit detected as no change — keeps that honest permanently.

## 4. A stale comment

A test repointed from `assertSameEntityRefs` to `assertSameCallIdentity` still explained its fixed `to_stage_id` in terms of the first function, which never reads the body. Inert, and it pointed the next reader at the wrong mechanism.

## Both new cases needed a second attempt, for the same reason

Written the obvious way, each passed **against** the defect:

- the escaping case had the ampersand raw on *both* sides, so `bytes.Equal` matched and the case proved nothing. The fixture now writes the edited side as `json.Marshal` actually writes it, and the mutation back to `bytes.Equal` fails it.
- the non-object case needed the edit-side row as well as the staged-side ones, since only one of the two decode paths had been reached.

**Mutation checks:** restoring `bytes.Equal` fails the escaping case and leaves the genuine-difference control passing; restoring the bare `fmt.Errorf` fails the array and scalar rows.

`make check-backend` green; the approvals integration lane green.