### PR TITLE
fix(search): the embedding lanes name only what the table accepts

### DIFF
--- a/backend/internal/modules/search/embeddablevocabulary_test.go
+++ b/backend/internal/modules/search/embeddablevocabulary_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+)
+
+// The embedding lanes may only name entity types the embedding TABLE accepts,
+// and the two maps that declare them must name the same set.
+//
+// Both obligations were stated in comments and held by nothing. An entity
+// listed in the lanes but absent from `embedding.entity_type`'s CHECK is not a
+// degraded lane, it is a write the database refuses — and the refusal surfaces
+// far from here, as a job that fails forever: embed_drift_sweep re-selects
+// whatever has no embedding row, so such a type is permanently pending, and
+// each pass spends a real embedding call on it, is refused, and abandons the
+// rest of that pass.
+//
+// Asserted transitively rather than by reading the migrations. enumBindings in
+// gates/enumsync_test.go already pins `embedding.entity_type`'s CHECK to
+// datasource.EntityType and fails on any inequality, so proving the lanes are
+// a SUBSET of that Go vocabulary proves they are admitted by the CHECK, with
+// no second parser of the schema to keep in step. Widening the CHECK alone
+// cannot satisfy this: the other gate would fail on the same change.
+func TestEveryEmbeddableEntityIsOneTheEmbeddingTableAccepts(t *testing.T) {
+	t.Parallel()
+
+	admitted := make(map[string]bool, len(datasource.EntityTypes()))
+	for _, e := range datasource.EntityTypes() {
+		admitted[string(e)] = true
+	}
+	if len(admitted) == 0 {
+		t.Fatal("datasource declares no entity type, so this gate is asserting nothing")
+	}
+
+	for _, entityType := range slices.Sorted(maps.Keys(pendingSources)) {
+		if !admitted[entityType] {
+			t.Errorf("pendingSources names %q, which datasource.EntityTypes() does not — "+
+				"embedding.entity_type's CHECK is pinned to that vocabulary, so every upsert for "+
+				"this type is refused by the database and embed_drift_sweep retries it forever",
+				entityType)
+		}
+	}
+	for _, entityType := range slices.Sorted(maps.Keys(embedText)) {
+		if !admitted[entityType] {
+			t.Errorf("embedText names %q, which datasource.EntityTypes() does not — see above", entityType)
+		}
+	}
+}
+
+// The per-id lane and the set-form lane are two views of one vocabulary, and
+// both files say so in prose. A type in one but not the other means the
+// backlog count and the live indexer disagree about what is embeddable: an
+// entity counted as pending that nothing embeds stays pending forever, and one
+// embedded but never counted makes the re-embed cost preview too cheap.
+func TestTheTwoEmbeddingLanesNameTheSameEntities(t *testing.T) {
+	t.Parallel()
+
+	pending := slices.Sorted(maps.Keys(pendingSources))
+	perID := slices.Sorted(maps.Keys(embedText))
+	if !slices.Equal(pending, perID) {
+		t.Errorf("pendingSources and embedText have diverged:\n  pendingSources: %v\n  embedText:      %v",
+			pending, perID)
+	}
+}

--- a/backend/internal/modules/search/embedgen.go
+++ b/backend/internal/modules/search/embedgen.go
@@ -31,12 +31,12 @@ func NewEmbedGen(store *Store, embedder Embedder) *EmbedGen {
 // pendingSources (the per-id and set-form views of the same source columns)
 // key off the same identifiers rather than each repeating the literal.
 const (
-	entityPerson        = "person"
-	entityOrganization  = "organization"
-	entityDeal          = "deal"
-	entityLead          = "lead"
-	entityActivity      = "activity"
-	entityProject       = "project"
+	entityPerson       = "person"
+	entityOrganization = "organization"
+	entityDeal         = "deal"
+	entityLead         = "lead"
+	entityActivity     = "activity"
+	entityProject      = "project"
 	// Keyword-searchable but NOT embeddable, and for a different reason than
 	// entityTag below: these two hold plenty of prose, but
 	// `embedding.entity_type` will not accept them (see embedText). Named
@@ -66,7 +66,7 @@ var embedText = map[string]string{
 	// mail is what pulled them back. A limited activity is therefore not indexed
 	// at all, and audiencerescope drops the vector when a row narrows.
 	entityActivity: `SELECT concat_ws(' ', subject, body) FROM activity WHERE id = $1 AND archived_at IS NULL AND audience = 'workspace'`,
-	entityProject: `SELECT concat_ws(' ', name, key, description) FROM project WHERE id = $1 AND archived_at IS NULL`,
+	entityProject:  `SELECT concat_ws(' ', name, key, description) FROM project WHERE id = $1 AND archived_at IS NULL`,
 	// NO product or offer_template ENTRY, and adding one back needs a schema
 	// change first, not just a line here. `embedding.entity_type` carries a
 	// CHECK pinned to datasource.EntityType by

--- a/backend/internal/modules/search/embedgen.go
+++ b/backend/internal/modules/search/embedgen.go
@@ -37,6 +37,11 @@ const (
 	entityLead          = "lead"
 	entityActivity      = "activity"
 	entityProject       = "project"
+	// Keyword-searchable but NOT embeddable, and for a different reason than
+	// entityTag below: these two hold plenty of prose, but
+	// `embedding.entity_type` will not accept them (see embedText). Named
+	// here with the rest because branches.go and queryfields.go key off the
+	// same identifiers.
 	entityProduct       = "product"
 	entityOfferTemplate = "offer_template"
 	// Not embeddable — a word has no prose to embed — but named here with the
@@ -61,13 +66,29 @@ var embedText = map[string]string{
 	// mail is what pulled them back. A limited activity is therefore not indexed
 	// at all, and audiencerescope drops the vector when a row narrows.
 	entityActivity: `SELECT concat_ws(' ', subject, body) FROM activity WHERE id = $1 AND archived_at IS NULL AND audience = 'workspace'`,
-	entityProject:  `SELECT concat_ws(' ', name, key, description) FROM project WHERE id = $1 AND archived_at IS NULL`,
-	// Not narrowed on `active`: the lexical branch indexes a discontinued
-	// product too, and a vector lane that dropped it would answer the same
-	// question two different ways depending on which lane ranked first.
-	entityProduct: `SELECT concat_ws(' ', name, sku, description) FROM product WHERE id = $1 AND archived_at IS NULL`,
-	// One column, because one column is all this table holds as prose.
-	entityOfferTemplate: `SELECT name FROM offer_template WHERE id = $1 AND archived_at IS NULL`,
+	entityProject: `SELECT concat_ws(' ', name, key, description) FROM project WHERE id = $1 AND archived_at IS NULL`,
+	// NO product or offer_template ENTRY, and adding one back needs a schema
+	// change first, not just a line here. `embedding.entity_type` carries a
+	// CHECK pinned to datasource.EntityType by
+	// gates/enumsync_test.go's enumBindings, and neither catalog table is in
+	// that vocabulary — so an UpsertEmbedding for one is rejected by the
+	// database, every time. It is not a degraded lane: it is a write that
+	// cannot land.
+	//
+	// The cost of listing them anyway was paid by embed_drift_sweep, which
+	// re-selects whatever has no embedding row: the catalog rows are
+	// permanently pending, so every pass embedded one, was refused by the
+	// CHECK, and returned the error — abandoning the rest of that pass. Map
+	// order is randomised, so each pass healed an arbitrary prefix of the
+	// other types and then died. A per-pass Gemini embedding call was spent
+	// on the row that could never be stored.
+	//
+	// Making the catalog vector-searchable is therefore a domain-vocabulary
+	// decision — EntityTypes() is enumerated by the agent command subjects,
+	// the generated tool schemas and the overlay vocabulary, and a gate
+	// requires the record provider to route every member — and not this
+	// module's to take alone. The lexical branch is unaffected either way:
+	// branches.go indexes both tables and keeps them keyword-searchable.
 }
 
 // HandleEvent maintains embeddings for created/updated/captured

--- a/backend/internal/modules/search/pending.go
+++ b/backend/internal/modules/search/pending.go
@@ -35,14 +35,12 @@ type pendingSource struct {
 // to BOTH maps; they must never diverge, since the pending count and the
 // live indexer must agree on what "this entity's text" means.
 var pendingSources = map[string]pendingSource{
-	entityPerson:        {table: entityPerson, text: "t.full_name"},
-	entityOrganization:  {table: entityOrganization, text: "concat_ws(' ', t.display_name, t.legal_name, t.industry)"},
-	entityDeal:          {table: entityDeal, text: "t.name"},
-	entityLead:          {table: entityLead, text: "concat_ws(' ', t.full_name, t.company_name, t.title)"},
-	entityActivity:      {table: entityActivity, text: "concat_ws(' ', t.subject, t.body)"},
-	entityProject:       {table: entityProject, text: "concat_ws(' ', t.name, t.key, t.description)"},
-	entityProduct:       {table: entityProduct, text: "concat_ws(' ', t.name, t.sku, t.description)"},
-	entityOfferTemplate: {table: entityOfferTemplate, text: "t.name"},
+	entityPerson:       {table: entityPerson, text: "t.full_name"},
+	entityOrganization: {table: entityOrganization, text: "concat_ws(' ', t.display_name, t.legal_name, t.industry)"},
+	entityDeal:         {table: entityDeal, text: "t.name"},
+	entityLead:         {table: entityLead, text: "concat_ws(' ', t.full_name, t.company_name, t.title)"},
+	entityActivity:     {table: entityActivity, text: "concat_ws(' ', t.subject, t.body)"},
+	entityProject:      {table: entityProject, text: "concat_ws(' ', t.name, t.key, t.description)"},
 }
 
 // PendingByWorkspace is what a re-embed pass for each enumerated workspace will


### PR DESCRIPTION
`embed_drift_sweep` has been failing **every 15 minutes** since the catalog reached search (`ff3ca4372`, #4026). Observed on a staging installation: 12 failures/hour, every hour, for days.

## What was wrong

`pendingSources` and `embedText` both listed `product` and `offer_template`. But `embedding.entity_type` carries a CHECK pinned to `datasource.EntityType` by `enumBindings` in `gates/enumsync_test.go`, and neither catalog table is in that vocabulary. So every `UpsertEmbedding` for one is **refused by the database**:

```
ERROR: new row for relation "embedding" violates check constraint
       "embedding_entity_type_check" (SQLSTATE 23514)
```

Not a degraded lane — a write that cannot land.

The sweep re-selects whatever has no embedding row, so those rows are **permanently pending**. Each pass embedded one, was refused, and returned the error, abandoning the rest of the pass. `pendingSources` is a Go map, so iteration order is randomised: each pass healed an **arbitrary prefix** of the other types and then died. Drift healing has been partial and non-deterministic this whole time, and a real Gemini embedding call was spent per pass on a row that could never be stored.

## Why remove rather than widen

Widening looks like the obvious fix and isn't available as a migration. `enumBindings` asserts **exact set equality** between `datasource.EntityType` and all four EntityType-bound CHECKs, so widening `embedding` alone fails that gate. And adding the two to `EntityType` is a domain-vocabulary change: `EntityTypes()` is enumerated by the agent command subjects, the generated agent tool schemas and the overlay vocabulary, and `TestTheRecordProviderServesExactlyTheSeamVocabulary` requires the record provider to **route every member** — products would have to become seam-readable records.

That is a product/architecture decision, not a bug fix, so it is filed separately rather than taken here.

Removing the two entries **costs no capability**: product embeddings have never once succeeded, so there is nothing working to lose. The lexical branch is untouched — `branches.go` still indexes both tables, so the catalog stays keyword-searchable, and `queryfields.go` still answers for its fields.

## Two gates for what only comments held

Both files stated these obligations in prose and nothing enforced either:

- **Every embeddable type is one the embedding table accepts.** Asserted *transitively* — as a subset of `datasource.EntityTypes()` — rather than by parsing the migrations, because `enumBindings` already pins that CHECK to it. So there is no second parser of the schema to keep in step, and widening the CHECK alone cannot satisfy this gate, since the other one fails on the same change.
- **The two lanes name the same set.** A type in one but not the other means the backlog count and the live indexer disagree: an entity counted as pending that nothing embeds stays pending forever, and one embedded but never counted makes the re-embed cost preview too cheap.

Confirmed both **fail** when `product` is put back:
```
pendingSources names "product", which datasource.EntityTypes() does not — embedding.entity_type's
CHECK is pinned to that vocabulary, so every upsert for this type is refused by the database and
embed_drift_sweep retries it forever
```

## Verification

- `go test ./internal/modules/search/` passes; `go build ./...` clean across the tree.
- `craft static --strict` diff-scoped — 0 blocker, 0 major, 0 minor.
- No existing test referenced `pendingSources`, `embedText` or `entityProduct`, which is why nothing caught this for as long as it ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)