### PR TITLE
fix(docs): a citation names a document git ignores

### DIFF
--- a/docs/evidence/extension-tier/DESIGN.md
+++ b/docs/evidence/extension-tier/DESIGN.md
@@ -24,9 +24,10 @@ Review history is in `REVIEW-v1.md`. Demo detail is in `NOTES-SCOPE.md`.
 > [#659](https://github.com/margince/margince/pull/659)). Corrections are made where the claim
 > was, not appended elsewhere; where a correction came from a demonstrated failure the demonstration is
 > named. **Where the ledger and the code disagreed, the code won.** The evidence, in order of
-> authority: the code; `.superpowers/sdd/extension-tier-slices/progress.md` (the ledger — every task,
-> finding, ruling and deferral, in order); then `REVIEW-fable.md`, `REVIEW-codex.md`,
-> `UAT-EVIDENCE-RERUN.md` and the `task-*-report.md` files, all in the same directory.
+> authority: the code; a working ledger of every task, finding, ruling and
+> deferral, in order, kept outside this tree during the build and not shipped
+> with it; then `REVIEW-fable.md`, `REVIEW-codex.md`, `UAT-EVIDENCE-RERUN.md`
+> and the `task-*-report.md` files, all in the same directory as this one.
 >
 > One thing not to lose in the corrections: the four load-bearing properties this design was built
 > around — additive composition, the inert declaration, validate-then-apply, and the empty-tree


### PR DESCRIPTION
## Summary
- `docs/evidence/extension-tier/DESIGN.md:27` cited `.superpowers/sdd/extension-tier-slices/progress.md`, a path that never shipped with the tree — a reader following it in a fresh clone finds nothing.
- Fixed per `TestPublicTreeCitesNoDocumentGitIgnores`'s own guidance: state the fact directly instead of pointing at a path that only ever existed on the build author's machine.

This is a pre-existing red on `main` (confirmed via a clean checkout of `origin/main` before this fix), unrelated to any feature work — split out on its own so it can merge independently and unblock the shared `deterministic-gates` check for every other open PR.

## Test plan
- [x] `go test ./gates/... -run TestPublicTreeCitesNoDocumentGitIgnores` — PASS
- [x] `make check-go` — full pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvvZzihBBSeaLc3WcZ6Xh1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead citation in the extension-tier design docs so readers following it in a fresh clone no longer hit a missing path.

`docs/evidence/extension-tier/DESIGN.md` now states the ledger's location directly instead of pointing at `.superpowers/sdd/extension-tier-slices/progress.md`, a path that never shipped with the tree. This pre-existing failure on `main` blocks the `deterministic-gates` check for other open PRs, so it's split out to merge independently.

<sup>Written for commit 58ecef6a16dff0d47222870c56ab3581adf815cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the evidence-authority guidance by describing the working ledger generically rather than referencing a specific internal path.
  - Preserved the existing authority order: code, working ledger, then review, UAT, and report materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->