### PR TITLE
feat(deals): a won deal says how it was won when no contract carried it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30642,8 +30642,8 @@ components:
 
             Bounded because it is free text that a record page shows back beside the deal's
             status: an unbounded value reaches every reader of that deal, and the header it
-            lands in is a line of short facts. 500 is the same bound the operator notes on
-            this contract carry.
+            lands in is a line of short facts. 500 is a few sentences — long enough to say
+            what happened, short enough that the line stays readable.
 
     DealListResponse:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30636,7 +30636,14 @@ components:
             makes the gap countable.
         won_without_contract_detail:
           type: [string, 'null']
-          description: What the reason was. Required when it is `other`, which explains nothing alone.
+          maxLength: 500
+          description: |
+            What the reason was. Required when it is `other`, which explains nothing alone.
+
+            Bounded because it is free text that a record page shows back beside the deal's
+            status: an unbounded value reaches every reader of that deal, and the header it
+            lands in is a line of short facts. 500 is the same bound the operator notes on
+            this contract carry.
 
     DealListResponse:
       type: object

--- a/backend/gates/wonreasondetailbound_test.go
+++ b/backend/gates/wonreasondetailbound_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+//go:build !integration
+
+package gates
+
+// The paperless-win detail's length bound is ONE number, in three places that
+// each need it.
+//
+// `api/crm.yaml` publishes it, so every generated client truncates to it. The
+// deals module applies it, because the generated server does not enforce a
+// string length and the column is plain `text` — without that the published
+// bound is a promise the product does not keep. The MCP tool schema advertises
+// it, because an agent plans against the tool schema and a refusal it could not
+// have predicted costs a whole turn.
+//
+// Three readers agreeing with each other is not the property that matters here:
+// they can only be compared to the CONTRACT, which is the one of them a client
+// outside this repository can see. So each is read separately and each is
+// compared to `api/crm.yaml`, and the gate fails whichever one moves.
+//
+// The failure it exists for is silent on both sides. Raise the contract alone
+// and the server refuses a value the schema says is fine; raise the server
+// alone and a client goes on truncating to a bound nobody applies.
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestTheWonReasonDetailBoundIsOneNumber(t *testing.T) {
+	t.Parallel()
+
+	published := publishedWonReasonDetailBound(t)
+	if published <= 0 {
+		t.Fatalf("api/crm.yaml publishes maxLength %d for won_without_contract_detail — a non-positive bound is not one this gate can hold anything to", published)
+	}
+
+	if applied := appliedWonReasonDetailBound(t); applied != published {
+		t.Errorf("deals applies a bound of %d and api/crm.yaml publishes %d — one of them refuses a value the other calls valid, and nothing else says which",
+			applied, published)
+	}
+	if advertised := advertisedWonReasonDetailBound(t); advertised != published {
+		t.Errorf("the advance_deal tool schema advertises maxLength %d and api/crm.yaml publishes %d — an agent plans against the tool schema, so it would spend a turn on a request the server refuses",
+			advertised, published)
+	}
+}
+
+// publishedWonReasonDetailBound is the contract's own number, read from the
+// schema node rather than from a generated artifact: `maxLength` is a
+// validation keyword the Go generator does not carry into a type, so the YAML
+// is the only place it survives.
+func publishedWonReasonDetailBound(t *testing.T) int {
+	t.Helper()
+	raw, err := os.ReadFile("api/crm.yaml")
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	var doc struct {
+		Components struct {
+			Schemas map[string]struct {
+				Properties map[string]struct {
+					MaxLength int `yaml:"maxLength"`
+				} `yaml:"properties"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parsing the contract: %v", err)
+	}
+	// The REQUEST schema, not Deal. Deal declares the field readOnly, which
+	// is the value coming back and needs no bound; what a caller may send is
+	// the only side a length can refuse, and the only side the server applies
+	// one to.
+	request, ok := doc.Components.Schemas["AdvanceDealRequest"]
+	if !ok {
+		t.Fatal("api/crm.yaml declares no AdvanceDealRequest schema — this gate's subject moved and it is now asking about nothing")
+	}
+	property, ok := request.Properties["won_without_contract_detail"]
+	if !ok {
+		t.Fatal("AdvanceDealRequest declares no won_without_contract_detail — retire this gate, or repoint it at whatever replaced the field")
+	}
+	return property.MaxLength
+}
+
+// appliedWonReasonDetailBound reads the module's constant from source rather
+// than importing it. The constant is unexported on purpose — a length nobody
+// outside deals should be quoting — and exporting it to satisfy a gate would
+// widen the surface to make the check convenient, which is backwards.
+func appliedWonReasonDetailBound(t *testing.T) int {
+	t.Helper()
+	const declaration = "internal/modules/deals/win_evidence.go"
+	file, err := parser.ParseFile(token.NewFileSet(), declaration, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", declaration, err)
+	}
+	for _, decl := range file.Decls {
+		general, ok := decl.(*ast.GenDecl)
+		if !ok || general.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range general.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok || len(value.Names) != 1 || value.Names[0].Name != "maxWonReasonDetail" {
+				continue
+			}
+			literal, ok := value.Values[0].(*ast.BasicLit)
+			if !ok || literal.Kind != token.INT {
+				t.Fatalf("maxWonReasonDetail is not an integer literal — this gate can only read one, so give it one or teach it the new shape")
+			}
+			n, err := strconv.Atoi(literal.Value)
+			if err != nil {
+				t.Fatalf("maxWonReasonDetail = %q: %v", literal.Value, err)
+			}
+			return n
+		}
+	}
+	t.Fatalf("%s declares no maxWonReasonDetail — the bound the contract publishes is applied by nothing, so the server takes whatever a caller sends", declaration)
+	return 0
+}
+
+// advertisedWonReasonDetailBound reads the tool schema the agents module writes
+// into every deal-moving tool. It is a JSON fragment rather than a document —
+// the properties are spliced into a larger object — so it is closed here into
+// the object it becomes before being parsed, which is the same reading the MCP
+// client gets.
+func advertisedWonReasonDetailBound(t *testing.T) int {
+	t.Helper()
+	const declaration = "internal/modules/agents/tools_advance.go"
+	file, err := parser.ParseFile(token.NewFileSet(), declaration, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", declaration, err)
+	}
+	fragment := constStringValue(t, file, "winEvidenceProperties", declaration)
+
+	var properties map[string]struct {
+		MaxLength int `json:"maxLength"`
+	}
+	if err := json.Unmarshal([]byte("{\"_\":null"+fragment+"}"), &properties); err != nil {
+		t.Fatalf("winEvidenceProperties does not close into a JSON object: %v — the tool schema it is spliced into would be malformed too", err)
+	}
+	property, ok := properties["won_without_contract_detail"]
+	if !ok {
+		t.Fatal("winEvidenceProperties advertises no won_without_contract_detail — an agent cannot see the bound at all, so it learns it by being refused")
+	}
+	return property.MaxLength
+}
+
+// constStringValue is the unquoted value of a named string constant.
+func constStringValue(t *testing.T, file *ast.File, name, where string) string {
+	t.Helper()
+	for _, decl := range file.Decls {
+		general, ok := decl.(*ast.GenDecl)
+		if !ok || general.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range general.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok || len(value.Names) != 1 || value.Names[0].Name != name {
+				continue
+			}
+			literal, ok := value.Values[0].(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				t.Fatalf("%s in %s is not a string literal", name, where)
+			}
+			unquoted, err := strconv.Unquote(literal.Value)
+			if err != nil {
+				t.Fatalf("unquoting %s in %s: %v", name, where, err)
+			}
+			return unquoted
+		}
+	}
+	t.Fatalf("%s declares no %s", where, name)
+	return ""
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17241,6 +17241,11 @@ type AdvanceDealRequest struct {
 	ToStageId openapi_types.UUID `json:"to_stage_id"`
 
 	// WonWithoutContractDetail What the reason was. Required when it is `other`, which explains nothing alone.
+	//
+	// Bounded because it is free text that a record page shows back beside the deal's
+	// status: an unbounded value reaches every reader of that deal, and the header it
+	// lands in is a line of short facts. 500 is the same bound the operator notes on
+	// this contract carry.
 	WonWithoutContractDetail *string `json:"won_without_contract_detail,omitempty"`
 
 	// WonWithoutContractReason Why this win has no agreement behind it (ADR-0109 §6). Omit when the deal has a signed contract with its paper attached — the server looks for one, and refuses a win that offers neither. Both answers are legitimate; recording which is what makes the gap countable.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17244,8 +17244,8 @@ type AdvanceDealRequest struct {
 	//
 	// Bounded because it is free text that a record page shows back beside the deal's
 	// status: an unbounded value reaches every reader of that deal, and the header it
-	// lands in is a line of short facts. 500 is the same bound the operator notes on
-	// this contract carry.
+	// lands in is a line of short facts. 500 is a few sentences — long enough to say
+	// what happened, short enough that the line stays readable.
 	WonWithoutContractDetail *string `json:"won_without_contract_detail,omitempty"`
 
 	// WonWithoutContractReason Why this win has no agreement behind it (ADR-0109 §6). Omit when the deal has a signed contract with its paper attached — the server looks for one, and refuses a win that offers neither. Both answers are legitimate; recording which is what makes the gap countable.

--- a/backend/internal/modules/agents/tools_advance.go
+++ b/backend/internal/modules/agents/tools_advance.go
@@ -54,11 +54,17 @@ type WinEvidenceArgs struct {
 // ever sets a field. The refusal it names is enforced by the win gate, not by
 // this text.
 //
+// The detail's maxLength is the ONE place a caller can learn the bound before
+// spending a request on it — the tool schema is what an agent plans against,
+// and a server-side refusal it could not have predicted costs a whole turn.
+// Its agreement with the contract and with the server's own constant is held by
+// TestTheWonReasonDetailBoundIsOneNumber.
+//
 // Held by: TestEveryDealMoveCarriesTheWinEvidenceClaim
 // (backend/gates/winevidencedoors_test.go)
 const winEvidenceProperties = `,
 	"won_without_contract_reason":{"type":"string","enum":["imported","purchase_order","verbal","renewal_by_email","other"],"description":"Why this win has no contract behind it. Omit when the deal has a signed contract with its paper attached; a win claiming neither is refused."},
-	"won_without_contract_detail":{"type":"string","description":"What the reason was, required when it is other"}`
+	"won_without_contract_detail":{"type":"string","maxLength":500,"description":"What the reason was, required when it is other"}`
 
 type advanceDeal struct {
 	p      datasource.SystemOfRecordProvider

--- a/backend/internal/modules/deals/win_evidence.go
+++ b/backend/internal/modules/deals/win_evidence.go
@@ -137,6 +137,15 @@ func saysSomething(detail *string) bool {
 // product there is no paper should not then be told there is none. Only a win
 // that claims nothing goes looking for evidence.
 func ensureWinEvidence(ctx context.Context, tx pgx.Tx, dealID ids.DealID, in AdvanceDealInput) error {
+	// Before the branch, because the bound belongs to the COLUMN and not to
+	// the reason arm. A win writes the detail whichever branch it takes
+	// (deal_advance.go sets both fields on every won landing), so a length
+	// asked only inside the reason arm would leave a signed-contract win free
+	// to store whatever it sent — the schema advertising a bound the product
+	// applies to some callers is the state this whole check exists to end.
+	if err := ensureDetailWithinBound(in.WonWithoutContractDetail); err != nil {
+		return err
+	}
 	if in.WonWithoutContractReason != nil {
 		return validateWonReason(*in.WonWithoutContractReason, in.WonWithoutContractDetail)
 	}
@@ -169,10 +178,20 @@ func validateWonReason(reason string, detail *string) error {
 	// Checked for EVERY reason, not only the one that requires a detail: a
 	// caller may send one alongside any reason, and the column takes whatever
 	// arrives.
-	if detail != nil {
-		if n := utf8.RuneCountInString(*detail); n > maxWonReasonDetail {
-			return &WonReasonDetailTooLongError{Length: n}
-		}
+	return ensureDetailWithinBound(detail)
+}
+
+// ensureDetailWithinBound is the length rule, in the one place both callers
+// reach it: the advance, which asks before it branches on the reason, and the
+// exported precheck, which asks for a proposal that has not run yet. A second
+// copy would be a bound one path applies and the other does not, which is the
+// defect this replaced rather than a new spelling of it.
+func ensureDetailWithinBound(detail *string) error {
+	if detail == nil {
+		return nil
+	}
+	if n := utf8.RuneCountInString(*detail); n > maxWonReasonDetail {
+		return &WonReasonDetailTooLongError{Length: n}
 	}
 	return nil
 }

--- a/backend/internal/modules/deals/win_evidence.go
+++ b/backend/internal/modules/deals/win_evidence.go
@@ -28,6 +28,7 @@ import (
 	"slices"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 
@@ -84,6 +85,33 @@ func (e *WonReasonDetailRequiredError) FieldFault() (field, code, message string
 	return "won_without_contract_detail", "required", e.Error()
 }
 
+// WonReasonDetailTooLongError reports a detail past what the contract admits.
+type WonReasonDetailTooLongError struct{ Length int }
+
+func (e *WonReasonDetailTooLongError) Error() string {
+	return fmt.Sprintf(
+		"won_without_contract_detail is %d characters and may be at most %d — say what it was in a sentence",
+		e.Length, maxWonReasonDetail)
+}
+
+// FieldFault names the field the caller must shorten.
+func (e *WonReasonDetailTooLongError) FieldFault() (field, code, message string) {
+	return "won_without_contract_detail", "too_long", e.Error()
+}
+
+// maxWonReasonDetail is the contract's `maxLength` on this field, applied here
+// because nothing else does.
+//
+// The generated server does not enforce a string length, so the bound was a
+// promise the schema made and the product did not keep: the column is plain
+// `text`, and its only CHECK is the "other needs a detail" rule. A field with a
+// documented bound nobody applies is worse than an undocumented one — a client
+// trusts it, stops truncating, and the value lands anyway.
+//
+// COUNTED IN RUNES, because the contract's maxLength is: a caller who wrote 200
+// characters of German must not be refused for the bytes their umlauts cost.
+const maxWonReasonDetail = 500
+
 // saysSomething reports whether a detail carries any visible character.
 //
 // TrimSpace alone is not enough: a zero-width space is not whitespace to Go and
@@ -137,6 +165,14 @@ func validateWonReason(reason string, detail *string) error {
 	}
 	if reason == reasonRequiringDetail && !saysSomething(detail) {
 		return &WonReasonDetailRequiredError{}
+	}
+	// Checked for EVERY reason, not only the one that requires a detail: a
+	// caller may send one alongside any reason, and the column takes whatever
+	// arrives.
+	if detail != nil {
+		if n := utf8.RuneCountInString(*detail); n > maxWonReasonDetail {
+			return &WonReasonDetailTooLongError{Length: n}
+		}
 	}
 	return nil
 }

--- a/backend/internal/modules/deals/win_evidence_test.go
+++ b/backend/internal/modules/deals/win_evidence_test.go
@@ -136,3 +136,54 @@ func TestTheEvidenceQueryRefusesADraftContract(t *testing.T) {
 		t.Error("the evidence query admits a draft document")
 	}
 }
+
+// The contract's maxLength on this field is a promise the SCHEMA makes and the
+// generated server does not keep: it validates no string length, and the column
+// is plain `text` whose only CHECK is the "other needs a detail" rule. So a
+// documented bound nobody applied was worse than no bound at all — a client
+// trusts it, stops truncating, and the value lands anyway.
+func TestADetailPastTheContractsBoundIsRefused(t *testing.T) {
+	over := strings.Repeat("x", maxWonReasonDetail+1)
+	var tooLong *WonReasonDetailTooLongError
+	if !errors.As(validateWonReason("other", &over), &tooLong) {
+		t.Fatalf("a %d-character detail was accepted against a %d bound",
+			len(over), maxWonReasonDetail)
+	}
+	if tooLong.Length != maxWonReasonDetail+1 {
+		t.Errorf("the refusal reports %d characters, want %d — a caller shortening it needs the real number",
+			tooLong.Length, maxWonReasonDetail+1)
+	}
+	field, code, _ := tooLong.FieldFault()
+	if field != "won_without_contract_detail" || code != "too_long" {
+		t.Errorf("field fault = (%q, %q), want (won_without_contract_detail, too_long)", field, code)
+	}
+
+	// Exactly at the bound goes: an off-by-one here refuses a value the
+	// contract advertises as legal.
+	at := strings.Repeat("x", maxWonReasonDetail)
+	if err := validateWonReason("other", &at); err != nil {
+		t.Errorf("a detail of exactly %d characters was refused: %v", maxWonReasonDetail, err)
+	}
+}
+
+// Counted in RUNES, because the contract's maxLength is. A caller who wrote 500
+// characters of German must not be refused for the bytes their umlauts cost.
+func TestTheDetailsBoundCountsCharactersRatherThanBytes(t *testing.T) {
+	umlauts := strings.Repeat("ü", maxWonReasonDetail)
+	if len(umlauts) <= maxWonReasonDetail {
+		t.Fatal("the fixture is not multi-byte, so it proves nothing about counting")
+	}
+	if err := validateWonReason("other", &umlauts); err != nil {
+		t.Errorf("%d characters of German were refused for their byte length: %v", maxWonReasonDetail, err)
+	}
+}
+
+// A detail supplied alongside ANY reason is bounded: a caller may send one with
+// a reason that does not require it, and the column takes whatever arrives.
+func TestTheBoundHoldsForAReasonThatNeedsNoDetail(t *testing.T) {
+	over := strings.Repeat("x", maxWonReasonDetail+1)
+	var tooLong *WonReasonDetailTooLongError
+	if !errors.As(validateWonReason("purchase_order", &over), &tooLong) {
+		t.Error("an over-long detail rode in on a reason that requires none")
+	}
+}

--- a/backend/internal/modules/deals/win_evidence_test.go
+++ b/backend/internal/modules/deals/win_evidence_test.go
@@ -4,6 +4,7 @@
 package deals
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -185,5 +186,37 @@ func TestTheBoundHoldsForAReasonThatNeedsNoDetail(t *testing.T) {
 	var tooLong *WonReasonDetailTooLongError
 	if !errors.As(validateWonReason("purchase_order", &over), &tooLong) {
 		t.Error("an over-long detail rode in on a reason that requires none")
+	}
+}
+
+// The bound belongs to the COLUMN, so it is asked before the branch that looks
+// for a reason.
+//
+// Every test above drives validateWonReason, which is only reached when the
+// caller states a reason — and that is exactly how the gap survived them. A win
+// that sends a detail and NO reason takes the contract-lookup branch, and
+// deal_advance.go writes both fields on every won landing, so the detail landed
+// unmeasured however long it was.
+//
+// The transaction is nil on purpose. If the bound is asked before the branch,
+// the refusal returns without a database ever being reached; if it moves back
+// behind the reason arm, this panics rather than quietly passing.
+func TestAnOverlongDetailIsRefusedEvenWhenNoReasonIsStated(t *testing.T) {
+	over := strings.Repeat("x", maxWonReasonDetail+1)
+
+	var tooLong *WonReasonDetailTooLongError
+	err := ensureWinEvidence(context.Background(), nil, ids.DealID{UUID: ids.NewV7()},
+		AdvanceDealInput{WonWithoutContractDetail: &over})
+	if !errors.As(err, &tooLong) {
+		t.Fatalf("a %d-character detail with no stated reason was admitted (%v) — a win with a signed contract would have written it, past the bound the schema advertises",
+			maxWonReasonDetail+1, err)
+	}
+
+	// A detail within the bound and no reason falls through to the contract
+	// lookup, which is the ordinary path. Asserting the refusal alone would
+	// pass against a gate that refused every such win.
+	within := strings.Repeat("x", maxWonReasonDetail)
+	if err := ensureDetailWithinBound(&within); err != nil {
+		t.Errorf("a detail of exactly %d characters was refused: %v", maxWonReasonDetail, err)
 	}
 }

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,7 +6,7 @@
   "catalog": {
     "tools": 74,
     "system_frame_tokens": 353,
-    "tokens": 22325,
+    "tokens": 22333,
     "median_tool_tokens": 264,
     "mean_tool_tokens": 301
   },
@@ -104,7 +104,7 @@
     },
     {
       "name": "progress_deal",
-      "tokens": 501
+      "tokens": 505
     },
     {
       "name": "resolve_entities",
@@ -124,7 +124,7 @@
     },
     {
       "name": "advance_deal",
-      "tokens": 443
+      "tokens": 447
     },
     {
       "name": "annotate_brief",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1634 | 4% | 21576 | 6 | 6 |
 | `overnight_at_risk_sweep` | 7 | 2509 | 7% | 20701 | 15 | 10 |
-| _whole served catalog, for scale_ | 74 | 22325 | 68% | — | — | — |
+| _whole served catalog, for scale_ | 74 | 22333 | 68% | — | — | — |
 
 ### `morning_brief`
 
@@ -143,12 +143,12 @@ a term in an addition.
 | `update_record` | 572 | 4 scenarios |
 | `send_message` | 518 | — |
 | `list_records` | 508 | — |
-| `progress_deal` | 501 | 3 scenarios |
+| `progress_deal` | 505 | 3 scenarios |
 | `resolve_entities` | 498 | — |
 | `query_workspace` | 484 | 3 scenarios |
 | `create_record` | 473 | 1 scenario |
 | `run_analytics_query` | 465 | — |
-| `advance_deal` | 443 | 1 scenario |
+| `advance_deal` | 447 | 1 scenario |
 | `annotate_brief` | 418 | — |
 | `review_commitments` | 401 | 1 scenario |
 | `book_meeting` | 393 | — |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (100)
+## Parity (102)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -26,6 +26,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `airoutingschema_test.go` | H3 | What the EDITOR accepts, checked against what the parser accepts. |
 | `aitaskparity_test.go` | H3 | Every ai\_task an emitter writes into the AI-activity projection must be a task the AI contract declares. |
 | `aitaskrunenum_test.go` | H3 | The ai\_task.state\_changed payload's closed vocabularies must equal the ai\_task\_run column CHECKs they are projected into. |
+| `appviewfixtures_test.go` | H2 | A view's fixture is the tool's answer, and this is what makes that true. |
 | `auditcoherence_test.go` | H3 | The audit\_log enum-coherence gate as a fitness function. |
 | `authwaitparity_test.go` | H3 | How long an in-flight authentication may be held waiting on somebody else's server. |
 | `authzcategories_test.go` | H2 | The outbound category vocabulary is spelled TWICE — once in Go, once as a CHECK constraint on communication\_decision — and the two must agree. |
@@ -47,6 +48,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `contractvocabulary_test.go` | H3 | A membership set built from a generated enum's own constants must hold every member of that enum. |
 | `corepicklistcontract_test.go` | H3 | The core picklist value sets against the contract that owns them. |
 | `dealmoveargument_test.go` | H2 | One rule, read on both sides of a compose seam. |
+| `dealmovemirror_test.go` | H2 | One rule, spelled on both sides of a module boundary, held equal in both directions. |
 | `dedupeevidencefields_test.go` | H1 | The dedupe evidence snapshot is stored as free JSON, so nothing about a field name is checked when it is written. |
 | `deexceptionmirror_test.go` | H3 | The engine's test fixture for the German exception is the pack's declaration, or the tests prove nothing about what ships. |
 | `dsrqueueishumanonly_test.go` | H2 | The subject-request queue is human-only in the contract because it is human-only in the store. |
@@ -310,7 +312,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 | `writeliveness_test.go` | H2 | The LIVENESS obligation as a fitness function: a write that targets one standing row of a table which can be archived either REFUSES an archived row, DECLARES that it deliberately reaches one, or is ratified with a reason. |
 
-## Prohibition (52)
+## Prohibition (53)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -319,6 +321,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `authzmetriclabels_test.go` | H2 | The outbound decision counter labels only closed vocabularies, and never the recipient. |
 | `backfillledgerlock_test.go` | H2 | A transaction that writes the backfill creation ledger locks the run row first. |
 | `capabilitypathlog_test.go` | H2 | A request path reaches a log line through capabilitypath.Redact, never raw. |
+| `commentnamedtests_test.go` | H1 | A test named in a comment exists. |
 | `connectoractor_test.go` | H1 | A connector's actor id is DERIVED from the work, never written down. |
 | `constraintnameleak_test.go` | H2 | A constraint's name goes in the operator's log, never in the caller's refusal. |
 | `contentionprobe_test.go` | H2 | A contention probe that cannot see the backend it is waiting for. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (101)
+## Parity (100)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -26,7 +26,6 @@ The eight shapes, what each is for, and how each one silently passes:
 | `airoutingschema_test.go` | H3 | What the EDITOR accepts, checked against what the parser accepts. |
 | `aitaskparity_test.go` | H3 | Every ai\_task an emitter writes into the AI-activity projection must be a task the AI contract declares. |
 | `aitaskrunenum_test.go` | H3 | The ai\_task.state\_changed payload's closed vocabularies must equal the ai\_task\_run column CHECKs they are projected into. |
-| `appviewfixtures_test.go` | H2 | A view's fixture is the tool's answer, and this is what makes that true. |
 | `auditcoherence_test.go` | H3 | The audit\_log enum-coherence gate as a fitness function. |
 | `authwaitparity_test.go` | H3 | How long an in-flight authentication may be held waiting on somebody else's server. |
 | `authzcategories_test.go` | H2 | The outbound category vocabulary is spelled TWICE — once in Go, once as a CHECK constraint on communication\_decision — and the two must agree. |
@@ -48,7 +47,6 @@ The eight shapes, what each is for, and how each one silently passes:
 | `contractvocabulary_test.go` | H3 | A membership set built from a generated enum's own constants must hold every member of that enum. |
 | `corepicklistcontract_test.go` | H3 | The core picklist value sets against the contract that owns them. |
 | `dealmoveargument_test.go` | H2 | One rule, read on both sides of a compose seam. |
-| `dealmovemirror_test.go` | H2 | One rule, spelled on both sides of a module boundary, held equal in both directions. |
 | `dedupeevidencefields_test.go` | H1 | The dedupe evidence snapshot is stored as free JSON, so nothing about a field name is checked when it is written. |
 | `deexceptionmirror_test.go` | H3 | The engine's test fixture for the German exception is the pack's declaration, or the tests prove nothing about what ships. |
 | `dsrqueueishumanonly_test.go` | H2 | The subject-request queue is human-only in the contract because it is human-only in the store. |
@@ -117,6 +115,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `shippingloopreachesthelane_test.go` | H2 | The routine the rulebook tells a contributor to run reaches the integration lane. |
 | `teamoutlookmirror_test.go` | H3 | The team's frozen outlook and the rep's are the same fact over different books, so they are the same SHAPE or one of them is lying. |
 | `transcriptmarker_test.go` | H3 | One value, spelled in two modules, because a module never imports a sibling. |
+| `wonreasondetailbound_test.go` | H2 | The paperless-win detail's length bound is ONE number, in three places that each need it. |
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
@@ -311,7 +310,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 | `writeliveness_test.go` | H2 | The LIVENESS obligation as a fitness function: a write that targets one standing row of a table which can be archived either REFUSES an archived row, DECLARES that it deliberately reaches one, or is ratified with a reason. |
 
-## Prohibition (53)
+## Prohibition (52)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -320,7 +319,6 @@ The eight shapes, what each is for, and how each one silently passes:
 | `authzmetriclabels_test.go` | H2 | The outbound decision counter labels only closed vocabularies, and never the recipient. |
 | `backfillledgerlock_test.go` | H2 | A transaction that writes the backfill creation ledger locks the run row first. |
 | `capabilitypathlog_test.go` | H2 | A request path reaches a log line through capabilitypath.Redact, never raw. |
-| `commentnamedtests_test.go` | H1 | A test named in a comment exists. |
 | `connectoractor_test.go` | H1 | A connector's actor id is DERIVED from the work, never written down. |
 | `constraintnameleak_test.go` | H2 | A constraint's name goes in the operator's log, never in the caller's refusal. |
 | `contentionprobe_test.go` | H2 | A contention probe that cannot see the backend it is waiting for. |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 74,
     "resources": 12,
-    "tool_catalog_bytes": 213120,
+    "tool_catalog_bytes": 213152,
     "resource_catalog_bytes": 4584,
-    "approx_wire_tokens_total": 54426,
+    "approx_wire_tokens_total": 54434,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 51869,
-      "input_schema_bytes": 45443,
+      "input_schema_bytes": 45475,
       "output_schema_bytes": 99854,
-      "description_plus_input_schema_bytes": 97312
+      "description_plus_input_schema_bytes": 97344
     }
   },
   "tools": {
@@ -306,6 +306,7 @@
             },
             "won_without_contract_detail": {
               "description": "What the reason was, required when it is other",
+              "maxLength": 500,
               "type": "string"
             },
             "won_without_contract_reason": {
@@ -8253,6 +8254,7 @@
             },
             "won_without_contract_detail": {
               "description": "What the reason was, required when it is other",
+              "maxLength": 500,
               "type": "string"
             },
             "won_without_contract_reason": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 74 |
 | Resources | 12 |
-| Tool catalog | 208.1 KB |
+| Tool catalog | 208.2 KB |
 | Resource catalog | 4.5 KB |
-| Approx. wire tokens | 54426 |
+| Approx. wire tokens | 54434 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -33,7 +33,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 | Descriptions (incl. governance clause) | 50.7 KB | 24% | Yes, every step |
 | Input schemas | 44.4 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.6 KB | 7% | Partly |
-| **Description + input schema** | **95.0 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **95.1 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -640,6 +640,7 @@ Move a deal to a different stage of its pipeline. The stage is named by id from 
     },
     "won_without_contract_detail": {
       "description": "What the reason was, required when it is other",
+      "maxLength": 500,
       "type": "string"
     },
     "won_without_contract_reason": {
@@ -9023,6 +9024,7 @@ Move a deal to a new stage and leave a note on its timeline saying why, in one c
     },
     "won_without_contract_detail": {
       "description": "What the reason was, required when it is other",
+      "maxLength": 500,
       "type": "string"
     },
     "won_without_contract_reason": {

--- a/docs/reference/mcp-tool-coverage.json
+++ b/docs/reference/mcp-tool-coverage.json
@@ -5,7 +5,7 @@
     "driven": 7,
     "never_driven": 67,
     "permitted_but_never_required": 13,
-    "tokens_served_but_never_driven": 18322,
+    "tokens_served_but_never_driven": 18330,
     "use_case_cases": 7,
     "cases_with_a_committed_run": 7,
     "acceptance_criteria_named": 6,
@@ -270,7 +270,7 @@
     },
     {
       "name": "progress_deal",
-      "tokens": 501,
+      "tokens": 505,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],
@@ -300,7 +300,7 @@
     },
     {
       "name": "advance_deal",
-      "tokens": 443,
+      "tokens": 447,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],

--- a/docs/reference/mcp-tool-coverage.md
+++ b/docs/reference/mcp-tool-coverage.md
@@ -29,7 +29,7 @@ This page does not grade single steps or name a best model per site — that is
 | … some case requires | 7 |
 | … **no case requires** | 67 |
 | … of those, permitted somewhere but never required | 13 |
-| Prompt tokens spent on tools no case requires | 18322 |
+| Prompt tokens spent on tools no case requires | 18330 |
 | Use cases | 7 |
 | … with a committed run | 7 |
 | Acceptance criteria the cases declare | 15 |
@@ -104,10 +104,10 @@ stopped being able to call it. A tool in the `permitted` column is worse than on
 | `update_record` | 572 | — | — |
 | `send_message` | 518 | — | — |
 | `list_records` | 508 | — | `morning_brief`, `overnight_at_risk_sweep` |
-| `progress_deal` | 501 | — | — |
+| `progress_deal` | 505 | — | — |
 | `resolve_entities` | 498 | `case1_log_it`, `case2_business_card` | — |
 | `run_analytics_query` | 465 | — | — |
-| `advance_deal` | 443 | — | — |
+| `advance_deal` | 447 | — | — |
 | `annotate_brief` | 418 | — | `morning_brief` |
 | `review_commitments` | 401 | — | `overnight_at_risk_sweep` |
 | `book_meeting` | 393 | — | — |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21839,7 +21839,14 @@ export interface components {
              * @enum {string|null}
              */
             won_without_contract_reason?: "imported" | "purchase_order" | "verbal" | "renewal_by_email" | "other" | null;
-            /** @description What the reason was. Required when it is `other`, which explains nothing alone. */
+            /**
+             * @description What the reason was. Required when it is `other`, which explains nothing alone.
+             *
+             *     Bounded because it is free text that a record page shows back beside the deal's
+             *     status: an unbounded value reaches every reader of that deal, and the header it
+             *     lands in is a line of short facts. 500 is the same bound the operator notes on
+             *     this contract carry.
+             */
             won_without_contract_detail?: string | null;
         };
         DealListResponse: {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21844,8 +21844,8 @@ export interface components {
              *
              *     Bounded because it is free text that a record page shows back beside the deal's
              *     status: an unbounded value reaches every reader of that deal, and the header it
-             *     lands in is a line of short facts. 500 is the same bound the operator notes on
-             *     this contract carry.
+             *     lands in is a line of short facts. 500 is a few sentences — long enough to say
+             *     what happened, short enough that the line stays readable.
              */
             won_without_contract_detail?: string | null;
         };

--- a/frontend/src/screens/deal360/deal360.stories.tsx
+++ b/frontend/src/screens/deal360/deal360.stories.tsx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { components } from "../../api/schema";
-import { DealIdentityLine } from "../deals";
+import { DealIdentityLine } from "../dealidentity";
 import { installFetchStub, jsonResponse, StoryProviders } from "../story-utils";
 import { DealPulse } from "./dealpulse";
 import { DealSeats } from "./dealseats";

--- a/frontend/src/screens/deal360/deal360.test.tsx
+++ b/frontend/src/screens/deal360/deal360.test.tsx
@@ -434,6 +434,39 @@ describe("the identity line says what it is worth, where it is, and whose it is"
     ).not.toBeInTheDocument();
   });
 
+  it("keeps a long hand-written reason from pushing the facts off the line", () => {
+    // The identity line is a row of SHORT facts — the stage, the owner, the
+    // partner. This is the only free text on it, and the contract's 500-char
+    // bound stops a value nobody can read without stopping one that crowds out
+    // its neighbours. The opening rides the line; the whole answer stays
+    // reachable, because the reader most likely to look is the person checking
+    // what they typed.
+    const long =
+      `Renewed on a handshake at the trade fair ${"and again ".repeat(20)}`.trim();
+    show(
+      <DealIdentityLine
+        deal={{
+          amount_minor: 1000,
+          currency: "EUR",
+          stage_id: "st-1",
+          status: "won",
+          won_without_contract_reason: "other",
+          won_without_contract_detail: long,
+        }}
+        stages={stages}
+        locale="en"
+      />,
+    );
+    expect(screen.queryByText(long)).not.toBeInTheDocument();
+    const shown = screen.getByTitle(long);
+    expect(shown.textContent ?? "").toMatch(
+      /^Renewed on a handshake at the trade fair/,
+    );
+    expect((shown.textContent ?? "").length).toBeLessThan(long.length);
+    // The stage is still on the line beside it, which is the point.
+    expect(screen.getByText("Qualified")).toBeInTheDocument();
+  });
+
   it("says nothing about paperwork on a won deal a contract carried", () => {
     // The ordinary case, and it needs no sentence. A line on every won deal
     // would bury the ones that need reading — which is the whole point of

--- a/frontend/src/screens/deal360/deal360.test.tsx
+++ b/frontend/src/screens/deal360/deal360.test.tsx
@@ -385,6 +385,82 @@ describe("the identity line says what it is worth, where it is, and whose it is"
     expect(screen.queryByText("—")).not.toBeInTheDocument();
   });
 
+  it("says how a won deal was won when no contract carried it", () => {
+    // The server treats this answer as load-bearing — the whole justification
+    // for letting the deal close without paperwork is that the gap becomes
+    // countable — and nothing read it back, so the rep who answered could not
+    // check their own answer.
+    show(
+      <DealIdentityLine
+        deal={{
+          amount_minor: 1000,
+          currency: "EUR",
+          stage_id: "st-1",
+          status: "won",
+          won_without_contract_reason: "purchase_order",
+        }}
+        stages={stages}
+        locale="en"
+      />,
+    );
+    expect(
+      screen.getByText(en["deals.winReasonPurchaseOrder"]),
+    ).toBeInTheDocument();
+  });
+
+  it("prints the words a person wrote rather than the category they chose", () => {
+    // `other` is the only reason carrying a detail, and the detail is the only
+    // part of this answer somebody typed. "Something else: renewed on a
+    // handshake" says the category twice and buries it.
+    show(
+      <DealIdentityLine
+        deal={{
+          amount_minor: 1000,
+          currency: "EUR",
+          stage_id: "st-1",
+          status: "won",
+          won_without_contract_reason: "other",
+          won_without_contract_detail: "Renewed on a handshake at the fair",
+        }}
+        stages={stages}
+        locale="en"
+      />,
+    );
+    expect(
+      screen.getByText("Renewed on a handshake at the fair"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(en["deals.winReasonOther"]),
+    ).not.toBeInTheDocument();
+  });
+
+  it("says nothing about paperwork on a won deal a contract carried", () => {
+    // The ordinary case, and it needs no sentence. A line on every won deal
+    // would bury the ones that need reading — which is the whole point of
+    // showing this at all.
+    show(
+      <DealIdentityLine
+        deal={{
+          amount_minor: 1000,
+          currency: "EUR",
+          stage_id: "st-1",
+          status: "won",
+        }}
+        stages={stages}
+        locale="en"
+      />,
+    );
+    for (const key of [
+      "deals.winReasonPurchaseOrder",
+      "deals.winReasonVerbal",
+      "deals.winReasonRenewalByEmail",
+      "deals.winReasonImported",
+      "deals.winReasonOther",
+    ] as const) {
+      expect(screen.queryByText(en[key])).not.toBeInTheDocument();
+    }
+  });
+
   it("never prints a stage id the pipeline cannot name", () => {
     // The case a null stage_id CANNOT test: an id that is present and does not
     // resolve. An overlay-mirror deal carries the incumbent's own pipeline id,

--- a/frontend/src/screens/deal360/deal360.test.tsx
+++ b/frontend/src/screens/deal360/deal360.test.tsx
@@ -3,6 +3,8 @@
 
 /** @vitest-environment jsdom */
 import "@testing-library/jest-dom/vitest";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
@@ -459,12 +461,48 @@ describe("the identity line says what it is worth, where it is, and whose it is"
     );
     // Every word of it, reachable by a reader that does not hover.
     expect(screen.getByText(long)).toBeInTheDocument();
-    // And the stage is still on the line beside it, which is what the clamp is
-    // for. The width itself is CSS and not assertable here; what this pins is
-    // that the fact carries the class the clamp hangs on, so removing it is a
-    // failing test rather than a silently wide line.
+    // And the stage is still on the line beside it, which is what the bound is
+    // for. What this pins is that the fact carries the class the bound hangs
+    // on, so removing it is a failing test rather than a silently wide line;
+    // that the class does not CLIP is held by the rule itself, below, because
+    // jsdom applies no stylesheet and presence in the DOM proves nothing about
+    // what a reader can see.
     expect(screen.getByText(long)).toHaveClass("deal-win-detail");
     expect(screen.getByText("Qualified")).toBeInTheDocument();
+  });
+
+  // The bound is on WIDTH, never on content — asserted against the stylesheet,
+  // because jsdom applies none and a rendered tree cannot tell a wrapped value
+  // from a clipped one.
+  //
+  // This has been wrong twice in opposite directions, which is why it is held
+  // rather than described. Clipped with the rest in a `title` needs a mouse;
+  // clipped with no `title` is unreadable for everyone. Either way the reader
+  // who loses is the person checking the words they just typed, and the value
+  // exists to be audited.
+  it("bounds the won-reason detail's width and never its content", () => {
+    const css = readFileSync(
+      join(resolve(__dirname, ".."), "dealstatus.css"),
+      "utf8",
+    );
+    const rule = /\.deal-win-detail\s*\{([^}]*)\}/.exec(css);
+    expect(rule, ".deal-win-detail is gone from dealstatus.css").not.toBeNull();
+    const body = rule?.[1] ?? "";
+
+    // A width bound, so the identity line stays a line of short facts.
+    expect(body).toMatch(/max-width:/);
+    // And nothing that hides what does not fit inside it.
+    for (const clip of [
+      /overflow\s*:\s*hidden/,
+      /text-overflow\s*:/,
+      /white-space\s*:\s*nowrap/,
+      /line-clamp\s*:/,
+    ]) {
+      expect(
+        body,
+        `.deal-win-detail clips its content (${clip.source}); the value is what a controller is shown`,
+      ).not.toMatch(clip);
+    }
   });
 
   it("says nothing about paperwork on a won deal a contract carried", () => {

--- a/frontend/src/screens/deal360/deal360.test.tsx
+++ b/frontend/src/screens/deal360/deal360.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { components } from "../../api/schema";
 import { LocaleProvider } from "../../i18n";
 import { en } from "../../i18n/en";
-import { DealIdentityLine } from "../deals";
+import { DealIdentityLine } from "../dealidentity";
 import { DealPulse } from "./dealpulse";
 import { DealSeats } from "./dealseats";
 import { DealStrip } from "./dealstrip";

--- a/frontend/src/screens/deal360/deal360.test.tsx
+++ b/frontend/src/screens/deal360/deal360.test.tsx
@@ -434,13 +434,13 @@ describe("the identity line says what it is worth, where it is, and whose it is"
     ).not.toBeInTheDocument();
   });
 
-  it("keeps a long hand-written reason from pushing the facts off the line", () => {
-    // The identity line is a row of SHORT facts — the stage, the owner, the
-    // partner. This is the only free text on it, and the contract's 500-char
-    // bound stops a value nobody can read without stopping one that crowds out
-    // its neighbours. The opening rides the line; the whole answer stays
-    // reachable, because the reader most likely to look is the person checking
-    // what they typed.
+  it("keeps a long hand-written reason readable rather than only hoverable", () => {
+    // The identity line is a row of SHORT facts, so this one is bounded — but
+    // VISUALLY, with the whole string in the DOM. An earlier version trimmed it
+    // in TS and put the rest in a `title`, which reads as solved and is not: a
+    // tooltip wants a mouse, is ignored by most screen readers, and never
+    // appears for a keyboard or touch reader. The person most likely to look is
+    // the one checking the words they just typed.
     const long =
       `Renewed on a handshake at the trade fair ${"and again ".repeat(20)}`.trim();
     show(
@@ -457,13 +457,13 @@ describe("the identity line says what it is worth, where it is, and whose it is"
         locale="en"
       />,
     );
-    expect(screen.queryByText(long)).not.toBeInTheDocument();
-    const shown = screen.getByTitle(long);
-    expect(shown.textContent ?? "").toMatch(
-      /^Renewed on a handshake at the trade fair/,
-    );
-    expect((shown.textContent ?? "").length).toBeLessThan(long.length);
-    // The stage is still on the line beside it, which is the point.
+    // Every word of it, reachable by a reader that does not hover.
+    expect(screen.getByText(long)).toBeInTheDocument();
+    // And the stage is still on the line beside it, which is what the clamp is
+    // for. The width itself is CSS and not assertable here; what this pins is
+    // that the fact carries the class the clamp hangs on, so removing it is a
+    // failing test rather than a silently wide line.
+    expect(screen.getByText(long)).toHaveClass("deal-win-detail");
     expect(screen.getByText("Qualified")).toBeInTheDocument();
   });
 

--- a/frontend/src/screens/dealidentity.tsx
+++ b/frontend/src/screens/dealidentity.tsx
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The one line of facts under a deal's name, and the facts it draws.
+//
+// Its own file rather than a section of the deal screen: the screen is at the
+// tree's file-length ceiling, and this is a self-contained presentational row
+// with its own type, read by the deal page and by the 360's tests and stories.
+
+import type { ReactNode } from "react";
+import type { components } from "../api/schema";
+import {
+  IdentityFact,
+  IdentityLine,
+  IdentityMeta,
+} from "../design-system/identityline";
+import { FieldGuard } from "../design-system/rbac";
+import { formatMoney } from "../format/format";
+import { type Locale, useT } from "../i18n";
+import {
+  type WonWithoutContract,
+  WonWithoutContractFact,
+} from "./dealwinreason";
+import {
+  EntityRef,
+  rosterOwnerName,
+  useRoster,
+  useRosterPartial,
+} from "./entityref";
+
+type Deal = components["schemas"]["Deal"];
+
+// What the identity line reads off a deal. Every field is optional because
+// every one of them is a fact a deal can lack or a reader can be refused.
+export type DealIdentity = Pick<
+  Deal,
+  | "amount_minor"
+  | "currency"
+  | "stage_id"
+  | "owner_id"
+  | "organization_id"
+  | "partner_org_id"
+  | "partner_attribution"
+  | "masked_fields"
+> &
+  WonWithoutContract;
+
+/**
+ * The one line of facts under a deal's name: what it is worth, where it sits
+ * on the board, whose deal it is, and — when one brought it — which partner.
+ *
+ * It is the design system's `IdentityLine`, the same row the account and the
+ * contact draw under their own names, so the three records read the same way.
+ * These facts used to stand in a labelled box beside the verbs instead
+ * (`DealFacts`), which made the deal the only record whose head answered "what
+ * is this" in a different shape from every other — and cost the verbs the room
+ * they need beside a name at the record rung.
+ *
+ * The partner was editable in the form and rendered nowhere, so a deal that a
+ * partner sourced looked identical to one we won alone. That is the fact the
+ * commission is computed from, and a figure a partner is paid on has to be
+ * visible on the record it came from.
+ *
+ * Each reference goes through EntityRef, which resolves the name and links to
+ * the record — and withholds both when the reader may not open it, which is
+ * why the ids are not printed as a fallback. A withheld fact NAMES the field
+ * it withholds: on a line of joined facts a bare mask says only "something
+ * here is hidden", and the amount, the company and the partner are three
+ * different things to be refused.
+ */
+export function DealIdentityLine({
+  deal,
+  stages,
+  locale,
+}: Readonly<{
+  // The facts this line draws and no more. A presentational row does not need
+  // a whole `Deal` to say what one is worth, and asking for one makes every
+  // story and test that draws the line assemble a record it does not read.
+  deal: DealIdentity;
+  // The stages the PAGE already sorted for the board, not a second read.
+  stages: readonly { id: string; name: string }[];
+  locale: Locale;
+}>) {
+  const t = useT();
+  // Only asked for when there is an owner to name: an unowned deal needs no
+  // roster read to say so.
+  const roster = useRoster("user", Boolean(deal.owner_id));
+  const partial = useRosterPartial("user", Boolean(deal.owner_id));
+  const masked = deal.masked_fields ?? [];
+  // An em dash rather than the stage id: a deal in overlay mode carries no
+  // native pipeline row, and printing a UUID where a stage name goes reads as
+  // a fault.
+  const stage = stages.find((candidate) => candidate.id === deal.stage_id);
+  return (
+    <IdentityMeta>
+      <IdentityLine>
+        {masked.includes("organization_id") ? (
+          <IdentityFact>
+            {t("create.organization")} <FieldGuard mode="masked" />
+          </IdentityFact>
+        ) : (
+          deal.organization_id && (
+            <IdentityFact>
+              <EntityRef kind="organization" id={deal.organization_id} />
+            </IdentityFact>
+          )
+        )}
+        <IdentityFact>
+          {/* A masked amount NAMES the field, like every other refusal on this
+              line: a lone lock among joined facts says only that something
+              here is hidden, and "no value recorded" and "you may not see the
+              value" are different statements about a deal. */}
+          {masked.includes("amount_minor") ? (
+            <>
+              {t("deals.amount")} <FieldGuard mode="masked" />
+            </>
+          ) : (
+            dealAmount(deal, locale)
+          )}
+        </IdentityFact>
+        <IdentityFact>{stage?.name ?? "—"}</IdentityFact>
+        <IdentityFact quiet>
+          {t("list.owner")}:{" "}
+          {rosterOwnerName(
+            deal.owner_id,
+            roster,
+            partial,
+            t,
+            t("co.pulse.unowned"),
+          )}
+        </IdentityFact>
+        {masked.includes("partner_org_id") ? (
+          // No attribution word here: what the partner did is withheld WITH
+          // the partner, so naming one would decide what a partner nobody
+          // could see is owed.
+          <IdentityFact>
+            {t("deal.partnerOrg")} <FieldGuard mode="masked" />
+          </IdentityFact>
+        ) : (
+          deal.partner_org_id && (
+            <IdentityFact>
+              {/* Sourced and influenced are paid differently, so the line says
+                  which one rather than a neutral "partner: X" that hides the
+                  distinction the commission turns on. */}
+              {t(
+                deal.partner_attribution === "influenced"
+                  ? "deal.partnerInfluenced"
+                  : "deal.partnerSourced",
+              )}{" "}
+              <EntityRef kind="organization" id={deal.partner_org_id} />
+            </IdentityFact>
+          )
+        )}
+        <WonWithoutContractFact deal={deal} />
+      </IdentityLine>
+    </IdentityMeta>
+  );
+}
+
+// The value, or an em dash when the deal carries none. The masked case is the
+// caller's, because a refusal on this line is written as the field's name
+// beside the mark rather than as the mark alone.
+function dealAmount(deal: DealIdentity, locale: Locale): ReactNode {
+  if (deal.amount_minor == null || !deal.currency) {
+    return "—";
+  }
+  return formatMoney(deal.amount_minor, deal.currency, locale);
+}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3869,18 +3869,41 @@ function WonWithoutContractFact({ deal }: Readonly<{ deal: DealIdentity }>) {
     return null;
   }
   const label = t(WON_REASON_LABELS[reason]);
+  // The detail replaces the label for `other`, and does not follow it:
+  // "Something else: renewed on a handshake" says the category twice and
+  // buries the only part written by a person. Every other reason is its own
+  // answer and carries no detail.
+  const detail = reason === "other" ? deal.won_without_contract_detail : null;
+  if (!detail) {
+    return <IdentityFact>{label}</IdentityFact>;
+  }
+  // Free text on a line of SHORT facts. The contract bounds the value at 500
+  // characters, which stops a stored value nobody can read; it does not stop
+  // one that pushes the stage and the owner off the line beside it. So the line
+  // shows an opening that fits and the full answer rides the title, which is
+  // where a reader checking their own words looks next.
+  //
+  // Trimmed in TS rather than by an ellipsis rule, deliberately: a CSS clamp on
+  // a flex row needs min-width and overflow on the fact AND its line, which is
+  // a change to a shared design-system row for one screen's field.
+  const shown =
+    detail.length > WON_DETAIL_INLINE
+      ? `${detail.slice(0, WON_DETAIL_INLINE).trimEnd()}…`
+      : detail;
   return (
     <IdentityFact>
-      {/* The detail replaces the label for `other`, and does not follow it:
-          "Something else: renewed on a handshake" says the category twice and
-          buries the only part written by a person. Every other reason is its
-          own answer and carries no detail. */}
-      {reason === "other" && deal.won_without_contract_detail
-        ? deal.won_without_contract_detail
-        : label}
+      {/* The title rides a span rather than the fact: IdentityFact draws a
+          plain element and forwards no attributes, so a title handed to it
+          would be dropped without a word. */}
+      <span title={detail}>{shown}</span>
     </IdentityFact>
   );
 }
+
+// How much of a free-text win reason rides the identity line. Long enough for
+// the answers people actually give ("on a framework agreement signed in March")
+// and short enough to leave the facts beside it readable.
+const WON_DETAIL_INLINE = 60;
 
 // The value, or an em dash when the deal carries none. The masked case is the
 // caller's, because a refusal on this line is written as the field's name

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3877,33 +3877,21 @@ function WonWithoutContractFact({ deal }: Readonly<{ deal: DealIdentity }>) {
   if (!detail) {
     return <IdentityFact>{label}</IdentityFact>;
   }
-  // Free text on a line of SHORT facts. The contract bounds the value at 500
-  // characters, which stops a stored value nobody can read; it does not stop
-  // one that pushes the stage and the owner off the line beside it. So the line
-  // shows an opening that fits and the full answer rides the title, which is
-  // where a reader checking their own words looks next.
+  // Free text on a line of SHORT facts, so it is bounded — visually, and with
+  // the whole string still in the DOM.
   //
-  // Trimmed in TS rather than by an ellipsis rule, deliberately: a CSS clamp on
-  // a flex row needs min-width and overflow on the fact AND its line, which is
-  // a change to a shared design-system row for one screen's field.
-  const shown =
-    detail.length > WON_DETAIL_INLINE
-      ? `${detail.slice(0, WON_DETAIL_INLINE).trimEnd()}…`
-      : detail;
-  return (
-    <IdentityFact>
-      {/* The title rides a span rather than the fact: IdentityFact draws a
-          plain element and forwards no attributes, so a title handed to it
-          would be dropped without a word. */}
-      <span title={detail}>{shown}</span>
-    </IdentityFact>
-  );
+  // It used to be trimmed in TS with the rest in a `title`. That reads as
+  // solved and is not: a tooltip wants a mouse, is ignored by most screen
+  // readers, and never appears for a keyboard or touch reader — so the people
+  // who could not read the answer would have included the person checking the
+  // words they had just typed, which is who this fact exists for.
+  //
+  // The clamp is a class on this screen's own stylesheet rather than a rule in
+  // the design system: one screen's free-text field is not a shape the shared
+  // identity row owes everybody, and IdentityFact already takes a className for
+  // exactly this.
+  return <IdentityFact className="deal-win-detail">{detail}</IdentityFact>;
 }
-
-// How much of a free-text win reason rides the identity line. Long enough for
-// the answers people actually give ("on a framework agreement signed in March")
-// and short enough to leave the facts beside it readable.
-const WON_DETAIL_INLINE = 60;
 
 // The value, or an em dash when the deal carries none. The masked case is the
 // caller's, because a refusal on this line is written as the field's name

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -50,11 +50,6 @@ import {
   RecordView,
 } from "../design-system/composed";
 import { IconAction } from "../design-system/iconaction";
-import {
-  IdentityFact,
-  IdentityLine,
-  IdentityMeta,
-} from "../design-system/identityline";
 import type { ListChip } from "../design-system/listsurface";
 import type { ListColumn, ListSelection } from "../design-system/listtable";
 import { OpenEmailDrawer } from "../design-system/openemaildrawer";
@@ -115,6 +110,7 @@ import { useDealRecipientAddress } from "./deal360/usedealrecipient";
 import { DealBulkBar } from "./dealbulk";
 import { DealEmailAside } from "./dealemail";
 import { DealFiles } from "./dealfiles";
+import { DealIdentityLine } from "./dealidentity";
 import {
   DealProjectChip,
   dealProjectFields,
@@ -128,11 +124,9 @@ import { EditAction } from "./edit";
 import {
   EntityRef,
   type OwnerNaming,
-  rosterOwnerName,
   rosterOwnerNaming,
   useEntityName,
   useRoster,
-  useRosterPartial,
 } from "./entityref";
 import { RecordHistoryTab } from "./history";
 import {
@@ -3712,196 +3706,6 @@ function dealStageSteps({
 // doesn't push the render-prop closure over the cognitive-complexity budget.
 // Every prop here is a value already resolved by DealScreen — no new
 // fetches, no behavior change from the pre-tab layout.
-// What the identity line reads off a deal. Every field is optional because
-// every one of them is a fact a deal can lack or a reader can be refused.
-type DealIdentity = Pick<
-  Deal,
-  | "amount_minor"
-  | "currency"
-  | "stage_id"
-  | "owner_id"
-  | "organization_id"
-  | "partner_org_id"
-  | "partner_attribution"
-  | "masked_fields"
-  | "won_without_contract_reason"
-  | "won_without_contract_detail"
-> &
-  // `status` is required on a Deal and optional here, which is the rest of this
-  // type's rule stated for the one field that would otherwise break it: the line
-  // draws the facts it is given, and every story and test that draws it builds
-  // the smallest deck that says something. Absent reads as "not a won deal",
-  // which is what a deck omitting it means.
-  Partial<Pick<Deal, "status">>;
-
-/**
- * The one line of facts under a deal's name: what it is worth, where it sits
- * on the board, whose deal it is, and — when one brought it — which partner.
- *
- * It is the design system's `IdentityLine`, the same row the account and the
- * contact draw under their own names, so the three records read the same way.
- * These facts used to stand in a labelled box beside the verbs instead
- * (`DealFacts`), which made the deal the only record whose head answered "what
- * is this" in a different shape from every other — and cost the verbs the room
- * they need beside a name at the record rung.
- *
- * The partner was editable in the form and rendered nowhere, so a deal that a
- * partner sourced looked identical to one we won alone. That is the fact the
- * commission is computed from, and a figure a partner is paid on has to be
- * visible on the record it came from.
- *
- * Each reference goes through EntityRef, which resolves the name and links to
- * the record — and withholds both when the reader may not open it, which is
- * why the ids are not printed as a fallback. A withheld fact NAMES the field
- * it withholds: on a line of joined facts a bare mask says only "something
- * here is hidden", and the amount, the company and the partner are three
- * different things to be refused.
- */
-export function DealIdentityLine({
-  deal,
-  stages,
-  locale,
-}: Readonly<{
-  // The facts this line draws and no more. A presentational row does not need
-  // a whole `Deal` to say what one is worth, and asking for one makes every
-  // story and test that draws the line assemble a record it does not read.
-  deal: DealIdentity;
-  // The stages the PAGE already sorted for the board, not a second read.
-  stages: readonly { id: string; name: string }[];
-  locale: Locale;
-}>) {
-  const t = useT();
-  // Only asked for when there is an owner to name: an unowned deal needs no
-  // roster read to say so.
-  const roster = useRoster("user", Boolean(deal.owner_id));
-  const partial = useRosterPartial("user", Boolean(deal.owner_id));
-  const masked = deal.masked_fields ?? [];
-  // An em dash rather than the stage id: a deal in overlay mode carries no
-  // native pipeline row, and printing a UUID where a stage name goes reads as
-  // a fault.
-  const stage = stages.find((candidate) => candidate.id === deal.stage_id);
-  return (
-    <IdentityMeta>
-      <IdentityLine>
-        {masked.includes("organization_id") ? (
-          <IdentityFact>
-            {t("create.organization")} <FieldGuard mode="masked" />
-          </IdentityFact>
-        ) : (
-          deal.organization_id && (
-            <IdentityFact>
-              <EntityRef kind="organization" id={deal.organization_id} />
-            </IdentityFact>
-          )
-        )}
-        <IdentityFact>
-          {/* A masked amount NAMES the field, like every other refusal on this
-              line: a lone lock among joined facts says only that something
-              here is hidden, and "no value recorded" and "you may not see the
-              value" are different statements about a deal. */}
-          {masked.includes("amount_minor") ? (
-            <>
-              {t("deals.amount")} <FieldGuard mode="masked" />
-            </>
-          ) : (
-            dealAmount(deal, locale)
-          )}
-        </IdentityFact>
-        <IdentityFact>{stage?.name ?? "—"}</IdentityFact>
-        <IdentityFact quiet>
-          {t("list.owner")}:{" "}
-          {rosterOwnerName(
-            deal.owner_id,
-            roster,
-            partial,
-            t,
-            t("co.pulse.unowned"),
-          )}
-        </IdentityFact>
-        {masked.includes("partner_org_id") ? (
-          // No attribution word here: what the partner did is withheld WITH
-          // the partner, so naming one would decide what a partner nobody
-          // could see is owed.
-          <IdentityFact>
-            {t("deal.partnerOrg")} <FieldGuard mode="masked" />
-          </IdentityFact>
-        ) : (
-          deal.partner_org_id && (
-            <IdentityFact>
-              {/* Sourced and influenced are paid differently, so the line says
-                  which one rather than a neutral "partner: X" that hides the
-                  distinction the commission turns on. */}
-              {t(
-                deal.partner_attribution === "influenced"
-                  ? "deal.partnerInfluenced"
-                  : "deal.partnerSourced",
-              )}{" "}
-              <EntityRef kind="organization" id={deal.partner_org_id} />
-            </IdentityFact>
-          )
-        )}
-        <WonWithoutContractFact deal={deal} />
-      </IdentityLine>
-    </IdentityMeta>
-  );
-}
-
-/**
- * How a won deal was won, when it was won without a contract.
- *
- * The server treats this answer as load-bearing — the whole justification for
- * letting the deal close without paperwork is that the gap becomes countable —
- * and until now no screen read it back. The rep who answered could not check
- * their own answer, and a won deal with paper looked identical to one without.
- *
- * On the identity line rather than in a pane, beside the `won` badge it
- * qualifies: it is a fact about the deal's standing, which is what this line
- * is for, and a reader asking "won on what?" is looking at the badge.
- *
- * Absent, never a placeholder, when the deal is not won or a contract carried
- * it. "Won with a contract" is the ordinary case and needs no sentence; a line
- * saying so on every won deal would bury the ones that need reading.
- */
-function WonWithoutContractFact({ deal }: Readonly<{ deal: DealIdentity }>) {
-  const t = useT();
-  const reason = deal.won_without_contract_reason;
-  if (deal.status !== "won" || !reason) {
-    return null;
-  }
-  const label = t(WON_REASON_LABELS[reason]);
-  // The detail replaces the label for `other`, and does not follow it:
-  // "Something else: renewed on a handshake" says the category twice and
-  // buries the only part written by a person. Every other reason is its own
-  // answer and carries no detail.
-  const detail = reason === "other" ? deal.won_without_contract_detail : null;
-  if (!detail) {
-    return <IdentityFact>{label}</IdentityFact>;
-  }
-  // Free text on a line of SHORT facts, so it is bounded — visually, and with
-  // the whole string still in the DOM.
-  //
-  // It used to be trimmed in TS with the rest in a `title`. That reads as
-  // solved and is not: a tooltip wants a mouse, is ignored by most screen
-  // readers, and never appears for a keyboard or touch reader — so the people
-  // who could not read the answer would have included the person checking the
-  // words they had just typed, which is who this fact exists for.
-  //
-  // The clamp is a class on this screen's own stylesheet rather than a rule in
-  // the design system: one screen's free-text field is not a shape the shared
-  // identity row owes everybody, and IdentityFact already takes a className for
-  // exactly this.
-  return <IdentityFact className="deal-win-detail">{detail}</IdentityFact>;
-}
-
-// The value, or an em dash when the deal carries none. The masked case is the
-// caller's, because a refusal on this line is written as the field's name
-// beside the mark rather than as the mark alone.
-function dealAmount(deal: DealIdentity, locale: Locale): ReactNode {
-  if (deal.amount_minor == null || !deal.currency) {
-    return "—";
-  }
-  return formatMoney(deal.amount_minor, deal.currency, locale);
-}
 
 // Deal360 leads the page. It is absent on an overlay-backed deal: the briefing
 // is written from records this installation holds, and a mirrored deal's

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3724,7 +3724,15 @@ type DealIdentity = Pick<
   | "partner_org_id"
   | "partner_attribution"
   | "masked_fields"
->;
+  | "won_without_contract_reason"
+  | "won_without_contract_detail"
+> &
+  // `status` is required on a Deal and optional here, which is the rest of this
+  // type's rule stated for the one field that would otherwise break it: the line
+  // draws the facts it is given, and every story and test that draws it builds
+  // the smallest deck that says something. Absent reads as "not a won deal",
+  // which is what a deck omitting it means.
+  Partial<Pick<Deal, "status">>;
 
 /**
  * The one line of facts under a deal's name: what it is worth, where it sits
@@ -3832,8 +3840,45 @@ export function DealIdentityLine({
             </IdentityFact>
           )
         )}
+        <WonWithoutContractFact deal={deal} />
       </IdentityLine>
     </IdentityMeta>
+  );
+}
+
+/**
+ * How a won deal was won, when it was won without a contract.
+ *
+ * The server treats this answer as load-bearing — the whole justification for
+ * letting the deal close without paperwork is that the gap becomes countable —
+ * and until now no screen read it back. The rep who answered could not check
+ * their own answer, and a won deal with paper looked identical to one without.
+ *
+ * On the identity line rather than in a pane, beside the `won` badge it
+ * qualifies: it is a fact about the deal's standing, which is what this line
+ * is for, and a reader asking "won on what?" is looking at the badge.
+ *
+ * Absent, never a placeholder, when the deal is not won or a contract carried
+ * it. "Won with a contract" is the ordinary case and needs no sentence; a line
+ * saying so on every won deal would bury the ones that need reading.
+ */
+function WonWithoutContractFact({ deal }: Readonly<{ deal: DealIdentity }>) {
+  const t = useT();
+  const reason = deal.won_without_contract_reason;
+  if (deal.status !== "won" || !reason) {
+    return null;
+  }
+  const label = t(WON_REASON_LABELS[reason]);
+  return (
+    <IdentityFact>
+      {/* The detail replaces the label for `other`, and does not follow it:
+          "Something else: renewed on a handshake" says the category twice and
+          buries the only part written by a person. Every other reason is its
+          own answer and carries no detail. */}
+      {reason === "other" && deal.won_without_contract_detail
+        ? deal.won_without_contract_detail
+        : label}
+    </IdentityFact>
   );
 }
 

--- a/frontend/src/screens/dealstatus.css
+++ b/frontend/src/screens/dealstatus.css
@@ -42,17 +42,18 @@
 
 /* The one FREE-TEXT fact on the deal's identity line: how a deal was won when
    no contract carried it, in the words a person typed.
-   
-   The whole string stays in the DOM and the clamp is visual only. A truncated
-   string with the rest in a `title` reads as solved and is not: a tooltip needs
-   a mouse, so the keyboard, touch and screen-reader readers — including the one
-   checking the words they just typed, which is who this fact exists for — would
-   have been the ones who could not read it. */
+
+   BOUNDED IN WIDTH, NOT IN CONTENT. It wraps rather than clipping, because the
+   fact exists to be read: a clip with the rest in a `title` needs a mouse, and
+   a clip with no `title` at all is simply unreadable — the person checking the
+   words they just typed is exactly who this is for, and both spellings failed
+   them. The server bounds the value at 500 characters, so wrapping cannot cost
+   more than a few lines and .identity-line already wraps.
+
+   `anywhere` because the value is free text: an unbroken 400-character token is
+   a thing a person can type, and without it that one would push the line wider
+   than the column instead of wrapping inside the max-width. */
 .deal-win-detail {
-  display: inline-block;
   max-width: 22rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  vertical-align: bottom;
+  overflow-wrap: anywhere;
 }

--- a/frontend/src/screens/dealstatus.css
+++ b/frontend/src/screens/dealstatus.css
@@ -39,3 +39,20 @@
 .deal360-fold > summary:hover {
   color: var(--textPrimary);
 }
+
+/* The one FREE-TEXT fact on the deal's identity line: how a deal was won when
+   no contract carried it, in the words a person typed.
+   
+   The whole string stays in the DOM and the clamp is visual only. A truncated
+   string with the rest in a `title` reads as solved and is not: a tooltip needs
+   a mouse, so the keyboard, touch and screen-reader readers — including the one
+   checking the words they just typed, which is who this fact exists for — would
+   have been the ones who could not read it. */
+.deal-win-detail {
+  display: inline-block;
+  max-width: 22rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}

--- a/frontend/src/screens/dealwinreason.tsx
+++ b/frontend/src/screens/dealwinreason.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { components } from "../api/schema";
+import { IdentityFact } from "../design-system/identityline";
+import { useT } from "../i18n";
+import { WON_REASON_LABELS } from "./winreason";
+import "./dealstatus.css";
+
+type Deal = components["schemas"]["Deal"];
+
+/**
+ * The facts this component draws and no more — the same rule the identity line
+ * it sits on follows. `status` is required on a Deal and optional here, because
+ * every story and test that draws this builds the smallest deck that says
+ * something, and absent reads as "not a won deal", which is what such a deck
+ * means.
+ */
+export type WonWithoutContract = Partial<
+  Pick<
+    Deal,
+    "status" | "won_without_contract_reason" | "won_without_contract_detail"
+  >
+>;
+
+/**
+ * How a won deal was won, when it was won without a contract.
+ *
+ * The server treats this answer as load-bearing — the whole justification for
+ * letting the deal close without paperwork is that the gap becomes countable —
+ * and until now no screen read it back. The rep who answered could not check
+ * their own answer, and a won deal with paper looked identical to one without.
+ *
+ * On the identity line rather than in a pane, beside the `won` badge it
+ * qualifies: it is a fact about the deal's standing, which is what this line
+ * is for, and a reader asking "won on what?" is looking at the badge.
+ *
+ * Absent, never a placeholder, when the deal is not won or a contract carried
+ * it. "Won with a contract" is the ordinary case and needs no sentence; a line
+ * saying so on every won deal would bury the ones that need reading.
+ */
+export function WonWithoutContractFact({
+  deal,
+}: Readonly<{ deal: WonWithoutContract }>) {
+  const t = useT();
+  const reason = deal.won_without_contract_reason;
+  if (deal.status !== "won" || !reason) {
+    return null;
+  }
+  const label = t(WON_REASON_LABELS[reason]);
+  // The detail replaces the label for `other`, and does not follow it:
+  // "Something else: renewed on a handshake" says the category twice and
+  // buries the only part written by a person. Every other reason is its own
+  // answer and carries no detail.
+  const detail = reason === "other" ? deal.won_without_contract_detail : null;
+  if (!detail) {
+    return <IdentityFact>{label}</IdentityFact>;
+  }
+  // Free text on a line of SHORT facts, so it is bounded — visually, and with
+  // the whole string still in the DOM.
+  //
+  // It used to be trimmed in TS with the rest in a `title`. That reads as
+  // solved and is not: a tooltip wants a mouse, is ignored by most screen
+  // readers, and never appears for a keyboard or touch reader — so the people
+  // who could not read the answer would have included the person checking the
+  // words they had just typed, which is who this fact exists for.
+  //
+  // The clamp is a class on this screen's own stylesheet rather than a rule in
+  // the design system: one screen's free-text field is not a shape the shared
+  // identity row owes everybody, and IdentityFact already takes a className for
+  // exactly this.
+  return <IdentityFact className="deal-win-detail">{detail}</IdentityFact>;
+}

--- a/frontend/src/screens/dealwinreason.tsx
+++ b/frontend/src/screens/dealwinreason.tsx
@@ -56,17 +56,21 @@ export function WonWithoutContractFact({
   if (!detail) {
     return <IdentityFact>{label}</IdentityFact>;
   }
-  // Free text on a line of SHORT facts, so it is bounded — visually, and with
-  // the whole string still in the DOM.
+  // Free text on a line of SHORT facts, so its WIDTH is bounded and its
+  // content is not: it wraps inside a max-width rather than clipping.
   //
-  // It used to be trimmed in TS with the rest in a `title`. That reads as
-  // solved and is not: a tooltip wants a mouse, is ignored by most screen
-  // readers, and never appears for a keyboard or touch reader — so the people
-  // who could not read the answer would have included the person checking the
-  // words they had just typed, which is who this fact exists for.
+  // Two earlier spellings were worse. Trimmed in TS with the rest in a `title`
+  // reads as solved and is not — a tooltip wants a mouse, is ignored by most
+  // screen readers, and never appears for a keyboard or touch reader. Clipped
+  // with no `title` is simply unreadable for everyone looking at it. Either way
+  // the reader who loses is the person checking the words they just typed,
+  // which is who this fact exists for.
   //
-  // The clamp is a class on this screen's own stylesheet rather than a rule in
-  // the design system: one screen's free-text field is not a shape the shared
+  // Wrapping is affordable because the server bounds the value: 500 characters
+  // is a few lines, and the identity line already wraps.
+  //
+  // The rule is a class on this screen's own stylesheet rather than one in the
+  // design system: one screen's free-text field is not a shape the shared
   // identity row owes everybody, and IdentityFact already takes a className for
   // exactly this.
   return <IdentityFact className="deal-win-detail">{detail}</IdentityFact>;


### PR DESCRIPTION
Closes #2105.

A deal can be won without a contract by stating why, and the server treats that answer as load-bearing — the whole justification for allowing the exit is that the gap becomes **countable**. No screen read it back.

So the rep who answered *"on a purchase order"* could not see their own answer, a mistyped detail on `other` could not be spotted, and a won deal with paper looked identical to one without — at the record where somebody would ask the question.

## Where it goes

On the **identity line**, beside the `won` badge it qualifies. It is a fact about the deal's standing, which is what that line is for, and a reader asking "won on what?" is already looking at the badge. Everything needed existed: `WON_REASON_LABELS` and the `deals.winReason*` keys in all three locales.

## Two judgement calls

**For `other`, the detail replaces the label rather than following it.** "Something else: renewed on a handshake" says the category twice and buries the only part a person wrote. Every other reason is its own complete answer and carries no detail.

**Absent, never a placeholder, when a contract carried the win.** That is the ordinary case and needs no sentence — a line on every won deal would bury the ones worth reading, which is the whole reason to show this at all.

## The type change

`status` joins `DealIdentity` as **optional**, though it is required on a `Deal`. Making it required here broke every story and test that builds the smallest deck saying something — which is this type's stated rule ("a presentational row does not need a whole `Deal`"). Absent reads as "not a won deal", which is what such a deck means.

## Tests

Three, in `deal360.test.tsx` beside the existing identity-line tests, each mutation-checked:

- The reason is shown on a won deal with no contract.
- `other` prints the words a person wrote, and **not** the category — asserted both ways.
- A won deal that a contract carried says nothing about paperwork, checked against all five labels rather than one, so a future reason cannot slip through as a placeholder.

Removing the component fails the first two; collapsing the `other` branch to the label fails the second.

## Not decided here

The issue also asks whether a won deal's reason should be **correctable** without reopening the deal. It is not today — the fields are `readOnly` on the schema and only settable through an advance — and the issue says that may well be the right answer, since the value is an assertion made at a moment and the audit trail records who made it. This change only makes the assertion visible; it does not touch how it is set.

`make check-fe` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deal identity views now display “won without contract” reasons and supporting details.
  * Long free-text details wrap within the deal identity layout instead of widening or clipping the page.

* **Bug Fixes**
  * Deal win details are now limited to 500 characters, with Unicode characters counted correctly.
  * The limit is consistently reflected in deal workflows and available input guidance.

* **Documentation**
  * Updated tool and API references to document the 500-character detail limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->