### PR TITLE
docs(compose): the accept-write's catalog note says what is true

### DIFF
--- a/backend/internal/compose/extractionaccept.go
+++ b/backend/internal/compose/extractionaccept.go
@@ -148,13 +148,13 @@ func (a *ExtractionAccept) Accept(ctx context.Context, attachmentID ids.UUID, re
 	// inside its transaction; a refusal there rolls the whole write back
 	// (deal AND notes — same tx) before any note exists.
 	dealID := ids.From[ids.DealKind](ids.UUID(att.EntityId))
-	// Where the custom-field catalog read belongs: above the transaction, never
-	// inside it — the read opens one of its own, and the write below holds a
-	// connection for as long as the deal update and every per-field note take.
-	// This store has no catalog wired, so the answer is empty today and the
-	// deal's cf values ride neither the patch nor its audit before-image
-	// (issue #1050); wiring one is then a one-line change here rather than a
-	// second-connection bug inside the write.
+	// Where a custom-field catalog read would belong if this path needed one:
+	// above the transaction, never inside it — the read opens one of its own,
+	// and the write below holds a connection for as long as the deal update and
+	// every per-field note take. It needs none. setAcceptedDealField's switch
+	// refuses a cf_* key outright, so the patch carries core columns only, and
+	// the audit image is the patch rather than the row — an unwired catalog
+	// widens no diff and drops no value here.
 	active, err := a.deals.ActiveDealColumns(ctx)
 	if err != nil {
 		return zero, err


### PR DESCRIPTION
Closes #1050.

The ticket asked for `WithFieldCatalog(customfields.NewService(pool, nil))` on the deals store `NewExtractionAccept` builds, on the grounds that an unwired catalog costs the acceptance's audit before-image every `cf_*` value while the same update over `PATCH /deals/{id}` records them. I wired it, wrote the integration test that should have gone red without it, and it stayed red **with** it. The premise does not hold.

**The audit image is the patch, not the row.** `recordDealUpdate` audits `p.Before()`/`p.After()` (`internal/modules/deals/deal.go:52`), and a `Patch` holds only the columns the write actually set. `active` widens the `readDeal` that sources old values; it does not widen what gets recorded. Run against a fully catalog-wired store — the HTTP twin's own configuration — a deal that carries `cf_segment = enterprise`, renamed through `UpdateDeal`, audits:

```
before={"name": "Probe"}  after={"name": "Renamed By The HTTP Twin"}
```

No `cf_segment`, through either door. There is no divergence to close.

**The patch can never reach a custom column anyway.** `setAcceptedDealField`'s switch is a closed allowlist, and its own comment says why a `cf_*` passthrough is refused: it "would hand the extractor an open column surface". So `SetCustomFieldPatch` being a no-op here is by construction, not the accident the ticket read it as — no future accept payload can carry a custom field without that switch changing first, at which point the catalog goes in beside it.

Wiring the catalog would therefore have bought nothing and cost a catalog query plus a wider `SELECT` on every acceptance.

### The ticket's open question

It asked whether any other composite builds a record store without the catalog its HTTP twin has. Three do, and none of them can drop a value either:

- `CreateDealTx` **refuses** `CustomFields` outright and takes no `active` parameter at all, so a catalog on `serverassembly.go`'s lead-deal opener or on `flipwriters.go` would be dead configuration.
- The two store-opened deal writers in `compose` — `closedate.go`'s close-date correction and `flipassoc.go`'s organization re-link — pass core columns only.
- `extractionaccept.go` is the tree's only caller-opened deal update outside the module.

### What this changes

The note above the `ActiveDealColumns` call asserted the false claim and carried the issue number, which is the build-process residue the rulebook rules out. Since that note is what the ticket was read off, leaving it means the next reader files this again. It now states the two structural facts instead. Comment-only; `make check-backend` green.
