### PR TITLE
fix(comms): the carriage gate holds the aggregate the send actually applies

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31980,6 +31980,7 @@ components:
             max_total_bytes:
               type: integer
               format: int64
+              minimum: 1
               description: |
                 Largest total across every file on one message, in bytes — the smaller of
                 this transport's own aggregate and the product's send budget. Always

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31958,7 +31958,7 @@ components:
             re-conflate a deployment fact with a tenant one.
         attachments:
           type: object
-          required: [carries, max_files, max_bytes_per_file, max_body_with_files]
+          required: [carries, max_files, max_bytes_per_file, max_total_bytes, max_body_with_files]
           description: |
             What this transport can carry alongside a message. Published because the
             composer must warn BEFORE a human presses send: a mismatch discovered at
@@ -31968,8 +31968,22 @@ components:
             default, so a connector that never declared carriage reports false rather than
             being mistaken for capable. A zero bound means "no limit beyond the contract's
             own", never "zero allowed".
+
+            `max_total_bytes` is the exception to that rule and is never zero: every
+            transport has an aggregate, because the product has one whether or not the
+            provider declares its own. It is the bound a composer must warn against
+            FIRST — `max_files` and `max_bytes_per_file` cannot express it between them,
+            so a message of ten files each under the per-file cap can pass both and still
+            be ten times what a send may carry.
           properties:
             carries: { type: boolean }
+            max_total_bytes:
+              type: integer
+              format: int64
+              description: |
+                Largest total across every file on one message, in bytes — the smaller of
+                this transport's own aggregate and the product's send budget. Always
+                present and always positive.
             max_files:
               type: integer
               description: Most files in one message. Never more than the contract's own `attachment_ids` cap of 10.

--- a/backend/internal/compose/commsattachments.go
+++ b/backend/internal/compose/commsattachments.go
@@ -170,21 +170,20 @@ func (a commsAttachments) ReadForSend(
 // published bounds admit, because a transport declaring ten files at 20 MiB each
 // promises ten times what this allows, so parking is the least it owes the
 // person who was told the message would go.
+// It is now the BACKSTOP rather than the first thing a person hears: the
+// carriage gate applies the same budget from the staged sizes, before any
+// object is opened, and parks with a reason naming the total and the bound.
+// This still runs, because the sizes it sums are the bytes actually read while
+// the gate's are the ones the rows recorded, and a send may not carry more than
+// the budget whichever of the two is wrong.
 func overSendBudget(total int64) error {
-	if total <= maxSendBytes {
+	if total <= comms.MaxSendBytes {
 		return nil
 	}
 	return fmt.Errorf(
 		"comms: this message's files total more than %d MiB, which is more than a send may carry: %w",
-		maxSendBytes>>20, connector.ErrFilesNotCarried)
+		comms.MaxSendBytes>>20, connector.ErrFilesNotCarried)
 }
-
-// maxSendBytes caps what ONE message may carry in total.
-//
-// Below what mailbox providers accept (Gmail refuses past 25 MiB after
-// encoding), so a message this passes is one the provider will take rather than
-// one this product built and the wire refused.
-const maxSendBytes = 20 << 20
 
 // readOne reads one attachment fully, closing the object either way.
 func (a commsAttachments) readOne(ctx context.Context, id ids.UUID) ([]byte, error) {

--- a/backend/internal/compose/commssendbudget_test.go
+++ b/backend/internal/compose/commssendbudget_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/modules/comms"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -28,8 +29,8 @@ func TestTheAggregateSendBudgetParksInsteadOfRetrying(t *testing.T) {
 		refused bool
 	}{
 		{"an empty message", 0, false},
-		{"exactly at the bound", maxSendBytes, false},
-		{"one byte over", maxSendBytes + 1, true},
+		{"exactly at the bound", comms.MaxSendBytes, false},
+		{"one byte over", comms.MaxSendBytes + 1, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := overSendBudget(tc.total)

--- a/backend/internal/compose/handlers_channelproviders.go
+++ b/backend/internal/compose/handlers_channelproviders.go
@@ -25,6 +25,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/modules/comms"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 	"github.com/margince/margince/backend/pkg/extension"
@@ -132,6 +133,11 @@ func publishedChannelProviders(registered []channelProviderFacts, sending map[st
 		entry.Attachments.Carries = carriage.Carries
 		entry.Attachments.MaxFiles = carriage.MaxFiles
 		entry.Attachments.MaxBytesPerFile = carriage.MaxBytesPerFile
+		// The EFFECTIVE aggregate, from the same helper the carriage gate
+		// refuses on, so the number a composer warns with is the number a send
+		// applies. Publishing the provider's own would tell a composer nothing
+		// about the budget that actually stops the message.
+		entry.Attachments.MaxTotalBytes = comms.AggregateCarriageBound(carriage)
 		entry.Attachments.MaxBodyWithFiles = carriage.MaxBodyWithFiles
 		out = append(out, entry)
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -20284,6 +20284,13 @@ type ChannelProviderEntry struct {
 	// default, so a connector that never declared carriage reports false rather than
 	// being mistaken for capable. A zero bound means "no limit beyond the contract's
 	// own", never "zero allowed".
+	//
+	// `max_total_bytes` is the exception to that rule and is never zero: every
+	// transport has an aggregate, because the product has one whether or not the
+	// provider declares its own. It is the bound a composer must warn against
+	// FIRST — `max_files` and `max_bytes_per_file` cannot express it between them,
+	// so a message of ten files each under the per-file cap can pass both and still
+	// be ten times what a send may carry.
 	Attachments struct {
 		Carries bool `json:"carries"`
 
@@ -20297,6 +20304,11 @@ type ChannelProviderEntry struct {
 
 		// MaxFiles Most files in one message. Never more than the contract's own `attachment_ids` cap of 10.
 		MaxFiles int `json:"max_files"`
+
+		// MaxTotalBytes Largest total across every file on one message, in bytes — the smaller of
+		// this transport's own aggregate and the product's send budget. Always
+		// present and always positive.
+		MaxTotalBytes int64 `json:"max_total_bytes"`
 	} `json:"attachments"`
 
 	// CredentialModel How a connection to this transport is credentialed — one shared bot for the

--- a/backend/internal/modules/comms/gates.go
+++ b/backend/internal/modules/comms/gates.go
@@ -72,10 +72,10 @@ func (d *Dispatcher) gateSendAuthority(ctx context.Context, del Delivery, grante
 // a different provider, a file added by a later edit. The human should get the
 // message back with a reason, which is what parking does.
 //
-// It checks FOUR things, not one: whether files may go at all, how many may ride
-// in one message, how large each may be, and — for a transport that carries
-// text-with-files as a caption — how long the covering text may be. All four are
-// the provider's own limits, published on the channel directory so the composer
+// It checks FIVE things, not one: whether files may go at all, how many may
+// ride in one message, how large each may be, how large they are TOGETHER, and
+// — for a transport that carries text-with-files as a caption — how long the
+// covering text may be. Four are the provider's own limits, published on the channel directory so the composer
 // warns first, and every one of them parks for the same reason: a message that
 // went out missing a file, or truncated to fit a caption, is not the message a
 // human approved.
@@ -92,6 +92,42 @@ func (d *Dispatcher) gateAttachmentCarriage(ctx context.Context, del Delivery, s
 	return outcomeUndecided, 0, nil
 }
 
+// MaxSendBytes caps what ONE message may carry in total, across every file on
+// it.
+//
+// Below what mailbox providers accept (Gmail refuses past 25 MiB after
+// encoding), so a message this passes is one the provider will take rather than
+// one this product built and the wire refused. It also bounds what a worker
+// serving every send in the installation holds at once: ten files at the upload
+// limit is a quarter of a gigabyte, and base64 encoding doubles it.
+//
+// It lives HERE, with the gate that tells a human about it, and the read path
+// that enforces it as a backstop reads this same constant
+// (compose/commsattachments.go). Two spellings of one budget is how the number
+// a composer is shown comes to differ from the number a send applies, which is
+// the whole defect this bound had.
+const MaxSendBytes = 20 << 20
+
+// aggregateBound is the largest total a message on this transport may carry:
+// the provider's own aggregate where it declares one, and the product's budget
+// otherwise — whichever is smaller.
+//
+// Published by the channel directory and applied by carriageRefusal from this
+// one function, so the number the composer warns with is the number the send
+// refuses on. A provider declaring no aggregate of its own is held to the
+// product's, which is the same "a zero bound means no limit beyond the
+// contract's own" rule the other three bounds follow.
+func aggregateBound(carriage connector.Carriage) int64 {
+	if carriage.MaxTotalBytes > 0 && carriage.MaxTotalBytes < MaxSendBytes {
+		return carriage.MaxTotalBytes
+	}
+	return MaxSendBytes
+}
+
+// AggregateCarriageBound is aggregateBound for the channel directory, which
+// publishes the same number this package refuses on.
+func AggregateCarriageBound(carriage connector.Carriage) int64 { return aggregateBound(carriage) }
+
 // carriageRefusal is why this message may not go out as staged, or "" when it
 // may. ONE function so the four refusals read together and none can be added
 // without a reason a person can act on.
@@ -99,7 +135,9 @@ func (d *Dispatcher) gateAttachmentCarriage(ctx context.Context, del Delivery, s
 // A zero bound means "no limit beyond the contract's own", never "zero allowed"
 // — the only field that says nothing may go is Carries. A connector that
 // declares carriage without naming a limit is therefore held to the contract's
-// own caps rather than parked on every send.
+// own caps rather than parked on every send. The aggregate is the one bound the
+// contract always has: a provider that declares none of its own still gets
+// MaxSendBytes.
 func carriageRefusal(del Delivery, carriage connector.Carriage) string {
 	if !carriage.Carries {
 		return fmt.Sprintf(
@@ -120,6 +158,21 @@ func carriageRefusal(del Delivery, carriage connector.Carriage) string {
 					"share it another way, or send a smaller version",
 				file.Filename, humanBytes(carriage.MaxBytesPerFile), del.Provider)
 		}
+	}
+	// The AGGREGATE, which the three bounds above cannot see between them: ten
+	// files each under the per-file cap can still total ten times what a send
+	// may carry. Without it the read path refuses instead — correctly, but only
+	// after the composer said the message was fine, and after every object has
+	// been opened.
+	var total int64
+	for _, file := range del.Attachments {
+		total += file.ByteSize
+	}
+	if bound := aggregateBound(carriage); total > bound {
+		return fmt.Sprintf(
+			"this message's %d files come to %s together, and the %s channel carries at most %s in one "+
+				"message; it was not sent — send them across several messages, or share the largest another way",
+			len(del.Attachments), humanBytes(total), del.Provider, humanBytes(bound))
 	}
 	if body := utf8.RuneCountInString(del.Body); carriage.MaxBodyWithFiles > 0 && body > carriage.MaxBodyWithFiles {
 		return fmt.Sprintf(

--- a/backend/internal/modules/comms/gates_carriage_test.go
+++ b/backend/internal/modules/comms/gates_carriage_test.go
@@ -76,6 +76,49 @@ func TestAttachmentCarriageGateParksRatherThanStripping(t *testing.T) {
 		{name: "a long body with NO files is not the caption case", carriage: connector.Carriage{Carries: true, MaxBodyWithFiles: 8}, files: 0, bodyLen: 4096},
 		{name: "a sub-MiB bound is reported as itself, not as 0 MiB", carriage: connector.Carriage{Carries: true, MaxBytesPerFile: 900 << 10}, files: 1, fileBytes: 1 << 20, wantPark: true, wantReason: []string{"900.0 KiB"}},
 		{name: "a bound that is not a whole MiB is not rounded up", carriage: connector.Carriage{Carries: true, MaxBytesPerFile: 10_000_000}, files: 1, fileBytes: 20 << 20, wantPark: true, wantReason: []string{"9.5 MiB"}},
+
+		// The issue's own scenario: three 8 MiB files on a transport declaring
+		// 10 × 20 MiB. Every per-file bound admits it, the count admits it, and
+		// together they are more than a send may carry. Before this bound the
+		// composer called the message fine, the gate passed, and the read path
+		// refused after opening every object — the human heard "the retry ladder
+		// is exhausted", which names no cause.
+		{
+			name:      "three files under every per-file bound are over the aggregate",
+			carriage:  connector.Carriage{Carries: true, MaxFiles: 10, MaxBytesPerFile: 20 << 20},
+			files:     3,
+			fileBytes: 8 << 20,
+			wantPark:  true,
+			// The total AND the bound: "too big" without either number leaves a
+			// person guessing how much to drop.
+			wantReason: []string{"3 files", "24.0 MiB", "20.0 MiB", "several messages"},
+		},
+		{
+			name:      "the same three files under the aggregate go",
+			carriage:  connector.Carriage{Carries: true, MaxFiles: 10, MaxBytesPerFile: 20 << 20},
+			files:     3,
+			fileBytes: 6 << 20,
+		},
+		// A provider whose OWN aggregate is tighter than the product's is held
+		// to its own; one declaring none is held to the product's, which is the
+		// case above. This is the only bound with no "zero means unbounded"
+		// reading, because the product always has one.
+		{
+			name:       "a provider's tighter aggregate binds before the product's",
+			carriage:   connector.Carriage{Carries: true, MaxFiles: 10, MaxBytesPerFile: 20 << 20, MaxTotalBytes: 5 << 20},
+			files:      2,
+			fileBytes:  3 << 20,
+			wantPark:   true,
+			wantReason: []string{"6.0 MiB", "5.0 MiB"},
+		},
+		{
+			name:       "a provider's LOOSER aggregate does not widen the product's",
+			carriage:   connector.Carriage{Carries: true, MaxFiles: 10, MaxBytesPerFile: 50 << 20, MaxTotalBytes: 45 << 20},
+			files:      3,
+			fileBytes:  8 << 20,
+			wantPark:   true,
+			wantReason: []string{"24.0 MiB", "20.0 MiB"},
+		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			d, store := gateHarness(t)

--- a/backend/pkg/extension/files.go
+++ b/backend/pkg/extension/files.go
@@ -264,4 +264,13 @@ type Carriage struct {
 	// counted in CHARACTERS because a caption cap is a provider's rune count and
 	// not a byte budget.
 	MaxBodyWithFiles int
+	// MaxTotalBytes bounds what one message may carry ACROSS its files, where
+	// the provider has an aggregate of its own. Zero means it has none — not
+	// that nothing may go — and the product's own send budget applies instead.
+	//
+	// It is a separate bound because MaxFiles and MaxBytesPerFile cannot express
+	// it between them: ten files each under the per-file cap can total ten times
+	// what a send may carry, which is a message the composer called fine and the
+	// send refuses.
+	MaxTotalBytes int64
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23026,9 +23026,23 @@ export interface components {
              *     default, so a connector that never declared carriage reports false rather than
              *     being mistaken for capable. A zero bound means "no limit beyond the contract's
              *     own", never "zero allowed".
+             *
+             *     `max_total_bytes` is the exception to that rule and is never zero: every
+             *     transport has an aggregate, because the product has one whether or not the
+             *     provider declares its own. It is the bound a composer must warn against
+             *     FIRST — `max_files` and `max_bytes_per_file` cannot express it between them,
+             *     so a message of ten files each under the per-file cap can pass both and still
+             *     be ten times what a send may carry.
              */
             attachments: {
                 carries: boolean;
+                /**
+                 * Format: int64
+                 * @description Largest total across every file on one message, in bytes — the smaller of
+                 *     this transport's own aggregate and the product's send budget. Always
+                 *     present and always positive.
+                 */
+                max_total_bytes: number;
                 /** @description Most files in one message. Never more than the contract's own `attachment_ids` cap of 10. */
                 max_files: number;
                 /**

--- a/frontend/src/screens/channelproviders.test.tsx
+++ b/frontend/src/screens/channelproviders.test.tsx
@@ -46,6 +46,9 @@ function transport(provider: string, label: string): Entry {
       max_files: 0,
       max_bytes_per_file: 0,
       max_body_with_files: 0,
+      // Never zero on the wire: every transport has an aggregate, because the
+      // product has one whether or not the provider declares its own.
+      max_total_bytes: 20 * 1024 * 1024,
     },
   };
 }


### PR DESCRIPTION
Closes #2047.

A transport declared **ten files at 20 MiB each** and the real ceiling was **20 MiB in total** — one tenth of what was published. The issue's own scenario: three 8 MiB files pass every published bound, so the composer says the message is fine, the carriage gate passes, and the read path refuses after opening every object. The delivery then climbs the whole retry ladder, re-reading ~24 MiB from the blobstore on each rung, and the human is finally told *"the retry ladder is exhausted"* — a reason that names no cause.

## The aggregate is its own bound

`MaxFiles` and `MaxBytesPerFile` cannot express it between them, which is exactly why the gate could pass a message the send refuses.

- **`connector.Carriage.MaxTotalBytes`** — a provider's own aggregate, zero meaning it has none of its own.
- **`carriageRefusal` checks it**, from the staged sizes, before any object is opened, and parks with a reason naming **the total, the bound, and what to do**. "Too big" without both numbers leaves a person guessing how much to drop.
- **`GET /v1/channel-providers` publishes the EFFECTIVE bound**, from the same helper the gate refuses on — so the number a composer warns with is the number a send applies. Publishing the provider's own would tell a composer nothing about the budget that actually stops the message.

## One budget, one spelling

`maxSendBytes` moves to `comms.MaxSendBytes`, beside the gate that tells a human about it, and the read path reads it from there. Two spellings of one budget is precisely how the number a composer is shown came to differ from the number a send applies.

The read path **stays** as the backstop, and the comment says why rather than leaving it looking redundant: the gate sums the sizes the rows recorded, this sums the bytes actually read, and a send may not carry more than the budget whichever of the two is wrong.

## The one bound with no "zero means unbounded" reading

Every other field follows "a zero bound means no limit beyond the contract's own". `max_total_bytes` is never zero and the contract says so: every transport has an aggregate, because the **product** has one whether or not the provider declares its own. A provider with a tighter aggregate is held to its own; one with a looser one does not widen the product's.

## Tests

Four cases added to `TestAttachmentCarriageGateParksRatherThanStripping`, both mutations checked:

- The issue's scenario — three 8 MiB files under a 10 × 20 MiB declaration — parks, and the reason carries `24.0 MiB`, `20.0 MiB` and what to do instead.
- The same three files at 6 MiB each go, so the bound is the aggregate and not "three files".
- A provider's **tighter** aggregate binds before the product's.
- A provider's **looser** aggregate does not widen the product's — the case that would otherwise let a connector opt out of the budget by declaring a big number.

`make check-backend` and `make check-fe` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC