### PR TITLE
The unassigned queue is a view, and the owner is where the reader acts

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2150,7 +2150,6 @@ export const de = {
   "lead.filterScoreCool": "Ab 40",
   "lead.details": "Details",
   "lead.ladder.title": "Wo dieser Lead steht",
-  "lead.railTitle": "Verantwortlich",
   "lead.detailsUnset": "Nicht gesetzt",
   "lead.terminalReadOnly":
     "Dieser Lead ist abgeschlossen und nimmt keine Änderungen an.",
@@ -2310,6 +2309,8 @@ export const de = {
   "lead.assignedAway":
     "{names} an {owner} zugewiesen — nicht mehr unter „Meine“.",
   "lead.viewNew": "Neu",
+  "lead.viewNewUnassigned": "Neu & nicht zugewiesen",
+  "lead.viewUnassigned": "Warteschlange",
   "lead.viewNeedsFollowUp": "Nachfassen",
   "lead.viewEngaged": "Im Gespräch",
   "lead.ladder": "Lead-Status",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2230,7 +2230,6 @@ export const en = {
   "lead.filterScoreCool": "40 and up",
   "lead.details": "Details",
   "lead.ladder.title": "Where this lead stands",
-  "lead.railTitle": "Owner",
   "lead.detailsUnset": "Not set",
   "lead.terminalReadOnly": "This lead is closed and takes no changes.",
   "lead.notYoursToChange":
@@ -2382,6 +2381,8 @@ export const en = {
   "list.showAll": "Show all",
   "lead.assignedAway": "{names} assigned to {owner} — no longer in Mine.",
   "lead.viewNew": "New",
+  "lead.viewNewUnassigned": "New & unassigned",
+  "lead.viewUnassigned": "Unassigned queue",
   "lead.viewNeedsFollowUp": "Needs follow-up",
   "lead.viewEngaged": "Engaged",
   "lead.ladder": "Lead status",

--- a/frontend/src/i18n/record-noun.test.ts
+++ b/frontend/src/i18n/record-noun.test.ts
@@ -505,7 +505,6 @@ const HUMAN_SENSE_KEYS: Record<string, readonly string[]> = {
     "import.objectHint.lead",
     "lead.bulkOwner",
     "lead.bulkOwnerPick",
-    "lead.railTitle",
     "lead.scoreOverridden",
     "lead.trigger.humanQualify",
     "list.filterOwnerAll",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2134,7 +2134,6 @@ export const vi = {
   "lead.details": "Chi ti\u1ebft",
   "lead.ladder.title":
     "Kh\u00e1ch h\u00e0ng ti\u1ec1m n\u0103ng n\u00e0y \u0111ang \u1edf \u0111\u00e2u",
-  "lead.railTitle": "Người phụ trách",
   "lead.detailsUnset": "Chưa đặt",
   "lead.terminalReadOnly":
     "Khách hàng tiềm năng này đã đóng và không nhận thay đổi.",
@@ -2290,6 +2289,8 @@ export const vi = {
   "lead.assignedAway":
     "{names} đã được giao cho {owner} — không còn trong “Của tôi”.",
   "lead.viewNew": "Mới",
+  "lead.viewNewUnassigned": "Mới & chưa giao",
+  "lead.viewUnassigned": "Hàng chờ chưa giao",
   "lead.viewNeedsFollowUp": "Cần theo dõi",
   "lead.viewEngaged": "Đang trao đổi",
   "lead.ladder": "Trạng thái khách hàng tiềm năng",

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -575,6 +575,25 @@ function LeadsWorkbench({
         dataChips={ownerChips}
         views={[
           ...standardViews(viewerId, { sort: "", mineFirst: !opensOnAll }),
+          // The unassigned queue as a VIEW, not only a chip. It was reachable
+          // by opening the owner dial and picking a value, which is a thing
+          // you find if you already know it is there; a lead nobody owns is
+          // the one a queue exists to surface.
+          //
+          // Oldest first, deliberately against the other views' work-queue
+          // order: what makes an unassigned lead urgent is how long it has sat
+          // there with nobody answering it, and the newest arrival is the one
+          // that can wait.
+          {
+            label: "lead.viewUnassigned",
+            sort: "created_at",
+            filters: { unassigned: "true" },
+          },
+          {
+            label: "lead.viewNewUnassigned",
+            sort: "created_at",
+            filters: { status: "new", unassigned: "true" },
+          },
           { label: "lead.viewNew", sort: "", filters: { status: "new" } },
           {
             label: "lead.viewNeedsFollowUp",

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -1317,6 +1317,68 @@ describe("LeadsScreen — search/sort/pagination + status filter (P-14)", () => 
     ).toBeTruthy();
   });
 
+  it("the Unassigned view asks for ownerless leads, oldest first", async () => {
+    // The queue's whole point is the lead nobody has answered yet, and what
+    // makes one urgent is how long it has waited — so this view sorts against
+    // the others, ascending by arrival.
+    const { urls } = stubFetch(async () =>
+      jsonResponse({
+        data: [lead],
+        page: { next_cursor: null, has_more: false },
+      }),
+    );
+    render(<LeadsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Jonas Petersen")).toBeTruthy(),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Unassigned queue" }),
+    );
+
+    // Both dials in the SAME request, and NOT the New & unassigned view's
+    // request, which also asks unassigned=true and also sorts by arrival. An
+    // assertion satisfied by either one is satisfied by the wrong one: the
+    // earlier version of this test stayed green with the sort deleted.
+    await waitFor(() =>
+      expect(
+        urls.some(
+          (url) =>
+            url.includes("unassigned=true") &&
+            !url.includes("status=") &&
+            /[?&]sort=created_at(&|$)/.test(url),
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("the New & unassigned view composes both dimensions in one ask", async () => {
+    // Status is lifecycle and ownership is ownership: a New lead may already
+    // have an owner, and an older Contacted one may have none. The view that
+    // answers "new work nobody has picked up" has to say both.
+    const { urls } = stubFetch(async () =>
+      jsonResponse({
+        data: [lead],
+        page: { next_cursor: null, has_more: false },
+      }),
+    );
+    render(<LeadsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Jonas Petersen")).toBeTruthy(),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "New & unassigned" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        urls.some(
+          (url) =>
+            url.includes("unassigned=true") && url.includes("status=new"),
+        ),
+      ).toBe(true),
+    );
+  });
+
   it("fetches the next cursor page when the pager steps past the loaded page", async () => {
     const { urls } = stubFetch(async (url) => {
       if (url.includes("cursor=c1")) {
@@ -2212,6 +2274,25 @@ describe("LeadScreen — owner display + assign to me (P-11)", () => {
     await waitFor(() => expect(screen.getByText("Unassigned")).toBeTruthy());
     const assign = await screen.findByRole("button", { name: "Assign" });
     expect(assign.hasAttribute("disabled")).toBe(true);
+  });
+
+  // Ownership lived only in the details pane, which is open by default and
+  // remembers being hidden — so for anyone who had ever collapsed it, the one
+  // control that takes a lead out of the queue sat behind a toggle they had to
+  // remember. It belongs where the reader acts.
+  it("keeps the owner reachable with the details pane collapsed", async () => {
+    stubFetchWithMe(async (url) => {
+      if (url.includes("/leads/l-1")) {
+        return jsonResponse({ ...lead, owner_id: null, writable: false });
+      }
+      return undefined;
+    }, "u-9");
+    render(<LeadScreen id="l-1" />);
+    await waitFor(() => expect(screen.getByText("Unassigned")).toBeTruthy());
+
+    // Collapse the pane the owner used to live in, then look again.
+    await userEvent.click(screen.getByRole("button", { name: "Details" }));
+    expect(screen.getByRole("button", { name: "Assign" })).toBeTruthy();
   });
 
   it("hides Assign to me when the lead is already owned by the current user", async () => {

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -927,9 +927,11 @@ function LeadLadderPanel({
   );
 }
 
-// The lead's owner, wherever it is shown: the header where a reader acts, and
-// the details pane where they consult. ONE component, so the two cannot
-// disagree about who owns the lead or about whether the control is pressable.
+// The lead's owner, in the header where a reader acts.
+//
+// Its own component rather than inline in the header's props, because what
+// makes it pressable is three separate questions and they belong beside each
+// other rather than spread through a JSX attribute list.
 function LeadOwnerControl({
   lead,
   writer,
@@ -979,12 +981,12 @@ function LeadOwnerControl({
 }
 
 /**
- * The rail: the lead's own words, and who owns it.
+ * The rail: the lead's own words.
  *
- * Both are things a rep CONSULTS while doing the work in the column beside
- * it. The score used to fold into this column too; it is a reading with an
- * edit behind it and sits in the record's reading now, beside the inputs that
- * feed it.
+ * What a rep CONSULTS while doing the work in the column beside it. Two things
+ * have left this column for the same reason — the score, which is a reading
+ * with an edit behind it and belongs beside the inputs that feed it, and the
+ * owner, which is a thing a reader ACTS on and belongs in the header.
  */
 function LeadRail({
   lead,
@@ -1974,12 +1976,15 @@ function LeadRecord({
       // record was a printout. It opens the composer on this lead, as the
       // Email verb beside it does, and like that verb it is refused on a
       // closed lead — as text, since the verb already carries the reason.
-      // Owner beside the address, because both are things a reader ACTS on.
+      // Owner above the address: both are things a reader ACTS on, and the
+      // wide header stacks its pulse rather than laying it out in a row.
+      //
       // Ownership lived only in the details pane, which is open by default and
-      // remembers being hidden — so the one control that takes a lead out of
+      // REMEMBERS being hidden — so the one control that takes a lead out of
       // the unassigned queue was, for anyone who had ever collapsed the pane,
-      // behind a toggle they had to remember. The pane keeps its copy: same
-      // component, same data, one answer.
+      // behind a toggle they had to remember. It is rendered here and nowhere
+      // else: a second copy in the pane made every owner query on the page
+      // ambiguous, which is two controls disagreeing waiting to happen.
       pulse={
         <>
           <LeadOwnerControl

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -927,6 +927,57 @@ function LeadLadderPanel({
   );
 }
 
+// The lead's owner, wherever it is shown: the header where a reader acts, and
+// the details pane where they consult. ONE component, so the two cannot
+// disagree about who owns the lead or about whether the control is pressable.
+function LeadOwnerControl({
+  lead,
+  writer,
+  terminalReasonId,
+}: Readonly<{
+  lead: Lead;
+  writer: LeadWriter;
+  terminalReasonId: string;
+}>) {
+  const me = useMe();
+  // Assignment asks a DIFFERENT question from editing, so it drops the PER-ROW
+  // half of the editor's answer and keeps the rest. `writable` is false on a
+  // lead nobody owns — the write arm being right — and gating on it would shut
+  // the only door out of the unassigned queue.
+  //
+  // The other two axes still bind. useCanWrite is the object grant AND the
+  // seat ceiling: a read seat, or one holding no `lead.update`, gets no
+  // pressable control, because the server refuses them and a button that only
+  // fails is worse than none. An archived lead is refused too — a terminal
+  // record is nobody's to hand on.
+  const mayAssign = useCanWrite("lead", "update");
+  const refusedReasonId =
+    lead.archived_at || !mayAssign ? terminalReasonId : undefined;
+  return (
+    <LeadOwner
+      lead={lead}
+      meId={me.data?.user?.id}
+      refusedReasonId={refusedReasonId}
+      pending={
+        writer.patch.isPending ||
+        writer.claim.isPending ||
+        Boolean(refusedReasonId)
+      }
+      // A lead nobody owns is nobody's to change, so the PATCH this control
+      // used to send for EVERY pick was refused for the one pick a rep makes
+      // most: taking an unassigned lead. Picking yourself on an unowned lead
+      // goes through the claim door, which is the write the server actually
+      // admits; naming a colleague stays a patch, which the assignment gate
+      // answers.
+      onAssign={(ownerId) =>
+        !lead.owner_id && ownerId === me.data?.user?.id
+          ? writer.claim.mutate()
+          : writer.save({ owner_id: ownerId })
+      }
+    />
+  );
+}
+
 /**
  * The rail: the lead's own words, and who owns it.
  *
@@ -938,19 +989,10 @@ function LeadLadderPanel({
 function LeadRail({
   lead,
   writer,
-  terminalReasonId,
 }: Readonly<{
   lead: Lead;
   writer: LeadWriter;
-  terminalReasonId: string;
 }>) {
-  const t = useT();
-  const me = useMe();
-  // The object grant and the seat ceiling, without the per-row answer: see the
-  // control below for why the row half is deliberately absent.
-  const mayAssign = useCanWrite("lead", "update");
-  const assignRefusedReasonId =
-    lead.archived_at || !mayAssign ? terminalReasonId : undefined;
   return (
     <div className="record-stack">
       <LeadIdentityFields
@@ -959,43 +1001,6 @@ function LeadRail({
         saving={writer.patch.isPending}
         readOnlyReason={writer.readOnlyReason}
       />
-      <Panel title={t("lead.railTitle")}>
-        <PanelBody>
-          <LeadOwner
-            lead={lead}
-            meId={me.data?.user?.id}
-            // Assignment asks a DIFFERENT question from editing, so it drops
-            // the PER-ROW half of the editor's answer and keeps the rest.
-            // `writable` is false on a lead nobody owns — the write arm being
-            // right — and gating on it would shut the only door out of the
-            // unassigned queue, which is the bug this whole change is about.
-            //
-            // The other two axes still bind. useCanWrite is the object grant
-            // AND the seat ceiling: a read seat, or one holding no
-            // `lead.update`, gets no pressable control, because the server
-            // refuses them and a button that only fails is worse than none. An
-            // archived lead is refused too — a terminal record is nobody's to
-            // hand on.
-            refusedReasonId={assignRefusedReasonId}
-            pending={
-              writer.patch.isPending ||
-              writer.claim.isPending ||
-              Boolean(assignRefusedReasonId)
-            }
-            // A lead nobody owns is nobody's to change, so the PATCH this
-            // control used to send for EVERY pick was refused for the one
-            // pick a rep makes most: taking an unassigned lead. Picking
-            // yourself on an unowned lead goes through the claim door, which
-            // is the write the server actually admits; naming a colleague
-            // stays a patch, which the assignment gate answers.
-            onAssign={(ownerId) =>
-              !lead.owner_id && ownerId === me.data?.user?.id
-                ? writer.claim.mutate()
-                : writer.save({ owner_id: ownerId })
-            }
-          />
-        </PanelBody>
-      </Panel>
     </div>
   );
 }
@@ -1956,13 +1961,7 @@ function LeadRecord({
       // work and the context does not move when the tab does. The same pane,
       // fold and memory of it as every other record page.
       aside={
-        details.open ? (
-          <LeadRail
-            lead={lead}
-            writer={writer}
-            terminalReasonId={terminalReasonId}
-          />
-        ) : undefined
+        details.open ? <LeadRail lead={lead} writer={writer} /> : undefined
       }
       name={leadIdentityName(lead) || t("lead.unnamed")}
       avatarSrc={null}
@@ -1975,17 +1974,30 @@ function LeadRecord({
       // record was a printout. It opens the composer on this lead, as the
       // Email verb beside it does, and like that verb it is refused on a
       // closed lead — as text, since the verb already carries the reason.
+      // Owner beside the address, because both are things a reader ACTS on.
+      // Ownership lived only in the details pane, which is open by default and
+      // remembers being hidden — so the one control that takes a lead out of
+      // the unassigned queue was, for anyone who had ever collapsed the pane,
+      // behind a toggle they had to remember. The pane keeps its copy: same
+      // component, same data, one answer.
       pulse={
-        lead.email ? (
-          <ContactLink
-            kind="email"
-            value={lead.email}
-            record={{ entityType: "lead", entityId: id }}
-            readOnly={Boolean(lead.archived_at)}
-            className="link-button lead-email"
-            textClassName="lead-email"
+        <>
+          <LeadOwnerControl
+            lead={lead}
+            writer={writer}
+            terminalReasonId={terminalReasonId}
           />
-        ) : null
+          {lead.email ? (
+            <ContactLink
+              kind="email"
+              value={lead.email}
+              record={{ entityType: "lead", entityId: id }}
+              readOnly={Boolean(lead.archived_at)}
+              className="link-button lead-email"
+              textClassName="lead-email"
+            />
+          ) : null}
+        </>
       }
       actions={
         <LeadActions


### PR DESCRIPTION
Two things a manager needs were reachable only by knowing where to look.

**The queue was a dial, not a view.** A lead nobody owns was found by opening the owner filter and picking a value — a thing you find if you already know it is there. It is now a view of its own, beside New, plus the composition that answers the actual question: **New & unassigned**. Status is lifecycle and ownership is ownership, so a New lead may already have an owner and an older Contacted one may have none.

Oldest first, deliberately against every other view's order. What makes an unassigned lead urgent is how long it has sat with nobody answering it; the newest arrival is the one that can wait.

**The owner was in the pane.** The details pane opens by default and *remembers being hidden*, so for anyone who had ever collapsed it, the one control that takes a lead out of the queue sat behind a toggle they had to remember. It moves to the header, beside the address, because both are things a reader acts on.

One component, not two. Rendering it in both places made every owner query on the page ambiguous — the tests said so immediately — and two copies of one control are two chances to disagree about whether it is pressable. The rail keeps the identity fields it was really for, and `lead.railTitle` goes with the panel it titled.

The view is named "Unassigned queue" rather than "Unassigned" because the owner dial already offers that word, and two buttons with one name is what the accessible name is for.

## Tests

Four new cases: each view sends both dials in one request, and the owner stays reachable with the details pane collapsed. All mutation-checked.

Worth recording that the sort assertion **passed for the wrong reason twice** before it held. Asserting that `unassigned=true` and `sort=created_at` each appeared *somewhere* in the request list is satisfied by two unrelated fetches, and the sibling view sends both too — so the test stayed green with the sort deleted. It now requires them in the same URL and excludes the sibling's request explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the unassigned queue into its own view so ownerless leads are no longer hidden behind the owner filter, and moves the owner control to the header so assigning stays reachable when the details pane is collapsed.

**Views**
- "Unassigned queue" and "New & unassigned" sort oldest first, against the other views' order.
- "New & unassigned" composes status and ownership, since a New lead may already have an owner.

**Owner control**
- The owner control renders once, in the header; the rail's owner panel and `lead.railTitle` are gone.
- Self-assignment on an unowned lead uses the claim path; naming a colleague stays a patch.
- Four new tests cover the views and collapsed-pane reachability; the sort assertion now requires both dials in the same request.

<sup>Written for commit fefa4fefebaaa25a41df3af7ad0cefcd77a8c20c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

