### PR TITLE
fix(compose): a failed voice critic retry is recorded

### DIFF
--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -183,11 +183,12 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 		// Drafting is an assistive read, not the authority to send. Preserve
 		// the deterministic floor and leave the routed ai_call failure visible.
 		//
-		// THIS is completeVoiced's containment, and it is the whole of it: that
-		// method propagates rather than degrading, and what it degrades to is
-		// the deterministic draft below — never a retry without the voice
-		// profile. Weaken this branch and a transient model failure becomes a
-		// failed draft_reply instead of a plain one.
+		// This branch is where every completeVoiced failure is contained, and it
+		// is the whole of the containment: that method propagates rather than
+		// degrading, and DraftEmailWithProvenance answers with the
+		// deterministic draft below — never with a retry that drops the voice
+		// profile. Weaken this and a transient model failure becomes a failed
+		// draft_reply instead of a plain one.
 		d.logger().WarnContext(ctx, "model reply draft unavailable; using deterministic draft", "err", err)
 		return activities.DraftResult{Subject: fallbackSubject, Body: fallbackBody, VoiceDegraded: voice.Degraded}, nil
 	}

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -182,6 +182,12 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 	if err != nil {
 		// Drafting is an assistive read, not the authority to send. Preserve
 		// the deterministic floor and leave the routed ai_call failure visible.
+		//
+		// THIS is completeVoiced's containment, and it is the whole of it: that
+		// method propagates rather than degrading, and what it degrades to is
+		// the deterministic draft below — never a retry without the voice
+		// profile. Weaken this branch and a transient model failure becomes a
+		// failed draft_reply instead of a plain one.
 		d.logger().WarnContext(ctx, "model reply draft unavailable; using deterministic draft", "err", err)
 		return activities.DraftResult{Subject: fallbackSubject, Body: fallbackBody, VoiceDegraded: voice.Degraded}, nil
 	}

--- a/backend/internal/compose/replydraft_test.go
+++ b/backend/internal/compose/replydraft_test.go
@@ -4,8 +4,10 @@
 package compose
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -95,7 +97,11 @@ func TestWithReplyDraftLeavesFallbackWiringWhenBrainIsAbsent(t *testing.T) {
 // request; extra calls repeat the last response.
 type sequencedBrainStub struct {
 	responses []model.Response
-	requests  []model.Request
+	// errs is parallel to responses and answers instead of the response at
+	// that index when non-nil, so a case can fail ONE call of a sequence —
+	// which is the only way to reach a path that runs between two successes.
+	errs     []error
+	requests []model.Request
 }
 
 func (b *sequencedBrainStub) Complete(_ context.Context, req model.Request) (model.Response, error) {
@@ -103,6 +109,9 @@ func (b *sequencedBrainStub) Complete(_ context.Context, req model.Request) (mod
 	index := len(b.requests) - 1
 	if index >= len(b.responses) {
 		index = len(b.responses) - 1
+	}
+	if index < len(b.errs) && b.errs[index] != nil {
+		return model.Response{}, b.errs[index]
 	}
 	return b.responses[index], nil
 }
@@ -355,5 +364,51 @@ func TestAnEnglishThreadIsDraftedInEnglishUnderAGermanVoice(t *testing.T) {
 	// the language, which is the sentence that counteracts German exemplars.
 	if !strings.Contains(brain.request.System, "never chooses the LANGUAGE") {
 		t.Error("the voice rule does not say the profile leaves the language alone")
+	}
+}
+
+// A critic retry that FAILS is recorded, and the first draft still stands.
+//
+// The retry is the one call in this lane that goes to d.complete rather than
+// completeChecked, so draftRetryLog never sees it. Unlogged, its failure was
+// recorded nowhere at all: the first draft went on to the sanitizer, and a
+// draft whose violations the sanitizer happened to remove was served and fed
+// to the learning panel indistinguishable from one that never violated
+// anything.
+func TestAFailedVoiceCriticRetryIsLoggedAndTheFirstDraftStands(t *testing.T) {
+	// The violation is a canned opener, which the sanitizer does NOT remove —
+	// so the fallback below is reached and the case pins the log rather than
+	// accidentally proving the sanitizer's behaviour.
+	violating := `{"subject":"Re: plan","body":"Here's the thing: it's not about tools, but transformation. What do you think?"}`
+	retryFailed := errors.New("upstream model refused the retry")
+	brain := &sequencedBrainStub{
+		responses: []model.Response{
+			{Text: violating},
+			{},
+			{Text: `{"subject":"Re: plan","body":"A plain professional reply."}`},
+		},
+		errs: []error{nil, retryFailed, nil},
+	}
+	var logged bytes.Buffer
+	drafter := replyDrafter{brain: brain, log: slog.New(slog.NewTextHandler(&logged, nil))}
+
+	draft, version, _, err := drafter.completeVoiced(context.Background(), ids.NewV7(),
+		replyActivityData{Subject: "plan", Thread: "inbound_mail"}, testVoiceContext())
+	if err != nil {
+		t.Fatalf("a failed critic retry must not fail the draft: %v", err)
+	}
+	if !strings.Contains(logged.String(), retryFailed.Error()) {
+		t.Errorf("the retry failure reached no log: %q", logged.String())
+	}
+	// The first draft stood, kept its violations, and so took the plain
+	// fallback — which is the behaviour the log exists to make visible.
+	if version != nil {
+		t.Errorf("a fallback draft must not claim a voice version, got %v", version)
+	}
+	if draft.Body != "A plain professional reply." {
+		t.Errorf("draft = %+v, want the plain fallback", draft)
+	}
+	if len(brain.requests) != 3 {
+		t.Errorf("calls = %d, want voice + failed retry + plain", len(brain.requests))
 	}
 }

--- a/backend/internal/compose/replydraft_test.go
+++ b/backend/internal/compose/replydraft_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -399,6 +400,21 @@ func TestAFailedVoiceCriticRetryIsLoggedAndTheFirstDraftStands(t *testing.T) {
 	}
 	if !strings.Contains(logged.String(), retryFailed.Error()) {
 		t.Errorf("the retry failure reached no log: %q", logged.String())
+	}
+	// The count too, and derived from the production detector rather than
+	// written down: a hard-coded number would drift the day a floor rule is
+	// added, and a log line that says only "a retry failed" cannot tell a
+	// reader whether the draft it kept was one violation off or twelve.
+	first := replyDraft{
+		Subject: "Re: plan",
+		Body:    "Here's the thing: it's not about tools, but transformation. What do you think?",
+	}
+	wantCount := len(voiceDraftViolations(first))
+	if wantCount == 0 {
+		t.Fatal("the fixture body trips no floor rule, so this case never reaches the retry at all")
+	}
+	if !strings.Contains(logged.String(), fmt.Sprintf("violations=%d", wantCount)) {
+		t.Errorf("the log does not carry violations=%d: %q", wantCount, logged.String())
 	}
 	// The first draft stood, kept its violations, and so took the plain
 	// fallback — which is the behaviour the log exists to make visible.

--- a/backend/internal/compose/replydraftvoice.go
+++ b/backend/internal/compose/replydraftvoice.go
@@ -42,6 +42,14 @@ func (d replyDrafter) loadVoice(ctx context.Context) draftvoice.Context {
 // the deterministic anti-AI floor: detect → one critic retry → sanitize →
 // on surviving violations fall back to the plain draft and record the
 // failure as a rejected learning signal.
+//
+// It PROPAGATES its model failures — unlike loadVoice, recordVoiceDraft and
+// recordVoiceRejection below, which are best-effort and log. Three of its four
+// exits return an error, and the containment for all three is the caller's:
+// DraftEmailWithProvenance answers with the DETERMINISTIC draft, not with a
+// retry that drops the profile. Read as best-effort, the error return looks
+// vestigial and the caller's degrade looks removable — and removing it turns
+// every transient model failure into a failed draft_reply.
 func (d replyDrafter) completeVoiced(ctx context.Context, anchor ids.UUID, data replyActivityData, voice draftvoice.Context) (replyDraft, *int, *string, error) {
 	if !voice.OK {
 		draft, err := d.completeChecked(ctx, replyDraftSystem, data, nil)
@@ -61,7 +69,16 @@ func (d replyDrafter) completeVoiced(ctx context.Context, anchor ids.UUID, data 
 			return block(fence) + draftvoice.Feedback(violations)
 		}
 		retried, retryErr := d.complete(ctx, data, withFeedback)
-		if retryErr == nil {
+		if retryErr != nil {
+			// This is the one call in the lane that goes to d.complete rather
+			// than completeChecked, so draftRetryLog never sees it: unlogged,
+			// the failure is recorded nowhere at all. Keeping the first draft
+			// is the right answer — the re-check below still decides whether
+			// it may be served — but that decision is then made on a retry
+			// nobody can see happened.
+			d.logger().WarnContext(ctx, "voice critic retry failed; keeping the first draft with its violations",
+				"err", retryErr, "violations", len(violations))
+		} else {
 			draft = retried
 		}
 	}


### PR DESCRIPTION
Closes #962. Both defects, as filed.

### 1. The swallowed retry error

`completeVoiced`'s critic retry calls `d.complete` directly rather than `completeChecked`, so `draftRetryLog` never sees it — and `retryErr` reached neither the log nor the caller. There was no path by which the failure was recorded anywhere.

The consequence is the part worth stating: when the retry fails the FIRST draft stands, violations included, then goes through `Sanitize` and the re-check. A draft whose violations the sanitizer happened to remove is served and recorded via `recordVoiceDraft` — indistinguishable, in the learning signal, from a draft that never violated anything. The fallback behaviour is right; it was only invisible. It now warns with the error and the violation count.

### 2. The failure contract

`completeVoiced` returns its error at three of four exits, while `loadVoice`, `recordVoiceDraft` and `recordVoiceRejection` beside it are genuinely best-effort and log. Nothing said which this one was, and the containment lives a file away in `DraftEmailWithProvenance` — which answers with the **deterministic** draft, not with a retry that drops the profile.

One sentence at each end now says so, including what a reader would break by acting on the wrong reading: weaken that `if err != nil` and every transient model or `ai_call` failure becomes a failed `draft_reply` instead of a deterministic draft.

### Test

`TestAFailedVoiceCriticRetryIsLoggedAndTheFirstDraftStands` fails the middle call of the sequence — `sequencedBrainStub` gains an `errs` slot parallel to `responses`, which is the only way to reach a path that runs between two successes. It pins the logged error and the three consequences that follow it: no error returned, no voice version claimed, the plain fallback served, three brain calls.

The fixture violates with a canned opener specifically because the sanitizer does NOT remove that one — otherwise the case would have proved the sanitizer's behaviour by accident rather than the log's.

Mutation-checked with `if retryErr != nil && false`: the new case goes red, every other voiced-draft case stays green. `make check-backend` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice critic retry failures are now logged for improved visibility.
  * Draft generation continues using the initial draft and plain fallback when a voice retry fails, instead of failing the entire request.
* **Tests**
  * Added coverage for retry-failure handling and fallback draft behavior.
* **Documentation**
  * Clarified error-handling behavior for voice-based draft generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->