### PR TITLE
An unroutable lead says why, instead of reporting a clean run

### DIFF
--- a/backend/internal/compose/integration/leadrouting_integration_test.go
+++ b/backend/internal/compose/integration/leadrouting_integration_test.go
@@ -15,6 +15,7 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -182,5 +183,47 @@ func TestLeadRoutingLeavesHumanAssignmentsAlone(t *testing.T) {
 	})
 	if err != nil || runs != 1 {
 		t.Fatalf("run claim count = %d (%v), want 1", runs, err)
+	}
+}
+
+// An unroutable lead is a SKIP that says why, not a clean run that says
+// nothing.
+//
+// The reason was thrown away: Apply answered an empty result, the engine
+// recorded a successful firing, and a manager who found the lead still sitting
+// in the unassigned queue had the audit trail and nothing else to read. The
+// run row now carries the sentence.
+func TestAnUnroutableLeadRecordsWhyOnItsRun(t *testing.T) {
+	e := setupRouting(t)
+	enableLeadRouting(t, e.SearchEnv, map[string]any{
+		"owners":        []string{e.Rep1.String()},
+		"cap_per_owner": 1,
+	})
+
+	// The first lead takes the only seat's only slot.
+	if _, owner := e.routeNewLead(t, "manual"); owner == nil {
+		t.Fatal("the first lead did not route, so the second proves nothing")
+	}
+	leadID, owner := e.routeNewLead(t, "manual")
+	if owner != nil {
+		t.Fatalf("a lead routed to %v with the pool at capacity", owner)
+	}
+
+	var status string
+	var detail *string
+	// Keyed on the run's own idempotency key, which carries the LEAD and then
+	// the workspace: the engine was handed a synthetic envelope that never
+	// passed through the outbox, so a join to it finds nothing.
+	if err := e.Owner.QueryRow(context.Background(), `
+		SELECT status, detail::text FROM workflow_run
+		 WHERE handler = 'assign_lead_owner' AND idempotency_key LIKE $1`,
+		"assign_lead_owner:"+leadID.String()+"@%").Scan(&status, &detail); err != nil {
+		t.Fatalf("reading the routing run for the unroutable lead: %v", err)
+	}
+	if status != "skipped" {
+		t.Errorf("an unroutable lead's run is %q, want skipped — it neither applied nor failed", status)
+	}
+	if detail == nil || !strings.Contains(*detail, "capacity") {
+		t.Errorf("the run's detail is %v, want the capacity reason a manager reads", detail)
 	}
 }

--- a/backend/internal/modules/automation/engine_run.go
+++ b/backend/internal/modules/automation/engine_run.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strconv"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -177,11 +178,11 @@ func (e *WorkflowEngine) runOne(ctx context.Context, h workflow.Handler, ev work
 		// a DECLINED apply is the handler saying it looked and there was
 		// nothing to do. None is a dispatch failure.
 		//
-		// The declined arm matters most here: returning it would leave the bus
-		// entry unacked and redelivering forever — no dead-letter store yet —
-		// poisoning every sibling handler dispatched off the same event. That
-		// is the reason the Plan path already swallows its own decline, and
-		// the reason is the same on this side.
+		// The declined arm is the new one, and it is a skip rather than an
+		// error for the same reason the Plan path swallows its own decline:
+		// nothing went wrong. Returning it would put a healthy outcome in the
+		// subscriber's failure log, where a reader looking for real breakage
+		// would meet every lead a human claimed before routing ran.
 		//
 		// A real apply failure still surfaces, after its record committed.
 		return applyErr
@@ -297,7 +298,12 @@ func (e *WorkflowEngine) recordApplyOutcome(ctx context.Context, h workflow.Hand
 			// with its reason on the run, not a failure: nothing went wrong,
 			// and a reader asking why the lead is still unassigned gets the
 			// answer here rather than an empty successful run.
-			detail, err := reasonDetail(declinedApply.Reason)
+			// Held to the same bar as every other reason reaching this column,
+			// but not through sanitizedReason: that one collapses an unknown
+			// error to a generic phrase, which is right for a FAILURE and
+			// destroys the only thing a decline is for. declinedReason keeps
+			// the sentence and refuses the shapes a leak arrives in.
+			detail, err := reasonDetail(declinedReason(declinedApply.Reason))
 			if err != nil {
 				return err
 			}
@@ -452,3 +458,36 @@ func sanitizedReason(err error) string {
 		return "the action could not be completed"
 	}
 }
+
+// declinedReason bounds what a handler's decline may write to
+// workflow_run.detail.
+//
+// The column is read verbatim by anybody holding automation:read, and
+// workflow.Declined takes a plain string from a module — so this is the one
+// place standing between a handler and that reader. sanitizedReason is the
+// wrong tool: it answers a generic phrase for anything it does not recognise,
+// which is correct for a failure whose text may be a pgx error, and would
+// erase the sentence a decline exists to deliver.
+//
+// So: keep the sentence, refuse the shapes a database internal arrives in. A
+// SQLSTATE, a quoted identifier, or a pgx error's tell means somebody passed an
+// error's message where a written reason belongs, and the generic phrase is the
+// honest answer for that. Length is bounded for the same reason.
+func declinedReason(reason string) string {
+	const generic = "the automation found nothing to do"
+	trimmed := strings.TrimSpace(reason)
+	if trimmed == "" || len(trimmed) > declinedReasonMax {
+		return generic
+	}
+	for _, tell := range []string{"SQLSTATE", "pq:", "pgx:", "ERROR:", `"`, "\n"} {
+		if strings.Contains(trimmed, tell) {
+			return generic
+		}
+	}
+	return trimmed
+}
+
+// declinedReasonMax is a sentence, not a paragraph: a reason longer than this
+// is prose nobody reads on a run row, or a message that came from somewhere
+// other than an author.
+const declinedReasonMax = 160

--- a/backend/internal/modules/automation/engine_run.go
+++ b/backend/internal/modules/automation/engine_run.go
@@ -168,12 +168,22 @@ func (e *WorkflowEngine) runOne(ctx context.Context, h workflow.Handler, ev work
 	if recordErr := e.recordApplyOutcome(ctx, h, ev, result, applyErr); recordErr != nil {
 		return errors.Join(applyErr, recordErr)
 	}
-	if applyErr != nil && !errors.Is(applyErr, apperrors.ErrRequiresApproval) && !errors.Is(applyErr, ErrNoNotificationTransport) {
-		// A staged 🟡 is a healthy suspension, and a no-transport notify is
-		// the wiring-defect guard's honest skip (compose wires the durable
-		// notice transport; only a composition that forgot the seam takes
-		// it) — neither is a dispatch failure; a real apply failure still
-		// surfaces after its record committed.
+	var declinedApply *workflow.DeclinedError
+	if applyErr != nil && !errors.Is(applyErr, apperrors.ErrRequiresApproval) &&
+		!errors.Is(applyErr, ErrNoNotificationTransport) && !errors.As(applyErr, &declinedApply) {
+		// A staged 🟡 is a healthy suspension; a no-transport notify is the
+		// wiring-defect guard's honest skip (compose wires the durable notice
+		// transport, so only a composition that forgot the seam takes it); and
+		// a DECLINED apply is the handler saying it looked and there was
+		// nothing to do. None is a dispatch failure.
+		//
+		// The declined arm matters most here: returning it would leave the bus
+		// entry unacked and redelivering forever — no dead-letter store yet —
+		// poisoning every sibling handler dispatched off the same event. That
+		// is the reason the Plan path already swallows its own decline, and
+		// the reason is the same on this side.
+		//
+		// A real apply failure still surfaces, after its record committed.
 		return applyErr
 	}
 	return nil
@@ -228,6 +238,7 @@ func withSendingOwner(ctx context.Context, ev workflow.Event) context.Context {
 func (e *WorkflowEngine) recordApplyOutcome(ctx context.Context, h workflow.Handler, ev workflow.Event, result workflow.RunResult, applyErr error) error {
 	return e.db.Tx(ctx, func(tx pgx.Tx) error {
 		var staged *workflow.StagedApprovalError
+		var declinedApply *workflow.DeclinedError
 		switch {
 		case errors.As(applyErr, &staged):
 			// The staging pointer rides the detail column's approval_id
@@ -273,6 +284,20 @@ func (e *WorkflowEngine) recordApplyOutcome(ctx context.Context, h workflow.Hand
 			// Match/Plan condition-declined skip (recordSkip) and a real
 			// 'failed' — nothing went wrong with the firing itself.
 			detail, err := reasonDetail("no notification transport configured")
+			if err != nil {
+				return err
+			}
+			_, err = tx.Exec(ctx, `
+				UPDATE workflow_run SET status = 'skipped', detail = $3
+				WHERE handler = $1 AND idempotency_key = $2`, h.Spec().Name, runKey(h, ev), detail)
+			return err
+		case errors.As(applyErr, &declinedApply):
+			// The handler looked and found nothing to act on — an unroutable
+			// lead, say, where every eligible owner is at capacity. A skip
+			// with its reason on the run, not a failure: nothing went wrong,
+			// and a reader asking why the lead is still unassigned gets the
+			// answer here rather than an empty successful run.
+			detail, err := reasonDetail(declinedApply.Reason)
 			if err != nil {
 				return err
 			}

--- a/backend/internal/modules/automation/rundetail_test.go
+++ b/backend/internal/modules/automation/rundetail_test.go
@@ -99,3 +99,33 @@ func TestParseRunDetailSurfacesAMalformedPayload(t *testing.T) {
 		t.Fatal("decodeRunDetail accepted malformed jsonb without error")
 	}
 }
+
+// A decline's reason reaches workflow_run.detail, which anybody holding
+// automation:read reads verbatim. workflow.Declined takes a plain string from a
+// module, so this is the one place standing between a handler and that reader.
+func TestADeclinedReasonKeepsItsSentenceAndRefusesADatabaseInternal(t *testing.T) {
+	const generic = "the automation found nothing to do"
+
+	kept := "no eligible owner had capacity for this lead"
+	if got := declinedReason(kept); got != kept {
+		t.Errorf("a written reason came back %q, want it kept — collapsing it "+
+			"would erase the only thing a decline exists to say", got)
+	}
+
+	// Each of these is a message that came from somewhere other than an
+	// author, and each is a way a backend internal reaches a client.
+	for _, leak := range []string{
+		`ERROR: duplicate key value violates unique constraint "lead_pkey" (SQLSTATE 23505)`,
+		`pq: relation "workflow_run" does not exist`,
+		`pgx: column "owner_id" cannot be null`,
+		`a reason naming a "quoted identifier"`,
+		strings.Repeat("prose ", 40),
+		"",
+		"   ",
+	} {
+		if got := declinedReason(leak); got != generic {
+			t.Errorf("declinedReason(%.40q…) = %q, want the generic phrase — a "+
+				"reader holding automation:read must not meet a database internal", leak, got)
+		}
+	}
+}

--- a/backend/internal/modules/people/leadrouting.go
+++ b/backend/internal/modules/people/leadrouting.go
@@ -362,7 +362,14 @@ func (w leadRouting) Apply(ctx context.Context, ev workflow.Event, eff workflow.
 		return workflow.RunResult{}, err
 	}
 	if !decision.Assigned {
-		return workflow.RunResult{}, nil
+		// Not a failure and not a silent success: routing looked and placed
+		// nobody, and WHY is the answer a manager needs when they find the
+		// lead still sitting in the unassigned queue. An empty result recorded
+		// a clean run and threw the reason away.
+		//
+		// The reasons are this package's own closed vocabulary, so none of
+		// them can carry a database message to a reader.
+		return workflow.RunResult{}, workflow.Declined(routingDeclineReason(decision.Reason))
 	}
 	return workflow.RunResult{Applied: eff.Actions}, nil
 }
@@ -371,4 +378,26 @@ func (w leadRouting) Apply(ctx context.Context, ev workflow.Event, eff workflow.
 // lead.created must not re-route.
 func (leadRouting) IdempotencyKey(ev workflow.Event) string {
 	return assignLeadOwnerName + ":" + ev.Entity.ID.String()
+}
+
+// routingDeclineReason renders one of RouteLead's decision reasons as the
+// sentence a reader meets on the run.
+//
+// A closed switch rather than the raw reason: the decisions are this package's
+// vocabulary and a reader is not owed "no_capacity". An unrecognised reason
+// falls through to the general sentence rather than being printed, so a reason
+// added later cannot leak an internal spelling by being forgotten here.
+func routingDeclineReason(reason string) string {
+	switch reason {
+	case "no_capacity":
+		return "no eligible owner had capacity for this lead"
+	case "already_owned":
+		return "somebody already owns this lead"
+	case "terminal_status":
+		return "this lead is no longer open"
+	case "lead_gone":
+		return "this lead was archived before routing ran"
+	default:
+		return "routing placed no owner on this lead"
+	}
 }

--- a/backend/internal/shared/ports/workflow/workflow.go
+++ b/backend/internal/shared/ports/workflow/workflow.go
@@ -205,6 +205,26 @@ type RunResult struct {
 	AuditLogID ids.UUID
 }
 
+// DeclinedError is a handler saying it looked and there was nothing to do.
+//
+// A skip, never a failure: nothing went wrong, and a redelivery would meet the
+// same record and reach the same answer. The engine records it on the run with
+// this reason, which is what puts the answer in front of a reader — an Apply
+// that returns an empty result instead reads as a clean success and throws the
+// reason away.
+//
+// The reason is read verbatim by anybody holding automation:read, so it says
+// what the CONDITION was and never carries an error's own message: no SQLSTATE,
+// no table or column name.
+type DeclinedError struct {
+	Reason string
+}
+
+func (e *DeclinedError) Error() string { return e.Reason }
+
+// Declined builds the skip a handler returns to say it acted on nothing.
+func Declined(reason string) error { return &DeclinedError{Reason: reason} }
+
 // StagedApprovalError is the typed form of the "staged as approval"
 // answer: a chat client shows the message, while a programmatic caller
 // (the Surface-B runner) suspends on the id instead of parsing prose.


### PR DESCRIPTION
Routing that placed nobody answered an empty result, so the engine recorded the firing as **applied** and threw the reason away. A manager who found the lead still sitting in the unassigned queue had the audit trail and nothing else: the run history — the place a reader goes when an automation did not do what they expected — said it worked.

It is a **skip with its reason** now. Nothing went wrong, and a redelivery would meet the same record and reach the same answer, which is exactly what `skipped` means here. `failed` would put a working installation in the health lane.

## How the reason travels

`workflow.Declined` carries it, beside the port's other typed answers, because a module cannot import automation's own unexported decline. The engine already honoured that shape on the **Plan** path and had no arm for it on **Apply**, which is why routing had nowhere to put the sentence.

The declined apply must not surface as a dispatch failure, for the reason the plan path already states in its own comment: the bus entry would go unacked and redeliver forever — there is no dead-letter store — poisoning every sibling handler dispatched off the same event. Getting this wrong was visible immediately: three existing routing tests went red before the suppression was added.

The reasons are a **closed switch** over this package's own vocabulary rather than the raw decision string. `workflow_run.detail` is read verbatim by anybody holding `automation:read`, and a reason added later that nobody translates falls through to the general sentence instead of leaking an internal spelling.

## What this deliberately does not do

**Retry is not widened to reach these.** `/automations/runs/{id}/retry` acts on failed runs, and re-running "is anybody free?" against the same capacity asks a settled question expecting a different answer. Capacity returning is what resolves it, and the reason now says so.

The retry half of this work turned out to be already shipped: the endpoint exists, and `assign_lead_owner` already declares itself re-drivable without duplicating, having been established safe because `RouteLead` reads the owner under the row lock and returns early once anybody holds it.

## Tests

One integration case against real Postgres: a pool at capacity leaves the lead unowned, and its run row reads `skipped` carrying the capacity sentence. Mutation-checked — restoring the empty result makes the run read `applied` with a null detail, which is the exact silent success this removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lead routing that placed nobody previously recorded its run as applied, so the audit trail said it worked while the lead sat unassigned. The run now reads as `skipped` with a human-readable reason.

**Notes**
- A handler can now return `workflow.Declined`; the engine records it as a skip rather than a dispatch failure, which would log a healthy outcome in the subscriber's failure log.
- The reason reaching `workflow_run.detail` — read verbatim by anyone with `automation:read` — is guarded twice: routing's reasons come from a closed switch over its own decision vocabulary, and `declinedReason` passes written sentences while refusing database tells (SQLSTATE, pq/pgx messages, quoted identifiers, newlines, prose past a sentence's length) with a generic phrase.
- Retry is not extended to these skips: rerunning "does an owner have capacity?" against the same capacity asks a settled question; capacity returning is what resolves it.
- Adds an integration test asserting an unroutable lead's run reads `skipped` with the capacity reason.

<sup>Written for commit 5a68aaed77b1d292b35a5680776665df83d8ebd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unroutable leads now receive a clear, recorded explanation when routing is skipped, including capacity, ownership, terminal-status, or archived-lead reasons.
  - Workflow runs distinguish skipped outcomes from failures, preserving the reason for future review.
- **Bug Fixes**
  - Expected routing declines no longer appear as dispatch failures or interfere with other workflow processing.
- **Tests**
  - Added coverage verifying that leads skipped because of capacity are recorded with the appropriate status and explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->