### PR TITLE
test(compose): the deep-read precedence cases seed through the writer

### DIFF
--- a/backend/internal/compose/deepreadaccept_integration_test.go
+++ b/backend/internal/compose/deepreadaccept_integration_test.go
@@ -45,15 +45,21 @@ func TestDeepReadOfferingsDedupeOnValueKeyAndTheApplyRespectsHumanPrecedence(t *
 
 	// A human has claimed the service fact. The read must land the product
 	// beside it and leave this row exactly as it is.
-	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(context.Background(), `
-			INSERT INTO organization_fact (organization_id, category, field, value, value_key, evidence_snippet, source_url, confidence, source, captured_by)
-			VALUES ($1, 'offering', 'service', 'CRM Rollout (human curated)', 'crm rollout',
-			        'set by hand', '', 1, 'human', $2)`,
-			org, "human:"+e.Rep1.String())
-		return err
-	}); err != nil {
-		t.Fatal(err)
+	//
+	// Seeded through the writer, because the row IS what this case protects:
+	// CreateOrganizationFact mints it human-owned from birth, which is the
+	// property both enrichment upserts consult. The hand INSERT that stood here
+	// made a row the writer cannot — it supplied value_key 'crm rollout' beside
+	// the value "CRM Rollout (human curated)", which the writer's own derivation
+	// keys as 'crm rollout (human curated)'. The precedence rule was therefore
+	// being judged against a precondition no human could have created, and a
+	// drift in captured_by, in source, or in that derivation would have left
+	// this case green while production moved.
+	humanService := people.FactCreateInput{Category: "offering", Field: "service", Value: "CRM Rollout"}
+	if _, err := people.NewStore(e.DB()).CreateOrganizationFact(
+		e.As(e.Rep1, nil, integration.AdminPerms), ids.From[ids.OrganizationKind](org), humanService,
+	); err != nil {
+		t.Fatalf("seeding the human-claimed service fact: %v", err)
 	}
 
 	done, _ := runServicesDeepRead(t, e, org)
@@ -93,7 +99,7 @@ func TestDeepReadOfferingsDedupeOnValueKeyAndTheApplyRespectsHumanPrecedence(t *
 	if factRows != 2 {
 		t.Fatalf("%d organization_fact rows after the read, want 2 (the human's service + the landed product)", factRows)
 	}
-	if serviceValue != "CRM Rollout (human curated)" || serviceCapturedBy != "human:"+e.Rep1.String() {
+	if serviceValue != humanService.Value || serviceCapturedBy != "human:"+e.Rep1.String() {
 		t.Fatalf("service row = %q by %q — the read overwrote a human-claimed fact", serviceValue, serviceCapturedBy)
 	}
 	if productValue != "Margince — our CRM product" {
@@ -176,15 +182,14 @@ func TestAcceptedEmployeeRangeFactFillsSizeBandWhenUnambiguous(t *testing.T) {
 	// upsert refuses the agent's fact, so the column must not contradict the
 	// human's standing statement either.
 	claimed := insertOrg(t, e, e.Rep1, "claimed.example", "")
-	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(context.Background(), `
-			INSERT INTO organization_fact (organization_id, category, field, value, value_key, evidence_snippet, source_url, confidence, source, captured_by)
-			VALUES ($1, 'company', 'employee_range', '11-50', '',
-			        'set by hand', '', 1, 'human', $2)`,
-			claimed, "human:"+e.Rep1.String())
-		return err
-	}); err != nil {
-		t.Fatal(err)
+	// Through the writer, for the reason the offerings case states at length:
+	// the standing statement this promotion must not contradict is a row
+	// CreateOrganizationFact makes, and a fixture that merely resembles one
+	// keeps passing after the writer's shape has moved.
+	if _, err := store.CreateOrganizationFact(ctx, ids.From[ids.OrganizationKind](claimed),
+		people.FactCreateInput{Category: "company", Field: "employee_range", Value: "11-50"},
+	); err != nil {
+		t.Fatalf("seeding the human-claimed employee_range fact: %v", err)
 	}
 	if err := store.ApplyDeepRead(ctx, people.DeepReadProposal{
 		OrganizationID: ids.From[ids.OrganizationKind](claimed),


### PR DESCRIPTION
Closes #886. Rule 6: *a test that supplies its own version of production proves nothing about production.*

Both cases exist to prove an accepted proposal does **not** overwrite what a human put there. What they protect is a row `Store.CreateOrganizationFact` makes — with its own authorization, audit row, outbox event and `captured_by` stamp. Both seeded it with a direct `INSERT INTO organization_fact`.

### The fixture was not merely a copy — it was a row the writer cannot make

The offerings case supplied `value_key = 'crm rollout'` beside `value = 'CRM Rollout (human curated)'`. The writer never takes a key from its caller; `factValueKeyFor` derives it, and `NormalizeFactValueKey("CRM Rollout (human curated)")` is `'crm rollout (human curated)'`. There is no principal that could have produced the seeded row.

That matters because the row's key is exactly what makes the case bite: the precedence rule only fires when the read's fact and the human's row collide on `value_key`. The fixture manufactured that collision by hand, so the case was asserting the guard against a precondition production cannot reach — and any drift in the derivation, in the `human:` stamp, or in the `source` value would have left both tests green while the invariant they name had moved.

The fixture also differed from the writer in two smaller ways it had no reason to: `evidence_snippet = 'set by hand'` and a hand-assembled `"human:"+uuid` where the writer takes `storekit.CapturedBy(ctx)`.

### The change

Both seeds now go through `CreateOrganizationFact`, which is the right writer for a human-curated fact and says so: *"the row is human-owned from birth, which is also what protects it: both enrichment upserts decline to overwrite a row whose captured_by is a human."* That property is the one under test, so the seed should be the thing that establishes it.

- offerings: value `"CRM Rollout"`, whose derived key is `'crm rollout'` — the collision the case needs, now produced rather than declared. The assertion reads the value off the input rather than repeating a literal.
- employee_range: value `"11-50"`, a single-value company field, so the derived key is `''` as before.

### Held

Mutation-checked by pointing the enrichment upsert's `captured_by NOT LIKE 'human:%'` at a prefix nothing carries: **both** cases go red, so the seeded precondition is load-bearing in each. The old fixtures would have survived a change to the `human:` prefix itself, since they wrote that string in by hand — which is the class of drift the ticket names.

`make check-backend` green; both cases and their four neighbours pass on the real-Postgres lane.
