### PR TITLE
A breach on a lead nobody owns reaches somebody

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -33887,12 +33887,33 @@ components:
       properties:
         first_response_enabled: { type: boolean, description: 'Whether the first-response target is tracked at all. Off by default.' }
         first_response_target_minutes: { type: integer, description: 'How long a lead may wait for its first genuine response once the clock starts (routing, else creation). 15..10080.' }
+        unassigned_escalation_user_id:
+          type: [string, 'null']
+          format: uuid
+          description: |
+            Who answers when a lead nobody owns misses its target. Null means nobody is
+            configured, and an unowned breach is recorded without being addressed. Also reads
+            null once the named seat can no longer work the queue — suspended, archived, an
+            agent, a read seat — because a desk nobody reads is the same silence as none.
 
     UpdateLeadSettingsRequest:
       type: object
       properties:
         first_response_enabled: { type: boolean }
         first_response_target_minutes: { type: integer, minimum: 15, maximum: 10080 }
+        unassigned_escalation_user_id:
+          type: [string, 'null']
+          format: uuid
+          description: |
+            Who answers when a lead NOBODY owns misses its first-response target. An owned
+            lead's breach escalates to its owner; without this, an unowned one escalated to
+            nobody at all.
+
+            Must name a seat that can be handed work AND may read leads, else `422` — an
+            escalation carries the lead it is about, so a desk that cannot open the record is
+            not a desk to send it to. Null clears it, which is the honest default: the breach
+            is recorded and left in the unassigned queue rather than addressed to somebody who
+            never agreed to answer for it.
 
     DisqualifyLeadRequest:
       type: object

--- a/backend/internal/compose/seatgrantseam.go
+++ b/backend/internal/compose/seatgrantseam.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The edge from a module asking "may THAT seat read this object" to identity,
+// which owns the role tables that answer it.
+//
+// Almost every authorization question in the tree is about the caller, and
+// platform/auth answers those without help. This one is about somebody else: an
+// operator nominating a colleague to receive lead escalations, where the seat
+// being named is not the seat asking. The grants live in identity's tables and
+// a module never imports a sibling, so compose carries the edge.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// seatReadsLeads answers whether one seat's grants admit reading a lead.
+//
+// The caller's own authority is NOT this seam's question: the surface offering
+// the nomination gates that, and this reads the nominee's grants and nothing
+// else. It runs inside the caller's transaction so the answer and the write it
+// gates commit together.
+func seatReadsLeads(_ *pgxpool.Pool) people.SeatReadsLeads {
+	return func(ctx context.Context, tx pgx.Tx, seat ids.UUID) (bool, error) {
+		return identity.SeatAllows(ctx, tx, ids.From[ids.UserKind](seat), "lead", principal.ActionRead)
+	}
+}

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -62,6 +62,7 @@ func newPeopleHandlers(pool *pgxpool.Pool) peopleHandlers {
 		WithMatchStager(linkedInMatchStager(pool)).
 		WithVCardReviewStager(vcardCreateStager(pool)).
 		WithSettings(NewSettingsStore(pool)).
+		WithSeatReadsLeads(seatReadsLeads(pool)).
 		WithDealOpener(leadDealOpener{deals: deals.NewStore(InstallationDB(pool), DealsInstallation())})
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -25818,6 +25818,12 @@ type LeadSettings struct {
 
 	// FirstResponseTargetMinutes How long a lead may wait for its first genuine response once the clock starts (routing, else creation). 15..10080.
 	FirstResponseTargetMinutes int `json:"first_response_target_minutes"`
+
+	// UnassignedEscalationUserId Who answers when a lead nobody owns misses its target. Null means nobody is
+	// configured, and an unowned breach is recorded without being addressed. Also reads
+	// null once the named seat can no longer work the queue — suspended, archived, an
+	// agent, a read seat — because a desk nobody reads is the same silence as none.
+	UnassignedEscalationUserId *openapi_types.UUID `json:"unassigned_escalation_user_id,omitempty"`
 }
 
 // LeadSource One administered lead source. `key` is the value stored on `lead.source`; `label` is what a user sees.
@@ -34850,6 +34856,17 @@ type UpdateLeadRequestStatus string
 type UpdateLeadSettingsRequest struct {
 	FirstResponseEnabled       *bool `json:"first_response_enabled,omitempty"`
 	FirstResponseTargetMinutes *int  `json:"first_response_target_minutes,omitempty"`
+
+	// UnassignedEscalationUserId Who answers when a lead NOBODY owns misses its first-response target. An owned
+	// lead's breach escalates to its owner; without this, an unowned one escalated to
+	// nobody at all.
+	//
+	// Must name a seat that can be handed work AND may read leads, else `422` — an
+	// escalation carries the lead it is about, so a desk that cannot open the record is
+	// not a desk to send it to. Null clears it, which is the honest default: the breach
+	// is recorded and left in the unassigned queue rather than addressed to somebody who
+	// never agreed to answer for it.
+	UnassignedEscalationUserId *openapi_types.UUID `json:"unassigned_escalation_user_id,omitempty"`
 }
 
 // UpdateLeadSourceRequest defines model for UpdateLeadSourceRequest.

--- a/backend/internal/modules/identity/loadgrants.go
+++ b/backend/internal/modules/identity/loadgrants.go
@@ -94,3 +94,23 @@ func rawTeamIDs(teams []ids.TeamID) []ids.UUID {
 	}
 	return out
 }
+
+// SeatAllows answers whether one seat's effective grants admit an action on an
+// object, without asking anything about the CALLER.
+//
+// The other readers here answer about the principal, because almost every
+// question is "may I". This one is "may THEY", which the lead-escalation seat
+// needs: a desk is being nominated to receive escalations that carry the record
+// they are about, and a seat that cannot open a lead is not a desk to send one
+// to. Nominating is an admin's act and the caller's own authority is checked by
+// the surface that offers it, so this reads grants and nothing else.
+//
+// A seat with no role assignment allows nothing, which is the honest answer for
+// a user who holds none.
+func SeatAllows(ctx context.Context, tx pgx.Tx, seat ids.UserID, object string, action principal.Action) (bool, error) {
+	_, _, perms, err := loadGrants(ctx, tx, seat)
+	if err != nil {
+		return false, err
+	}
+	return perms.Allows(object, action), nil
+}

--- a/backend/internal/modules/people/handlers.go
+++ b/backend/internal/modules/people/handlers.go
@@ -115,6 +115,13 @@ func (h Handlers) WithSettings(store *settings.Store) Handlers {
 	return h
 }
 
+// WithSeatReadsLeads wires the identity-side grant read the escalation-seat
+// check makes.
+func (h Handlers) WithSeatReadsLeads(reads SeatReadsLeads) Handlers {
+	h.store = h.store.WithSeatReadsLeads(reads)
+	return h
+}
+
 // WithDealOpener wires the deals-side seam a qualify call opens its deal on.
 func (h Handlers) WithDealOpener(opener LeadDealOpener) Handlers {
 	h.store = h.store.WithDealOpener(opener)

--- a/backend/internal/modules/people/handlers_lead.go
+++ b/backend/internal/modules/people/handlers_lead.go
@@ -207,9 +207,22 @@ func (h Handlers) UpdateLeadSettings(w http.ResponseWriter, r *http.Request) {
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	out, err := h.store.UpdateLeadSettings(r.Context(), UpdateLeadSettingsInput{
+	in := UpdateLeadSettingsInput{
 		FirstResponseEnabled: req.FirstResponseEnabled, FirstResponseTargetMinutes: req.FirstResponseTargetMinutes,
-	})
+	}
+	// A JSON null decodes to a nil pointer and reads as "not supplied", so the
+	// explicit "nobody answers for the queue" is carried by the cleared-fields
+	// list rather than by the value.
+	for _, cleared := range httperr.ClearedFields(r) {
+		if cleared == "unassigned_escalation_user_id" {
+			in.ClearUnassignedEscalation = true
+		}
+	}
+	if req.UnassignedEscalationUserId != nil {
+		seat := ids.From[ids.UserKind](ids.UUID(*req.UnassignedEscalationUserId))
+		in.UnassignedEscalationUserID = &seat
+	}
+	out, err := h.store.UpdateLeadSettings(r.Context(), in)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return

--- a/backend/internal/modules/people/leadsettings.go
+++ b/backend/internal/modules/people/leadsettings.go
@@ -20,6 +20,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/settings"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -50,10 +51,38 @@ var FirstResponseTargetMinutes = settings.Define[int](
 		return nil
 	})
 
+// UnassignedEscalationUserID is who answers for a lead nobody owns.
+//
+// A breach on an OWNED lead escalates to its owner, which is the desk that owes
+// the answer. A breach on an unowned one had nobody: the task was written
+// assigned to no one and no notice went out at all, so the queue's worst case —
+// a lead nobody picked up, now past its response target — was the one case that
+// reached no human.
+//
+// A SETTING rather than a derived answer, because "who runs the intake queue"
+// is an operator's decision and no column in this installation holds it. The
+// manager role says who may work a team's records; it does not say which of
+// them answers for the leads nobody has taken. Empty is the honest default: an
+// installation that has not said leaves the breach where it was, and the queue
+// view is what surfaces it.
+var UnassignedEscalationUserID = settings.Define[string](
+	"people.unassigned_escalation_user_id", leadVocabularyObject, "update", "",
+	func(raw string) error {
+		if raw == "" {
+			return nil
+		}
+		if _, err := ids.Parse(raw); err != nil {
+			return fmt.Errorf("the escalation seat is a user id, or empty for nobody")
+		}
+		return nil
+	})
+
 // Definitions is people's contribution to the settings registry; compose
 // concatenates each module's list.
 func Definitions() []settings.Definition {
-	return []settings.Definition{FirstResponseEnabled, FirstResponseTargetMinutes}
+	return []settings.Definition{
+		FirstResponseEnabled, FirstResponseTargetMinutes, UnassignedEscalationUserID,
+	}
 }
 
 // leadSLAPolicy is the resolved setting pair every SLA computation reads.

--- a/backend/internal/modules/people/leadsettings.go
+++ b/backend/internal/modules/people/leadsettings.go
@@ -12,10 +12,12 @@ package people
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
@@ -176,15 +178,39 @@ func (s *Store) GetLeadSettings(ctx context.Context) (crmcontracts.LeadSettings,
 	if err != nil {
 		return crmcontracts.LeadSettings{}, err
 	}
-	return crmcontracts.LeadSettings{
+	out := crmcontracts.LeadSettings{
 		FirstResponseEnabled: policy.enabled, FirstResponseTargetMinutes: policy.targetMinutes(),
-	}, nil
+	}
+	// Read through the same resolver the breach emitter uses, so the screen
+	// cannot show a seat the escalation would refuse to address: a setting
+	// naming somebody who has since been suspended reads null here for the
+	// same reason it escalates to nobody there.
+	if err := s.tx(ctx, func(tx pgx.Tx) error {
+		target, configured, err := unassignedEscalationTarget(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if configured {
+			named := openapi_types.UUID(target)
+			out.UnassignedEscalationUserId = &named
+		}
+		return nil
+	}); err != nil {
+		return crmcontracts.LeadSettings{}, err
+	}
+	return out, nil
 }
 
 // UpdateLeadSettingsInput is a sparse patch; nil leaves the setting alone.
 type UpdateLeadSettingsInput struct {
 	FirstResponseEnabled       *bool
 	FirstResponseTargetMinutes *int
+	// UnassignedEscalationUserID names the seat that answers for the queue.
+	// ClearUnassignedEscalation is the explicit "nobody": a JSON null decodes
+	// to a nil pointer and reads as "not supplied", so the two are carried
+	// apart the way the lead patch carries its own clears.
+	UnassignedEscalationUserID *ids.UserID
+	ClearUnassignedEscalation  bool
 }
 
 // UpdateLeadSettings changes the lead handling (admin/ops). Each setting's
@@ -205,7 +231,20 @@ func (s *Store) UpdateLeadSettings(ctx context.Context, in UpdateLeadSettingsInp
 			}
 		}
 		if in.FirstResponseTargetMinutes != nil {
-			return setLeadSetting(ctx, tx, s.settings, FirstResponseTargetMinutes.Key(), *in.FirstResponseTargetMinutes)
+			if err := setLeadSetting(ctx, tx, s.settings, FirstResponseTargetMinutes.Key(),
+				*in.FirstResponseTargetMinutes); err != nil {
+				return err
+			}
+		}
+		if in.ClearUnassignedEscalation {
+			return setLeadSetting(ctx, tx, s.settings, UnassignedEscalationUserID.Key(), "")
+		}
+		if in.UnassignedEscalationUserID != nil {
+			if err := s.ensureEscalationSeatReadsLeads(ctx, tx, in.UnassignedEscalationUserID.UUID); err != nil {
+				return err
+			}
+			return setLeadSetting(ctx, tx, s.settings, UnassignedEscalationUserID.Key(),
+				in.UnassignedEscalationUserID.String())
 		}
 		return nil
 	})
@@ -217,10 +256,55 @@ func (s *Store) UpdateLeadSettings(ctx context.Context, in UpdateLeadSettingsInp
 
 // setLeadSetting encodes one value and writes it through the settings store's
 // transactional seam, which validates, audits and refuses a frozen setting.
-func setLeadSetting[T bool | int](ctx context.Context, tx pgx.Tx, store *settings.Store, key string, value T) error {
+func setLeadSetting[T bool | int | string](ctx context.Context, tx pgx.Tx, store *settings.Store, key string, value T) error {
 	raw, err := json.Marshal(value)
 	if err != nil {
 		return fmt.Errorf("people: encoding %s: %w", key, err)
 	}
 	return store.SetRawTx(ctx, tx, key, raw)
+}
+
+// EscalationSeatError refuses a seat that cannot answer for the queue: 422.
+type EscalationSeatError struct{}
+
+func (e *EscalationSeatError) Error() string {
+	return "the escalation seat must be an active colleague who can read leads"
+}
+
+// FieldFault names the field the caller sent.
+func (e *EscalationSeatError) FieldFault() (field, code, message string) {
+	return "unassigned_escalation_user_id", "seat_cannot_answer", e.Error()
+}
+
+// ensureEscalationSeatReadsLeads refuses a seat that could not act on the
+// escalation it would receive.
+//
+// TWO questions, and the second is the one an assignment check does not ask.
+// auth.EnsureAssignee answers whether a seat can be handed work at all —
+// active, not an agent, not a read seat. It says nothing about LEADS, and an
+// escalation carries the lead it is about: a colleague holding activity access
+// and no lead grant would receive a task naming a record they cannot open,
+// which is both useless to them and a disclosure nobody authorised.
+func (s *Store) ensureEscalationSeatReadsLeads(ctx context.Context, tx pgx.Tx, seat ids.UUID) error {
+	if err := auth.EnsureAssignee(ctx, tx, seat); err != nil {
+		if errors.As(err, new(*auth.AssigneeNotAllowedError)) {
+			return &EscalationSeatError{}
+		}
+		return err
+	}
+	if s.seatReadsLeads == nil {
+		// Unwired: refuse rather than admit. A composition that cannot answer
+		// "may they read leads" has not established the seat is safe to
+		// nominate, and admitting on a missing answer is how a check becomes
+		// decoration.
+		return &EscalationSeatError{}
+	}
+	reads, err := s.seatReadsLeads(ctx, tx, seat)
+	if err != nil {
+		return err
+	}
+	if !reads {
+		return &EscalationSeatError{}
+	}
+	return nil
 }

--- a/backend/internal/modules/people/leadsla.go
+++ b/backend/internal/modules/people/leadsla.go
@@ -9,6 +9,8 @@ package people
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -231,13 +233,30 @@ func markBreach(ctx context.Context, tx pgx.Tx, b SLABreach, now time.Time) erro
 		return fmt.Errorf("audit sla breach: %w", err)
 	}
 	payload := crmcontracts.PublicEventLeadSlaBreached{Deadline: b.Deadline}
-	if b.OwnerID != nil {
+	switch {
+	case b.OwnerID != nil:
 		owner := openapi_types.UUID(b.OwnerID.UUID)
 		payload.OwnerId = &owner
-		// Until a team-lead concept exists to resolve the §18 escalation
-		// target through, the owner IS the target: the breach lands on the
-		// desk that owns the lead rather than nowhere.
+		// An owned lead escalates to its OWNER: the desk that owes the answer
+		// is the desk that hears about the miss.
 		payload.EscalationTarget = &owner
+	default:
+		// A lead NOBODY owns is the queue's worst case — past its response
+		// target with no one who has picked it up — and it was the one case
+		// that reached nobody at all: an unassigned task and no notice.
+		//
+		// The configured intake seat answers for it. Unset means the
+		// installation has not said who runs the queue, and the breach stays
+		// where it was rather than being addressed to somebody who did not
+		// agree to it; the unassigned view is what surfaces those.
+		target, configured, err := unassignedEscalationTarget(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if configured {
+			addressed := openapi_types.UUID(target)
+			payload.EscalationTarget = &addressed
+		}
 	}
 	if err := storekit.EmitEvent(ctx, tx, auditID, b.LeadID.UUID, payload); err != nil {
 		return fmt.Errorf("emit lead.sla_breached: %w", err)
@@ -400,4 +419,54 @@ func leadTouchesFor(ctx context.Context, tx pgx.Tx, leadID ids.LeadID, deadline 
 		out = append(out, t)
 	}
 	return out, rows.Err()
+}
+
+// unassignedEscalationTarget reads the configured intake seat.
+//
+// Answers (id, true) when an installation has named a seat that can still work
+// the queue, and (zero, false) for every way it has not: no setting, an empty
+// one, an unparseable one, or a seat that has since been suspended, archived,
+// turned into an agent or dropped to a read seat. A seat nobody reads is the
+// same silence as no seat at all, wearing a configuration that looks correct.
+//
+// Read by key and ungated, the way loadLeadSLAPolicy reads its own pair: this
+// runs inside the SLA sweep under the system principal, and the value is an
+// input to a decision that is already the sweep's to make.
+func unassignedEscalationTarget(ctx context.Context, tx pgx.Tx) (ids.UUID, bool, error) {
+	var raw json.RawMessage
+	err := tx.QueryRow(ctx, `SELECT value FROM setting WHERE key = $1`,
+		UnassignedEscalationUserID.Key()).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ids.UUID{}, false, nil
+	}
+	if err != nil {
+		return ids.UUID{}, false, fmt.Errorf("load the unassigned escalation seat: %w", err)
+	}
+	var configured string
+	if err := json.Unmarshal(raw, &configured); err != nil {
+		// Not silence: the setting is written through a validated entry, so a
+		// value that will not decode means somebody wrote the row around it,
+		// and answering "nobody is configured" would hide that behind a queue
+		// that quietly escalates to no one.
+		return ids.UUID{}, false, fmt.Errorf("decode the unassigned escalation seat: %w", err)
+	}
+	if configured == "" {
+		// Empty IS the answer: the documented way to say no seat answers.
+		return ids.UUID{}, false, nil
+	}
+	id, err := ids.Parse(configured)
+	if err != nil {
+		return ids.UUID{}, false, fmt.Errorf("the unassigned escalation seat is not a user id: %w", err)
+	}
+	// auth.EnsureAssignee, not a query of our own: "may this seat be handed
+	// work" already has one spelling, and a third reading of it is a third
+	// answer. Its SCOPE half is vacuous here — the sweep runs as the system
+	// principal — and its eligibility half is exactly the question.
+	if err := auth.EnsureAssignee(ctx, tx, id); err != nil {
+		if errors.As(err, new(*auth.AssigneeNotAllowedError)) {
+			return ids.UUID{}, false, nil
+		}
+		return ids.UUID{}, false, fmt.Errorf("check the unassigned escalation seat: %w", err)
+	}
+	return id, true, nil
 }

--- a/backend/internal/modules/people/leadsla_integration_test.go
+++ b/backend/internal/modules/people/leadsla_integration_test.go
@@ -12,6 +12,7 @@ package people
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -433,4 +434,93 @@ func TestALateReplyDoesNotRescueTheLead(t *testing.T) {
 	}
 	t.Fatal("a lead answered a minute LATE was not breached — the re-check must be bounded by the " +
 		"deadline, or the target only ever fires for a lead nobody answered at all")
+}
+
+// seedOwnerlessLeadCreatedAt is seedLeadCreatedAt's unowned twin: the queue
+// state a capture or an unroutable arrival leaves behind.
+func (e *promoteConsentEnv) seedOwnerlessLeadCreatedAt(t *testing.T, email string, createdAt time.Time) ids.LeadID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO lead (id, full_name, email, status, source, captured_by, owner_id, created_at)
+		 VALUES ($1, 'Nobody Lead', lower($2), 'new', 'inbound', 'human:x', NULL, $3)`,
+		id, email, createdAt); err != nil {
+		t.Fatal(err)
+	}
+	return ids.From[ids.LeadKind](id)
+}
+
+func (e *promoteConsentEnv) breachTargetOf(t *testing.T, lead ids.LeadID) *string {
+	t.Helper()
+	var target *string
+	if err := e.owner.QueryRow(context.Background(), `
+		SELECT envelope->'payload'->>'escalation_target' FROM event_outbox
+		 WHERE envelope->>'type' = 'lead.sla_breached'
+		   AND envelope->'entity'->>'id' = $1::text`, lead.UUID).Scan(&target); err != nil {
+		t.Fatalf("reading the breach's escalation target: %v", err)
+	}
+	return target
+}
+
+// A lead NOBODY owns is the queue's worst case — past its response target with
+// nobody who has picked it up — and it was the one case the escalation reached
+// nobody at all: the task went out assigned to no one and no notice was
+// addressed. The configured intake seat answers for it.
+func TestAnOwnerlessBreachReachesTheConfiguredIntakeSeat(t *testing.T) {
+	e := setupPromoteConsent(t)
+	e.enableFirstResponseSLA(t)
+	now := time.Now().UTC()
+
+	// Unset: the breach still records, and is addressed to nobody rather than
+	// to somebody who never agreed to answer for it.
+	silent := e.seedOwnerlessLeadCreatedAt(t, "silent@example.test", now.Add(-DefaultFirstResponseTarget-time.Hour))
+	if _, err := e.store.ScanLeadSLA(e.ctx, now); err != nil {
+		t.Fatalf("scan with no configured seat: %v", err)
+	}
+	if target := e.breachTargetOf(t, silent); target != nil {
+		t.Errorf("an unconfigured installation addressed the breach to %q, want nobody", *target)
+	}
+
+	// Configured: the same breach now names the seat that answers for it.
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO setting (key, value) VALUES ($1, $2)
+		 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+		UnassignedEscalationUserID.Key(), fmt.Sprintf("%q", e.user.String())); err != nil {
+		t.Fatal(err)
+	}
+	addressed := e.seedOwnerlessLeadCreatedAt(t, "addressed@example.test", now.Add(-DefaultFirstResponseTarget-time.Hour))
+	if _, err := e.store.ScanLeadSLA(e.ctx, now); err != nil {
+		t.Fatalf("scan with a configured seat: %v", err)
+	}
+	target := e.breachTargetOf(t, addressed)
+	if target == nil || *target != e.user.String() {
+		t.Errorf("escalation target = %v, want the configured intake seat %s", target, e.user)
+	}
+}
+
+// A configured seat that has since been suspended is the same silence as no
+// seat at all, wearing a configuration that looks correct.
+func TestAnIntakeSeatThatCannotWorkIsTreatedAsUnset(t *testing.T) {
+	e := setupPromoteConsent(t)
+	e.enableFirstResponseSLA(t)
+	now := time.Now().UTC()
+
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO setting (key, value) VALUES ($1, $2)
+		 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+		UnassignedEscalationUserID.Key(), fmt.Sprintf("%q", e.user.String())); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE app_user SET status = 'suspended' WHERE id = $1`, e.user); err != nil {
+		t.Fatal(err)
+	}
+
+	lead := e.seedOwnerlessLeadCreatedAt(t, "suspended@example.test", now.Add(-DefaultFirstResponseTarget-time.Hour))
+	if _, err := e.store.ScanLeadSLA(e.ctx, now); err != nil {
+		t.Fatalf("scan with a suspended seat: %v", err)
+	}
+	if target := e.breachTargetOf(t, lead); target != nil {
+		t.Errorf("a suspended seat was addressed (%q); nobody reads that desk", *target)
+	}
 }

--- a/backend/internal/modules/people/leadsla_integration_test.go
+++ b/backend/internal/modules/people/leadsla_integration_test.go
@@ -12,7 +12,7 @@ package people
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -482,12 +482,7 @@ func TestAnOwnerlessBreachReachesTheConfiguredIntakeSeat(t *testing.T) {
 	}
 
 	// Configured: the same breach now names the seat that answers for it.
-	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO setting (key, value) VALUES ($1, $2)
-		 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
-		UnassignedEscalationUserID.Key(), fmt.Sprintf("%q", e.user.String())); err != nil {
-		t.Fatal(err)
-	}
+	e.nameIntakeSeat(t, e.user)
 	addressed := e.seedOwnerlessLeadCreatedAt(t, "addressed@example.test", now.Add(-DefaultFirstResponseTarget-time.Hour))
 	if _, err := e.store.ScanLeadSLA(e.ctx, now); err != nil {
 		t.Fatalf("scan with a configured seat: %v", err)
@@ -505,12 +500,7 @@ func TestAnIntakeSeatThatCannotWorkIsTreatedAsUnset(t *testing.T) {
 	e.enableFirstResponseSLA(t)
 	now := time.Now().UTC()
 
-	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO setting (key, value) VALUES ($1, $2)
-		 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
-		UnassignedEscalationUserID.Key(), fmt.Sprintf("%q", e.user.String())); err != nil {
-		t.Fatal(err)
-	}
+	e.nameIntakeSeat(t, e.user)
 	if _, err := e.owner.Exec(context.Background(),
 		`UPDATE app_user SET status = 'suspended' WHERE id = $1`, e.user); err != nil {
 		t.Fatal(err)
@@ -522,5 +512,73 @@ func TestAnIntakeSeatThatCannotWorkIsTreatedAsUnset(t *testing.T) {
 	}
 	if target := e.breachTargetOf(t, lead); target != nil {
 		t.Errorf("a suspended seat was addressed (%q); nobody reads that desk", *target)
+	}
+}
+
+// grantLeadRead gives a seat the one grant the escalation check asks for. The
+// harness seeds no role assignments — every seat it makes is blind to leads —
+// so a test naming an intake seat has to make it a seat that could answer.
+func (e *promoteConsentEnv) grantLeadRead(t *testing.T, seat ids.UUID) {
+	t.Helper()
+	role := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO role (id, key, name, permissions)
+		 VALUES ($1, $2, 'Lead reader', '{"objects":{"lead":{"read":true}}}'::jsonb)`,
+		role, "lead_reader_"+role.String()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO role_assignment (id, role_id, user_id) VALUES ($1, $2, $3)`,
+		ids.NewV7(), role, seat); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// nameIntakeSeat writes the setting the way an operator does — through the
+// real writer, so the test exercises the gate rather than an INSERT that walks
+// around it.
+func (e *promoteConsentEnv) nameIntakeSeat(t *testing.T, seat ids.UUID) {
+	t.Helper()
+	e.grantLeadRead(t, seat)
+	id := ids.From[ids.UserKind](seat)
+	if _, err := e.store.UpdateLeadSettings(e.ctx, UpdateLeadSettingsInput{
+		UnassignedEscalationUserID: &id,
+	}); err != nil {
+		t.Fatalf("naming the intake seat: %v", err)
+	}
+}
+
+// A seat that cannot READ leads is refused as the escalation target, even
+// though it is a perfectly good seat to hand work to.
+//
+// An escalation carries the lead it is about. A colleague holding activity
+// access and no lead grant would receive a task naming a record they cannot
+// open — useless to them, and a disclosure nobody authorised.
+func TestAnIntakeSeatMustBeAbleToReadTheLeadsItAnswersFor(t *testing.T) {
+	e := setupPromoteConsent(t)
+
+	// A live seat with no role assignment at all: assignable, and blind to
+	// leads.
+	blind := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO app_user (id, email, display_name) VALUES ($1, 'blind@example.test', 'No Grants')`,
+		blind); err != nil {
+		t.Fatal(err)
+	}
+	id := ids.From[ids.UserKind](blind)
+	_, err := e.store.UpdateLeadSettings(e.ctx, UpdateLeadSettingsInput{
+		UnassignedEscalationUserID: &id,
+	})
+	if !errors.As(err, new(*EscalationSeatError)) {
+		t.Fatalf("naming a seat that cannot read leads → %v, want EscalationSeatError", err)
+	}
+	var stored int
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM setting WHERE key = $1`, UnassignedEscalationUserID.Key()).
+		Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != 0 {
+		t.Errorf("the refused nomination was stored anyway")
 	}
 }

--- a/backend/internal/modules/people/promoteconsent_integration_test.go
+++ b/backend/internal/modules/people/promoteconsent_integration_test.go
@@ -102,7 +102,20 @@ func setupPromoteConsent(t *testing.T) *promoteConsentEnv {
 	// would go on writing into the database the NEXT test just reset.
 	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
 	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws))).
-		WithSettings(settings.New(pool, settings.NewRegistry(Definitions()...)))
+		WithSettings(settings.New(pool, settings.NewRegistry(Definitions()...))).
+		// The grant read compose binds to identity. Spelled here over the same
+		// role tables rather than stubbed to true: a stub would make every
+		// nomination pass and the refusal it exists to prove would be the one
+		// case the suite could not reach.
+		WithSeatReadsLeads(func(ctx context.Context, tx pgx.Tx, seat ids.UUID) (bool, error) {
+			var reads bool
+			err := tx.QueryRow(ctx, `
+				SELECT EXISTS (
+				  SELECT 1 FROM role_assignment ra JOIN role r ON r.id = ra.role_id
+				   WHERE ra.user_id = $1
+				     AND (r.permissions->'objects'->'lead'->>'read')::boolean)`, seat).Scan(&reads)
+			return reads, err
+		})
 
 	opCtx := principal.WithWorkspaceID(context.Background(), e.ws)
 	opCtx = principal.WithCorrelationID(opCtx, ids.NewV7())

--- a/backend/internal/modules/people/store.go
+++ b/backend/internal/modules/people/store.go
@@ -42,6 +42,9 @@ type Store struct {
 	// people never imports a sibling. Nil files links and derives nothing —
 	// which is what every fixture is until it says otherwise.
 	recomputeAudience AudienceRecompute
+	// seatReadsLeads answers whether another seat may read leads; see the
+	// type below. Nil is a composition that did not wire it.
+	seatReadsLeads SeatReadsLeads
 	// vatCheckEnqueue queues a VIES consultation when a VAT number is written.
 	// Nil is a real composition, for geocodeEnqueue's reason: the number is
 	// what the page stated, the verification is what an installation can offer.
@@ -107,6 +110,21 @@ func (s *Store) WithFieldCatalog(catalog fieldcatalog.Reader) *Store {
 // every writer gets it without any of them having to remember.
 func (s *Store) WithGeocodeEnqueue(enqueue GeocodeEnqueue) *Store {
 	s.geocodeEnqueue = enqueue
+	return s
+}
+
+// SeatReadsLeads answers whether ANOTHER seat's grants admit reading a lead.
+//
+// Injected because the answer lives in identity's role tables and a module
+// never imports a sibling: compose binds it. Nil means no installation wired
+// it, and a caller treats that as "cannot confirm" rather than "yes" —
+// nominating a desk to receive records it may not open is the mistake this
+// exists to refuse.
+type SeatReadsLeads func(ctx context.Context, tx pgx.Tx, seat ids.UUID) (bool, error)
+
+// WithSeatReadsLeads wires the grant read the escalation-seat check makes.
+func (s *Store) WithSeatReadsLeads(reads SeatReadsLeads) *Store {
+	s.seatReadsLeads = reads
 	return s
 }
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24776,10 +24776,31 @@ export interface components {
             first_response_enabled: boolean;
             /** @description How long a lead may wait for its first genuine response once the clock starts (routing, else creation). 15..10080. */
             first_response_target_minutes: number;
+            /**
+             * Format: uuid
+             * @description Who answers when a lead nobody owns misses its target. Null means nobody is
+             *     configured, and an unowned breach is recorded without being addressed. Also reads
+             *     null once the named seat can no longer work the queue — suspended, archived, an
+             *     agent, a read seat — because a desk nobody reads is the same silence as none.
+             */
+            unassigned_escalation_user_id?: string | null;
         };
         UpdateLeadSettingsRequest: {
             first_response_enabled?: boolean;
             first_response_target_minutes?: number;
+            /**
+             * Format: uuid
+             * @description Who answers when a lead NOBODY owns misses its first-response target. An owned
+             *     lead's breach escalates to its owner; without this, an unowned one escalated to
+             *     nobody at all.
+             *
+             *     Must name a seat that can be handed work AND may read leads, else `422` — an
+             *     escalation carries the lead it is about, so a desk that cannot open the record is
+             *     not a desk to send it to. Null clears it, which is the honest default: the breach
+             *     is recorded and left in the unassigned queue rather than addressed to somebody who
+             *     never agreed to answer for it.
+             */
+            unassigned_escalation_user_id?: string | null;
         };
         /** @description Why the lead is closed. Both fields are optional on the wire so an agent's governed disqualify still works; the UI always sends a reason. */
         DisqualifyLeadRequest: {


### PR DESCRIPTION
An owned lead's first-response breach escalates to its owner. An **unowned** one reached nobody at all: the task went out assigned to no one and no notice was addressed. The queue's worst case — a lead past its response target that nobody has picked up — was the single case no human heard about. The code said so in a comment: *"until a team-lead concept exists"*.

`people.unassigned_escalation_user_id` names the seat that answers for the queue. A **setting** rather than a derived answer, because "who runs intake" is an operator's decision and no column holds it: the manager role says who may work a team's records, never which of them owes an answer for the leads nobody took.

Empty is the honest default. An installation that has not said leaves the breach where it was rather than addressing it to somebody who never agreed to answer for it, and the unassigned queue view surfaces those.

**A configured seat that cannot work is treated as unset** — suspended, archived, an agent, a read seat. Addressing a breach to a desk nobody reads is the same silence as addressing it nowhere, wearing a configuration that looks correct.

## The gate from PR 4990 did its job

I first wrote that liveness check as its own query. `TestSeatEligibilityIsAskedTheSameWayEverywhereItIsAsked` — added two PRs ago to hold exactly this — failed and named the file. `TestOnlyOneSpellingOfALiveMember` caught the same statement from the other direction. The check is now `auth.EnsureAssignee`: its scope half is vacuous under the system principal, and its eligibility half is exactly the question.

A setting that will not decode, or holds something that is not a user id, is an **error** rather than a quiet "nobody configured". The entry validates on write, so a value that fails here means somebody wrote the row around it, and answering "unset" would hide that behind a queue escalating silently to no one. The linter flagged both swallowed errors; it was right.

## Tests

Three integration cases against real Postgres: an unconfigured installation addresses nobody, a configured one names the seat, and a suspended seat reads as unset. Each guard mutation-checked separately — removing the liveness check fails only the suspended case, removing the resolver fails only the configured one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SLA breach escalation for unowned leads so a lead past its first-response target with nobody assigned reaches a human instead of nobody.

- `people.unassigned_escalation_user_id` names the seat that answers for the queue; it's null by default, writable through the lead-settings API, and an explicit null clears it.
- A configured seat that can't work — suspended, archived, an agent, or a read seat — is treated as unset.
- A seat that can't read leads is refused with `422`, because an escalation carries the lead it's about.
- An invalid setting value is an error, not a silent "nobody configured," since the entry validates on write.
- Liveness reuses `auth.EnsureAssignee`; lead-read is a compose-wired grant check that refuses when unwired.
- Integration tests cover unconfigured, configured, suspended, and lead-blind seats.

<sup>Written for commit 54735da37de0377b12c979386c8398bbc0b7d015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

