### PR TITLE
fix(comms): transmission gets its own pool, off the queue that carries polls

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -93,6 +93,23 @@
 # reads the DECLARED queue) with no client to work it.
 queues:
   default: {max_workers: 5}
+  comms_send:
+    max_workers: 3
+    reason: >-
+      A send is long and outbound-bound now that it carries files: the upload's
+      request budget is three minutes, because a 20 MiB album cannot cross the
+      wire in thirty seconds. On the default queue five concurrent sends
+      occupied every worker for minutes at a time, and that queue also carries
+      Telegram polls, capture syncs and close-date jobs — so a burst of large
+      sends made inbound capture late and nothing said why.
+
+      This is the category jobqueues' own posture was written for: the AI
+      capture pool's reason names "delay sends, Telegram polls, and capture
+      syncs" as the thing to avoid, and the send had since become a member of
+      it. THREE rather than deep read's two: unlike a crawl, a send is a
+      message a person pressed a button for and is waiting on, so the pool is
+      wide enough that an ordinary text send is not queued behind two album
+      uploads.
   deep_read:
     max_workers: 2
     reason: >-
@@ -559,7 +576,7 @@ kinds:
   comms_send_email:
     role: worker
     go_type: SendEmailArgs
-    queue: default
+    queue: comms_send
     timeout: 5m
     opts_owner: caller
     registration: {when: [SendRegistry], absent: registers_nothing}

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -32,6 +32,27 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
+// commsSendQueue isolates transmission from the default queue.
+//
+// A send became long and outbound-bound when it started carrying files: the
+// upload's request budget is three minutes, because a 20 MiB album cannot cross
+// the wire in thirty seconds. On the shared queue five concurrent sends held
+// every worker for minutes, and that queue also carries Telegram polls, capture
+// syncs and close-date jobs — so a burst of large sends made inbound capture
+// late and nothing said why.
+//
+// jobqueues' own posture was written for this category: the AI-capture pool's
+// reason names "delay sends, Telegram polls, and capture syncs" as the thing to
+// avoid, and the send had since joined the set it was avoiding.
+//
+// THREE rather than deep read's two. A crawl is a background sweep; a send is a
+// message somebody pressed a button for and is waiting on, so the pool is wide
+// enough that an ordinary text send is not queued behind two album uploads.
+const (
+	commsSendQueue      = "comms_send"
+	commsSendMaxWorkers = 3
+)
+
 // SendEmailArgs transmits ONE staged delivery. The workspace travels with it
 // because comms_outbound reads are workspace-predicated and a job carries no
 // session: the worker binds this workspace before the dispatcher reads

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -98,14 +98,14 @@ const minSendSnooze = time.Second
 // there is nothing to deduplicate against — and a unique-by-args window would
 // silently drop the second of two legitimate sends staged in the same instant.
 //
-// No queue of its own either, unlike the deep-read and rate-refresh lanes. The
-// criterion those two were split out on is job LENGTH — a multi-minute crawl
-// evicting short maintenance work from the default pool. A send is the short
-// kind: one bounded network round trip, and a paced one snoozes rather than
-// holding its slot. It belongs with the default queue's other jobs, not with
-// the long ones.
+// The queue is named HERE and not only in the contract. comms_send_email is
+// opts_owner: caller, which makes api/jobs.yaml's `queue:` a description of
+// where the rows are meant to land rather than the thing that puts them there;
+// River reads this struct. An InsertOpts naming no queue is River's own
+// default, so leaving it out would keep the send on the shared pool however
+// the contract reads.
 func sendInsertOpts() *river.InsertOpts {
-	return &river.InsertOpts{MaxAttempts: sendMaxAttempts}
+	return &river.InsertOpts{Queue: commsSendQueue, MaxAttempts: sendMaxAttempts}
 }
 
 // deliveryDispatcher is the one attempt the worker drives. It exists so the

--- a/backend/internal/compose/commsjobs_test.go
+++ b/backend/internal/compose/commsjobs_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -399,5 +400,49 @@ func TestCommsSeatsActiveSeatRefusesWithNoWorkspaceBound(t *testing.T) {
 	}
 	if active {
 		t.Fatal("ActiveSeat reported an active seat with no workspace bound to check it against")
+	}
+}
+
+// A send lands on the queue the contract says it does.
+//
+// comms_send_email is opts_owner: caller, and that ownership level buys no
+// enforcement: api/jobs.yaml's `queue:` is read by the fleet surfaces and by
+// whoever sizes the pool, while the rows themselves go wherever this struct
+// says. The census checks the args-owned kinds against their declarations and
+// the periodic dispatcher supplies spec.Queue directly; a caller-owned kind
+// with a hand-built InsertOpts has neither, so the contract can be moved to a
+// new queue and the sends carry on landing on the old one with every check
+// green.
+//
+// Both sides are read here rather than compared to a literal: the declaration
+// through jobs.Declared, the routing through sendInsertOpts. A queue renamed
+// on one side alone fails.
+func TestSendEmailEnqueuesOnItsDeclaredQueue(t *testing.T) {
+	const kind = "comms_send_email"
+
+	var declared string
+	var found bool
+	for name, spec := range jobs.Declared() {
+		if name == kind {
+			declared, found = spec.Queue, true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("%s is not declared in api/jobs.yaml; this test's subject has been retired or renamed", kind)
+	}
+	if declared == river.QueueDefault {
+		t.Fatalf("%s declares the default queue; the isolation this test guards is gone, so remove it or restore the queue", kind)
+	}
+
+	enqueued := sendInsertOpts().Queue
+	if enqueued == "" {
+		t.Fatalf("sendInsertOpts names no queue, so River inserts on %q while the contract declares %q", river.QueueDefault, declared)
+	}
+	if enqueued != declared {
+		t.Fatalf("sendInsertOpts enqueues on %q but the contract declares %q", enqueued, declared)
+	}
+	if _, pooled := jobs.DeclaredQueues()[declared]; !pooled {
+		t.Fatalf("%s enqueues on %q, which no declared pool works — the rows would sit unclaimed", kind, declared)
 	}
 }

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "3c48ae49d7dde393546016f7e7c8645ef499cbe2cc17a2535ee5560bff9d07b7"
+const jobContractHash = "879eb0b605d352cc0ae5a36e54fad4b4cb635ca7ae053e0b6efef3d626ca1eb4"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it

--- a/backend/internal/compose/jobqueues.go
+++ b/backend/internal/compose/jobqueues.go
@@ -12,6 +12,12 @@ import "github.com/riverqueue/river"
 func jobQueues() map[string]river.QueueConfig {
 	return map[string]river.QueueConfig{
 		river.QueueDefault: {MaxWorkers: 5},
+		// A send carrying files is long and outbound-bound — a three-minute
+		// upload budget, because a 20 MiB album cannot cross the wire in
+		// thirty seconds. It is the category this file's posture was written
+		// for, and it was on the shared queue until it grew into one
+		// (commsSendQueue).
+		commsSendQueue: {MaxWorkers: commsSendMaxWorkers},
 		// Deep reads run on their own bounded pool so long crawls cannot
 		// evict the short maintenance jobs from the default queue.
 		deepReadQueue: {MaxWorkers: deepReadMaxWorkers},

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "3c48ae49d7dde393546016f7e7c8645ef499cbe2cc17a2535ee5560bff9d07b7"
+const JobContractHash = "879eb0b605d352cc0ae5a36e54fad4b4cb635ca7ae053e0b6efef3d626ca1eb4"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -290,7 +290,7 @@ var specs = map[string]Spec{
 		Kind:         "comms_send_email",
 		GoType:       "SendEmailArgs",
 		Role:         Worker,
-		Queue:        "default",
+		Queue:        "comms_send",
 		Timeout:      TimeoutPolicy{Fixed: 5 * time.Minute},
 		OptsOwner:    OptsCaller,
 		Registration: Registration{When: []string{"SendRegistry"}},
@@ -772,6 +772,7 @@ var specs = map[string]Spec{
 var queues = map[string]int{
 	"agent_scheduler":   2,
 	"ai_capture":        2,
+	"comms_send":        3,
 	"deep_read":         2,
 	"default":           5,
 	"geocode":           1,


### PR DESCRIPTION
Closes #2063.

A send became long and outbound-bound when it started carrying files: the upload's request budget is **three minutes**, because a 20 MiB album cannot cross the wire in thirty seconds. It was still on the default queue, whose five workers also serve Telegram polls, capture syncs and close-date jobs — so five concurrent sends held every worker for minutes, made inbound capture late, and nothing said why.

`jobqueues.go`'s own posture was written for this category, and names this exact consequence: the AI-capture pool's reason is to avoid *"delay sends, Telegram polls, and capture syncs"*. The send had since become a member of the set that argument protects.

## Three workers, not two

Deep read takes two. A crawl is a background sweep nobody is waiting on; a send is a message somebody pressed a button for. Three is wide enough that an ordinary text send is not queued behind two album uploads, and still bounded enough that the pool is a stated cost rather than a shared one.

## Not a vulnerability, and the issue is right about why

One message's bodies are capped at 20 MiB in aggregate by the read seam, and the peer is compiled in (`telegram.NewAPI(nil, "")` at every call site), so there is no input that multiplies the hold and no attacker-chosen slow peer. This is queue topology: the cost is now visible in the queue configuration instead of implicit in a client timeout.

## The census did the work

Worth recording, because it is the gate behaving exactly as its comment promises. It refused the move twice, in both directions:

```
queue "comms_send" is declared but jobQueues() builds no such pool — a fan-out
child is inserted on its DECLARED queue, so its rows would sit runnable with no
client working them; build it, or retire the declaration
```

and then, when I mutated the bound to check it was really held:

```
queue "comms_send" declares max_workers 3 but jobQueues() builds 9 — the file is
what operators read; move the number in both places
```

So the number an operator reads in `jobs.yaml` and the number a client runs at cannot drift apart, which is the whole reason the queue set is declared there.

`make check-backend` green; `internal/compose`, `internal/modules/comms` and `internal/platform/jobs` integration lanes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Outbound email sends now use a dedicated queue with controlled worker capacity.
  * File-enabled sends are isolated from the default queue, helping prevent long-running uploads from delaying other jobs.

* **Tests**
  * Added coverage confirming email-send jobs are assigned to the correct dedicated queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->