### PR TITLE
fix(infra): the dev Postgres gets a /dev/shm it can actually use

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -132,6 +132,23 @@ services:
     # also the direction that HELPS: a whole-schema reset needs more lock slots,
     # not fewer. Lower max_connections and that product falls with it, and the
     # 53200 the comment above is about comes back.
+    # /dev/shm, which is where this image puts every DYNAMIC shared memory
+    # segment (dynamic_shared_memory_type=posix). Docker's default for it is
+    # 64MB, and that default is not sized for the settings above: a parallel
+    # index build or maintenance pass asks for a 32MB segment in one go, and
+    # against 64MB shared with everything else already mapped there it fails
+    # with `could not resize shared memory segment ... No space left on device
+    # (SQLSTATE 53100)`. The failure lands wherever the lane happens to be —
+    # observed here as `make test-it` dying inside pgmigrate, on a different
+    # migration each run — so it does not name its own cause, which is why it
+    # is written down rather than left in the number.
+    #
+    # 1g is headroom, not a tuned figure: it is far above anything the lane has
+    # been seen to ask for, and /dev/shm is a tmpfs, so an unused gigabyte
+    # costs nothing. Raise it, never lower it — the setting only ever binds
+    # when something needs a segment, and the symptom of it binding is an
+    # unrelated-looking migration failure.
+    shm_size: 1g
     command:
       - postgres
       - -c


### PR DESCRIPTION
Found while verifying #820's change against the real-Postgres lane, which could not run at all.

### The symptom

```
migrate: pgmigrate: core 0001_baseline: ERROR: could not resize shared memory
segment "/PostgreSQL.2791547698" to 33554432 bytes: No space left on device (SQLSTATE 53100)
```

and on the next attempt the same error naming a *different* migration. Nothing is wrong with either migration — the failure lands wherever the lane happens to be when something asks for a dynamic shared memory segment.

### The cause

This image runs with `dynamic_shared_memory_type = posix`, so every dynamic segment is a file in `/dev/shm`. Docker's default `/dev/shm` is **64MB**, and the container was running at 96% of it before any test connected:

```
shm  64M  62M  2.9M  96% /dev/shm
```

A parallel index build asks for 32MB in one allocation. There is 2.9MB. It fails.

Restarting the container does not help — the allocation is what the running server holds, not leaked segments — and neither does turning off `max_parallel_maintenance_workers`, which I tried: the request still came.

### The fix

`shm_size: 1g` on the service. After recreating:

```
shm  1.0G  94M  931M  10% /dev/shm
```

and `make test-it DIR=backend/internal/modules/finance` runs clean, sync suite included.

1g is headroom, not a tuned number — far above anything the lane has been seen to ask for, and `/dev/shm` is a tmpfs, so an unused gigabyte costs nothing. The comment says the setting may be raised and not lowered, because the symptom of it binding again is a failure that names something else.

### Why the comment is as long as it is

This file already carries a long note about host ports below 32768, for the same reason: a constraint invisible in the number, whose violation shows up as an unrelated flake. This is the same shape, and the note sits directly above the `max_connections=408` the file already explains — the raise that made the fixed shared memory large enough for the default to matter.

`check-image-pins` and `check-host-ports` unaffected (no image or port changed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased PostgreSQL’s Docker shared-memory allocation to 1 GB, helping prevent storage-related database failures during development.

* **Documentation**
  * Added guidance explaining the previous memory limit and associated database errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->