### PR TITLE
fix(finance): the demo ledger anchors to its connection, not to a constant

### DIFF
--- a/backend/internal/compose/jobs_finance.go
+++ b/backend/internal/compose/jobs_finance.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -157,15 +158,21 @@ func (w *financeSyncSweepWorker) providerFor(
 ) (finance.Provider, bool, error) {
 	var (
 		name      string
+		createdAt time.Time
 		customers []finance.SourceCustomer
 	)
 	err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+		// created_at rides the read because it is the offline generator's
+		// ANCHOR: the demonstration ledger is measured back from the moment
+		// this connection was made, so it is fixed for a given installation
+		// and positioned freshly for a new one. A constant in the generator
+		// would leave the card's rolling windows behind as the calendar moved.
 		row := tx.QueryRow(ctx, `
-			SELECT provider FROM finance_connection
+			SELECT provider, created_at FROM finance_connection
 			 WHERE archived_at IS NULL AND status <> 'disconnected'
 			 ORDER BY created_at DESC
 			 LIMIT 1`)
-		if err := row.Scan(&name); err != nil {
+		if err := row.Scan(&name, &createdAt); err != nil {
 			// pgx.ErrNoRows lands here and is answered as "not configured" by
 			// the caller below; anything else is a real read failure.
 			return err
@@ -185,7 +192,7 @@ func (w *financeSyncSweepWorker) providerFor(
 			"finance: no reader for provider %q — this build ships only %q",
 			name, finance.OfflineProviderName)
 	}
-	return finance.NewOfflineProvider(workspace.String(), customers), true, nil
+	return finance.NewOfflineProvider(workspace.String(), customers, createdAt), true, nil
 }
 
 // linkedCustomers is the directory the offline provider generates for.

--- a/backend/internal/modules/finance/offline.go
+++ b/backend/internal/modules/finance/offline.go
@@ -13,11 +13,32 @@ package finance
 //
 // **Deterministic, and deterministic in the right way.** The seed is
 // sha256(workspace | external customer id), so the same customer produces the
-// same ledger on every machine, in every test, forever. What it does NOT
-// depend on is the clock: a second sync on a later day must produce the same
-// records, or every morning's pass would rewrite every row and the mirror
-// would report change where none happened. Dates are generated backwards from
-// a fixed epoch rather than from `now` for exactly that reason.
+// same amounts, archetype and payment behaviour on every machine, in every
+// test, forever. What it does NOT depend on is the clock: a second sync on a
+// later day must produce the same records, or every morning's pass would
+// rewrite every row and the mirror would report change where none happened.
+//
+// Dates are generated backwards from an ANCHOR the caller supplies, and the
+// anchor is a STORED value — the finance connection's own creation instant —
+// rather than the clock or a constant in this file. Both of the obvious
+// alternatives fail:
+//
+//   - `now` (or any boundary derived from it — start of month, start of week)
+//     moves, so the generated ledger moves with it and every sync past the
+//     boundary rewrites every row. That is the defect the anchor exists to
+//     prevent, and anchoring to a boundary only makes it periodic, which also
+//     makes the no-rewrite invariant depend on which day the suite runs.
+//   - A constant here does not move, and that is its problem: every figure the
+//     card shows is folded over a window measured back from now (365 days for
+//     net invoiced, 180 for timeliness), so as the calendar leaves the constant
+//     behind, fewer generated invoices fall inside the windows until the card
+//     is a set of refusals. Moving the constant forward periodically is a chore
+//     nobody remembers, and the ledger rots silently between bumps.
+//
+// A stored anchor is fixed for a given installation and fresh for a new one.
+// What it costs is stated plainly: the ledger is no longer byte-identical
+// ACROSS installations, only within one. The same shape, positioned per
+// installation.
 
 import (
 	"context"
@@ -32,31 +53,32 @@ import (
 // who sees this string knows the figures are demonstration data.
 const OfflineProviderName = "offline_demo"
 
-// offlineEpoch is the fixed point every generated date is measured back from.
-//
-// NOT time.Now(). A generator keyed on today produces a different ledger every
-// day for a customer nobody touched, so every sync would rewrite every row —
-// and the sync's whole job is to notice what actually changed.
-//
-// The cost of that choice is that the ledger ages: the figures are computed
-// over windows measured back from NOW, so as the calendar leaves the epoch
-// behind, fewer and fewer generated invoices fall inside them. Anything that
-// asserts a FIGURE over this ledger therefore reads it at a clock pinned to
-// this epoch, or it is measuring how long ago the epoch was.
-var offlineEpoch = time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
-
 // OfflineProvider generates one workspace's demonstration ledger.
 type OfflineProvider struct {
 	workspace string
+	// anchor is the fixed point every generated date is measured back from,
+	// truncated to a UTC day so the ledger reads as dates rather than instants.
+	// Supplied by the caller and stored, never read from the clock — see this
+	// file's header for why neither `now` nor a constant works.
+	anchor time.Time
 	// customers is the directory this provider answers. The sync maps them
 	// onto organizations by an explicit link, so the names here are the
 	// source's own and need not match any company in the CRM.
 	customers []SourceCustomer
 }
 
-// NewOfflineProvider builds the generator for one workspace's customers.
-func NewOfflineProvider(workspace string, customers []SourceCustomer) *OfflineProvider {
-	return &OfflineProvider{workspace: workspace, customers: customers}
+// NewOfflineProvider builds the generator for one workspace's customers,
+// measuring its ledger back from anchor.
+//
+// anchor is the connection's own creation instant in production. It is a
+// parameter rather than a clock read so the property that matters is visible at
+// the call site: pass a moving value here and every sync rewrites every row.
+func NewOfflineProvider(workspace string, customers []SourceCustomer, anchor time.Time) *OfflineProvider {
+	return &OfflineProvider{
+		workspace: workspace,
+		anchor:    anchor.UTC().Truncate(24 * time.Hour),
+		customers: customers,
+	}
 }
 
 // Name is the string stored on the connection and shown beside the figures,
@@ -117,7 +139,7 @@ func (p *OfflineProvider) InvoicesFor(
 	// Oldest first, so the settled ones the timeliness window reads sit at the
 	// front and the open tail is genuinely the recent end.
 	for period := offlineInvoices - 1; period >= 0; period-- {
-		issued := offlineEpoch.AddDate(0, 0, -period*offlineCadenceDays)
+		issued := p.anchor.AddDate(0, 0, -period*offlineCadenceDays)
 		due := issued.AddDate(0, 0, paymentTermDays)
 		invoice := SourceInvoice{
 			ExternalID: fmt.Sprintf("%s-INV-%04d", externalCustomerID, offlineInvoices-period),
@@ -156,7 +178,7 @@ func (p *OfflineProvider) InvoicesFor(
 			})
 		}
 	}
-	out.Invoices = append(out.Invoices, creditNoteFor(out.Invoices, externalCustomerID, rng))
+	out.Invoices = append(out.Invoices, creditNoteFor(out.Invoices, externalCustomerID, rng, p.anchor))
 	return out, nil
 }
 
@@ -209,18 +231,18 @@ func settle(invoice *SourceInvoice, kind archetype, rng *rand.Rand, due time.Tim
 // figure that has never been reduced is a figure nobody has checked.
 //
 // The target must be old enough that the note still lands on or before the
-// epoch. A note dated after it would be a generated row that moved past the
+// anchor. A note dated after it would be a generated row that moved past the
 // fixed point the whole ledger is measured back from — which is the one thing
 // this generator promises not to do.
 func creditNoteFor(
-	invoices []SourceInvoice, customerID string, rng *rand.Rand,
+	invoices []SourceInvoice, customerID string, rng *rand.Rand, anchor time.Time,
 ) SourceInvoice {
 	// Oldest first (InvoicesFor builds them that way), so the eligible targets
 	// are a PREFIX of the ledger — and the oldest invoice, eighteen months
 	// back, always qualifies, which is what makes this count at least one.
 	eligible := 0
 	for _, inv := range invoices {
-		if inv.IssuedOn.AddDate(0, 0, creditNoteDelayDays).After(offlineEpoch) {
+		if inv.IssuedOn.AddDate(0, 0, creditNoteDelayDays).After(anchor) {
 			break
 		}
 		eligible++

--- a/backend/internal/modules/finance/offline_test.go
+++ b/backend/internal/modules/finance/offline_test.go
@@ -9,11 +9,20 @@ package finance
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
+
+// offlineEpoch is the anchor every case in this suite generates against.
+//
+// It lives here rather than in the generator because production takes its
+// anchor from the finance connection's own creation instant; what a TEST needs
+// is a fixed one, so the assertions measure the formulas rather than how long
+// ago some constant was. The date itself carries no meaning beyond being fixed.
+var offlineEpoch = time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
 
 func ledgerFor(t *testing.T, customer string) SourceLedger {
 	t.Helper()
@@ -22,7 +31,7 @@ func ledgerFor(t *testing.T, customer string) SourceLedger {
 
 func ledgerIn(t *testing.T, workspace, customer string) SourceLedger {
 	t.Helper()
-	provider := NewOfflineProvider(workspace, []SourceCustomer{{ExternalID: customer}})
+	provider := NewOfflineProvider(workspace, []SourceCustomer{{ExternalID: customer}}, offlineEpoch)
 	ledger, err := provider.InvoicesFor(context.Background(), customer)
 	if err != nil {
 		t.Fatal(err)
@@ -324,4 +333,80 @@ func TestOnlyTheIdentityRateIsKnownWithoutARateSheet(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The ledger follows its ANCHOR and nothing else: two providers built for the
+// same workspace and customer at different anchors produce the same shape,
+// shifted by exactly the difference between them.
+//
+// Both halves are the point. Same shape — the amounts, the archetype and the
+// payment behaviour come off sha256(workspace | customer), which no anchor
+// touches — so an installation set up next year gets the same ledger, not a
+// different one. Shifted exactly — so the rolling windows the card folds over
+// (365 days for net invoiced, 180 for timeliness) find the same invoices
+// inside them whenever the installation was made, which is the whole point of
+// anchoring to a stored value instead of to a date in this repository.
+func TestTheGeneratedLedgerShiftsWithItsAnchorAndKeepsItsShape(t *testing.T) {
+	shift := 400 * 24 * time.Hour
+
+	early := ledgerAt(t, offlineEpoch)
+	late := ledgerAt(t, offlineEpoch.Add(shift))
+
+	if len(early.Invoices) != len(late.Invoices) {
+		t.Fatalf("invoice counts differ across anchors: %d vs %d — the anchor moved more than the dates",
+			len(early.Invoices), len(late.Invoices))
+	}
+	for i, want := range early.Invoices {
+		got := late.Invoices[i]
+		if got.ExternalID != want.ExternalID || got.NetMinor != want.NetMinor || got.Currency != want.Currency {
+			t.Fatalf("invoice %d differs beyond its dates: %+v vs %+v — the anchor reached the seed",
+				i, got, want)
+		}
+		if diff := got.IssuedOn.Sub(want.IssuedOn); diff != shift {
+			t.Errorf("invoice %s issued %v after the earlier anchor's, want exactly the anchor difference %v",
+				got.ExternalID, diff, shift)
+		}
+	}
+}
+
+// A second generation at the same anchor is byte-identical, which is the
+// invariant the anchor is a parameter to protect: the sync rewrites a row only
+// when the source actually changed, so a generator that answered differently on
+// a later day would have every morning's pass rewrite the whole mirror.
+func TestTheGeneratedLedgerDoesNotMoveWhenOnlyTheClockHas(t *testing.T) {
+	first := ledgerAt(t, offlineEpoch)
+	second := ledgerAt(t, offlineEpoch)
+
+	if !reflect.DeepEqual(first, second) {
+		t.Error("two generations at one anchor differ — every sync would rewrite every row")
+	}
+}
+
+// The anchor is truncated to a UTC day, so two connections made hours apart on
+// one day generate the same ledger — a demonstration ledger reads as dates, and
+// an invoice issued at 14:37 is noise a reader has to look past.
+func TestTheAnchorIsTruncatedToItsDay(t *testing.T) {
+	midnight := ledgerAt(t, offlineEpoch)
+	afternoon := ledgerAt(t, offlineEpoch.Add(14*time.Hour+37*time.Minute))
+
+	if !reflect.DeepEqual(midnight, afternoon) {
+		t.Error("two anchors on the same UTC day produced different ledgers")
+	}
+}
+
+// anchorCaseCustomer is the customer the anchor cases generate for. One is
+// enough here and three would be noise: what these assert is a property of the
+// ANCHOR, which the seed never sees — the customer's own space is swept by the
+// cases above that vary it.
+const anchorCaseCustomer = "acme-gmbh"
+
+// ledgerAt generates anchorCaseCustomer's ledger against a named anchor.
+func ledgerAt(t *testing.T, anchor time.Time) SourceLedger {
+	t.Helper()
+	ledger, err := NewOfflineProvider("ws-1", []SourceCustomer{{ExternalID: anchorCaseCustomer}}, anchor).
+		InvoicesFor(context.Background(), anchorCaseCustomer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ledger
 }

--- a/backend/internal/modules/finance/sync_integration_test.go
+++ b/backend/internal/modules/finance/sync_integration_test.go
@@ -147,7 +147,7 @@ func setupFinance(t *testing.T) *financeEnv {
 const ledgerSeed = "finance-integration-ledger"
 
 func (e *financeEnv) provider() Provider {
-	return NewOfflineProvider(ledgerSeed, []SourceCustomer{{ExternalID: e.external}})
+	return NewOfflineProvider(ledgerSeed, []SourceCustomer{{ExternalID: e.external}}, offlineEpoch)
 }
 
 // summaryAtEpoch reads the card at a clock pinned to the ledger's own epoch.


### PR DESCRIPTION
Closes #820, taking the shape the ticket identified: a **stored** anchor rather than a constant or the clock.

The anchor is the finance connection's own `created_at`, read beside the provider name `providerFor` already selects, so it costs no extra query.

- **Reproducible.** The same connection yields the same ledger, forever — `TestTheGeneratedLedgerDoesNotMoveWhenOnlyTheClockHas`.
- **Idempotent.** A sync tomorrow reads the same stored anchor, so the source records are unchanged and the mirror stays quiet. `TestASecondSyncOverAnUnchangedSourceWritesNothing` still holds.
- **Fresh where it matters.** An installation set up next year gets a ledger positioned relative to when it was set up.

`NewOfflineProvider` takes the anchor as a parameter rather than reading a clock, so the property that matters is visible at the call site: pass a moving value and every sync rewrites every row.

### The confirmation the ticket asked for

> Worth confirming that nothing downstream (screenshots, fixtures, docs) depends on the absolute dates before adopting it.

Nothing does. `2026-08-01` appears elsewhere only in frontend fixtures with their own unrelated literals; no doc, golden or screenshot reads the generated ledger's dates. The constant had exactly three consumers, all inside `internal/modules/finance`, and it now lives in `offline_test.go` as the suite's own fixed anchor — which is where a test's pinned clock belongs anyway, since what a test needs is a *fixed* anchor so the assertions measure the formulas rather than how long ago some constant was.

### What it costs, and where that is written

The generator's stated property weakens from "the same ledger on every machine" to "the same **shape** on every machine, positioned per installation". That is now in the file header beside the determinism claim it qualifies, along with why both obvious alternatives fail — `now` and any boundary derived from it move, and a boundary makes the no-rewrite invariant depend on which day the suite runs, which is the class of failure this whole thread was about.

### Tests

- `TestTheGeneratedLedgerShiftsWithItsAnchorAndKeepsItsShape` — two anchors 400 days apart produce the same invoice ids, amounts and currency, shifted by exactly the anchor difference. Both halves matter: same shape proves the anchor never reaches the seed, exact shift proves the rolling windows find the same invoices whenever the installation was made.
- `TestTheGeneratedLedgerDoesNotMoveWhenOnlyTheClockHas` — two generations at one anchor are `DeepEqual`.
- `TestTheAnchorIsTruncatedToItsDay` — two anchors on one UTC day agree.

Mutation-checked: replacing the stored anchor with a constant fails the first; dropping the truncation fails the third. `make check-backend` green, and the finance integration suite passes on the real-Postgres lane.

### Still open, deliberately

The ticket's last question — how long a demo installation is expected to stay fresh at all — is untouched. Under this scheme a demo running for two years drifts too, just from a much later start. That is a product call about the demo's lifetime, not a property of the generator.

**Note:** the real-Postgres lane could not run locally at all until #5019, which this was found behind.
