### PR TITLE
fix(agents): an MCP write applies the version pin it staged

### DIFF
--- a/backend/internal/compose/lifecycleoverlay_test.go
+++ b/backend/internal/compose/lifecycleoverlay_test.go
@@ -147,12 +147,12 @@ func overlayPinnedToolVerbs(t *testing.T) map[string]bool {
 // one-sided assertion while breaking every native workspace.
 func TestTheDisqualifyGuardRefusesInOverlayAndPassesInNative(t *testing.T) {
 	guard := nativeOnlyDisqualifier(overlayMode(), refusingDisqualifier{})
-	if _, err := guard.DisqualifyLead(context.Background(), ids.NewV7()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+	if _, err := guard.DisqualifyLead(context.Background(), ids.NewV7(), nil); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 		t.Errorf("overlay mode = %v, want ErrUnsupportedBySoR", err)
 	}
 
 	guard = nativeOnlyDisqualifier(nativeMode(), refusingDisqualifier{})
-	if _, err := guard.DisqualifyLead(context.Background(), ids.NewV7()); !errors.Is(err, errSeamReached) {
+	if _, err := guard.DisqualifyLead(context.Background(), ids.NewV7(), nil); !errors.Is(err, errSeamReached) {
 		t.Errorf("native mode = %v, want the seam reached", err)
 	}
 }
@@ -162,6 +162,6 @@ var errSeamReached = errors.New("seam reached")
 
 type refusingDisqualifier struct{}
 
-func (refusingDisqualifier) DisqualifyLead(context.Context, ids.UUID) (json.RawMessage, error) {
+func (refusingDisqualifier) DisqualifyLead(context.Context, ids.UUID, *int64) (json.RawMessage, error) {
 	return nil, errSeamReached
 }

--- a/backend/internal/compose/lifecycletools.go
+++ b/backend/internal/compose/lifecycletools.go
@@ -79,8 +79,9 @@ func relinkBatchWire(out activities.RelinkBatchResult) agents.RelinkBatchResult 
 
 type leadDisqualifier struct{ store *people.Store }
 
-func (l leadDisqualifier) DisqualifyLead(ctx context.Context, id ids.UUID) (json.RawMessage, error) {
-	out, err := l.store.DisqualifyLead(ctx, ids.From[ids.LeadKind](id), people.DisqualifyLeadInput{})
+func (l leadDisqualifier) DisqualifyLead(ctx context.Context, id ids.UUID, ifVersion *int64) (json.RawMessage, error) {
+	out, err := l.store.DisqualifyLead(ctx, ids.From[ids.LeadKind](id), people.DisqualifyLeadInput{},
+		people.OnlyAtVersion(ifVersion))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/compose/nativeonlytools.go
+++ b/backend/internal/compose/nativeonlytools.go
@@ -302,7 +302,7 @@ type disqualifierGuard struct {
 	inner agents.LeadDisqualifier
 }
 
-func (g disqualifierGuard) DisqualifyLead(ctx context.Context, id ids.UUID) (json.RawMessage, error) {
+func (g disqualifierGuard) DisqualifyLead(ctx context.Context, id ids.UUID, ifVersion *int64) (json.RawMessage, error) {
 	overlay, err := g.mode.isOverlayUncached(ctx)
 	if err != nil {
 		return nil, err
@@ -310,7 +310,7 @@ func (g disqualifierGuard) DisqualifyLead(ctx context.Context, id ids.UUID) (jso
 	if overlay {
 		return nil, apperrors.ErrUnsupportedBySoR
 	}
-	return g.inner.DisqualifyLead(ctx, id)
+	return g.inner.DisqualifyLead(ctx, id, ifVersion)
 }
 
 // nativeOnlyDemoter guards demote_lead, for the reason nativeOnlyDisqualifier

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -250,7 +250,7 @@ func (inertLifecycle) RelinkActivities(context.Context, []ids.UUID, string, ids.
 	return nil, nil
 }
 
-func (inertLifecycle) DisqualifyLead(context.Context, ids.UUID) (json.RawMessage, error) {
+func (inertLifecycle) DisqualifyLead(context.Context, ids.UUID, *int64) (json.RawMessage, error) {
 	return nil, nil
 }
 

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -197,7 +197,7 @@ func (seamProbeLifecycle) RelinkActivities(context.Context, []ids.UUID, string, 
 	return nil, errSeamReached
 }
 
-func (seamProbeLifecycle) DisqualifyLead(context.Context, ids.UUID) (json.RawMessage, error) {
+func (seamProbeLifecycle) DisqualifyLead(context.Context, ids.UUID, *int64) (json.RawMessage, error) {
 	return nil, errSeamReached
 }
 

--- a/backend/internal/modules/agents/pinfitness_test.go
+++ b/backend/internal/modules/agents/pinfitness_test.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// A tool that STAGES a target version APPLIES one (review-loop rule 2).
+//
+// The staging half already holds itself together: approvals.resolveTargetVersion
+// is the one place a pin is taken, and it takes one for every staged call whose
+// target has a version column and whose kind is not declared context-only or
+// unpinned. What nothing held is the other end — that the write the approval
+// releases is actually conditioned on the pin the human approved.
+//
+// Why that gap is not cosmetic. Redemption commits its OWN transaction and the
+// handler then opens a fresh one, so the skew check inside redemption proves the
+// row was at the approved version when the approval was CONSUMED, not when the
+// effect lands — and the agent controls both sides of that window, since its own
+// 🟢 update_record can commit inside it. The pin is what moves the version
+// compare into the transaction that mutates.
+//
+// The REST door gets this for free: compose forwards the released pin as the
+// request's own If-Match, so every operation behind that door is carried,
+// whether or not anyone remembered. The MCP door carries it per tool, through
+// pinForWrite — which is a call site somebody has to remember, and update_record
+// and disqualify_lead were both missing it. One credential, two doors, different
+// guarantees, which is the asymmetry ADR-0055 exists to close.
+//
+// So the corpus is the registry rather than a list, and the obligation is
+// checked in source rather than asserted per tool: a new stageable write is
+// judged the day it registers, not the day somebody remembers to add it here.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// pinExemptWrites are the stageable tools whose write has NO version to
+// condition, each saying which structural reason it is.
+//
+// Not a duplicate of approvals' own contextTargetKinds/unpinnedKinds, which a
+// reader might reasonably suspect. Those are keyed on staging KIND and describe
+// automation proposals (site_lead, deal_follow_up, capture_counterparty); these
+// are keyed on the TOOL TYPE and describe MCP write shapes. The two sets do not
+// intersect, and a module never imports a sibling, so this side could not read
+// that one even where they agreed.
+//
+// Each entry is structural rather than pending: a call that creates a row has no
+// prior version, and one pin cannot condition many rows. A third KIND of reason
+// appearing here is a finding — the list is meant to stay short and each line to
+// say why the rule does not reach.
+var pinExemptWrites = gatekit.Waive(map[string]string{
+	"createRecord":         "a create has no prior row, so there is no version to condition on. approvals.resolveTargetVersion answers unpinned for it on exactly the same ground — the target id is zero — so nothing is staged that this write fails to apply",
+	"sendMessageTool":      "the effect is a NEW activity filed against the target, not a write to it. A pin on the conversation would condition the reply on the thread not having moved, which is not what the human judged: they judged the words being sent",
+	"sendEmailTool":        "the effect is a NEW activity, on the ground sendMessageTool states. The target is what the message is ABOUT, and the version of a record nobody is editing binds nothing the approval rests on",
+	"sendAccountEmailTool": "the effect is a NEW activity and the call anchors on no row at all — its links carry the target. There is no operand row whose version could condition the send",
+	"bookMeetingTool":      "a booking creates its own row and anchors on no existing one; the links name what it is about. Nothing it writes has a prior version",
+	"mergeRecords":         "the merge conditions itself on both endpoints INSIDE its own transaction, under the locks it takes on the pair (people/merge.go). A pin here would be a third answer to a question the write already asks race-free, and only about the survivor — the source is the half a caller-supplied pin could never cover",
+	"relinkThread":         "a thread is MANY activity rows reached by key, and one pin cannot condition many rows. Its sibling relinkActivity takes one because it names exactly one activity; the batch shape is what makes the pin unrepresentable rather than forgotten, and relinkbatch.go re-checks each row under its own lock",
+	"relinkActivities":     "the batch form of relinkThread's reason: the call names a LIST of activities and a single version could only ever condition one of them. The per-row check under the write's own lock is what holds here, and it holds for every row rather than for one",
+})
+
+// pinDeferredWrites are stageable writes that SHOULD apply a pin and do not.
+//
+// A real verdict rather than a quiet exclusion: a bare exemption reads as
+// "handled", this reads as "decided, and not yet done", and the count below
+// keeps the hole visible. Every entry names its issue, which is a convention
+// rather than a checked rule for the reason the edge-reader census gives about
+// its own — a parallel map policing this one is how the two diverge.
+//
+// This set is EMPTY when nothing is pending, which is the state to get it back
+// to. It stays declared rather than deleted, because the next write that cannot
+// carry a pin today needs somewhere honest to go.
+var pinDeferredWrites = gatekit.Waive(map[string]string{
+	"promoteLead": "stages a pinnable lead version and applies none: LeadPromoter cannot carry one, exactly as LeadDisqualifier could not. The promotion mints a person from lead fields a concurrent edit may have changed since the human approved. Tracked in issue 5021 — the cost of leaving it is that an approved promotion can read content nobody released",
+	"demoteLead":  "stages a pinnable lead version and applies none, on the same seam shape as promoteLead. The reversal unwinds a promotion the approval may no longer be describing. Tracked in issue 5021 — same cost, in the opposite direction",
+})
+
+// pinnedWriteFloor is set below the live count of tools that must apply a pin.
+// It catches the reflection or the registry walk going to zero, which reports
+// PASS having judged nothing.
+const pinnedWriteFloor = 4
+
+// TestEveryStageableWriteAppliesTheVersionItStages walks the registry's
+// stageable tools and requires each one's Handle to reach pinForWrite.
+//
+// Per TYPE and via reflection rather than by tool name, because the name is the
+// wire's and the body is the type's: a rename on either side would otherwise
+// silently drop a tool out of the walk, and a walk that judges fewer tools than
+// it thinks reports PASS exactly like a clean tree.
+func TestEveryStageableWriteAppliesTheVersionItStages(t *testing.T) {
+	t.Parallel()
+	defer pinExemptWrites.AssertAllMatched(t)
+	defer pinDeferredWrites.AssertAllMatched(t)
+
+	reaching := handlesReachingPinForWrite(t)
+	registry := NewRegistry(&recordingApprovals{}, nil)
+	RegisterCoreTools(registry, elsewhereProvider{}, fixedStages{semantic: "won"}, nil, noConflicts{}, nil, nil)
+	RegisterCommsTools(registry, &recordingComms{}, elsewhereProvider{})
+	RegisterLifecycleTools(registry, elsewhereProvider{}, nil, inertLifecycle{}, inertLifecycle{}, inertLifecycle{})
+
+	pinned := 0
+	for name, tool := range registry.tools {
+		if _, isStageable := tool.(stageableTool); !isStageable {
+			continue
+		}
+		typeName := toolTypeName(tool)
+		verdict := pinVerdictFor(t, typeName)
+		reaches := reaching[typeName]
+		switch {
+		case reaches && verdict != "":
+			// A satisfied write that ALSO carries a verdict is how this census
+			// silently stops counting down: a deferred write that later gets
+			// its pin keeps matching for ever, and the hole reads as open when
+			// it is closed.
+			t.Errorf("%s (%s) applies a pin AND carries a %s verdict — remove the verdict, "+
+				"it describes code that now carries the rule", name, typeName, verdict)
+		case reaches, verdict != "":
+		default:
+			t.Errorf("%s (%s) can stage an approval but its Handle never reaches pinForWrite.\n"+
+				"  A staged call whose target has a version column gets one pinned at staging "+
+				"(approvals.resolveTargetVersion), and the write that releases it must be conditioned "+
+				"on that version — redemption commits its own transaction, so its skew check proves "+
+				"the row was right when the approval was CONSUMED, not when this write lands.\n"+
+				"  Route the write's version through pinForWrite(ctx, <the caller's if_version, or nil>), "+
+				"or declare the type in pinExemptWrites with the reason its write has no version to "+
+				"condition.", name, typeName)
+		}
+		if reaches {
+			pinned++
+		}
+	}
+	t.Logf("stageable writes: %d apply a pin, %d structurally exempt, %d DEFERRED (still unpinned)",
+		pinned, len(pinExemptWrites.Subjects()), len(pinDeferredWrites.Subjects()))
+	if pinned < pinnedWriteFloor {
+		t.Fatalf("only %d stageable writes were seen to apply a pin, below the %d floor — either the "+
+			"registry walk or the source census has stopped seeing this package, and both report PASS "+
+			"while judging nothing", pinned, pinnedWriteFloor)
+	}
+}
+
+// pinVerdictFor names the declaration a type sits in, and refuses one sitting in
+// two: the verdict IS the declaration, so a type with two of them has none.
+func pinVerdictFor(t *testing.T, typeName string) string {
+	t.Helper()
+	var found []string
+	for _, set := range []struct {
+		name    string
+		waivers *gatekit.Waivers[string]
+	}{
+		{"structural", pinExemptWrites},
+		{"deferred", pinDeferredWrites},
+	} {
+		if set.waivers.Waived(t, typeName) {
+			found = append(found, set.name)
+		}
+	}
+	if len(found) > 1 {
+		t.Errorf("%s carries %s verdicts at once: which declaration a write sits in IS its verdict, "+
+			"so two of them is none", typeName, strings.Join(found, " and "))
+		return ""
+	}
+	if len(found) == 1 {
+		return found[0]
+	}
+	return ""
+}
+
+// toolTypeName is the tool's own Go type, through a pointer receiver.
+func toolTypeName(tool any) string {
+	t := reflect.TypeOf(tool)
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t.Name()
+}
+
+// handlesReachingPinForWrite answers, per receiver type, whether its Handle
+// reaches pinForWrite — in its own body, or in a package-local function that
+// body calls.
+//
+// One level of following, and the reason is the one the job-actor census gives
+// about its own follow: a helper is what a write's pin resolution naturally
+// lives in, and a rule that read only the entry point would produce exemptions
+// for correct code. A rule that produces exemptions for correct code is one
+// whose exemption list stops meaning anything.
+func handlesReachingPinForWrite(t *testing.T) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	// Bodies by declaration name: methods under "Type.Method", plain functions
+	// under their bare name — the two vocabularies cannot collide, because a
+	// bare-name lookup can never reach a key holding a dot.
+	bodies := map[string]*ast.FuncDecl{}
+	handles := map[string]*ast.FuncDecl{}
+	for _, path := range agentsSourceFiles(t) {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s for the pin census: %v", path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || fn.Body == nil {
+				continue
+			}
+			if fn.Recv == nil {
+				bodies[fn.Name.Name] = fn
+				continue
+			}
+			recv := receiverTypeOf(fn)
+			bodies[recv+"."+fn.Name.Name] = fn
+			if fn.Name.Name == "Handle" {
+				handles[recv] = fn
+			}
+		}
+	}
+	if len(handles) == 0 {
+		t.Fatal("the census indexed no Handle methods at all — it is reading a tree it does not " +
+			"recognise, and an empty index judges every tool as failing rather than as unseen")
+	}
+	reaching := map[string]bool{}
+	for recv, fn := range handles {
+		reaching[recv] = reachesPinForWrite(fn, recv, bodies)
+	}
+	return reaching
+}
+
+// reachesPinForWrite is the body's own call to pinForWrite, or one made
+// anywhere down the chain of package functions it calls.
+//
+// TRANSITIVE, not one level. update_record is why: its Handle branches to
+// t.apply, which calls t.applyRecord, which is where the pin belongs — the
+// entry point is a dispatcher and the write is two hops down. A census that
+// stopped at one hop would have reported the tool this ticket is about as
+// still broken after it was fixed, which is the shape that gets a gate
+// deleted.
+//
+// seen is the cycle guard and the memo both; a name already on the stack
+// answers false, because a cycle that reached the pin reported it on the way in.
+func reachesPinForWrite(fn *ast.FuncDecl, recv string, bodies map[string]*ast.FuncDecl) bool {
+	return reachesFrom(fn, recv, bodies, map[string]bool{})
+}
+
+func reachesFrom(fn *ast.FuncDecl, recv string, bodies map[string]*ast.FuncDecl, seen map[string]bool) bool {
+	if callsPinForWrite(fn.Body) {
+		return true
+	}
+	for _, name := range calledDeclNames(fn.Body, recv, receiverNameOf(fn)) {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		if called, known := bodies[name]; known && reachesFrom(called, recv, bodies, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+func callsPinForWrite(body ast.Node) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if ident, isIdent := n.(*ast.Ident); isIdent && ident.Name == "pinForWrite" {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// calledDeclNames collects the calls in the body this package can resolve by
+// name: a bare identifier, and a selector on the body's OWN receiver — matched against
+// the receiver's actual variable name, since a census that assumed one spelling
+// would follow nothing in every method that chose another, and report those
+// tools as carrying no pin.
+//
+// A selector on anything else names a method on a type this census cannot
+// resolve without type information, and following it by name would answer a
+// different question.
+func calledDeclNames(body ast.Node, recv, recvVar string) []string {
+	var names []string
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, isCall := n.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			names = append(names, fun.Name)
+		case *ast.SelectorExpr:
+			if base, isIdent := fun.X.(*ast.Ident); isIdent && recvVar != "" && base.Name == recvVar {
+				names = append(names, recv+"."+fun.Sel.Name)
+			}
+		}
+		return true
+	})
+	return names
+}
+
+// receiverNameOf is the receiver's variable name, empty for an unnamed one.
+func receiverNameOf(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 || len(fn.Recv.List[0].Names) == 0 {
+		return ""
+	}
+	return fn.Recv.List[0].Names[0].Name
+}
+
+func receiverTypeOf(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	expr := fn.Recv.List[0].Type
+	if star, isStar := expr.(*ast.StarExpr); isStar {
+		expr = star.X
+	}
+	if ident, isIdent := expr.(*ast.Ident); isIdent {
+		return ident.Name
+	}
+	return ""
+}
+
+// agentsSourceFiles is this package's own non-test, non-generated sources.
+func agentsSourceFiles(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the agents package for the pin census: %v", err)
+	}
+	var paths []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") ||
+			strings.HasSuffix(name, "_test.go") || strings.HasSuffix(name, "_gen.go") {
+			continue
+		}
+		paths = append(paths, name)
+	}
+	slices.Sort(paths)
+	return paths
+}

--- a/backend/internal/modules/agents/pinfitness_test.go
+++ b/backend/internal/modules/agents/pinfitness_test.go
@@ -174,6 +174,8 @@ func pinVerdictFor(t *testing.T, typeName string) string {
 }
 
 // toolTypeName is the tool's own Go type, through a pointer receiver.
+//
+//craft:ignore naked-any the registry holds tools by the interface each satisfies, and this asks what CONCRETE type one is — a constrained parameter would name the very thing being read
 func toolTypeName(tool any) string {
 	t := reflect.TypeOf(tool)
 	for t.Kind() == reflect.Pointer {

--- a/backend/internal/modules/agents/tools_lifecycle.go
+++ b/backend/internal/modules/agents/tools_lifecycle.go
@@ -58,8 +58,14 @@ type ActivityRelinker interface {
 
 // LeadDisqualifier retires a lead: status disqualified + archived_at, the row
 // surviving so it stays fetchable by id.
+//
+// ifVersion carries the version the write must be conditioned on, exactly as
+// ProjectPhaseAdvancer's does. It is a parameter and not an omission because
+// this verb STAGES a target version at approval time: a pin staged and never
+// applied is a guarantee the approvals surface advertises and the write does
+// not keep.
 type LeadDisqualifier interface {
-	DisqualifyLead(ctx context.Context, id ids.UUID) (json.RawMessage, error)
+	DisqualifyLead(ctx context.Context, id ids.UUID, ifVersion *int64) (json.RawMessage, error)
 }
 
 // LeadDemoter reverses a promotion: the lead returns to the open ladder and
@@ -256,8 +262,15 @@ func (t disqualifyLead) Handle(ctx context.Context, in json.RawMessage) (json.Ra
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
+	// nil, because this tool takes no if_version of its own: the pin it applies
+	// is the one the approval was released against, or the one the auto-execute
+	// gate read the record at.
+	pin, err := pinForWrite(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
 	noteEvidence(ctx, datasource.EntityLead, args.LeadID)
-	return t.disqualifier.DisqualifyLead(ctx, args.LeadID)
+	return t.disqualifier.DisqualifyLead(ctx, args.LeadID, pin)
 }
 
 // --- demote_lead (🟡 write — reverses a promotion) ---

--- a/backend/internal/modules/agents/tools_lifecycle_test.go
+++ b/backend/internal/modules/agents/tools_lifecycle_test.go
@@ -157,11 +157,14 @@ func (a *recordingAdvancer) AdvanceProjectPhase(
 	return nil, nil
 }
 
-// recordingDisqualifier captures the id Handle passed to the store.
-type recordingDisqualifier struct{ id ids.UUID }
+// recordingDisqualifier captures the id and the pin Handle passed to the store.
+type recordingDisqualifier struct {
+	id  ids.UUID
+	pin *int64
+}
 
-func (d *recordingDisqualifier) DisqualifyLead(_ context.Context, id ids.UUID) (json.RawMessage, error) {
-	d.id = id
+func (d *recordingDisqualifier) DisqualifyLead(_ context.Context, id ids.UUID, ifVersion *int64) (json.RawMessage, error) {
+	d.id, d.pin = id, ifVersion
 	return nil, nil
 }
 
@@ -182,6 +185,44 @@ func TestDisqualifyLeadHandsTheNamedLeadToTheStore(t *testing.T) {
 
 	if _, err := tool.Handle(context.Background(), json.RawMessage(`{"lead_id":"not-a-uuid"}`)); err == nil {
 		t.Fatal("a malformed lead_id was accepted")
+	}
+}
+
+// A redeemed retry carries the version its approval was released against, and
+// this tool takes no if_version of its own — so the released pin is the ONLY
+// thing that can condition the write.
+//
+// Without it the write is unconditioned: redemption commits its own transaction
+// and this handler opens a fresh one, so the skew check inside redemption proves
+// the row was at the approved version when the approval was CONSUMED, not when
+// the disqualify lands — and the agent controls both sides of that window.
+func TestDisqualifyLeadCarriesTheReleasedPinToTheStore(t *testing.T) {
+	seam := &recordingDisqualifier{}
+	tool := disqualifyLead{disqualifier: seam}
+	id := ids.NewV7()
+	const approvedAt = int64(7)
+
+	ctx := withApprovalRedeemed(context.Background(), approvedAt, true)
+	if _, err := tool.Handle(ctx, json.RawMessage(`{"lead_id":"`+id.String()+`"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if seam.pin == nil {
+		t.Fatal("the store was handed no version — a redeemed retry then writes unconditioned")
+	}
+	if *seam.pin != approvedAt {
+		t.Errorf("store saw version %d, want the %d the approval was released against", *seam.pin, approvedAt)
+	}
+
+	// An unapproved call at a static tier has nothing to pin, and must not
+	// invent one: a version nothing established would refuse writes that are
+	// perfectly fine.
+	unapproved := &recordingDisqualifier{}
+	plain := disqualifyLead{disqualifier: unapproved}
+	if _, err := plain.Handle(context.Background(), json.RawMessage(`{"lead_id":"`+id.String()+`"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if unapproved.pin != nil {
+		t.Errorf("an unapproved call pinned version %d; nothing established one", *unapproved.pin)
 	}
 }
 

--- a/backend/internal/modules/agents/tools_update.go
+++ b/backend/internal/modules/agents/tools_update.go
@@ -238,11 +238,22 @@ func (t updateRecord) apply(ctx context.Context, args updateRecordArgs, patch js
 // needs the post-write state (server-derived fields, bumped version)
 // whether it answers with the record alone or splices staging info in.
 func (t updateRecord) applyRecord(ctx context.Context, args updateRecordArgs, patch json.RawMessage) (wireRecord, error) {
+	// Through pinForWrite, not the raw argument. A redeemed retry that supplied
+	// no if_version would otherwise write unconditioned: redemption commits its
+	// own transaction and this one opens a fresh one, so the skew check inside
+	// redemption proves the row was right when the approval was CONSUMED, not
+	// when the effect lands — and the agent controls both sides of that window.
+	// The REST door forwards the released pin as If-Match, so every operation
+	// behind it is already carried; this is the same guarantee on this door.
+	pin, err := pinForWrite(ctx, args.IfVersion)
+	if err != nil {
+		return wireRecord{}, err
+	}
 	ref, err := t.p.Update(ctx, datasource.UpdateInput{
 		Ref:       datasource.EntityRef{Type: datasource.EntityType(args.RecordType), ID: args.ID},
 		Patch:     patch,
 		Source:    ToolSource,
-		IfVersion: args.IfVersion,
+		IfVersion: pin,
 	})
 	if err != nil {
 		return wireRecord{}, err

--- a/backend/internal/modules/people/leaddisqualify.go
+++ b/backend/internal/modules/people/leaddisqualify.go
@@ -72,6 +72,12 @@ func (s *Store) DisqualifyLead(
 			if err != nil {
 				return out, err
 			}
+			// Under the lock, against the row this transaction will write — the
+			// version an agent's released approval was granted against, which
+			// its redemption verified in a transaction that has since committed.
+			if err := refuseIfVersionMoved(entityLead, current.Version, options); err != nil {
+				return out, err
+			}
 			if err := ensureDisqualifyReasonIfNamed(ctx, tx, in.ReasonID); err != nil {
 				return out, err
 			}

--- a/backend/internal/modules/people/leadvocabulary_integration_test.go
+++ b/backend/internal/modules/people/leadvocabulary_integration_test.go
@@ -371,3 +371,54 @@ func TestEveryLeadVocabularyMutationPublishesItsChange(t *testing.T) {
 		t.Errorf("lead_disqualify_reason.changed = %v, want %v", got, wantReasons)
 	}
 }
+
+// The version pin an agent's approval was released against is applied HERE, in
+// the transaction that writes, under the row lock the write already takes.
+//
+// Not decoration: redemption commits its own transaction and the caller then
+// opens a fresh one, so a check anywhere earlier proves the row was right when
+// the approval was consumed, not when the disqualify lands. A lead edited in
+// that window must lose to the compare rather than to timing.
+func TestDisqualifyRefusesAVersionThePinNoLongerNames(t *testing.T) {
+	e := setupPromoteConsent(t)
+	lead := e.seedLead(t, "pinned@example.test")
+
+	born, err := e.store.GetLead(e.ctx, lead, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if born.Version == nil {
+		t.Fatal("the seeded lead carries no version, so this case can pin nothing")
+	}
+	at := *born.Version
+
+	// The pin the write was authorised at still names the row: it lands.
+	stale := at - 1
+	if _, err := e.store.DisqualifyLead(e.ctx, lead, DisqualifyLeadInput{}, OnlyAtVersion(&stale)); !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("a stale pin err = %v, want ErrVersionSkew — the write ran on a row the approval "+
+			"does not describe", err)
+	}
+	closed, err := e.store.DisqualifyLead(e.ctx, lead, DisqualifyLeadInput{}, OnlyAtVersion(&at))
+	if err != nil {
+		t.Fatalf("the current version was refused: %v", err)
+	}
+	if closed.Status != crmcontracts.LeadStatusDisqualified {
+		t.Errorf("status = %v, want disqualified", closed.Status)
+	}
+}
+
+// No pin attaches no precondition, so a caller that has one and a caller that
+// does not spell the call the same way — which is what lets the unapproved
+// static-tier path keep working unchanged.
+func TestDisqualifyWithNoPinIsUnconditioned(t *testing.T) {
+	e := setupPromoteConsent(t)
+	lead := e.seedLead(t, "unpinned@example.test")
+
+	closed, err := e.store.DisqualifyLead(e.ctx, lead, DisqualifyLeadInput{}, OnlyAtVersion(nil))
+	if err != nil {
+		t.Fatalf("a nil pin refused the write: %v", err)
+	}
+	if closed.Status != crmcontracts.LeadStatusDisqualified {
+		t.Errorf("status = %v, want disqualified", closed.Status)
+	}
+}

--- a/backend/internal/modules/people/untouchedguard.go
+++ b/backend/internal/modules/people/untouchedguard.go
@@ -24,13 +24,17 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // WriteOption is a precondition a caller attaches to a write.
 type WriteOption func(*writeOptions)
 
-type writeOptions struct{ untouchedSince *time.Time }
+type writeOptions struct {
+	untouchedSince *time.Time
+	atVersion      *int64
+}
 
 // NotTouchedByHumanSince refuses the write when a HUMAN has acted on the record
 // since `at`. What counts as acting is any human-actor audit row on the entity,
@@ -41,12 +45,51 @@ func NotTouchedByHumanSince(at time.Time) WriteOption {
 	return func(o *writeOptions) { o.untouchedSince = &at }
 }
 
+// OnlyAtVersion refuses the write unless the record is still at this version —
+// the option form of the contract's optional If-Match, asked inside the
+// transaction that writes and under the row lock it already holds.
+//
+// A nil version attaches no precondition, so a caller that has one and a caller
+// that does not spell the call the same way. That matters at the seam this
+// exists for: an agent write carries the version its approval was released
+// against, and an unapproved call at a static tier carries none.
+func OnlyAtVersion(v *int64) WriteOption {
+	return func(o *writeOptions) { o.atVersion = v }
+}
+
 func collectWriteOptions(opts []WriteOption) writeOptions {
 	var out writeOptions
 	for _, apply := range opts {
 		apply(&out)
 	}
 	return out
+}
+
+// refuseIfVersionMoved answers skew when the locked row is no longer at the
+// version the caller's authority was granted against.
+//
+// current comes from a read taken AFTER the row lock, so what it compares is
+// the row this transaction is about to write — which is the whole point of the
+// pin travelling this far. A check before the lock proves the row was right a
+// moment ago and nothing about the write.
+func refuseIfVersionMoved(entity string, current *int64, o writeOptions) error {
+	if o.atVersion == nil {
+		return nil
+	}
+	// A row that answers no version cannot satisfy a pin, so it refuses rather
+	// than passing. The alternative reads as "checked" and is not: an unversioned
+	// read would wave through exactly the write the pin was attached to stop.
+	if current == nil {
+		return fmt.Errorf(
+			"the %s carries no version to compare against the %d this write was authorised at: %w",
+			entity, *o.atVersion, apperrors.ErrVersionSkew)
+	}
+	if *current == *o.atVersion {
+		return nil
+	}
+	return fmt.Errorf(
+		"the %s is at version %d, not the version %d this write was authorised against: %w",
+		entity, *current, *o.atVersion, apperrors.ErrVersionSkew)
 }
 
 // HumanTouchedError refuses a write whose caller asked for it only while the


### PR DESCRIPTION
Closes #813 — both defects it names, plus the derived obligation it asks for.

### 1. `update_record`

`applyRecord` passed `args.IfVersion` raw, so a redeemed retry that supplied no `if_version` wrote **unconditioned**. It goes through `pinForWrite` now, like its 🟡 siblings.

### 2. `disqualify_lead` — the sibling the ticket flagged as a seam-shape question

It stages a `TargetVersion` and its seam could not carry one, so the pin it staged could never be applied. `LeadDisqualifier` now takes `ifVersion *int64` as its last parameter, exactly as `ProjectPhaseAdvancer` already does, and the tool passes `pinForWrite(ctx, nil)` — nil because it takes no `if_version` of its own, so the released pin (or the auto-execute gate's admitted one) is the only thing that can condition it.

The store applies it **under the row lock it already takes**, comparing against a read taken *after* the lock — which is the whole point of the pin travelling this far. `people.OnlyAtVersion` is the option form, added beside `NotTouchedByHumanSince` because it is the same kind of thing: a precondition the write re-asks inside its own transaction.

Two details worth stating:
- a **nil** version attaches no precondition, so a caller that has one and a caller that does not spell the call identically — that is what keeps the unapproved static-tier path unchanged;
- a row that answers **no** version refuses rather than passing. Passing would read as "checked" and would wave through exactly the write the pin exists to stop.

### 3. The fitness test

`TestEveryStageableWriteAppliesTheVersionItStages` walks the registry's stageable tools and requires each one's `Handle` to reach `pinForWrite`. The corpus is the registry, so a new stageable write is judged the day it registers rather than the day somebody remembers to add it here.

Two design points it needed:

- **Transitive**, not one hop. `update_record`'s `Handle` branches to `apply`, which calls `applyRecord`, which is where the pin belongs — a one-hop census would have reported the tool this ticket is about as still broken after it was fixed, which is how a gate gets deleted.
- **Keyed on the Go type via reflection**, not the wire name, so a rename on either side cannot silently drop a tool out of the walk.

### What the census found beyond the ticket

Four more, split by what they actually are:

**Structural (declared, with the reason):** `relink_thread` and `relink_activities` name many rows — a thread by key, a batch by list — and one pin cannot condition many; the per-row check under each write's own lock is what holds there, and it holds for every row rather than for one. Plus the create and comms tools, whose effect is a new row with no prior version.

**A real gap (deferred, naming its issue):** `promote_lead` and `demote_lead` stage a pinnable lead version and apply none. Filed as #5021. They are declared rather than dropped, and the census prints the count — a bare exclusion reads as "handled", a deferral reads as "decided, and not yet done". Fixing them means widening two more seams and two more store entry points (`PromoteLeadInput` could carry it; `DemoteLead` takes positional arguments and no options), which would roughly double this diff.

`pinExemptWrites` is **not** a duplicate of approvals' `contextTargetKinds`/`unpinnedKinds`, which a reader might reasonably suspect: those are keyed on staging KIND and describe automation proposals, these on TOOL TYPE and describe MCP write shapes. The two sets do not intersect, and a module never imports a sibling, so this side could not read that one even where they agreed. The declaration says so.

### Held

- `TestDisqualifyLeadCarriesTheReleasedPinToTheStore` — a redeemed retry hands the seam the version its approval was released against, and an unapproved call hands it none.
- `TestDisqualifyRefusesAVersionThePinNoLongerNames` (real Postgres) — a stale pin answers `ErrVersionSkew`, the current one lands.
- `TestDisqualifyWithNoPinIsUnconditioned` — nil attaches nothing.

Mutation-checked four ways: reverting `update_record` to the raw argument and `disqualify_lead` to no pin each turns the census red naming that tool; adding a verdict for a write that *does* pin is caught as a stale verdict; and `true ||` on the store's compare fails the skew case.

`make check-backend` green.
