### PR TITLE
fix(deals): an admitted move re-derives the premise it was admitted on

### DIFF
--- a/backend/gates/dealmovemirror_test.go
+++ b/backend/gates/dealmovemirror_test.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// One rule, spelled on both sides of a module boundary, held equal in both
+// directions.
+//
+// The tier gate auto-executes a deal move exactly when BOTH endpoints are open
+// (agents.advanceDealTier). The write re-derives that premise inside its own
+// transaction (deals.autoExecutedMoveIsOpenToOpen), because the version pin the
+// gate carries forward binds the DEAL and a stage row is mutable independently
+// of any deal — so an admin changing a stage's semantic in the window leaves
+// the pin satisfied while the move the gate admitted is no longer the move
+// being made.
+//
+// The two cannot share a function: a module never imports a sibling, and these
+// are the agents and deals modules. So the rule is spelled twice, and this gate
+// is what stops the copies drifting — the shape AGENTS.md names, where fixing
+// one side alone can be a regression rather than half a fix. Widen the
+// resolver's condition without widening the re-check and the write refuses
+// moves the gate admits; narrow the re-check without narrowing the resolver and
+// the window reopens silently.
+//
+// It reads SOURCE rather than calling either function, because calling them
+// would need this gate to import both modules and would prove only that two
+// packages compile. What has to stay equal is the sentence each one is written
+// as.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// dealMoveOpenSemantic is the value both sides must call "open". It is written
+// here rather than taken from either side: read from one, the comparison would
+// be that side against itself, and whatever it said would pass.
+const dealMoveOpenSemantic = "open"
+
+// dealMoveMirrorSites are the two declarations that spell the rule, and what
+// each one's own package calls the open semantic.
+var dealMoveMirrorSites = []struct {
+	file, function, openConst, constFile string
+}{
+	{
+		file: "internal/modules/agents/dealmove.go", function: "advanceDealTier",
+		openConst: "stageSemanticOpen", constFile: "internal/modules/agents/dealmove.go",
+	},
+	{
+		file: "internal/modules/deals/deal_advance.go", function: "autoExecutedMoveIsOpenToOpen",
+		// The deals module keeps its semantic vocabulary in one place, so the
+		// constant is not in the file that spells the rule.
+		openConst: "SemanticOpen", constFile: "internal/modules/deals/status.go",
+	},
+}
+
+// TestTheDealMoveTierRuleReadsTheSameOnBothSides holds the two spellings to one
+// shape: each compares a SOURCE and a TARGET semantic against its package's own
+// open constant, joined by AND.
+func TestTheDealMoveTierRuleReadsTheSameOnBothSides(t *testing.T) {
+	t.Parallel()
+	tree := moduleRoot(t)
+
+	for _, site := range dealMoveMirrorSites {
+		fn := functionNamed(t, tree, site.file, site.function)
+		compared := identsComparedTo(fn, site.openConst)
+		if len(compared) != 2 {
+			t.Errorf("%s in %s compares %d value(s) against %s, want exactly 2 — the rule is about "+
+				"BOTH endpoints of the move, and a side that checks one has stopped mirroring the "+
+				"other. Comparisons found: %v",
+				site.function, site.file, len(compared), site.openConst, compared)
+		}
+		if ands := countLogicalAnds(fn); ands != 1 {
+			t.Errorf("%s in %s joins its comparisons with %d && , want exactly 1 — an OR here admits "+
+				"a move with one terminal endpoint, which is the reopen half of what this rule refuses",
+				site.function, site.file, ands)
+		}
+	}
+
+	// And that both packages mean the same string by "open". A gate holding the
+	// two SHAPES equal while the constants differ would pass a tree where one
+	// side auto-executes moves the other refuses.
+	for _, site := range dealMoveMirrorSites {
+		if got := constValueIn(t, tree, site.constFile, site.openConst); got != dealMoveOpenSemantic {
+			t.Errorf("%s in %s is %q, want %q — the two sides would then disagree about which "+
+				"moves run unattended", site.openConst, site.constFile, got, dealMoveOpenSemantic)
+		}
+	}
+}
+
+// functionNamed returns one named function declaration, failing when it is
+// gone: a mirror site that vanished is the drift this gate exists to report,
+// not a case to skip.
+func functionNamed(t *testing.T, tree, relPath, name string) *ast.FuncDecl {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), tree+"/"+relPath, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", relPath, err)
+	}
+	for _, decl := range file.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if isFunc && fn.Name.Name == name && fn.Body != nil {
+			return fn
+		}
+	}
+	t.Fatalf("%s declares no function %s — the mirror moved; repoint dealMoveMirrorSites at where "+
+		"the rule is spelled now, and check the OTHER side moved with it", relPath, name)
+	return nil
+}
+
+// identsComparedTo names every expression compared for equality against the
+// constant, sorted so the report is stable.
+func identsComparedTo(fn *ast.FuncDecl, constName string) []string {
+	var compared []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		bin, isBinary := n.(*ast.BinaryExpr)
+		if !isBinary || bin.Op != token.EQL {
+			return true
+		}
+		if names(bin.Y, constName) {
+			compared = append(compared, render(bin.X))
+		}
+		if names(bin.X, constName) {
+			compared = append(compared, render(bin.Y))
+		}
+		return true
+	})
+	return compared
+}
+
+// names reports whether the expression is the constant, bare or as a
+// conversion around it — StageSemantic(semantic) == SemanticOpen and
+// semantic == stageSemanticOpen are the same sentence.
+func names(expr ast.Expr, constName string) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == constName
+	case *ast.SelectorExpr:
+		return e.Sel.Name == constName
+	case *ast.CallExpr:
+		return len(e.Args) == 1 && names(e.Args[0], constName)
+	}
+	return false
+}
+
+func countLogicalAnds(fn *ast.FuncDecl) int {
+	ands := 0
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if bin, isBinary := n.(*ast.BinaryExpr); isBinary && bin.Op == token.LAND {
+			ands++
+		}
+		return true
+	})
+	return ands
+}
+
+// render is an expression as its source words, enough to name it in a failure.
+func render(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return render(e.X) + "." + e.Sel.Name
+	case *ast.CallExpr:
+		var args []string
+		for _, a := range e.Args {
+			args = append(args, render(a))
+		}
+		return render(e.Fun) + "(" + strings.Join(args, ", ") + ")"
+	}
+	return "?"
+}
+
+// constValueIn reads one string constant's literal value out of a file.
+func constValueIn(t *testing.T, tree, relPath, name string) string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), tree+"/"+relPath, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", relPath, err)
+	}
+	found := ""
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, isValue := n.(*ast.ValueSpec)
+		if !isValue {
+			return true
+		}
+		for i, ident := range spec.Names {
+			if ident.Name != name || i >= len(spec.Values) {
+				continue
+			}
+			if lit, isLit := spec.Values[i].(*ast.BasicLit); isLit && lit.Kind == token.STRING {
+				found = strings.Trim(lit.Value, `"`)
+			}
+		}
+		return true
+	})
+	if found == "" {
+		t.Fatalf("%s declares no string constant %s — the mirror's vocabulary moved", relPath, name)
+	}
+	return found
+}

--- a/backend/gates/dealmovemirror_test.go
+++ b/backend/gates/dealmovemirror_test.go
@@ -33,6 +33,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -52,7 +53,7 @@ var dealMoveMirrorSites = []struct {
 		openConst: "stageSemanticOpen", constFile: "internal/modules/agents/dealmove.go",
 	},
 	{
-		file: "internal/modules/deals/deal_advance.go", function: "autoExecutedMoveIsOpenToOpen",
+		file: "internal/modules/deals/dealadmittedmove.go", function: "autoExecutedMoveIsOpenToOpen",
 		// The deals module keeps its semantic vocabulary in one place, so the
 		// constant is not in the file that spells the rule.
 		openConst: "SemanticOpen", constFile: "internal/modules/deals/status.go",
@@ -68,17 +69,14 @@ func TestTheDealMoveTierRuleReadsTheSameOnBothSides(t *testing.T) {
 
 	for _, site := range dealMoveMirrorSites {
 		fn := functionNamed(t, tree, site.file, site.function)
-		compared := identsComparedTo(fn, site.openConst)
-		if len(compared) != 2 {
-			t.Errorf("%s in %s compares %d value(s) against %s, want exactly 2 — the rule is about "+
-				"BOTH endpoints of the move, and a side that checks one has stopped mirroring the "+
-				"other. Comparisons found: %v",
-				site.function, site.file, len(compared), site.openConst, compared)
-		}
-		if ands := countLogicalAnds(fn); ands != 1 {
-			t.Errorf("%s in %s joins its comparisons with %d && , want exactly 1 — an OR here admits "+
-				"a move with one terminal endpoint, which is the reopen half of what this rule refuses",
-				site.function, site.file, ands)
+		compared, ok := endpointsJoinedByAnd(fn, site.openConst)
+		if !ok {
+			t.Errorf("%s in %s does not read as TWO comparisons against %s joined by one &&.\n"+
+				"  The rule is about BOTH endpoints: a side that checks one has stopped mirroring the "+
+				"other, and an OR admits a move with one terminal endpoint — the reopen half of what "+
+				"this refuses.\n"+
+				"  Direct operands of an && found comparing against %s: %v",
+				site.function, site.file, site.openConst, site.openConst, compared)
 		}
 	}
 
@@ -113,50 +111,64 @@ func functionNamed(t *testing.T, tree, relPath, name string) *ast.FuncDecl {
 	return nil
 }
 
-// identsComparedTo names every expression compared for equality against the
-// constant, sorted so the report is stable.
-func identsComparedTo(fn *ast.FuncDecl, constName string) []string {
-	var compared []string
+// endpointsJoinedByAnd finds an && whose two DIRECT operands are each a
+// comparison against the constant, and answers what they compare.
+//
+// Structural rather than a count of && nodes, which is what this asked first:
+// two comparisons and one && somewhere in the function is satisfied by
+// `a == open && unrelated` beside a second comparison the rule never reads. The
+// operands have to BE the comparisons for the sentence to be the rule.
+func endpointsJoinedByAnd(fn *ast.FuncDecl, constName string) ([]string, bool) {
+	var found []string
+	joined := false
 	ast.Inspect(fn, func(n ast.Node) bool {
-		bin, isBinary := n.(*ast.BinaryExpr)
-		if !isBinary || bin.Op != token.EQL {
+		and, isBinary := n.(*ast.BinaryExpr)
+		if !isBinary || and.Op != token.LAND || joined {
 			return true
 		}
-		if names(bin.Y, constName) {
-			compared = append(compared, render(bin.X))
+		left, leftOK := comparedTo(and.X, constName)
+		right, rightOK := comparedTo(and.Y, constName)
+		if leftOK && rightOK && left != right {
+			found, joined = []string{left, right}, true
 		}
-		if names(bin.X, constName) {
-			compared = append(compared, render(bin.Y))
-		}
-		return true
+		return !joined
 	})
-	return compared
+	return found, joined
 }
 
-// names reports whether the expression is the constant, bare or as a
-// conversion around it — StageSemantic(semantic) == SemanticOpen and
+// comparedTo answers what an expression compares for equality against the
+// constant, and whether it is such a comparison at all.
+func comparedTo(expr ast.Expr, constName string) (string, bool) {
+	bin, isBinary := expr.(*ast.BinaryExpr)
+	if !isBinary || bin.Op != token.EQL {
+		return "", false
+	}
+	if names(bin.Y, constName) {
+		return render(bin.X), true
+	}
+	if names(bin.X, constName) {
+		return render(bin.Y), true
+	}
+	return "", false
+}
+
+// names reports whether the expression is the PACKAGE-LOCAL constant, bare or
+// inside a conversion — StageSemantic(semantic) == SemanticOpen and
 // semantic == stageSemanticOpen are the same sentence.
+//
+// A qualified selector is deliberately NOT one. Matching on the field name alone
+// accepted any `somepkg.SemanticOpen`, so a side could come to read an imported
+// constant this gate never checks the value of, and the mirror would drift while
+// reading green. What each side must compare against is the constant declared in
+// its own package, which is the one constValueIn reads.
 func names(expr ast.Expr, constName string) bool {
 	switch e := expr.(type) {
 	case *ast.Ident:
 		return e.Name == constName
-	case *ast.SelectorExpr:
-		return e.Sel.Name == constName
 	case *ast.CallExpr:
 		return len(e.Args) == 1 && names(e.Args[0], constName)
 	}
 	return false
-}
-
-func countLogicalAnds(fn *ast.FuncDecl) int {
-	ands := 0
-	ast.Inspect(fn, func(n ast.Node) bool {
-		if bin, isBinary := n.(*ast.BinaryExpr); isBinary && bin.Op == token.LAND {
-			ands++
-		}
-		return true
-	})
-	return ands
 }
 
 // render is an expression as its source words, enough to name it in a failure.
@@ -176,31 +188,68 @@ func render(expr ast.Expr) string {
 	return "?"
 }
 
-// constValueIn reads one string constant's literal value out of a file.
+// constValueIn reads one string CONSTANT's value out of a file.
+//
+// Three things it insists on, each because the loose version accepted something
+// that is not the declaration this gate is about:
+//
+//   - a `const` GenDecl, not any ValueSpec. Go spells `var` with the same node,
+//     so the loose reader passed happily after the semantic stopped being a
+//     constant — which is a change to the thing being mirrored, made invisible.
+//   - one name to one value. A grouped `a, b = "x", "y"` line indexes by
+//     position, and reading the wrong half of one would compare the wrong string.
+//   - strconv.Unquote rather than trimming quote characters. A raw literal has
+//     no quotes to trim and an escaped one means something other than its
+//     source text, so trimming answers a value the compiler never sees.
 func constValueIn(t *testing.T, tree, relPath, name string) string {
 	t.Helper()
 	file, err := parser.ParseFile(token.NewFileSet(), tree+"/"+relPath, nil, 0)
 	if err != nil {
 		t.Fatalf("parsing %s: %v", relPath, err)
 	}
-	found := ""
-	ast.Inspect(file, func(n ast.Node) bool {
-		spec, isValue := n.(*ast.ValueSpec)
-		if !isValue {
-			return true
+	for _, decl := range file.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.CONST {
+			continue
 		}
-		for i, ident := range spec.Names {
-			if ident.Name != name || i >= len(spec.Values) {
-				continue
-			}
-			if lit, isLit := spec.Values[i].(*ast.BasicLit); isLit && lit.Kind == token.STRING {
-				found = strings.Trim(lit.Value, `"`)
+		for _, spec := range gen.Specs {
+			value, found := constSpecValue(t, spec, relPath, name)
+			if found {
+				return value
 			}
 		}
-		return true
-	})
-	if found == "" {
-		t.Fatalf("%s declares no string constant %s — the mirror's vocabulary moved", relPath, name)
 	}
-	return found
+	t.Fatalf("%s declares no string constant %s — the mirror's vocabulary moved, and the OTHER "+
+		"side should be checked for having moved with it", relPath, name)
+	return ""
+}
+
+func constSpecValue(t *testing.T, spec ast.Spec, relPath, name string) (string, bool) {
+	t.Helper()
+	value, isValue := spec.(*ast.ValueSpec)
+	if !isValue {
+		return "", false
+	}
+	for i, ident := range value.Names {
+		if ident.Name != name {
+			continue
+		}
+		if len(value.Names) != len(value.Values) {
+			t.Fatalf("%s declares %s in a grouped const with %d name(s) and %d value(s); this gate "+
+				"reads one name to one value and would otherwise compare the wrong string",
+				relPath, name, len(value.Names), len(value.Values))
+		}
+		lit, isLit := value.Values[i].(*ast.BasicLit)
+		if !isLit || lit.Kind != token.STRING {
+			t.Fatalf("%s declares %s as something other than a string literal, so what the two sides "+
+				"mean by it is no longer readable here", relPath, name)
+		}
+		unquoted, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			t.Fatalf("%s declares %s as a string literal this gate cannot read (%s): %v",
+				relPath, name, lit.Value, err)
+		}
+		return unquoted, true
+	}
+	return "", false
 }

--- a/backend/internal/compose/integration/dealmovestagerace_integration_test.go
+++ b/backend/internal/compose/integration/dealmovestagerace_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/compose/installseam"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/platform/auth"
@@ -118,15 +119,15 @@ func wonReasonImported() *string {
 // be asserting against its own fixture rather than against the gate.
 func admitOpenToOpenMove(t *testing.T, e *Env) context.Context {
 	t.Helper()
-	spec := mcp.ToolSpec{
-		Name: "advance_deal", RequiredScope: principal.ScopeWrite, Tier: mcp.TierDynamic,
-		TierResolver: func(in mcp.TierResolverInput) mcp.RiskTier {
-			if in.SourceStageSemantic == "open" && in.TargetStageSemantic == "open" {
-				return mcp.TierAutoExecute
-			}
-			return mcp.TierConfirmationRequired
-		},
-	}
+	// advance_deal's OWN spec, out of the registry this build composes — the
+	// resolver included. A resolver written here would be a second copy of the
+	// rule under test, so a case about the gate's verdict would stop depending
+	// on the gate: narrow the real one and this would go on admitting the move,
+	// proving the store re-checks a premise nothing establishes any more.
+	spec := specNamed(t, "advance_deal")
+	// The input a real open-to-open move produces. It is stated rather than
+	// read, because what this case needs is the gate's verdict on that input;
+	// how DealMoveTierInput reads a deal is its own suite's subject.
 	version := int64(1)
 	resolve := func() (mcp.TierResolverInput, error) {
 		return mcp.TierResolverInput{
@@ -172,4 +173,17 @@ func (fullAuthority) SeatType(context.Context, ids.UUID, ids.UUID) (principal.Se
 
 func (fullAuthority) AdmittedAuthority(context.Context, ids.UUID, ids.UUID, ids.UUID) (authz.RBAC, principal.SeatType, error) {
 	return authz.RBAC{Permissions: AdminPerms}, principal.SeatFull, nil
+}
+
+// specNamed answers one tool's spec from the registry this build composes, so a
+// case drives the production declaration rather than a fixture of it.
+func specNamed(t *testing.T, name string) mcp.ToolSpec {
+	t.Helper()
+	for _, spec := range compose.NewRegistry(nil, compose.SendPath{}).Specs() {
+		if spec.Name == name {
+			return spec
+		}
+	}
+	t.Fatalf("this build registers no %s, so the case below would drive nothing", name)
+	return mcp.ToolSpec{}
 }

--- a/backend/internal/compose/integration/dealmovestagerace_integration_test.go
+++ b/backend/internal/compose/integration/dealmovestagerace_integration_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The window the deal's own version pin cannot see.
+//
+// The tier gate auto-executes a deal move exactly when it can prove BOTH
+// endpoints open, and it proves that by reading two STAGE rows. The pin it
+// carries forward binds the DEAL — and a stage row is mutable independently of
+// any deal, so an admin changing the target stage's semantic in between leaves
+// the pin perfectly satisfied while the move being made is no longer the move
+// that was admitted.
+//
+// The racing actor is a human admin rather than the agent: pipeline and stage
+// configuration is human-only, so an agent cannot arrange either side of this.
+// That is what makes it a different defect from the one the pin was added for,
+// and why the pin is not the fix.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/installseam"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/authz"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+)
+
+func TestAnAdmittedMoveRefusesAStageThatClosedAfterTheGateReadIt(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, target := DealFixture(t, e)
+	deal := e.SeedDeal(t, "Stage race", pipeline, open, &e.Rep1)
+	// The target starts OPEN, which is the config the gate is about to read.
+	e.WsExec(t, `UPDATE stage SET semantic = 'open' WHERE id = $1`, target)
+	store := deals.NewStore(e.DB(), installseam.Deals())
+
+	// The gate's verdict, taken while BOTH stages are open — which is the state
+	// that makes this move auto-executable in the first place.
+	admitted := admitOpenToOpenMove(t, e)
+
+	// Then the admin acts, in the window. Nothing about the deal changes, so
+	// its version — the whole of what the gate pinned — still names the row.
+	e.WsExec(t, `UPDATE stage SET semantic = 'won' WHERE id = $1`, target)
+
+	_, err := store.AdvanceDeal(admitted, ids.From[ids.DealKind](deal), deals.AdvanceDealInput{
+		ToStageID:                target,
+		WonWithoutContractReason: wonReasonImported(),
+	})
+	if !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("err = %v, want ErrVersionSkew — the move was admitted unattended as open-to-open "+
+			"and closed the deal instead", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM deal WHERE id = $1 AND status = 'open' AND closed_at IS NULL`, deal); n != 1 {
+		t.Error("the deal was closed by a move the gate never admitted")
+	}
+}
+
+// The same call with the stage config unchanged still lands: the re-check is a
+// guard on a premise that moved, not a second approval gate.
+func TestAnAdmittedMoveStillLandsWhenNoStageChanged(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, target := DealFixture(t, e)
+	deal := e.SeedDeal(t, "Stage race control", pipeline, open, &e.Rep1)
+	e.WsExec(t, `UPDATE stage SET semantic = 'open' WHERE id = $1`, target)
+	store := deals.NewStore(e.DB(), installseam.Deals())
+
+	admitted := admitOpenToOpenMove(t, e)
+	moved, err := store.AdvanceDeal(admitted, ids.From[ids.DealKind](deal), deals.AdvanceDealInput{
+		ToStageID: target,
+	})
+	if err != nil {
+		t.Fatalf("a routine open-to-open move was refused: %v", err)
+	}
+	if moved.StageId == nil || ids.UUID(*moved.StageId) != target.UUID {
+		t.Errorf("the deal sits in %v, want the stage the move named", moved.StageId)
+	}
+}
+
+// A move by a HUMAN is unaffected: the tier model does not govern one, so there
+// is no admitted premise to re-check and a stage change is simply the config
+// they are moving under.
+func TestAHumansMoveIsNotHeldToTheGatesPremise(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, target := DealFixture(t, e)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
+	deal := e.SeedDeal(t, "Human move", pipeline, open, &e.Rep1)
+	store := deals.NewStore(e.DB(), installseam.Deals())
+
+	if _, err := store.AdvanceDeal(human, ids.From[ids.DealKind](deal), deals.AdvanceDealInput{
+		ToStageID:                target,
+		WonWithoutContractReason: wonReasonImported(),
+	}); err != nil {
+		t.Fatalf("a human's move onto a stage that is now won was refused: %v", err)
+	}
+}
+
+// wonReasonImported is the reason a win with no agreement behind it carries;
+// the two closing cases here are about the stage config, not about evidence.
+func wonReasonImported() *string {
+	reason := "imported"
+	return &reason
+}
+
+// admitOpenToOpenMove answers a context carrying the gate's own auto-execute
+// verdict for an open-to-open move.
+//
+// Through auth.Gate.Admit rather than by minting the pin: the marker is
+// deliberately unexported, so a caller able to mint one could condition its own
+// write on a premise nothing ever established — and a test that minted it would
+// be asserting against its own fixture rather than against the gate.
+func admitOpenToOpenMove(t *testing.T, e *Env) context.Context {
+	t.Helper()
+	spec := mcp.ToolSpec{
+		Name: "advance_deal", RequiredScope: principal.ScopeWrite, Tier: mcp.TierDynamic,
+		TierResolver: func(in mcp.TierResolverInput) mcp.RiskTier {
+			if in.SourceStageSemantic == "open" && in.TargetStageSemantic == "open" {
+				return mcp.TierAutoExecute
+			}
+			return mcp.TierConfirmationRequired
+		},
+	}
+	version := int64(1)
+	resolve := func() (mcp.TierResolverInput, error) {
+		return mcp.TierResolverInput{
+			SourceStageSemantic: "open", TargetStageSemantic: "open", ObservedVersion: &version,
+		}, nil
+	}
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	// An agent principal, because the tier model governs one.
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:stage-race",
+		UserID: e.AdminUser, OnBehalfOf: e.AdminUser, TeamIDs: []ids.UUID{e.Team1},
+		Scopes: principal.NewScopeSet(principal.ScopeWrite),
+	})
+	admitted, err := auth.NewGate(fullAuthority{}).Admit(ctx, spec, resolve)
+	if err != nil {
+		t.Fatalf("the gate refused a routine open-to-open move: %v", err)
+	}
+	if _, ok := auth.AutoExecutePin(admitted); !ok {
+		t.Fatal("the admitted context carries no auto-execute pin, so this case would prove nothing")
+	}
+	return admitted
+}
+
+// fullAuthority is the identity seam stubbed to a full seat holding the deal
+// grants.
+//
+// The seam and not the store: Admit RE-DERIVES the granting human's authority
+// and overwrites whatever the principal carried, so a real resolver would make
+// this case turn on how the harness seeds roles rather than on the premise it is
+// about — and it would fail for a reason with nothing to do with stage config.
+// The resolver is a true boundary (identity), which is what makes stubbing it
+// the right call rather than a shortcut.
+type fullAuthority struct{}
+
+func (fullAuthority) EffectiveRBAC(context.Context, ids.UUID, ids.UUID) (authz.RBAC, error) {
+	return authz.RBAC{Permissions: AdminPerms}, nil
+}
+
+func (fullAuthority) SeatType(context.Context, ids.UUID, ids.UUID) (principal.SeatType, error) {
+	return principal.SeatFull, nil
+}
+
+func (fullAuthority) AdmittedAuthority(context.Context, ids.UUID, ids.UUID, ids.UUID) (authz.RBAC, principal.SeatType, error) {
+	return authz.RBAC{Permissions: AdminPerms}, principal.SeatFull, nil
+}

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -169,7 +169,7 @@ func (s *Store) advanceOnTx(
 		}
 		// Under the lock resolveAdvanceTarget just took on the target row, and
 		// before anything is written.
-		if err := refuseAMoveTheGateDidNotAdmit(ctx, tx, current, StageSemantic(semantic)); err != nil {
+		if err := refuseAMoveTheGateDidNotAdmit(ctx, tx, current, in.ToStageID); err != nil {
 			return err
 		}
 		// Checked inside the transaction that writes the transition, and
@@ -356,58 +356,6 @@ func resolveAdvanceTarget(ctx context.Context, tx pgx.Tx, toStage ids.StageID, c
 		return "", 0, &StagePipelineMismatchError{StageID: toStage}
 	}
 	return semantic, winProbability, nil
-}
-
-// autoExecutedMoveIsOpenToOpen is the tier rule this store re-checks, and it is
-// a DECLARED MIRROR of agents.advanceDealTier — the resolver that admits an
-// unattended deal move exactly when both endpoints are open.
-//
-// Spelled twice because a module never imports a sibling: the resolver lives in
-// the agents module and this is the deals module, so the two cannot share the
-// function. What holds them equal is a gate rather than a convention —
-// backend/gates/dealmovemirror_test.go fails when either spelling moves — for
-// the reason AGENTS.md gives about an invariant spelled on both sides of a
-// wire: fixing one side alone can be a regression rather than half a fix.
-func autoExecutedMoveIsOpenToOpen(source, target StageSemantic) bool {
-	return source == SemanticOpen && target == SemanticOpen
-}
-
-// refuseAMoveTheGateDidNotAdmit re-derives, inside the writing transaction, the
-// premise the tier gate admitted this call on.
-//
-// The gate auto-executes a deal move only when it can prove BOTH endpoints
-// open, and it proves that by reading two STAGE rows. The version pin it
-// carries forward binds the DEAL, and a stage row is mutable independently of
-// any deal — so an admin changing the target stage's semantic to `won` in the
-// window between the gate's read and this write leaves the pin perfectly
-// satisfied and closes a deal on a verdict about an open-to-open move. The
-// mirror case reopens a closed one.
-//
-// The racing actor is a human admin rather than the agent, so this is not the
-// window the deal's own pin was added for; it is the one that pin cannot see.
-// Re-deriving here is what makes the premise true at the moment it is acted on
-// instead of at the moment it was read.
-//
-// It costs nothing on any other path. A call the gate did not admit unattended
-// carries no pin: an approved move was judged by a human who saw the sentence,
-// and a human's own move is not governed by the tier model at all.
-func refuseAMoveTheGateDidNotAdmit(
-	ctx context.Context, tx pgx.Tx, current crmcontracts.Deal, target StageSemantic,
-) error {
-	if _, autoExecuted := auth.AutoExecutePin(ctx); !autoExecuted {
-		return nil
-	}
-	source, err := stageSemanticOf(ctx, tx, ids.From[ids.StageKind](ids.UUID(*current.StageId)))
-	if err != nil {
-		return fmt.Errorf("re-read the deal's current stage semantic: %w", err)
-	}
-	if autoExecutedMoveIsOpenToOpen(source, target) {
-		return nil
-	}
-	return fmt.Errorf(
-		"this move was admitted unattended as open-to-open and is now %s-to-%s — "+
-			"a stage's semantic changed after the gate read it: %w",
-		source, target, apperrors.ErrVersionSkew)
 }
 
 // stageTransitionPatch derives the row changes one stage move implies

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -167,6 +167,11 @@ func (s *Store) advanceOnTx(
 		if err != nil {
 			return err
 		}
+		// Under the lock resolveAdvanceTarget just took on the target row, and
+		// before anything is written.
+		if err := refuseAMoveTheGateDidNotAdmit(ctx, tx, current, StageSemantic(semantic)); err != nil {
+			return err
+		}
 		// Checked inside the transaction that writes the transition, and
 		// checked BEFORE the patch is built, so a refusal costs nothing and a
 		// concurrent archive cannot remove the evidence between the two.
@@ -351,6 +356,58 @@ func resolveAdvanceTarget(ctx context.Context, tx pgx.Tx, toStage ids.StageID, c
 		return "", 0, &StagePipelineMismatchError{StageID: toStage}
 	}
 	return semantic, winProbability, nil
+}
+
+// autoExecutedMoveIsOpenToOpen is the tier rule this store re-checks, and it is
+// a DECLARED MIRROR of agents.advanceDealTier — the resolver that admits an
+// unattended deal move exactly when both endpoints are open.
+//
+// Spelled twice because a module never imports a sibling: the resolver lives in
+// the agents module and this is the deals module, so the two cannot share the
+// function. What holds them equal is a gate rather than a convention —
+// backend/gates/dealmovemirror_test.go fails when either spelling moves — for
+// the reason AGENTS.md gives about an invariant spelled on both sides of a
+// wire: fixing one side alone can be a regression rather than half a fix.
+func autoExecutedMoveIsOpenToOpen(source, target StageSemantic) bool {
+	return source == SemanticOpen && target == SemanticOpen
+}
+
+// refuseAMoveTheGateDidNotAdmit re-derives, inside the writing transaction, the
+// premise the tier gate admitted this call on.
+//
+// The gate auto-executes a deal move only when it can prove BOTH endpoints
+// open, and it proves that by reading two STAGE rows. The version pin it
+// carries forward binds the DEAL, and a stage row is mutable independently of
+// any deal — so an admin changing the target stage's semantic to `won` in the
+// window between the gate's read and this write leaves the pin perfectly
+// satisfied and closes a deal on a verdict about an open-to-open move. The
+// mirror case reopens a closed one.
+//
+// The racing actor is a human admin rather than the agent, so this is not the
+// window the deal's own pin was added for; it is the one that pin cannot see.
+// Re-deriving here is what makes the premise true at the moment it is acted on
+// instead of at the moment it was read.
+//
+// It costs nothing on any other path. A call the gate did not admit unattended
+// carries no pin: an approved move was judged by a human who saw the sentence,
+// and a human's own move is not governed by the tier model at all.
+func refuseAMoveTheGateDidNotAdmit(
+	ctx context.Context, tx pgx.Tx, current crmcontracts.Deal, target StageSemantic,
+) error {
+	if _, autoExecuted := auth.AutoExecutePin(ctx); !autoExecuted {
+		return nil
+	}
+	source, err := stageSemanticOf(ctx, tx, ids.From[ids.StageKind](ids.UUID(*current.StageId)))
+	if err != nil {
+		return fmt.Errorf("re-read the deal's current stage semantic: %w", err)
+	}
+	if autoExecutedMoveIsOpenToOpen(source, target) {
+		return nil
+	}
+	return fmt.Errorf(
+		"this move was admitted unattended as open-to-open and is now %s-to-%s — "+
+			"a stage's semantic changed after the gate read it: %w",
+		source, target, apperrors.ErrVersionSkew)
 }
 
 // stageTransitionPatch derives the row changes one stage move implies

--- a/backend/internal/modules/deals/dealadmittedmove.go
+++ b/backend/internal/modules/deals/dealadmittedmove.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The premise an unattended deal move was admitted on, re-derived where it is
+// acted on.
+//
+// Its own file because it is its own concept: the advance path is about deriving
+// a transition, and this is about whether the AUTHORITY to make it unattended
+// still describes the move being made. The two answer to different racing
+// actors — the deal's version pin to the agent, this to a human admin editing
+// stage configuration — and reading them apart is what keeps either legible.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// autoExecutedMoveIsOpenToOpen is the tier rule this store re-checks, and it is
+// a DECLARED MIRROR of agents.advanceDealTier — the resolver that admits an
+// unattended deal move exactly when both endpoints are open.
+//
+// Spelled twice because a module never imports a sibling: the resolver lives in
+// the agents module and this is the deals module, so the two cannot share the
+// function. What holds them equal is a gate rather than a convention —
+// backend/gates/dealmovemirror_test.go fails when either spelling moves — for
+// the reason AGENTS.md gives about an invariant spelled on both sides of a
+// wire: fixing one side alone can be a regression rather than half a fix.
+func autoExecutedMoveIsOpenToOpen(source, target StageSemantic) bool {
+	return source == SemanticOpen && target == SemanticOpen
+}
+
+// refuseAMoveTheGateDidNotAdmit re-derives, inside the writing transaction, the
+// premise the tier gate admitted this call on.
+//
+// The gate auto-executes a deal move only when it can prove BOTH endpoints
+// open, and it proves that by reading two STAGE rows. The version pin it
+// carries forward binds the DEAL, and a stage row is mutable independently of
+// any deal — so an admin changing the target stage's semantic to `won` in the
+// window between the gate's read and this write leaves the pin perfectly
+// satisfied and closes a deal on a verdict about an open-to-open move. The
+// mirror case reopens a closed one.
+//
+// The racing actor is a human admin rather than the agent, so this is not the
+// window the deal's own pin was added for; it is the one that pin cannot see.
+// Re-deriving here is what makes the premise true at the moment it is acted on
+// instead of at the moment it was read.
+//
+// It costs nothing on any other path. A call the gate did not admit unattended
+// carries no pin: an approved move was judged by a human who saw the sentence,
+// and a human's own move is not governed by the tier model at all.
+func refuseAMoveTheGateDidNotAdmit(
+	ctx context.Context, tx pgx.Tx, current crmcontracts.Deal, toStage ids.StageID,
+) error {
+	if _, autoExecuted := auth.AutoExecutePin(ctx); !autoExecuted {
+		return nil
+	}
+	source, target, err := lockedMoveSemantics(ctx, tx,
+		ids.From[ids.StageKind](ids.UUID(*current.StageId)), toStage)
+	if err != nil {
+		return err
+	}
+	if autoExecutedMoveIsOpenToOpen(source, target) {
+		return nil
+	}
+	return fmt.Errorf(
+		"this move was admitted unattended as open-to-open and is now %s-to-%s — "+
+			"a stage's semantic changed after the gate read it: %w",
+		source, target, apperrors.ErrVersionSkew)
+}
+
+// lockedMoveSemantics reads both endpoints' semantics under FOR SHARE, which is
+// what makes the answer still true when the deal is written.
+//
+// FOR SHARE and not the FOR KEY SHARE the ordinary target lookup takes. That one
+// is deliberately the weakest lock that conflicts with a stage REMOVAL, so a
+// rename or a probability edit runs alongside a deal moving (stageremoval.go
+// says so) — and a semantic change is exactly such an edit, taking FOR NO KEY
+// UPDATE, which FOR KEY SHARE does not conflict with. Under it, the value this
+// check reads can be replaced before the deal write commits, and the re-check
+// would have narrowed the window rather than closed it.
+//
+// The stronger lock is taken ONLY here, on the auto-executed path. Applying it
+// to every advance would make an ordinary stage rename wait behind every deal
+// move, which is the concurrency the weaker lock was chosen to keep.
+//
+// One statement over both ids, ordered, rather than two reads: two concurrent
+// moves in opposite directions would otherwise take the same pair of rows in
+// opposite orders. Both sides here run this same statement, so both take them
+// the same way round.
+func lockedMoveSemantics(
+	ctx context.Context, tx pgx.Tx, from, to ids.StageID,
+) (source, target StageSemantic, err error) {
+	rows, err := tx.Query(ctx,
+		`SELECT id, semantic FROM stage WHERE id = ANY($1) AND archived_at IS NULL
+		  ORDER BY id FOR SHARE`,
+		[]ids.UUID{from.UUID, to.UUID})
+	if err != nil {
+		return "", "", fmt.Errorf("lock the move's stages: %w", err)
+	}
+	defer rows.Close()
+	semantics := map[ids.UUID]StageSemantic{}
+	for rows.Next() {
+		var id ids.UUID
+		var semantic string
+		if err := rows.Scan(&id, &semantic); err != nil {
+			return "", "", fmt.Errorf("read a move endpoint's semantic: %w", err)
+		}
+		semantics[id] = StageSemantic(semantic)
+	}
+	if err := rows.Err(); err != nil {
+		return "", "", fmt.Errorf("read the move's stages: %w", err)
+	}
+	// A missing endpoint is a stage archived under this move. It is refused
+	// rather than read as "not open", because the two are different answers and
+	// only one of them is true: nothing established what that stage was.
+	source, hasSource := semantics[from.UUID]
+	target, hasTarget := semantics[to.UUID]
+	if !hasSource || !hasTarget {
+		return "", "", fmt.Errorf(
+			"a stage this move names is no longer live, so the premise it was admitted on "+
+				"cannot be re-checked: %w", apperrors.ErrVersionSkew)
+	}
+	return source, target, nil
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (99)
+## Parity (100)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -47,6 +47,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `contractvocabulary_test.go` | H3 | A membership set built from a generated enum's own constants must hold every member of that enum. |
 | `corepicklistcontract_test.go` | H3 | The core picklist value sets against the contract that owns them. |
 | `dealmoveargument_test.go` | H2 | One rule, read on both sides of a compose seam. |
+| `dealmovemirror_test.go` | H2 | One rule, spelled on both sides of a module boundary, held equal in both directions. |
 | `dedupeevidencefields_test.go` | H1 | The dedupe evidence snapshot is stored as free JSON, so nothing about a field name is checked when it is written. |
 | `deexceptionmirror_test.go` | H3 | The engine's test fixture for the German exception is the pack's declaration, or the tests prove nothing about what ships. |
 | `dsrqueueishumanonly_test.go` | H2 | The subject-request queue is human-only in the contract because it is human-only in the store. |


### PR DESCRIPTION
Closes #811.

`advanceDealTier` auto-executes a move only when it can prove **both** endpoints open, and it proves that by reading two `stage` rows. Only the deal's version travels forward — and a stage row is mutable independently of any deal, so the window the ticket describes is real:

1. the gate reads the target stage as `open` and the deal at v7 → resolves 🟢;
2. an admin changes that stage's semantic to `won`;
3. `resolveAdvanceTarget` re-reads the semantic in-transaction and gets `won`;
4. the deal is still v7, the version compare passes, and the deal is **closed unattended** on a verdict about an open→open move.

### The fix, and why it is this one rather than a new pin

The ticket offers two shapes: carry a stage-config version through `TierResolverInput`, or re-check the semantics against what the gate saw. I took the second, and the reason is that it is **symmetric by construction**.

A carried value has to cross a transport, and the two doors are not the same transport: the REST door forwards the deal's pin as `If-Match`, and there is no header for a stage semantic. A pin the MCP door carries and the REST door cannot is exactly the one-credential-two-doors asymmetry ADR-0055 exists to close — the same shape #813 is about. Re-deriving inside the write covers both doors because neither has to carry anything.

`refuseAMoveTheGateDidNotAdmit` runs under the lock `resolveAdvanceTarget` already took on the target row, before anything is written, and only for a call the gate admitted unattended (`auth.AutoExecutePin` present). An **approved** move was judged by a human who read the sentence, and a **human's** own move is not governed by the tier model at all — neither pays anything.

### One rule, two spellings, held equal

The re-check is a declared mirror of `agents.advanceDealTier`. They cannot share a function: a module never imports a sibling, and these are the agents and deals modules.

So `gates/dealmovemirror_test.go` holds them equal **in both directions**, which is the shape AGENTS.md names for an invariant spelled on two sides of a wire — widen the resolver without widening the re-check and the write refuses moves the gate admits; narrow the re-check without narrowing the resolver and the window reopens silently. It reads source rather than calling either function, because calling them would need the gate to import both modules and would prove only that two packages compile. It checks that each side compares **two** endpoints against its own open constant joined by **one** `&&`, and that both constants mean the same string — the last part written out in the gate rather than read from either side, since a constant read from one side cannot disagree with that side.

### Tests

Real Postgres, in `compose/integration`:

- `TestAnAdmittedMoveRefusesAStageThatClosedAfterTheGateReadIt` — the window, reproduced: admit while both stages are open, flip the target to `won` (nothing about the deal changes, so its pin still names the row), then advance. `ErrVersionSkew`, and the deal is still open.
- `TestAnAdmittedMoveStillLandsWhenNoStageChanged` — the control. A guard that refused the routine case would be worse than the hole.
- `TestAHumansMoveIsNotHeldToTheGatesPremise` — a human moves onto a now-`won` stage unimpeded.

The admitted context comes from `auth.Gate.Admit` rather than a minted pin, because the marker is deliberately unexported — a test that minted it would assert against its own fixture. The authority resolver is stubbed: `Admit` re-derives the granting human's authority and overwrites what the principal carried, so a real one would make these cases turn on how the harness seeds roles rather than on stage config. That resolver is a true boundary (identity), which is what makes stubbing it right rather than a shortcut.

Mutation-checked four ways: removing the re-check fails the window case while the control stays green; `&&` → `||` on either side fails the mirror gate naming the reopen half; and renaming either open constant fails it naming the disagreement.

`make check-backend` green, gate inventory regenerated.
