### PR TITLE
fix(capture): a cleared verdict re-opens the mail it cleared

### DIFF
--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -400,6 +400,13 @@ func (w *counterpartyVerdictWorker) judgeWorkspace(ctx context.Context, workspac
 	if err := w.engine.ReconcileLedgerWorkspace(wsCtx); err != nil {
 		return err
 	}
+	// After the ledger settles, and before anything is offered to a human: a
+	// sender judged on an earlier tick, or by a door whose own release could not
+	// finish, still has mail a posture is holding for a question that has an
+	// answer.
+	if err := w.engine.WidenClearedSendersWorkspace(wsCtx); err != nil {
+		return err
+	}
 	if err := w.engine.StageReviewsWorkspace(wsCtx, 0); err != nil {
 		return err
 	}

--- a/backend/internal/compose/captureverdict.go
+++ b/backend/internal/compose/captureverdict.go
@@ -365,8 +365,15 @@ func (e *CounterpartyVerdictEngine) apply(
 		// would silently start hiding real mail, so there is none.
 		switch kind {
 		case capture.KindPerson:
-			triageDomain, err = e.createCounterparty(ctx, tx, row)
-			return err
+			if triageDomain, err = e.createCounterparty(ctx, tx, row); err != nil {
+				return err
+			}
+			// The mail a `classified` mailbox held while it waited for this
+			// answer. Bounded, and not drained here: this transaction already
+			// carries the ledger resolution and a person record, and a sender
+			// with a thousand held messages would hold it open for all of them.
+			// The reconciling pass finishes what this leaves.
+			return e.widenClearedSender(ctx, tx, row.Email)
 		case capture.KindRoleMailbox, capture.KindOrganizationSender:
 			// Real correspondence with no human to name. The message stays
 			// visible; no contact is invented for a mailbox nobody owns.

--- a/backend/internal/compose/captureverdictaccept.go
+++ b/backend/internal/compose/captureverdictaccept.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/approvals"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/people"
@@ -169,6 +170,18 @@ func applyCounterpartyAccept(ctx context.Context, tx pgx.Tx, store *people.Store
 	// Accepting the offer IS the assertion that a person is behind the address —
 	// the queue's whole question is whether to create this contact — so the
 	// ledger records that kind rather than leaving the model's guess standing.
-	return created.TriageDomain, pending.ResolveReviewedAs(ctx, tx, proposal.DispositionID,
-		capture.PendingStatusReal, capture.KindPerson, "accepted in the review queue")
+	if err := pending.ResolveReviewedAs(ctx, tx, proposal.DispositionID,
+		capture.PendingStatusReal, capture.KindPerson, "accepted in the review queue"); err != nil {
+		return "", err
+	}
+	// The same release the machine verdict makes, because this door settles the
+	// same question. Bounded here too, with the reconciling pass behind it. The
+	// widen re-reads the ledger itself, so a resolution that did not take
+	// releases nothing.
+	if _, err := capture.WidenClearedSenderTx(
+		ctx, tx, proposal.Email, clearedSenderLiveBound, activities.RecomputeAudienceTx,
+	); err != nil {
+		return "", err
+	}
+	return created.TriageDomain, nil
 }

--- a/backend/internal/compose/captureverdictwiden.go
+++ b/backend/internal/compose/captureverdictwiden.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Releasing the mail a `classified` mailbox held while it waited for a verdict
+// on the sender.
+//
+// Two callers, and the split is about transaction size rather than about
+// authority. The verdict's own transaction releases a bounded batch, so the
+// mailbox opens the moment the sender is judged; this pass drains whatever is
+// left, including every sender judged before the release existed at all.
+//
+// The entitlement is not passed between them. capture's predicate re-reads the
+// ledger inside the statement that claims the rows, so neither caller can widen
+// by asserting a verdict it did not durably record.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+const (
+	// clearedSenderLiveBound is what one verdict transaction releases before
+	// leaving the rest to the pass below. It shares that transaction with a
+	// ledger resolution and a person record, and the recompute takes a row lock
+	// per message, so a sender with a large backlog must not drain here.
+	clearedSenderLiveBound = 100
+	// clearedSenderSweepBudget is one workspace's share of a reconciling pass.
+	// A workspace with more held mail than this finishes on the following tick,
+	// which keeps one large tenant from spending the whole fleet-wide run.
+	clearedSenderSweepBudget = 2000
+	// clearedSenderSweepSenders bounds how many senders one pass looks at, so
+	// the scan that finds them stays a short read.
+	clearedSenderSweepSenders = 50
+)
+
+// widenClearedSender releases a bounded batch of the mail this sender's verdict
+// has just settled, on the verdict's own transaction.
+func (e *CounterpartyVerdictEngine) widenClearedSender(ctx context.Context, tx pgx.Tx, email string) error {
+	_, err := capture.WidenClearedSenderTx(ctx, tx, email, clearedSenderLiveBound, activities.RecomputeAudienceTx)
+	return err
+}
+
+// WidenClearedSendersWorkspace re-opens the mail still held about senders this
+// workspace has already judged to be real people.
+//
+// It is what makes the release survive a crash, a door that forgot to call the
+// live hook, and — the case it was written for — every sender judged before any
+// release existed, whose mail would otherwise stay limited for good because
+// nothing re-asks a question the ledger considers answered.
+//
+// One transaction per sender rather than one for the pass: a sender's drain
+// takes a row lock per message it moves, and holding those across an entire
+// workspace's backlog would block readers of mail this pass is not even about.
+func (e *CounterpartyVerdictEngine) WidenClearedSendersWorkspace(ctx context.Context) error {
+	return e.inWorkspace(ctx, func(wsCtx context.Context, _ ids.UUID) error {
+		var senders []string
+		if err := database.WithWorkspaceTx(wsCtx, e.pool, func(tx pgx.Tx) error {
+			var err error
+			senders, err = capture.ClearedSendersDueTx(wsCtx, tx, clearedSenderSweepSenders)
+			return err
+		}); err != nil {
+			return fmt.Errorf("verdict: reading the senders whose cleared mail is still held: %w", err)
+		}
+		budget := clearedSenderSweepBudget
+		for _, email := range senders {
+			if budget <= 0 {
+				return nil
+			}
+			var moved int
+			if err := database.WithWorkspaceTx(wsCtx, e.pool, func(tx pgx.Tx) error {
+				var err error
+				moved, err = capture.WidenClearedSenderAll(
+					wsCtx, tx, email, budget, activities.RecomputeAudienceTx)
+				return err
+			}); err != nil {
+				return fmt.Errorf("verdict: re-opening the mail a cleared sender's verdict settled: %w", err)
+			}
+			budget -= moved
+		}
+		return nil
+	})
+}

--- a/backend/internal/compose/captureverdictwiden_integration_test.go
+++ b/backend/internal/compose/captureverdictwiden_integration_test.go
@@ -149,6 +149,52 @@ func TestAThreadVerdictThatHeldOutranksAClearedSender(t *testing.T) {
 	}
 }
 
+// The import row's own status is not proof its thread is unjudged. Stamping a
+// settled verdict onto a thread's siblings is bounded per transaction, so a
+// long thread keeps rows reading NULL after a `held` verdict has committed —
+// and those are precisely the messages a seat asked to keep back.
+func TestAHeldThreadsUnstampedMessagesAreNotPublishedByASenderVerdict(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "chi@fvhospital.example"
+	mail := seedCapturedMail(t, e, sender, "Gehaltsanpassung")
+	seedPostureHeldImport(t, e, mail, e.Rep1)
+	// The verdict is settled on the THREAD while this message's own import row
+	// still says nothing — the state a bounded stamping pass leaves behind.
+	holdThreadFor(t, e, mail, e.Rep1)
+	dispositionID := seedPendingDisposition(t, e, sender, "fvhospital.example", mail)
+
+	judgeSenderAs(t, e, dispositionID, capture.KindPerson)
+
+	if got, _ := audienceAndReason(t, e, mail); got != "participants" {
+		t.Errorf("a message on a thread its seat held is %q: the release read the import row's "+
+			"own status as proof the thread was unjudged, and published mail a confidentiality "+
+			"verdict had already held", got)
+	}
+}
+
+// holdThreadFor settles this seat's confidentiality verdict on the message's
+// thread, leaving the message's own import row unstamped.
+func holdThreadFor(t *testing.T, e *integration.Env, activityID, seat ids.UUID) {
+	t.Helper()
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		// The seeded mail carries no thread of its own, so the conversation this
+		// verdict is about has to be named first.
+		if _, err := tx.Exec(context.Background(),
+			`UPDATE activity SET thread_key = 'thread-' || $1::text WHERE id = $1`,
+			activityID); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_thread_verdict (thread_key, user_id, status, seen_addresses)
+			SELECT a.thread_key, $2, 'held', ARRAY[]::text[]
+			  FROM activity a WHERE a.id = $1`, activityID, seat)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("holding the thread: %v", err)
+	}
+}
+
 // A row written before the product recorded more than one reason says only
 // which rule matched first. It is not PROVABLY posture-only, so it is refused
 // rather than guessed at — the same trade widenhistory makes.

--- a/backend/internal/compose/captureverdictwiden_integration_test.go
+++ b/backend/internal/compose/captureverdictwiden_integration_test.go
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// A `classified` mailbox holds each message until something judges its sender.
+// These tests are about what happens when something does.
+//
+// Most of the file is refusals, for the same reason widenhistory's tests are:
+// the release itself is one statement, and what makes it safe is everything it
+// declines to publish — a sender judged real but not a person, a mailbox that
+// asked to hold everything, a thread a confidentiality verdict already settled,
+// and a message a second rule held for a reason of its own.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// The defect this whole change is about: a sender the classifier cleared, and
+// mail that stays limited to its participants for good because nothing re-asks
+// a question the ledger already answered.
+func TestARealPersonVerdictReopensTheMailThePostureHeld(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "chi@fvhospital.example"
+	mail := seedCapturedMail(t, e, sender, "FVH | Remaining specialities")
+	seedPostureHeldImport(t, e, mail, e.Rep1)
+	dispositionID := seedPendingDisposition(t, e, sender, "fvhospital.example", mail)
+
+	if got, reason := audienceAndReason(t, e, mail); got != "participants" || reason != "posture" {
+		t.Fatalf("the mail was born %q / %q, want participants / posture — the fixture is not held at all",
+			got, reason)
+	}
+
+	judgeSenderAs(t, e, dispositionID, capture.KindPerson)
+
+	if got, reason := audienceAndReason(t, e, mail); got != "workspace" || reason != "" {
+		t.Errorf("after its sender was judged a real person the mail is %q / %q, want workspace: "+
+			"a cleared verdict never re-opened the mail it cleared", got, reason)
+	}
+	if posture := importPosture(t, e, mail); posture != "shared" {
+		t.Errorf("the import row still reads %q, want shared: the derivation will re-pin the row "+
+			"to participants on the next recompute", posture)
+	}
+}
+
+// status `real` is not the question. advisor, role_mailbox and
+// organization_sender all settle `real`, and none of them is a person whose
+// mail a posture should stop holding — an advisor's most of all, since that
+// record is deliberately kept to its owner.
+func TestAVerdictThatIsRealButNotAPersonPublishesNothing(t *testing.T) {
+	for _, kind := range []string{capture.KindAdvisor, capture.KindRoleMailbox, capture.KindOrganizationSender} {
+		t.Run(kind, func(t *testing.T) {
+			e := integration.Setup(t)
+			sender := fmt.Sprintf("%s@kanzlei.example", kind)
+			mail := seedCapturedMail(t, e, sender, "Aufhebungsvertrag")
+			seedPostureHeldImport(t, e, mail, e.Rep1)
+			dispositionID := seedPendingDisposition(t, e, sender, "kanzlei.example", mail)
+
+			judgeSenderAs(t, e, dispositionID, kind)
+
+			if got, _ := audienceAndReason(t, e, mail); got != "participants" {
+				t.Errorf("a %s verdict published the mail as %q: the release asked for status "+
+					"alone instead of asking whether a PERSON was behind the address", kind, got)
+			}
+		})
+	}
+}
+
+// Noise settles the sender in the other direction entirely, and its mail is the
+// mail the posture was right about.
+func TestANoiseVerdictLeavesThePostureHeldMailHeld(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "newsletter@versand.example"
+	mail := seedCapturedMail(t, e, sender, "Unser Newsletter")
+	seedPostureHeldImport(t, e, mail, e.Rep1)
+	dispositionID := seedPendingDisposition(t, e, sender, "versand.example", mail)
+
+	judgeSenderAs(t, e, dispositionID, capture.KindNewsletter)
+
+	if got, _ := audienceAndReason(t, e, mail); got != "participants" {
+		t.Errorf("a newsletter verdict published its sender's mail as %q", got)
+	}
+}
+
+// A `held` mailbox promises to hold whatever any classifier concludes. A
+// verdict is an answer to `classified`'s question, not to this one.
+func TestAClearedSenderNeverOpensAHeldMailbox(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "chi@fvhospital.example"
+	mail := seedCapturedMail(t, e, sender, "FVH | Remaining specialities")
+	seedImport(t, e, mail, e.Rep1, "held", nil, []string{"posture"})
+	dispositionID := seedPendingDisposition(t, e, sender, "fvhospital.example", mail)
+
+	judgeSenderAs(t, e, dispositionID, capture.KindPerson)
+
+	if posture := importPosture(t, e, mail); posture != "held" {
+		t.Errorf("the import row moved to %q: a mailbox that asked to hold everything had its "+
+			"posture rewritten by a verdict about one sender", posture)
+	}
+}
+
+// The posture was one of two reasons, so releasing on the posture's own answer
+// would discard the other. The counterparty hold is the seat's separate
+// decision about this correspondent and no verdict speaks for it.
+func TestAClearedSenderDoesNotLiftACounterpartyHold(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "anwalt@studiolegal.example"
+	mail := seedCapturedMail(t, e, sender, "Aufhebungsvertrag")
+	seedImport(t, e, mail, e.Rep1, "classified", nil, []string{"counterparty", "posture"})
+	dispositionID := seedPendingDisposition(t, e, sender, "studiolegal.example", mail)
+
+	judgeSenderAs(t, e, dispositionID, capture.KindPerson)
+
+	if posture := importPosture(t, e, mail); posture != "classified" {
+		t.Errorf("the import row moved to %q: a message a seat's own counterparty hold also caught "+
+			"was released by a verdict that knew nothing about that hold", posture)
+	}
+}
+
+// A confidentiality verdict on the thread is written onto the import row
+// without touching its reasons, so the exact-array match alone would not
+// notice it. The status clause is what refuses.
+func TestAThreadVerdictThatHeldOutranksAClearedSender(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "chi@fvhospital.example"
+	mail := seedCapturedMail(t, e, sender, "Gehaltsanpassung")
+	held := capture.VerdictHeld
+	seedImport(t, e, mail, e.Rep1, "classified", &held, []string{"posture"})
+	dispositionID := seedPendingDisposition(t, e, sender, "fvhospital.example", mail)
+
+	judgeSenderAs(t, e, dispositionID, capture.KindPerson)
+
+	if posture := importPosture(t, e, mail); posture != "classified" {
+		t.Errorf("the import row moved to %q: a thread a confidentiality verdict held was "+
+			"re-opened by a verdict about its sender", posture)
+	}
+}
+
+// A row written before the product recorded more than one reason says only
+// which rule matched first. It is not PROVABLY posture-only, so it is refused
+// rather than guessed at — the same trade widenhistory makes.
+func TestMailCapturedBeforeReasonsWereRecordedStaysHeld(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "chi@fvhospital.example"
+	mail := seedCapturedMail(t, e, sender, "FVH | Remaining specialities")
+	seedImport(t, e, mail, e.Rep1, "classified", nil, nil)
+	dispositionID := seedPendingDisposition(t, e, sender, "fvhospital.example", mail)
+
+	judgeSenderAs(t, e, dispositionID, capture.KindPerson)
+
+	if posture := importPosture(t, e, mail); posture != "classified" {
+		t.Errorf("the import row moved to %q: a row that never recorded its reasons was released "+
+			"as though the posture had been the only one", posture)
+	}
+}
+
+// The reconciling pass reads the ledger directly rather than being told which
+// verdict just landed, so the kind filter has to hold there on its own — this is
+// the only place a non-person `real` verdict can reach the release at all.
+func TestTheReconcilingPassLeavesARealButNonPersonSenderHeld(t *testing.T) {
+	for _, kind := range []string{capture.KindAdvisor, capture.KindRoleMailbox, capture.KindOrganizationSender} {
+		t.Run(kind, func(t *testing.T) {
+			e := integration.Setup(t)
+			sender := fmt.Sprintf("%s@kanzlei.example", kind)
+			mail := seedCapturedMail(t, e, sender, "Aufhebungsvertrag")
+			seedPostureHeldImport(t, e, mail, e.Rep1)
+			dispositionID := seedPendingDisposition(t, e, sender, "kanzlei.example", mail)
+			settleDisposition(t, e, dispositionID, capture.PendingStatusReal, kind)
+
+			engine := NewCounterpartyVerdictEngine(e.Pool, nil, slog.Default())
+			if err := engine.WidenClearedSendersWorkspace(
+				principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
+				t.Fatalf("the reconciling pass: %v", err)
+			}
+
+			if got, _ := audienceAndReason(t, e, mail); got != "participants" {
+				t.Errorf("the pass published a %s sender's mail as %q: its scan asked for status "+
+					"`real` alone, which every one of these kinds satisfies", kind, got)
+			}
+		})
+	}
+}
+
+// The staging shape: a sender judged long before any release existed, whose
+// mail nothing will ever revisit unless a pass goes looking. This is the half
+// that makes the fix reach mail already captured.
+func TestTheVerdictPassDrainsSendersClearedBeforeTheRelease(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "chi@fvhospital.example"
+	mail := seedCapturedMail(t, e, sender, "FVH | Remaining specialities")
+	seedPostureHeldImport(t, e, mail, e.Rep1)
+	dispositionID := seedPendingDisposition(t, e, sender, "fvhospital.example", mail)
+	settleDisposition(t, e, dispositionID, capture.PendingStatusReal, capture.KindPerson)
+
+	engine := NewCounterpartyVerdictEngine(e.Pool, nil, slog.Default())
+	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	if err := engine.WidenClearedSendersWorkspace(wsCtx); err != nil {
+		t.Fatalf("the reconciling pass: %v", err)
+	}
+
+	if got, _ := audienceAndReason(t, e, mail); got != "workspace" {
+		t.Fatalf("mail from a sender cleared before the release existed is still %q: the pass "+
+			"that drains the backlog reached nothing", got)
+	}
+	// Idempotent: a second pass finds the same senders settled and nothing due,
+	// so it must neither fail its own progress check nor move anything.
+	if err := engine.WidenClearedSendersWorkspace(wsCtx); err != nil {
+		t.Errorf("a second reconciling pass over drained senders: %v", err)
+	}
+}
+
+// A sender with more held mail than one pass may spend has to finish on a later
+// tick rather than holding a transaction open for all of it.
+func TestTheReconcilingPassStopsAtItsBudgetAndFinishesOnTheNextTick(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "chi@fvhospital.example"
+	const held = clearedSenderSweepBudget + 5
+	var last ids.UUID
+	for i := range held {
+		last = seedCapturedMail(t, e, sender, fmt.Sprintf("held message %d", i))
+		seedPostureHeldImport(t, e, last, e.Rep1)
+	}
+	dispositionID := seedPendingDisposition(t, e, sender, "fvhospital.example", last)
+	settleDisposition(t, e, dispositionID, capture.PendingStatusReal, capture.KindPerson)
+
+	engine := NewCounterpartyVerdictEngine(e.Pool, nil, slog.Default())
+	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	if err := engine.WidenClearedSendersWorkspace(wsCtx); err != nil {
+		t.Fatalf("the first reconciling pass: %v", err)
+	}
+	if left := stillHeld(t, e, sender); left == 0 {
+		t.Fatalf("one pass released all %d messages: the budget never interrupted the drain, so a "+
+			"large sender spends the whole fleet-wide run", held)
+	}
+	if err := engine.WidenClearedSendersWorkspace(wsCtx); err != nil {
+		t.Fatalf("the second reconciling pass: %v", err)
+	}
+	if left := stillHeld(t, e, sender); left != 0 {
+		t.Errorf("%d messages are still held after a second pass: the drain does not resume where "+
+			"the budget stopped it", left)
+	}
+}
+
+// judgeSenderAs drives the real engine to one scripted answer, so the release is
+// reached the way production reaches it rather than by calling it directly.
+func judgeSenderAs(t *testing.T, e *integration.Env, dispositionID ids.UUID, kind string) {
+	t.Helper()
+	runVerdict(t, e, &scriptedVerdictBrain{verdicts: map[string]string{dispositionID.String(): kind}})
+	if got := dispositionStatus(t, e, dispositionID); got == capture.PendingStatusPending {
+		t.Fatalf("the disposition is still pending: the scripted answer never reached the ledger, " +
+			"so this test asserts about a verdict that was never taken")
+	}
+}
+
+// seedPostureHeldImport writes the import row a `classified` mailbox writes for
+// a message whose sender it has not yet had judged.
+func seedPostureHeldImport(t *testing.T, e *integration.Env, activityID, seat ids.UUID) {
+	t.Helper()
+	seedImport(t, e, activityID, seat, "classified", nil, []string{"posture"})
+}
+
+// seedImport writes one seat's capture_import row and the audience the birth
+// decision would have written alongside it.
+func seedImport(
+	t *testing.T, e *integration.Env, activityID, seat ids.UUID,
+	posture string, verdictStatus *string, reasons []string,
+) {
+	t.Helper()
+	reason := ""
+	if len(reasons) > 0 {
+		reason = reasons[0]
+	}
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_import
+			  (activity_id, user_id, posture_at_import, verdict_status, verdict_reason, verdict_reasons)
+			VALUES ($1, $2, $3, $4, NULLIF($5, ''), $6)`,
+			activityID, seat, posture, verdictStatus, reason, reasons); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(), `
+			UPDATE activity SET audience = 'participants', audience_reason = $2 WHERE id = $1`,
+			activityID, reason)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seeding the import row: %v", err)
+	}
+}
+
+// settleDisposition records a verdict the way a pass on an earlier day would
+// have left it: settled on the ledger, with no release behind it.
+func settleDisposition(t *testing.T, e *integration.Env, id ids.UUID, status, kind string) {
+	t.Helper()
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			UPDATE capture_pending_counterparty
+			   SET status = $2, kind = $3, resolved_at = now()
+			 WHERE id = $1`, id, status, kind)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("settling the disposition: %v", err)
+	}
+}
+
+func audienceAndReason(t *testing.T, e *integration.Env, activityID ids.UUID) (audience, reason string) {
+	t.Helper()
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT audience, coalesce(audience_reason, '') FROM activity WHERE id = $1`,
+			activityID).Scan(&audience, &reason)
+	})
+	if err != nil {
+		t.Fatalf("reading the audience: %v", err)
+	}
+	return audience, reason
+}
+
+func importPosture(t *testing.T, e *integration.Env, activityID ids.UUID) string {
+	t.Helper()
+	var posture string
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT posture_at_import FROM capture_import WHERE activity_id = $1`,
+			activityID).Scan(&posture)
+	})
+	if err != nil {
+		t.Fatalf("reading the import posture: %v", err)
+	}
+	return posture
+}
+
+// stillHeld counts what a further pass would still claim for this sender.
+func stillHeld(t *testing.T, e *integration.Env, sender string) int {
+	t.Helper()
+	return countIn(t, e, `
+		SELECT count(*) FROM capture_import i
+		  JOIN activity a ON a.id = i.activity_id
+		 WHERE a.counterparty_email = $1 AND i.posture_at_import = 'classified'`, sender)
+}

--- a/backend/internal/compose/integration/capture/capture_clearedsender_birth_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_clearedsender_birth_integration_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture
+
+// What a `classified` mailbox does with mail from a sender it has ALREADY had
+// judged.
+//
+// The release that re-opens held mail answers the messages that arrived before
+// the verdict. This is the other half: once the question is settled, the next
+// message from that sender must not be held for it again — nothing re-asks a
+// question the ledger considers answered, so a message held here stays held for
+// good.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	capturemod "github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestMailCapturedAfterAClearedVerdictIsBornOpen(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+	setPosture(t, env, e.Rep1, capturemod.PostureClassified)
+	clearSender(t, e, "chi@fvhospital.example")
+
+	sync(t, email("chi@fvhospital.example", "Chi Phan", captureOwner,
+		"cleared-1@fvhospital.example", ""))
+
+	activityID := newestActivityID(t, e)
+	if got, reason := audienceOf(t, e, activityID); got != "workspace" || reason != "" {
+		t.Errorf("mail from a sender already judged a real person was born %q / %q, want workspace: "+
+			"the mailbox held it for a question that has an answer, and nothing re-asks it",
+			got, reason)
+	}
+}
+
+// The rung only substitutes the mailbox's own posture. Everything stricter ran
+// before it and still decides: a seat's counterparty hold is their decision
+// about this correspondent, and no verdict about the sender speaks for it.
+func TestAClearedSenderIsStillHeldByThisSeatsOwnHold(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+	setPosture(t, env, e.Rep1, capturemod.PostureClassified)
+	clearSender(t, e, "anwalt@studiolegal.example")
+	holdCounterparty(t, e, e.Rep1, capturemod.HoldKindDomain, "studiolegal.example")
+
+	sync(t, email("anwalt@studiolegal.example", "Dr. Legal", captureOwner,
+		"cleared-2@studiolegal.example", ""))
+
+	activityID := newestActivityID(t, e)
+	if got, reason := audienceOf(t, e, activityID); got != "participants" || reason != "counterparty" {
+		t.Errorf("a message under this seat's own counterparty hold was born %q / %q, want "+
+			"participants / counterparty: a verdict about the sender overrode a hold that was "+
+			"never about the verdict", got, reason)
+	}
+}
+
+// A sender judged real but not a PERSON leaves the question the posture asked
+// unanswered — an advisor's record is deliberately kept to its owner, and their
+// mail is exactly the mail a classified mailbox means to hold.
+func TestAnAdvisorVerdictDoesNotOpenTheNextMessage(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+	setPosture(t, env, e.Rep1, capturemod.PostureClassified)
+	settleSender(t, e, "anwalt@kanzlei.example", capturemod.PendingStatusReal, capturemod.KindAdvisor)
+
+	sync(t, email("anwalt@kanzlei.example", "Dr. Legal", captureOwner,
+		"cleared-3@kanzlei.example", ""))
+
+	activityID := newestActivityID(t, e)
+	if got, _ := audienceOf(t, e, activityID); got != "participants" {
+		t.Errorf("mail from an advisor was born %q: the rung asked for status alone rather than "+
+			"whether a person was behind the address", got)
+	}
+}
+
+// clearSender records the settled verdict that a real person is behind this
+// address, which is what the birth ladder reads.
+func clearSender(t *testing.T, e *integration.SearchEnv, email string) {
+	t.Helper()
+	settleSender(t, e, email, capturemod.PendingStatusReal, capturemod.KindPerson)
+}
+
+// settleSender writes one settled ledger row, against the earlier message that
+// raised the question. Written directly because what the scenario needs is the
+// ledger state a verdict pass leaves behind, and driving the classifier would
+// test the classifier instead.
+func settleSender(t *testing.T, e *integration.SearchEnv, email, status, kind string) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		// The ledger row names the message that first asked about this sender,
+		// so one has to exist for it to point at.
+		asked := ids.NewV7()
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, body, direction, source_system, source_id,
+			                      source, captured_by, counterparty_email)
+			VALUES ($1, 'email', 'the message that asked', 'body', 'inbound', 'gmail', $2,
+			        'gmail:'||$2, 'connector:gmail', $3)`,
+			asked, "asked-"+asked.String(), email); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_pending_counterparty
+			  (id, email, domain, display_name, activity_id, owner_id, status, kind, resolved_at)
+			VALUES ($1, $2, split_part($2, '@', 2), 'Settled Sender', $3, $4, $5, $6, now())`,
+			ids.NewV7(), email, asked, e.Rep1, status, kind)
+		return err
+	}); err != nil {
+		t.Fatalf("settling the sender's verdict: %v", err)
+	}
+}

--- a/backend/internal/modules/capture/birthdecision.go
+++ b/backend/internal/modules/capture/birthdecision.go
@@ -227,6 +227,23 @@ func decideBirthTx(
 	if err != nil {
 		return birthDecision{}, err
 	}
+	if posture == PostureClassified {
+		// `classified` holds a message until something judges its sender, and for
+		// this sender something already has. Holding it anyway would record a
+		// question that is answered — and nothing later re-asks it, so the message
+		// would stay limited for good.
+		//
+		// Only this rung is affected. Steps 1 to 4 have already run and any hold
+		// they placed survives, because they set decision.posture and this does
+		// not clear it.
+		cleared, err := senderClearedPersonTx(ctx, tx, rec.Counterparty.Email)
+		if err != nil {
+			return birthDecision{}, err
+		}
+		if cleared {
+			posture = PostureShared
+		}
+	}
 	if posture != PostureShared {
 		// The mailbox's own standing answer, recorded even when something
 		// stricter already decided. It outlives any one counterparty hold, so a

--- a/backend/internal/modules/capture/widenclearedsender.go
+++ b/backend/internal/modules/capture/widenclearedsender.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -55,6 +56,13 @@ const clearedSenderBatch = 500
 //     is not ours to move. That verdict is written onto the import row without
 //     touching verdict_reasons, so the exact-array clause below does NOT imply
 //     it stayed silent.
+//   - and no HOLDING verdict on the thread itself, asked of that ledger rather
+//     than of the import row. The row's own status is not proof the thread has
+//     none: stamping a settled verdict onto a thread's siblings is bounded per
+//     transaction, so a long thread keeps unstamped rows reading NULL for as
+//     long as the repair takes. Those rows are exactly the mail a seat's
+//     confidentiality verdict just held, and the pass that would eventually
+//     stamp them arrives after this one would have published them.
 //   - verdict_reasons = ARRAY['posture'] — EXACT match, the same argument
 //     widenDue makes: a message held by the posture AND anything else records
 //     both, and releasing it would discard the other reason. A row written
@@ -73,6 +81,10 @@ const clearedSenderWidenDue = `EXISTS (
 			 WHERE p.email = $1 AND p.status = 'real' AND p.kind = 'person')
 	   AND i.posture_at_import = 'classified'
 	   AND i.verdict_status IS NULL
+	   AND NOT EXISTS (
+			SELECT 1 FROM capture_thread_verdict v
+			 WHERE v.thread_key = a.thread_key AND v.user_id = i.user_id
+			   AND v.status IN ('held', 'unsure', 'held_by_owner', 'pending'))
 	   AND i.verdict_reasons = ARRAY['posture']
 	   AND a.counterparty_email = $1
 	   AND a.restricted_at IS NULL`
@@ -164,19 +176,18 @@ func sortActivityIDs(list []ids.ActivityID) {
 //
 // Senders rather than rows: the widen claims per sender, and asking for the work
 // this way lets each one take its own transaction.
+//
+// It asks the SAME predicate the claim asks, with the sender's own address
+// substituted for the parameter, because a selector that admits what the writer
+// refuses never drains: the pass would find the sender every tick, move nothing,
+// and its progress check would fail a run that had no work to do. Spelling the
+// clauses again here is what would let the two drift apart.
 func ClearedSendersDueTx(ctx context.Context, tx pgx.Tx, limit int) ([]string, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT DISTINCT a.counterparty_email
 		  FROM capture_import i
 		  JOIN activity a ON a.id = i.activity_id
-		 WHERE EXISTS (
-		           SELECT 1 FROM capture_pending_counterparty p
-		            WHERE p.email = a.counterparty_email
-		              AND p.status = 'real' AND p.kind = 'person')
-		   AND i.posture_at_import = 'classified'
-		   AND i.verdict_status IS NULL
-		   AND i.verdict_reasons = ARRAY['posture']
-		   AND a.restricted_at IS NULL
+		 WHERE `+strings.ReplaceAll(clearedSenderWidenDue, "$1", "a.counterparty_email")+`
 		 ORDER BY a.counterparty_email
 		 LIMIT $1`, limit)
 	if err != nil {

--- a/backend/internal/modules/capture/widenclearedsender.go
+++ b/backend/internal/modules/capture/widenclearedsender.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// Re-opening the mail a mailbox held while it waited for a verdict on the sender.
+//
+// A `classified` mailbox asks one question of every message: who is this from?
+// Until something answers, the message is held on the posture. When the verdict
+// answers "a real person", the question the hold was waiting for is settled, and
+// the mail it held has no remaining reason to stay limited.
+//
+// widenhistory.go re-opens what a SEAT's counterparty hold caught; this re-opens
+// what a POSTURE held about one SENDER. The shapes are deliberately the same —
+// exact-array predicate, bounded batches, progress-proving loop — because both
+// are widening in a derivation that is otherwise tighten-only, and both must
+// prove they release only what they are entitled to.
+//
+// No hold-clearing seam here, unlike widenhistory.go: 'posture' is not one of the
+// reasons activities carries on the row itself (rowCarriedHold reads only
+// no_record, no_counterparty, workspace_floor, counterparty and
+// explicitly_confidential), so rewriting the import rows is enough for the
+// recompute to reach a new answer.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// clearedSenderBatch bounds the statement, matching widenBatch.
+const clearedSenderBatch = 500
+
+// clearedSenderWidenDue is which import rows a settled real/person verdict may
+// re-open, and it is the whole safety property of this file.
+//
+// The ledger clause is FIRST and is not optional. A caller cannot establish
+// real/person by having just written it: createCounterparty answers nil after
+// correcting its own resolution to `suppressed`, and a review acceptance can
+// update no row at all. So the entitlement is re-read here, inside the same
+// statement that claims the rows, and every caller inherits it.
+//
+//   - a settled ledger row, status 'real' AND kind 'person' — never status
+//     alone. advisor, role_mailbox and organization_sender are all 'real' and
+//     none of them is a person whose mail a posture should stop holding.
+//   - posture_at_import = 'classified' — never 'held'. A held mailbox promises
+//     to hold whatever any classifier concludes, so a verdict is not an answer
+//     to it; 'classified' is the posture that was waiting for exactly this.
+//   - verdict_status IS NULL — a thread confidentiality verdict that has spoken
+//     is not ours to move. That verdict is written onto the import row without
+//     touching verdict_reasons, so the exact-array clause below does NOT imply
+//     it stayed silent.
+//   - verdict_reasons = ARRAY['posture'] — EXACT match, the same argument
+//     widenDue makes: a message held by the posture AND anything else records
+//     both, and releasing it would discard the other reason. A row written
+//     before verdict_reasons existed has NULL and matches nothing, so
+//     pre-migration mail is not re-opened in bulk rather than guessed at.
+//   - the activity's own counterparty_email — the sender the ledger row is
+//     about, in the one normalization both tables share.
+//
+// What it therefore leaves held, deliberately: a message whose stored
+// counterparty is a colleague or the owner's own alias, because the ladder
+// substituted an external recipient when it asked the verdict question. Those
+// rows are not provably about this sender, and matching any cleared participant
+// instead would release mail on the strength of somebody else's clearance.
+const clearedSenderWidenDue = `EXISTS (
+			SELECT 1 FROM capture_pending_counterparty p
+			 WHERE p.email = $1 AND p.status = 'real' AND p.kind = 'person')
+	   AND i.posture_at_import = 'classified'
+	   AND i.verdict_status IS NULL
+	   AND i.verdict_reasons = ARRAY['posture']
+	   AND a.counterparty_email = $1
+	   AND a.restricted_at IS NULL`
+
+// ClearedSenderRemainingTx counts what a further pass would still claim, so a
+// caller can prove each pass made progress rather than trusting that it did.
+func ClearedSenderRemainingTx(ctx context.Context, tx pgx.Tx, email string) (int, error) {
+	var n int
+	err := tx.QueryRow(ctx, `
+		SELECT count(*)
+		  FROM capture_import i
+		  JOIN activity a ON a.id = i.activity_id
+		 WHERE `+clearedSenderWidenDue, normalizeEmail(email)).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("capture: counting the mail a cleared sender's verdict re-opens: %w", err)
+	}
+	return n, nil
+}
+
+// WidenClearedSenderTx re-opens one bounded batch of the mail a posture held
+// about this sender, and answers how many rows it moved. The caller loops until
+// it answers zero, or until its own budget runs out.
+//
+// limit is the caller's remaining budget rather than a constant, because the
+// budget has to interrupt the drain itself: a single sender with thousands of
+// held messages would otherwise hold one transaction open for all of them, and a
+// cap checked only between senders would never fire.
+func WidenClearedSenderTx(
+	ctx context.Context, tx pgx.Tx, email string, limit int, recompute AudienceRecomputer,
+) (int, error) {
+	if limit <= 0 {
+		return 0, nil
+	}
+	if limit > clearedSenderBatch {
+		limit = clearedSenderBatch
+	}
+	rows, err := tx.Query(ctx, `
+		WITH due AS (
+			SELECT i.id
+			  FROM capture_import i
+			  JOIN activity a ON a.id = i.activity_id
+			 WHERE `+clearedSenderWidenDue+`
+			 ORDER BY i.id
+			 LIMIT $2
+			 FOR UPDATE OF i SKIP LOCKED
+		)
+		UPDATE capture_import i
+		   SET posture_at_import = 'shared',
+		       verdict_reason = NULL,
+		       verdict_reasons = NULL
+		  FROM due
+		 WHERE i.id = due.id
+		RETURNING i.activity_id`, normalizeEmail(email), limit)
+	if err != nil {
+		return 0, fmt.Errorf("capture: claiming the import rows a cleared sender re-opens: %w", err)
+	}
+	var touched []ids.ActivityID
+	for rows.Next() {
+		var id ids.ActivityID
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("capture: reading a claimed import row: %w", err)
+		}
+		touched = append(touched, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("capture: claiming the import rows a cleared sender re-opens: %w", err)
+	}
+	// Sorted before recomputing, because the recompute takes FOR UPDATE on each
+	// activity in turn. Two passes claiming different seats' import rows for an
+	// overlapping set of activities would otherwise take those row locks in
+	// whatever order each UPDATE returned them, which is a deadlock the import
+	// rows' own SKIP LOCKED cannot prevent. One agreed order removes it.
+	sortActivityIDs(touched)
+	return len(touched), recomputeEach(ctx, tx, touched, recompute)
+}
+
+// sortActivityIDs puts a claimed batch into one agreed order before anything
+// locks the rows it names.
+func sortActivityIDs(list []ids.ActivityID) {
+	slices.SortFunc(list, func(a, b ids.ActivityID) int {
+		return bytes.Compare(a.UUID[:], b.UUID[:])
+	})
+}
+
+// ClearedSendersDueTx names the settled senders that still have mail a posture
+// is holding, so a reconciling pass can drain what the live path missed.
+//
+// Senders rather than rows: the widen claims per sender, and asking for the work
+// this way lets each one take its own transaction.
+func ClearedSendersDueTx(ctx context.Context, tx pgx.Tx, limit int) ([]string, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT DISTINCT a.counterparty_email
+		  FROM capture_import i
+		  JOIN activity a ON a.id = i.activity_id
+		 WHERE EXISTS (
+		           SELECT 1 FROM capture_pending_counterparty p
+		            WHERE p.email = a.counterparty_email
+		              AND p.status = 'real' AND p.kind = 'person')
+		   AND i.posture_at_import = 'classified'
+		   AND i.verdict_status IS NULL
+		   AND i.verdict_reasons = ARRAY['posture']
+		   AND a.restricted_at IS NULL
+		 ORDER BY a.counterparty_email
+		 LIMIT $1`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("capture: reading the senders whose cleared mail is still held: %w", err)
+	}
+	defer rows.Close()
+	var senders []string
+	for rows.Next() {
+		var email string
+		if err := rows.Scan(&email); err != nil {
+			return nil, fmt.Errorf("capture: reading a sender whose cleared mail is still held: %w", err)
+		}
+		senders = append(senders, email)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("capture: reading the senders whose cleared mail is still held: %w", err)
+	}
+	return senders, nil
+}
+
+// WidenClearedSenderAll drains this sender within the caller's budget, proving
+// progress on every pass.
+//
+// The progress check is the same one widenAll makes, and for the same reason:
+// the loop terminates only while the predicate excludes what the statement
+// writes, and a predicate that stopped doing so would spin here holding this
+// transaction's locks. Every pass must leave strictly fewer rows due than the
+// one before.
+func WidenClearedSenderAll(
+	ctx context.Context, tx pgx.Tx, email string, budget int, recompute AudienceRecomputer,
+) (int, error) {
+	total, remaining := 0, -1
+	for total < budget {
+		moved, err := WidenClearedSenderTx(ctx, tx, email, budget-total, recompute)
+		if err != nil {
+			return 0, err
+		}
+		if moved == 0 {
+			return total, nil
+		}
+		total += moved
+		left, err := ClearedSenderRemainingTx(ctx, tx, email)
+		if err != nil {
+			return 0, err
+		}
+		if remaining >= 0 && left >= remaining {
+			return 0, fmt.Errorf(
+				"capture: re-opening a cleared sender's mail made no progress: %d rows still due after a pass that moved %d",
+				left, moved)
+		}
+		remaining = left
+	}
+	return total, nil
+}
+
+// senderClearedPersonTx answers whether this address already has a settled
+// verdict saying it is a real person.
+//
+// Deliberately narrower than the disposition lookup the sink makes when it
+// decides whether to CREATE a contact: that one also counts an existing person
+// record as evidence, and a person record can exist for reasons that never
+// judged the sender. Opening a mailbox's held mail is a disclosure, so it asks
+// only for the verdict itself.
+func senderClearedPersonTx(ctx context.Context, tx pgx.Tx, email string) (bool, error) {
+	folded := normalizeEmail(email)
+	if folded == "" {
+		return false, nil
+	}
+	var cleared bool
+	err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM capture_pending_counterparty
+			 WHERE email = $1 AND status = 'real' AND kind = 'person')`,
+		folded).Scan(&cleared)
+	if err != nil {
+		return false, fmt.Errorf("capture: reading whether this sender is already judged a person: %w", err)
+	}
+	return cleared, nil
+}

--- a/backend/internal/modules/people/agentcreatevisibility_integration_test.go
+++ b/backend/internal/modules/people/agentcreatevisibility_integration_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// Who can see a contact an AGENT typed in.
+//
+// A create through the tool surface reaches the same store method the UI and
+// the REST API reach, so the only thing that ever distinguished them was the
+// principal behind the call. It used to: an agent-created contact was born
+// owner-scoped and no colleague could see it, which reads to the person who
+// asked for it as the contact simply not being there.
+//
+// The capture paths are the ones that still mint owner-scoped contacts, and
+// they say so on the spec rather than being inferred from who is acting.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestAContactAnAgentCreatesBelongsToTheWorkspace(t *testing.T) {
+	e := setupCapturePrivacy(t)
+
+	created, err := e.store.CreatePerson(e.asAgent(e.owner), CreatePersonInput{
+		FullName: "Lucy Vo",
+		Emails:   []PersonEmailInput{{Email: "lucy.vo@kunde.example", EmailType: "work", IsPrimary: true}},
+		Source:   "manual",
+	})
+	if err != nil {
+		t.Fatalf("creating a person as an agent: %v", err)
+	}
+
+	if got := e.visibilityOf(t, ids.From[ids.PersonKind](ids.UUID(created.Id))); got != visibilityWorkspace {
+		t.Errorf("a contact an agent created is %q, want workspace: the rep was told it exists "+
+			"and no colleague can see it, which is indistinguishable from it never being created",
+			got)
+	}
+}
+
+// The control beside it. A human create was always `workspace`, and the point
+// of the change is that the two doors now agree — so a test that only checked
+// the agent could pass against a store that published nothing at all.
+func TestAContactAHumanCreatesBelongsToTheWorkspace(t *testing.T) {
+	e := setupCapturePrivacy(t)
+
+	created, err := e.store.CreatePerson(e.as(e.owner, principal.RowScopeAll), CreatePersonInput{
+		FullName: "Marta Kern",
+		Emails:   []PersonEmailInput{{Email: "marta.kern@kunde.example", EmailType: "work", IsPrimary: true}},
+		Source:   "manual",
+	})
+	if err != nil {
+		t.Fatalf("creating a person as a human: %v", err)
+	}
+
+	if got := e.visibilityOf(t, ids.From[ids.PersonKind](ids.UUID(created.Id))); got != visibilityWorkspace {
+		t.Errorf("a contact a human created is %q, want workspace", got)
+	}
+}
+
+// A capture path still keeps its contact to the mailbox owner, and it does so
+// by SAYING so — the spec carries OwnerScoped, so the privacy survives an
+// actor-type rule going away.
+func TestACapturedContactIsStillTheMailboxOwnersAlone(t *testing.T) {
+	e := setupCapturePrivacy(t)
+	ctx := e.as(e.owner, principal.RowScopeAll)
+
+	var id ids.PersonID
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		owner := ids.From[ids.UserKind](e.owner)
+		id, err = createPerson(ctx, tx, PersonResolution{Decision: DecisionNoMatch}, PersonSpec{
+			FullName: "Unjudged Sender",
+			// An owner-scoped row names its owner, or it is readable by nobody
+			// at all — the database refuses the pair outright.
+			Visibility: visibilityFor(true),
+			OwnerID:    &owner,
+			Source:     "capture",
+			CapturedBy: "connector:gmail",
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("minting an owner-scoped capture contact: %v", err)
+	}
+
+	if got := e.visibilityOf(t, id); got != visibilityOwner {
+		t.Errorf("a capture-minted contact is %q, want owner: a mailbox with a year of history "+
+			"names correspondents the workspace has no business reading", got)
+	}
+}
+
+// asAgent is `as` with the principal a tool call arrives under: an agent acting
+// on one human's behalf, carrying that human's own grants.
+func (e *privacyEnv) asAgent(user ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:tools", UserID: user, OnBehalfOf: user,
+		TeamIDs: []ids.UUID{e.team},
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				"person": {Create: true, Read: true, Update: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}


### PR DESCRIPTION
Closes #5009.

A `classified` mailbox holds each message until something judges its sender. When the counterparty verdict answered "a real person", nothing revisited the mail that hold had caught, and nothing consulted the answer on the way in either. On staging that is 246 messages from senders the classifier cleared, still limited to their participants, permanently — 198 of them one client's.

## What changed

**A release.** `capture/widenclearedsender.go`, shaped after the counterparty hold's own widening in `widenhistory.go`: bounded batches, a progress-proving drain, and an exact `ARRAY['posture']` match so only mail the posture ALONE held is re-opened. Claimed ids are sorted before the recompute, because that takes a row lock per activity and two passes claiming different seats' import rows for overlapping activities would otherwise lock them in opposite orders.

**The entitlement is re-read inside the claiming statement**, not passed in. `createCounterparty` answers nil after correcting its own resolution to `suppressed`, and `ResolveReviewedAs` can update no row at all, so "the caller just wrote real/person" is not something a release may believe.

**Two live hooks** — the machine verdict's `KindPerson` arm and the review queue's accept — each bounded at 100 so a large backlog never shares a transaction with a ledger resolution and a person record. **A reconciling stage** on the verdict pass drains the rest; that stage is also what reaches every sender judged before any of this existed, so the existing backlog needs no migration.

**A rung in the birth ladder**, inside the posture step rather than before it, so the workspace floor, a counterparty hold, a confidential marker and an inherited thread verdict all still decide first.

## What it refuses

Each refusal has a test that fails when its clause is reverted (mutation-checked one clause at a time):

| Refused | Clause |
| --- | --- |
| a `held` mailbox | `posture_at_import = 'classified'` |
| a thread verdict that spoke | `verdict_status IS NULL` |
| a seat's own counterparty hold | exact `ARRAY['posture']` |
| a row that never recorded its reasons | same, NULL matches nothing |
| advisor, role_mailbox, organization_sender | `kind = 'person'`, never status alone |

The last one is the sharpest: all three settle status `real`, and an advisor's record is deliberately kept to its owner.

## Deliberately left held

Mail whose stored `counterparty_email` is a colleague or the owner's alias, because the ladder substituted an external recipient when it asked the verdict question. Those rows are not provably about the cleared sender, and matching any cleared participant instead would release mail on the strength of somebody else's clearance.

## Tests

11 new integration tests across `internal/compose` and `internal/compose/integration/capture`, including the backfill drain, its idempotent second run, and a sender larger than one pass's budget finishing on the next tick. Full `internal/compose` and `internal/compose/integration/capture` lanes green.

## Note on the gate

`make check-backend` fails on `origin/main` itself, on `TestEveryRawReaderOfTheSettingTableCarriesAVerdict` (an unratified raw setting read in `people/leadsla.go`, arrived with the lead-SLA work). Reproduced on a pristine worktree of `origin/main`; filed as #5030. Every other leg is green here, including all four craft roots, arch-lint, rls-store-path and the file-length cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #5009. A `classified` mailbox holds mail until its sender is judged, but a "real person" verdict never re-opened the held mail, and new mail from cleared senders was born held. Now mail held only by the posture is re-opened on clearance, and new mail from already-cleared senders is born open.

**What changed**
- The verdict and review-queue accept each release a bounded batch (100); a reconciling pass on the verdict tick drains the rest.
- The pass also reaches senders judged before this existed, so the existing backlog needs no migration.
- The birth ladder checks the settled verdict inside the posture step, so stricter holds still decide first.
- The release re-reads the ledger inside the claiming statement, so a caller cannot widen by asserting a verdict it did not durably record.
- The release asks the thread's own verdict ledger rather than the row's status, and the reconciling pass's sender scan asks the claim's own predicate.
- Adds 11 integration tests covering the release, its refusals, the backfill, idempotency, and budget resumption.

**What stays held**
- Only rows where the posture alone held the mail are re-opened: `posture_at_import = 'classified'`, `verdict_status IS NULL`, exact `ARRAY['posture']` reasons, and a ledger entry with status `real` AND kind `person`.
- `held` mailboxes, a seat's own counterparty hold, pre-reason rows, and non-person `real` kinds (`advisor`, `role_mailbox`, `organization_sender`) stay held.
- Mail on a thread the seat held stays held even when its row reads no verdict, since a held verdict's stamps can lag a long thread.
- Mail whose stored counterparty is a colleague or the owner's alias stays held, since it is not provably about the cleared sender.

Note: `make check-backend` fails on `origin/main` itself (`TestEveryRawReaderOfTheSettingTableCarriesAVerdict`, filed as #5030); all other checks are green.

<sup>Written for commit c094c43d6f694e2fe9fc88360e26965984cbe958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mail previously held while awaiting a sender verdict is now released when the sender is confirmed as a real person.
  - Existing held mail is reconciled automatically, and future messages from cleared senders can enter the workspace directly.
  - Other protections—including counterparty, confidentiality, thread, and non-person verdict holds—remain enforced.
  - Processing is performed in bounded batches to support reliable background reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->