### PR TITLE
fix(deals): the sweep writes only what changed, and never calls a guess final

### DIFF
--- a/backend/internal/compose/closedate_integration_test.go
+++ b/backend/internal/compose/closedate_integration_test.go
@@ -248,7 +248,7 @@ func TestForecastExcludesFlaggedDealsFromCommitAndBestCase(t *testing.T) {
 
 // --- B-E09.20: the A6 tiers ---
 
-func TestCloseDateSweepAutoRollsClearOverdueActiveDeal(t *testing.T) {
+func TestCloseDateSweepRollsClearOverdueActiveDealProvisionally(t *testing.T) {
 	e := setupCloseDate(t)
 	// Early stage (20%), plainly overdue, touched 3 days ago, no forecast
 	// override → the §11 worked example's 🟢 case. Two open stages remain
@@ -264,11 +264,17 @@ func TestCloseDateSweepAutoRollsClearOverdueActiveDeal(t *testing.T) {
 	if swept.expectedClose == nil || !swept.expectedClose.Equal(want) {
 		t.Errorf("auto-rolled date = %v, want %s (2 stages × 14-day fallback)", swept.expectedClose, want.Format(time.DateOnly))
 	}
-	if swept.provisional {
-		t.Error("🟢 auto-apply is final — the date must not be provisional")
+	// The rolled date is a stage-velocity estimate, so it lands PROVISIONAL
+	// and asks. The 🟢 tier buys promptness — the deal stops claiming a date
+	// that has passed, tonight, without waiting for a human — not the claim
+	// that a buyer agreed to the replacement. Nothing on this path read a
+	// buyer's message, and a date nobody confirmed must not enter supported
+	// forecast claims looking confirmed.
+	if !swept.provisional {
+		t.Error("the auto-rolled date is a velocity estimate — it must be provisional")
 	}
-	if got := e.pendingCorrections(t, id); got != 0 {
-		t.Errorf("🟢 tier staged %d approvals, want none (the rep is informed, not asked)", got)
+	if got := e.pendingCorrections(t, id); got != 1 {
+		t.Errorf("🟢 tier staged %d approvals, want 1 — an estimate is confirmed, not announced", got)
 	}
 
 	// Reversibility: the audit row carries the exact before/after images.

--- a/backend/internal/modules/deals/closedate.go
+++ b/backend/internal/modules/deals/closedate.go
@@ -24,8 +24,15 @@ const (
 	// CloseDateMinHistory is CLOSE_DATE_MIN_HISTORY: won deals required
 	// before the workspace's observed stage velocity outranks the fallback.
 	CloseDateMinHistory = 20
-	// CloseDateAutoApplyEnabled is CLOSE_DATE_AUTOAPPLY, the master enable
-	// for the 🟢 tier; off routes every correction 🟡 provisional-confirm.
+	// CloseDateAutoApplyEnabled is CLOSE_DATE_AUTOAPPLY, which selects whether
+	// a clearly-overdue early-stage date is replaced on the spot (🟢) or left
+	// for the human to correct on the 🟡 card.
+	//
+	// It no longer decides whether the replacement is FINAL. Both tiers write a
+	// provisional date and raise the confirm, because both write the same
+	// stage-velocity estimate — see CloseDateActionAutoApply in the sweep. The
+	// operational stop is deals.MaintenanceWritesEnabled, which is a live
+	// setting rather than this compile-time constant.
 	CloseDateAutoApplyEnabled = true
 
 	// unrealisticSoonMaxProb bounds the §11 unrealistic_soon flag: at or
@@ -147,10 +154,13 @@ func CloseDateAssessment(in CloseDateInput, now time.Time, workspaceTZ *time.Loc
 	out.ProposedClose = &proposed
 	out.Action = closeDateAction(findings, in, CloseDateAutoApplyEnabled)
 	out.Downgrade = out.Action == CloseDateActionDowngradeAndReview
-	// A 🟡 date is a guess by definition; a 🔻 deal only gets a guessed
-	// date when the invariant forces one (past or missing) — it is never
-	// re-dated optimistically on top of the downgrade.
+	// Every date this assessment proposes is a guess: proposedCloseDate reads
+	// stage velocity, never a buyer's message. So 🟢 and 🟡 are both
+	// provisional, and a 🔻 deal gets one only where the invariant forces a
+	// date (past or missing) — it is never re-dated optimistically on top of
+	// the downgrade.
 	out.Provisional = out.Action == CloseDateActionProvisionalConfirm ||
+		out.Action == CloseDateActionAutoApply ||
 		(out.Downgrade && (findings.overdue || findings.missing))
 	return out
 }

--- a/backend/internal/modules/deals/closedate_test.go
+++ b/backend/internal/modules/deals/closedate_test.go
@@ -9,6 +9,8 @@ package deals
 import (
 	"testing"
 	"time"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 )
 
 // closeClock is noon UTC so the workspace-zone date is unambiguous.
@@ -113,9 +115,11 @@ func TestCloseDateActionTiers(t *testing.T) {
 		wantDowngrade   bool
 	}{
 		// §11 worked example: early-stage, clear-overdue, active, outside
-		// the forecast → the agent rolls the date, final.
-		{"clear overdue on an active low-stakes deal auto-applies",
-			activeDeal(datep(-12)), CloseDateActionAutoApply, false, false},
+		// the forecast → the agent rolls the date at once rather than
+		// leaving it for a human. PROVISIONAL, because what it rolls to is
+		// a stage-velocity estimate: 🟢 buys promptness, never the claim
+		// that a buyer agreed to the replacement.
+		{"clear overdue auto-applies provisionally", activeDeal(datep(-12)), CloseDateActionAutoApply, true, false},
 		{"forecast-bearing overdue goes provisional",
 			commit(activeDeal(datep(-12))), CloseDateActionProvisionalConfirm, true, false},
 		{"late stage overdue goes provisional", func() CloseDateInput {
@@ -258,5 +262,38 @@ func TestOverdueIsAskedInTheInstallationsZone(t *testing.T) {
 	tomorrow := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
 	if CloseIsOverdue(tomorrow, now, saigon) {
 		t.Error("a deal expected on the 24th is overdue on the 24th in Saigon")
+	}
+}
+
+// The 🔻 branch used to assign the notched category unconditionally. Since
+// forecastDowngrade floors at "omitted", a deal already sitting there was
+// assigned "omitted" again every night it stayed quiet — and storekit.Patch
+// records an assignment without comparing it, so that non-empty patch became
+// a real audit row and a real deal.updated event for a change that never
+// happened. Thirty-two of forty such rows in one installation were identical
+// before/after images.
+func TestAnUnchangedForecastCategoryIsNotWritten(t *testing.T) {
+	omitted := "omitted"
+	cases := []struct {
+		name      string
+		stored    *string
+		effective string
+		notched   string
+		wantWrite bool
+	}{
+		{"already at the floor, stored explicitly", &omitted, "omitted", "omitted", false},
+		// The nullable column is why the comparison is against the EFFECTIVE
+		// category: this deal carries no override, its probability already
+		// reads omitted, and writing "omitted" into the NULL changes nothing
+		// a reader can see. Comparing the raw NULL would call it a move.
+		{"already at the floor, derived from probability", nil, "omitted", "omitted", false},
+		{"a real notch down still writes", &omitted, "pipeline", "omitted", true},
+	}
+	for _, c := range cases {
+		p := storekit.NewPatch()
+		setForecastCategory(p, c.stored, c.effective, c.notched)
+		if p.Empty() == c.wantWrite {
+			t.Errorf("%s: patch empty = %v, want a write = %v", c.name, p.Empty(), c.wantWrite)
+		}
 	}
 }

--- a/backend/internal/modules/deals/closedate_test.go
+++ b/backend/internal/modules/deals/closedate_test.go
@@ -273,25 +273,32 @@ func TestOverdueIsAskedInTheInstallationsZone(t *testing.T) {
 // happened. Thirty-two of forty such rows in one installation were identical
 // before/after images.
 func TestAnUnchangedForecastCategoryIsNotWritten(t *testing.T) {
-	omitted := "omitted"
+	omitted, pipeline := "omitted", "pipeline"
+	// Below every forecast threshold, so a deal with no override derives
+	// "pipeline" — the state a first downgrade actually moves away from.
+	const lowStageWinProbability = 20
 	cases := []struct {
 		name      string
 		stored    *string
-		effective string
 		notched   string
 		wantWrite bool
 	}{
-		{"already at the floor, stored explicitly", &omitted, "omitted", "omitted", false},
-		// The nullable column is why the comparison is against the EFFECTIVE
-		// category: this deal carries no override, its probability already
-		// reads omitted, and writing "omitted" into the NULL changes nothing
-		// a reader can see. Comparing the raw NULL would call it a move.
-		{"already at the floor, derived from probability", nil, "omitted", "omitted", false},
-		{"a real notch down still writes", &omitted, "pipeline", "omitted", true},
+		// The floor case, and the one that wrote a row every night: an
+		// explicitly-omitted deal notches to omitted, which is where it
+		// already is.
+		{"already at the floor", &omitted, "omitted", false},
+		// A deal carrying no override sits at the probability-derived
+		// default, so the first notch down is a real move and must write.
+		{"no override, first notch down", nil, "omitted", true},
+		{"a real notch down still writes", &pipeline, "omitted", true},
 	}
 	for _, c := range cases {
+		// Derive the effective category the way the sweep does rather than
+		// stating it: a hand-written pair can describe a deal
+		// effectiveForecastCategory would never produce.
+		effective := effectiveForecastCategory(c.stored, lowStageWinProbability)
 		p := storekit.NewPatch()
-		setForecastCategory(p, c.stored, c.effective, c.notched)
+		setForecastCategory(p, c.stored, effective, c.notched)
 		if p.Empty() == c.wantWrite {
 			t.Errorf("%s: patch empty = %v, want a write = %v", c.name, p.Empty(), c.wantWrite)
 		}

--- a/backend/internal/modules/deals/closedatecorrect.go
+++ b/backend/internal/modules/deals/closedatecorrect.go
@@ -96,10 +96,11 @@ func setCloseDate(p *storekit.Patch, before *time.Time, proposed time.Time) {
 // that did not happen, forever.
 //
 // The comparison is against the EFFECTIVE category rather than the stored
-// column, and that distinction is the whole guard: the column is nullable, and
-// a deal with a NULL forecast_category whose probability already reads
-// "omitted" is not moved by writing "omitted" into it. Comparing against the
-// raw NULL would call that a change and put it in the diff.
+// column, because the column is nullable and the two disagree: a deal with no
+// override carries NULL while reading as its probability-derived default. The
+// notch is computed from the effective reading, so the guard has to ask the
+// same question — comparing against a raw NULL would find every value
+// different and write on every pass, which is the bug it exists to stop.
 func setForecastCategory(p *storekit.Patch, stored *string, effective, notched string) {
 	if effective == notched {
 		return

--- a/backend/internal/modules/deals/closedatecorrect.go
+++ b/backend/internal/modules/deals/closedatecorrect.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// Choosing and writing ONE deal's close-date correction.
+//
+// The pass that finds the deals lives in closedatesweep.go; this file is what
+// happens to a single one once it is flagged — which tier applies, which fields
+// that tier is allowed to move, and the two guards that keep an unchanged value
+// out of the audit trail.
+//
+// The split is by concept rather than by size: a reader asking "what does the
+// sweep do to a deal" reads this file, and one asking "which deals does it
+// reach" reads the other.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The §7 forecast categories, as the deal column spells them.
+//
+// Named here rather than imported: forecasting declares the same four words for
+// its own readings, and a module never imports a sibling. Two spellings of a
+// database enum is the price of that rule, and the column is what holds them
+// together — a change to either would fail the other's tests against it.
+// correctionFlagsKey names the hygiene findings inside a correction's
+// deal.updated payload — one spelling for all three tiers.
+const correctionFlagsKey = "flags"
+
+const (
+	forecastCommit   = "commit"
+	forecastBestCase = "best_case"
+	forecastPipeline = "pipeline"
+	forecastOmitted  = "omitted"
+)
+
+// effectiveForecastCategory is the §7 reading: the rep's explicit
+// override wins; otherwise the stage probability derives the default
+// (commit ≥ 90, best-case ≥ 50).
+func effectiveForecastCategory(override *string, winProbability int) string {
+	if override != nil {
+		return *override
+	}
+	switch {
+	case winProbability >= forecastCommitMinProb:
+		return forecastCommit
+	case winProbability >= lateStageMinProb:
+		return forecastBestCase
+	default:
+		return forecastPipeline
+	}
+}
+
+// forecastDowngrade is the 🔻 notch: Commit→Best-case→Pipeline→Omitted,
+// never below Omitted.
+func forecastDowngrade(category string) string {
+	switch category {
+	case forecastCommit:
+		return forecastBestCase
+	case forecastBestCase:
+		return forecastPipeline
+	default:
+		return forecastOmitted
+	}
+}
+
+// setCloseDate assigns the sweep's proposed date only where it differs from the
+// one the deal already claims.
+//
+// The sweep re-flags a deal every night it stays quiet, and its proposal is
+// derived from stage velocity rather than from the calendar — so it frequently
+// recomputes the date the deal already has. storekit.Patch records an assignment
+// without comparing it, so an unconditional Set would put that date in the audit
+// diff and in deal_forecast_history on every pass, and a reconstruction would
+// read a forecast moving nightly while standing still.
+func setCloseDate(p *storekit.Patch, before *time.Time, proposed time.Time) {
+	if before != nil && before.Equal(proposed) {
+		return
+	}
+	p.SetDate(closeDateField, before, &proposed)
+}
+
+// setForecastCategory assigns the notched category only where it differs from
+// the one the deal effectively carries.
+//
+// The same reasoning as setCloseDate, and the branch it guards used to lack it.
+// forecastDowngrade floors at "omitted", so a deal already sitting there was
+// assigned "omitted" again every night it stayed quiet — a patch that is not
+// Empty(), so an audit row and a deal.updated event were written for a change
+// that did not happen, forever.
+//
+// The comparison is against the EFFECTIVE category rather than the stored
+// column, and that distinction is the whole guard: the column is nullable, and
+// a deal with a NULL forecast_category whose probability already reads
+// "omitted" is not moved by writing "omitted" into it. Comparing against the
+// raw NULL would call that a change and put it in the diff.
+func setForecastCategory(p *storekit.Patch, stored *string, effective, notched string) {
+	if effective == notched {
+		return
+	}
+	p.Set("forecast_category", stored, notched)
+}
+
+// correct applies one deal's A6 tier. The write runs in its own audited
+// transaction; the 🟡 staging follows it (Stage opens its own) — if the
+// staging fails the provisional row simply re-enters the next sweep.
+func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidate, hygiene CloseDateHygiene, category string, now time.Time, loc *time.Location) error {
+	if !hygiene.Flagged {
+		if cand.provisional {
+			// The date itself is clean (the sweep set it), but the human
+			// has not confirmed it yet: keep the 🟡 surface alive if the
+			// previous staging expired undecided.
+			//
+			return c.ensureStaged(ctx, cand, 0, CloseDateCorrection{
+				DealID:              cand.id,
+				ExpectedCloseDate:   cand.expectedClose.Format(time.DateOnly),
+				PreviousCloseDate:   dateString(cand.expectedClose),
+				RemainingOpenStages: StagesRemaining(cand.remainingOpen),
+				Asking:              AskingIsThisDateRight,
+				Basis:               quietHoldingBasis,
+			})
+		}
+		return nil
+	}
+
+	proposal := CloseDateCorrection{
+		DealID:              cand.id,
+		ExpectedCloseDate:   hygiene.ProposedClose.Format(time.DateOnly),
+		PreviousCloseDate:   dateString(cand.expectedClose),
+		RemainingOpenStages: StagesRemaining(cand.remainingOpen),
+		Asking:              AskingIsThisDateRight,
+		Flags:               hygiene.Flags,
+		Basis:               pacedBasis(StagesToGo(cand.remainingOpen)),
+	}
+
+	switch hygiene.Action {
+	// 🟢 and 🟡 write the SAME THING, and sharing the branch is the point.
+	//
+	// Both replace the date with proposedCloseDate's stage-velocity estimate,
+	// mark it provisional, and raise the confirm. 🟢 used to clear
+	// close_date_provisional instead, which made a guess indistinguishable from
+	// a date a customer had given: it counted toward supported forecast claims,
+	// and the rep saw no sign that nobody had confirmed it. Neither path reads
+	// a buyer's message, so neither may call its replacement final — that needs
+	// attributable evidence or a person's answer.
+	//
+	// What still separates the tiers is the AUDIT LABEL, which records the
+	// policy that admitted the deal: auto_apply for a clear-overdue early-stage
+	// deal the sweep corrects without waiting, provisional_confirm for
+	// everything else. One write, two names for why it happened.
+	case CloseDateActionAutoApply, CloseDateActionProvisionalConfirm:
+		label := "provisional_confirm"
+		if hygiene.Action == CloseDateActionAutoApply {
+			label = "auto_apply"
+		}
+		version, err := c.apply(ctx, cand, label, func(p *storekit.Patch) {
+			setCloseDate(p, cand.expectedClose, *hygiene.ProposedClose)
+			if !cand.provisional {
+				p.Set("close_date_provisional", false, true)
+			}
+		}, map[string]any{correctionFlagsKey: hygiene.Flags, "basis": proposal.Basis})
+		if err != nil {
+			return err
+		}
+		return c.ensureStaged(ctx, cand, version, proposal)
+
+	case CloseDateActionDowngradeAndReview:
+		notched := forecastDowngrade(category)
+		version, err := c.apply(ctx, cand, "downgrade_and_review", func(p *storekit.Patch) {
+			setForecastCategory(p, cand.forecastCat, category, notched)
+			if hygiene.Provisional {
+				// Only the invariant forces a date onto a quiet deal —
+				// never an optimistic re-date on top of the downgrade.
+				setCloseDate(p, cand.expectedClose, *hygiene.ProposedClose)
+				if !cand.provisional {
+					p.Set("close_date_provisional", false, true)
+				}
+			}
+		}, map[string]any{correctionFlagsKey: hygiene.Flags, "at_risk": true})
+		if err != nil {
+			return err
+		}
+		// The 🟡 review: gone quiet — still alive? The proposal keeps the
+		// stage-velocity date the assessment computed, on BOTH branches. It
+		// used to be overwritten here with the deal's CURRENT date whenever the
+		// invariant did not force a re-date, which asked a human to confirm the
+		// date the deal already had — a card with nothing in it to approve.
+		review := proposal
+		// A different question from the 🟡 confirm, and the memory keys on which:
+		// a rep who said this date is fine has not said the deal is still alive.
+		review.Asking = AskingIsThisDealAlive
+		review.Basis = c.quietBasis(ctx, cand.id, now, loc)
+		return c.ensureStaged(ctx, cand, version, review)
+	}
+	return fmt.Errorf("close-date sweep: no executor for action %q", hygiene.Action)
+}
+
+// quietBasis is the reason the quiet review shows: which way the silence runs,
+// who is on the far end of it, and how long it has lasted.
+//
+// A failure to READ the correspondence is not a reason to fail the sweep — the
+// downgrade has already committed and the review is what is left to raise. So a
+// read error degrades to the generic sentence and is logged, rather than
+// aborting a pass over every other deal in the workspace.
+func (c *CloseDateCorrector) quietBasis(ctx context.Context, dealID ids.DealID, now time.Time, loc *time.Location) string {
+	facts, names, err := c.reviewer.ReadForOwner(ctx, dealID)
+	if err != nil {
+		c.log.WarnContext(ctx, "close-date quiet review fell back to a generic reason",
+			"deal_id", dealID, "error", err)
+		return quietFallbackBasis
+	}
+	return quietReason(facts, names, now, loc)
+}

--- a/backend/internal/modules/deals/closedatesweep.go
+++ b/backend/internal/modules/deals/closedatesweep.go
@@ -28,6 +28,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/platform/settings"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -176,7 +177,7 @@ func (c *CloseDateCorrector) sweepWorkspace(ctx context.Context) error {
 			WaitUntil:           cand.waitUntil,
 			StageWinProbability: cand.winProbability,
 			RemainingOpenStages: cand.remainingOpen,
-			InForecastCommit:    category == "commit" || category == "best_case",
+			InForecastCommit:    category == forecastCommit || category == forecastBestCase,
 			StageVelocityDays:   velocity,
 		}, now, loc)
 		if err := c.correct(ctx, cand, hygiene, category, now, loc); err != nil {
@@ -215,154 +216,6 @@ func (c *CloseDateCorrector) stageVelocityDays(ctx context.Context, pipelineID i
 	return *medianSeconds / 86400, nil
 }
 
-// effectiveForecastCategory is the §7 reading: the rep's explicit
-// override wins; otherwise the stage probability derives the default
-// (commit ≥ 90, best-case ≥ 50).
-func effectiveForecastCategory(override *string, winProbability int) string {
-	if override != nil {
-		return *override
-	}
-	switch {
-	case winProbability >= forecastCommitMinProb:
-		return "commit"
-	case winProbability >= lateStageMinProb:
-		return "best_case"
-	default:
-		return "pipeline"
-	}
-}
-
-// forecastDowngrade is the 🔻 notch: Commit→Best-case→Pipeline→Omitted,
-// never below Omitted.
-func forecastDowngrade(category string) string {
-	switch category {
-	case "commit":
-		return "best_case"
-	case "best_case":
-		return "pipeline"
-	default:
-		return "omitted"
-	}
-}
-
-// setCloseDate assigns the sweep's proposed date only where it differs from the
-// one the deal already claims.
-//
-// The sweep re-flags a deal every night it stays quiet, and its proposal is
-// derived from stage velocity rather than from the calendar — so it frequently
-// recomputes the date the deal already has. storekit.Patch records an assignment
-// without comparing it, so an unconditional Set would put that date in the audit
-// diff and in deal_forecast_history on every pass, and a reconstruction would
-// read a forecast moving nightly while standing still.
-func setCloseDate(p *storekit.Patch, before *time.Time, proposed time.Time) {
-	if before != nil && before.Equal(proposed) {
-		return
-	}
-	p.SetDate(closeDateField, before, &proposed)
-}
-
-// correct applies one deal's A6 tier. The write runs in its own audited
-// transaction; the 🟡 staging follows it (Stage opens its own) — if the
-// staging fails the provisional row simply re-enters the next sweep.
-func (c *CloseDateCorrector) correct(ctx context.Context, cand closeDateCandidate, hygiene CloseDateHygiene, category string, now time.Time, loc *time.Location) error {
-	if !hygiene.Flagged {
-		if cand.provisional {
-			// The date itself is clean (the sweep set it), but the human
-			// has not confirmed it yet: keep the 🟡 surface alive if the
-			// previous staging expired undecided.
-			//
-			return c.ensureStaged(ctx, cand, 0, CloseDateCorrection{
-				DealID:              cand.id,
-				ExpectedCloseDate:   cand.expectedClose.Format(time.DateOnly),
-				PreviousCloseDate:   dateString(cand.expectedClose),
-				RemainingOpenStages: StagesRemaining(cand.remainingOpen),
-				Asking:              AskingIsThisDateRight,
-				Basis:               quietHoldingBasis,
-			})
-		}
-		return nil
-	}
-
-	proposal := CloseDateCorrection{
-		DealID:              cand.id,
-		ExpectedCloseDate:   hygiene.ProposedClose.Format(time.DateOnly),
-		PreviousCloseDate:   dateString(cand.expectedClose),
-		RemainingOpenStages: StagesRemaining(cand.remainingOpen),
-		Asking:              AskingIsThisDateRight,
-		Flags:               hygiene.Flags,
-		Basis:               pacedBasis(StagesToGo(cand.remainingOpen)),
-	}
-
-	switch hygiene.Action {
-	case CloseDateActionAutoApply:
-		_, err := c.apply(ctx, cand, "auto_apply", func(p *storekit.Patch) {
-			setCloseDate(p, cand.expectedClose, *hygiene.ProposedClose)
-			if cand.provisional {
-				p.Set("close_date_provisional", true, false)
-			}
-		}, map[string]any{"flags": hygiene.Flags, "basis": proposal.Basis})
-		return err
-
-	case CloseDateActionProvisionalConfirm:
-		version, err := c.apply(ctx, cand, "provisional_confirm", func(p *storekit.Patch) {
-			setCloseDate(p, cand.expectedClose, *hygiene.ProposedClose)
-			if !cand.provisional {
-				p.Set("close_date_provisional", false, true)
-			}
-		}, map[string]any{"flags": hygiene.Flags, "basis": proposal.Basis})
-		if err != nil {
-			return err
-		}
-		return c.ensureStaged(ctx, cand, version, proposal)
-
-	case CloseDateActionDowngradeAndReview:
-		notched := forecastDowngrade(category)
-		version, err := c.apply(ctx, cand, "downgrade_and_review", func(p *storekit.Patch) {
-			p.Set("forecast_category", cand.forecastCat, notched)
-			if hygiene.Provisional {
-				// Only the invariant forces a date onto a quiet deal —
-				// never an optimistic re-date on top of the downgrade.
-				setCloseDate(p, cand.expectedClose, *hygiene.ProposedClose)
-				if !cand.provisional {
-					p.Set("close_date_provisional", false, true)
-				}
-			}
-		}, map[string]any{"flags": hygiene.Flags, "at_risk": true})
-		if err != nil {
-			return err
-		}
-		// The 🟡 review: gone quiet — still alive? The proposal keeps the
-		// stage-velocity date the assessment computed, on BOTH branches. It
-		// used to be overwritten here with the deal's CURRENT date whenever the
-		// invariant did not force a re-date, which asked a human to confirm the
-		// date the deal already had — a card with nothing in it to approve.
-		review := proposal
-		// A different question from the 🟡 confirm, and the memory keys on which:
-		// a rep who said this date is fine has not said the deal is still alive.
-		review.Asking = AskingIsThisDealAlive
-		review.Basis = c.quietBasis(ctx, cand.id, now, loc)
-		return c.ensureStaged(ctx, cand, version, review)
-	}
-	return fmt.Errorf("close-date sweep: no executor for action %q", hygiene.Action)
-}
-
-// quietBasis is the reason the quiet review shows: which way the silence runs,
-// who is on the far end of it, and how long it has lasted.
-//
-// A failure to READ the correspondence is not a reason to fail the sweep — the
-// downgrade has already committed and the review is what is left to raise. So a
-// read error degrades to the generic sentence and is logged, rather than
-// aborting a pass over every other deal in the workspace.
-func (c *CloseDateCorrector) quietBasis(ctx context.Context, dealID ids.DealID, now time.Time, loc *time.Location) string {
-	facts, names, err := c.reviewer.ReadForOwner(ctx, dealID)
-	if err != nil {
-		c.log.WarnContext(ctx, "close-date quiet review fell back to a generic reason",
-			"deal_id", dealID, "error", err)
-		return quietFallbackBasis
-	}
-	return quietReason(facts, names, now, loc)
-}
-
 // apply runs one tier's write shape: re-verify the deal is still open
 // and live under a row lock, patch it, audit with the exact before/after
 // diff (the reversibility the 🟢 tier promises), and emit deal.updated —
@@ -386,6 +239,18 @@ func (c *CloseDateCorrector) apply(ctx context.Context, cand closeDateCandidate,
 		}
 		if DealStatus(status) != DealOpen {
 			return nil
+		}
+		// The kill switch, read here rather than once per pass: an operator who
+		// switches maintenance off mid-sweep stops the next deal's write, not
+		// the one after it. A halted write is not a failure — the pass carries
+		// on assessing, and the version is still read so a 🟡 staging binds to
+		// the row a human would see.
+		on, err := settings.ApplyTx(ctx, tx, MaintenanceWritesEnabled)
+		if err != nil {
+			return fmt.Errorf("read whether deal maintenance may write: %w", err)
+		}
+		if !on {
+			return tx.QueryRow(ctx, `SELECT version FROM deal WHERE id = $1`, cand.id).Scan(&version)
 		}
 		patch := storekit.NewPatch()
 		build(patch)

--- a/backend/internal/modules/deals/settingsentry.go
+++ b/backend/internal/modules/deals/settingsentry.go
@@ -5,8 +5,9 @@ package deals
 
 // The deals module's own settings declarations.
 //
-// One entry today, and it is a kill switch rather than a preference: the
-// installation's answer to whether stage automation may move a deal at all.
+// Both entries are kill switches rather than preferences: the installation's
+// answer to whether stage automation may move a deal, and whether the nightly
+// maintenance sweep may write to one.
 
 import (
 	"github.com/margince/margince/backend/internal/platform/settings"
@@ -41,7 +42,41 @@ var StageAutopilotEnabled = settings.Define[bool](
 // answer to who owns a pipeline.
 const stageAutomationObject = "pipeline"
 
+// MaintenanceWritesEnabled is the installation-wide answer to whether the
+// nightly close-date sweep may write to a deal at all.
+//
+// DEFAULT TRUE, unlike its sibling above, because the sweep already ships on: a
+// switch that defaulted to off would silently stop work an installation is
+// relying on the moment it appeared. What this entry buys is a way to STOP the
+// sweep without a redeploy — the tier it governs was a compile-time constant,
+// so halting a misbehaving pass meant shipping a new binary.
+//
+// It gates EVERY automatic write the sweep makes: the direct re-date, the
+// provisional write and the downgrade. A switch that stopped one branch while
+// two others kept writing would not be a kill switch, and an operator reaching
+// for it is not distinguishing between tiers.
+//
+// Read INSIDE each write's own transaction, for the reason
+// StageAutopilotModeTx gives: read once at the top of a pass instead, it would
+// authorize writes on an answer that was true when the pass started.
+//
+// Assessment, the receipt and Undo stay outside its reach on purpose. Switching
+// maintenance off stops NEW changes; it does not hide the changes already made
+// or take away a reader's ability to reverse one.
+var MaintenanceWritesEnabled = settings.Define[bool](
+	"deals.maintenance_writes_enabled",
+	maintenanceObject,
+	"update",
+	true,
+	nil, // a bool has two values and both mean something; nothing to validate
+).MachineryApplied() // the sweep reads it; no request carries it
+
+// maintenanceObject is the RBAC object gating maintenance governance. `deal`,
+// because a deal is what the sweep writes — the grant that lets somebody update
+// a deal is the one that lets them say whether the machine may.
+const maintenanceObject = "deal"
+
 // Definitions is the deals module's contribution to the settings catalog.
 func Definitions() []settings.Definition {
-	return []settings.Definition{StageAutopilotEnabled}
+	return []settings.Definition{StageAutopilotEnabled, MaintenanceWritesEnabled}
 }


### PR DESCRIPTION
The nightly close-date sweep had three defects that made the machine's work look more certain, or more plentiful, than it was.

**A quiet deal at the floor wrote an audit row every night.** `forecastDowngrade` floors at `omitted`, and the downgrade branch assigned the notched category unconditionally. `storekit.Patch` records an assignment without comparing it, so a deal already omitted produced a real audit row and a real `deal.updated` event for a change that never happened — 32 of 40 such rows in one installation were identical before/after images. `setForecastCategory` now guards the branch the way `setCloseDate` already guarded its own.

**A guess was written as a confirmed date.** The auto-apply tier cleared `close_date_provisional`, which made a stage-velocity estimate indistinguishable from a date a customer had given: it counted toward supported forecast claims, and the rep saw no sign that nobody had confirmed it. Nothing on that path reads a buyer's message. Both tiers now write the same provisional date and raise the confirm; the audit label still records which policy admitted the deal.

**There was no way to stop it.** The tier switch was a compile-time constant, so halting a misbehaving sweep meant shipping a binary. `deals.MaintenanceWritesEnabled` is a live setting, read inside each write's own transaction so flipping it off stops the next write rather than the one after, and it gates every branch. Default true, because the sweep already ships on. Assessment, the receipt and Undo stay outside its reach: switching maintenance off stops new changes without hiding the ones already made or blocking a reversal.

`closedatesweep.go` crossed the 500-line cap, so choosing and writing one deal's correction moved to `closedatecorrect.go`.

## Verification

- `make check-backend` green apart from `TestEveryRawReaderOfTheSettingTableCarriesAVerdict`, which is red on clean `origin/main` for an unrelated reader in `people/leadsla.go` and is being fixed in #5027.
- Integration lanes green: `deals`, `compose` (`CloseDate|NightlyCheck|SecondCheck|Quiet`), `compose/integration`.
- The no-op guard is mutation-checked: reverting it fails the new test.
- Two existing tests asserted the old behaviour and now assert the new one — the 🟢 date is provisional, and it stages a confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the nightly close-date sweep so it writes only real changes, never calls a stage-velocity guess final, and can be stopped without shipping a binary.

**Bug Fixes**
- A deal already at the "omitted" forecast floor no longer writes an audit row and `deal.updated` event every night; the category write now skips when the effective category is unchanged.
- The auto-apply tier no longer clears `close_date_provisional`; it writes the same provisional date as the provisional-confirm tier and raises the confirm, with the audit label recording which policy admitted the deal.

**New Features**
- `deals.MaintenanceWritesEnabled` is a live kill switch, defaulting to true, that gates every automatic write and is read inside each write's transaction so flipping it off stops the next write. Assessment, the receipt, and Undo stay outside its reach.

<sup>Written for commit 3ec4171c9158892f620f082d9f5cd5cdc570dbd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

