### PR TITLE
feat(gates): an App view's fixture is held to its tool's output schema

### DIFF
--- a/backend/gates/appviewfixtures_test.go
+++ b/backend/gates/appviewfixtures_test.go
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// A view's fixture is the tool's answer, and this is what makes that true.
+//
+// Every MCP App view renders `structuredContent.data` from one tool's result,
+// and the member names its TypeScript reads are a hand-written mirror of the Go
+// result struct. Nothing connected the two: a rename on the Go side compiles,
+// ships, and produces a view that renders its EMPTY STATE — the views narrow
+// every field through guards and answer empty rather than throwing, so the
+// failure is contained and silent, and reads as "no data" rather than "the
+// contract moved".
+//
+// And every test stays green, because the fixture each view is tested against
+// is hand-built from the same reading. That is review-loop rule 6 exactly: a
+// suite can be entirely green about a payload production no longer produces.
+//
+// So the fixture is the thing to hold. It is what the view's suite draws, so a
+// fixture true to the contract makes those tests true to it too — and it is
+// checkable from here, where the tool's own OUTPUT SCHEMA is available. The
+// schema is derived from the Go type by reflection (agents/outputshapes.go), so
+// a renamed struct member is a renamed schema property, and this gate goes red
+// on the change that used to blank a panel.
+//
+// Nothing here is listed. The tools that carry a view declare it
+// (mcp.ToolUI.ResourceURI), the view's directory is derived from that URI the
+// same way the document's own file name is (agents/apps/fetch.go), and the
+// members come from the schema and the fixture. A sixth view inherits the check
+// by existing.
+
+import (
+	"encoding/json"
+	"maps"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// appFixtureDir is where a view's hand-written fixture lives, keyed by the
+// directory its URI derives to.
+const appFixtureDir = "../frontend/src/mcp-apps"
+
+// envelopeMembers are the ones the ENVELOPE owns rather than the tool. Every
+// fixture is an Envelope wrapping the tool's data, so these two names appear in
+// all of them and belong to no result struct.
+var envelopeMembers = map[string]bool{envelopeDataMember: true, "warnings": true}
+
+// envelopeDataMember is where a tool's own shape sits inside the envelope
+// schema. It matches the constant the deriver writes; spelled here rather than
+// imported because agents keeps it unexported, and a gate that reached for it
+// would be asserting the deriver against itself.
+const envelopeDataMember = "data"
+
+// fixtureMemberOnlyInTheView ratifies a fixture member the schema does not
+// publish. It is empty and meant to stay so: a member the view reads and the
+// tool does not answer is the defect this gate is about, wearing the other
+// direction.
+var fixtureMemberOnlyInTheView = gatekit.Waive(map[string]string{})
+
+// appFixtureFloor is the number of views the sweep must find. Below it the
+// derivation has stopped reaching the catalog, and a sweep that judges nothing
+// reports PASS.
+const appFixtureFloor = 4
+
+// fixtureKey matches one member of a JavaScript object literal. This tree's
+// formatter puts one key per line, which is what makes a line-wise read of a
+// fixture complete rather than approximate — and appFixtureFloor plus the
+// per-fixture count below are what fail if that ever stops being true.
+var fixtureKey = regexp.MustCompile(`^\s*([a-z][A-Za-z0-9_]*)\s*:`)
+
+func TestEveryAppViewFixtureMatchesItsToolsOutputSchema(t *testing.T) {
+	t.Parallel()
+	defer fixtureMemberOnlyInTheView.AssertAllMatched(t)
+
+	checked := 0
+	for _, spec := range compose.NewRegistry(nil, compose.SendPath{}).Specs() {
+		if spec.UI == nil || spec.OutputSchema == nil {
+			continue
+		}
+		dir := viewDirOf(spec.UI.ResourceURI)
+		path := appFixtureDir + "/" + dir + "/fixture.ts"
+		source, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			// A view with no fixture is not a finding here: the geo probe
+			// answers no tool's result and renders no record. What would be a
+			// finding is a fixture that disagrees with a schema, and there is
+			// none to disagree.
+			continue
+		}
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		checked++
+		published, required := toolShapeMembers(t, spec.Name, spec.OutputSchema)
+		if len(published) == 0 {
+			t.Errorf("%s publishes an output schema with no properties, so this fixture is checked "+
+				"against nothing", spec.Name)
+			continue
+		}
+		fixture := fixtureMembers(source)
+		if len(fixture) < 2 {
+			t.Errorf("%s read %d member(s) out of %s — the fixture is not being read, and a fixture "+
+				"nobody reads passes every comparison below", spec.Name, len(fixture), path)
+			continue
+		}
+		compareFixtureToSchema(t, spec.Name, dir, fixture, published, required)
+	}
+	if checked < appFixtureFloor {
+		t.Fatalf("the sweep checked %d view fixture(s), below the %d floor — the tool-to-view "+
+			"derivation has stopped reaching the catalog, which reports PASS having compared nothing",
+			checked, appFixtureFloor)
+	}
+}
+
+// compareFixtureToSchema reports both directions of the drift.
+func compareFixtureToSchema(t *testing.T, tool, dir string, fixture, published, required map[string]bool) {
+	t.Helper()
+	for _, member := range slices.Sorted(maps.Keys(fixture)) {
+		if envelopeMembers[member] || published[member] {
+			continue
+		}
+		subject := dir + ":" + member
+		if fixtureMemberOnlyInTheView.Waived(t, subject) {
+			continue
+		}
+		t.Errorf("%s/fixture.ts carries %q, which %s does not publish.\n"+
+			"  The fixture is what the view's suite draws, so a member the tool never answers is a "+
+			"panel tested against a payload production does not produce.\n"+
+			"  Rename it to what the result struct answers, or ratify it in "+
+			"fixtureMemberOnlyInTheView[%q] with the reason the view needs a member the tool does not send.",
+			dir, member, tool, subject)
+	}
+	// The other direction, and only for what the schema REQUIRES. A fixture is
+	// one realistic answer, so an optional member it happens not to exercise is
+	// a choice rather than drift — reporting those would bury the one finding
+	// that matters under every field a payload may omit. A REQUIRED member
+	// missing means the fixture is not an answer the tool could have sealed.
+	for _, member := range slices.Sorted(maps.Keys(required)) {
+		if fixture[member] || !published[member] {
+			continue
+		}
+		t.Errorf("%s REQUIRES %q and %s/fixture.ts does not carry it.\n"+
+			"  The fixture claims to be shaped as the tool seals it, so a required member missing from "+
+			"it is a payload the tool could not have produced — and the view is tested against it.",
+			tool, member, dir)
+	}
+}
+
+// viewDirOf derives a view's directory from its URI, the way the document's own
+// file name is derived from it rather than listed beside it.
+func viewDirOf(uri string) string {
+	_, file, found := strings.Cut(uri, "ui://margince/")
+	if !found {
+		return ""
+	}
+	return strings.TrimSuffix(file, ".html")
+}
+
+// schemaMembers collects every property name a schema publishes, at any depth,
+// and separately every one a payload must carry.
+//
+// The two walks differ, and the difference is the whole correctness of the
+// second. PUBLISHED is every property anywhere in the document: the fixture is a
+// whole payload, so a nested member is as much part of the contract as a
+// top-level one, and a fixture member that appears nowhere in the schema is
+// drift wherever it sits.
+//
+// REQUIRED follows only what is reachable THROUGH required members. A `required`
+// list inside an optional sub-object says "if you send this object, send these"
+// — it does not say the payload must have them. Collecting those flatly reported
+// every field of every branch a realistic fixture chose not to exercise, which
+// is dozens of findings burying the one that matters.
+func toolShapeMembers(t *testing.T, tool string, raw json.RawMessage) (published, required map[string]bool) {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("%s's output schema is not JSON: %v", tool, err)
+	}
+	// The ADVERTISED schema is the envelope's, with the tool's own shape under
+	// `data` (agents/outputshapes.go seals every result). The fixture models the
+	// TypeScript Envelope, whose other members are the seal Invoke adds and are
+	// deliberately not written by hand — so the subject here is `data` and not
+	// the document, or every fixture is reported for lacking a trace id.
+	props, isObject := doc["properties"].(map[string]any)
+	if !isObject {
+		t.Fatalf("%s's output schema publishes no properties, so there is no tool shape to compare "+
+			"a fixture against", tool)
+	}
+	shape, sealed := props[envelopeDataMember]
+	if !sealed {
+		t.Fatalf("%s's output schema has no %q member — the envelope's shape moved, and this gate is "+
+			"comparing fixtures against the wrong half of it", tool, envelopeDataMember)
+	}
+	published, required = map[string]bool{}, map[string]bool{}
+	collectPublished(shape, published)
+	collectRequired(shape, required)
+	return published, required
+}
+
+func collectPublished(node any, out map[string]bool) {
+	switch n := node.(type) {
+	case map[string]any:
+		if props, isObject := n["properties"].(map[string]any); isObject {
+			for name, child := range props {
+				out[name] = true
+				collectPublished(child, out)
+			}
+		}
+		for key, child := range n {
+			if key != "properties" {
+				collectPublished(child, out)
+			}
+		}
+	case []any:
+		for _, child := range n {
+			collectPublished(child, out)
+		}
+	}
+}
+
+// collectRequired descends only through members the payload must carry, and
+// stops at an array.
+//
+// An array's element schema says what a ROW must have, and whether the fixture
+// has any rows is not something the schema can say. Descending anyway asserted
+// every field of every element type against a fixture that legitimately draws
+// `about: []` — seven findings about an empty list, which is the census crying
+// wolf at exactly the volume that gets one deleted.
+//
+// Little is lost, because the direction that catches this ticket's defect is the
+// other one: a renamed element member makes the fixture carry a name the schema
+// no longer publishes, and that check is total and reaches every depth.
+func collectRequired(node any, out map[string]bool) {
+	schema, isObject := node.(map[string]any)
+	if !isObject {
+		return
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if names, hasRequired := schema["required"].([]any); hasRequired {
+		for _, name := range names {
+			text, isText := name.(string)
+			if !isText {
+				continue
+			}
+			out[text] = true
+			if child, published := props[text]; published {
+				collectRequired(child, out)
+			}
+		}
+	}
+}
+
+// fixtureMembers reads the object-literal keys out of a fixture, comments and
+// string contents excluded — a `//` note naming a member, or a member name
+// inside a quoted value, is prose rather than a key.
+func fixtureMembers(source []byte) map[string]bool {
+	out := map[string]bool{}
+	for _, line := range strings.Split(string(source), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+		if m := fixtureKey.FindStringSubmatch(line); m != nil {
+			out[m[1]] = true
+		}
+	}
+	return out
+}

--- a/backend/gates/appviewfixtures_test.go
+++ b/backend/gates/appviewfixtures_test.go
@@ -66,6 +66,16 @@ const envelopeDataMember = "data"
 // direction.
 var fixtureMemberOnlyInTheView = gatekit.Waive(map[string]string{})
 
+// viewsWithoutAFixture ratifies a view that models no payload, keyed by the
+// tool that carries it.
+//
+// Declared rather than skipped. A missing fixture is otherwise indistinguishable
+// from a deleted one, and deleting a fixture would drop its view out of this
+// check with nothing to notice — a census counting down in silence.
+var viewsWithoutAFixture = gatekit.Waive(map[string]string{
+	"check_location_support": "the geo probe renders no record and answers no tool's result: it reports whether THIS host lets a view read the device's position, which is a fact about the client rather than a payload. There is no shape for a fixture to model. It is also meant to be deleted once the host matrix is filled in, which its own catalog entry says",
+})
+
 // appFixtureFloor is the number of views the sweep must find. Below it the
 // derivation has stopped reaching the catalog, and a sweep that judges nothing
 // reports PASS.
@@ -77,17 +87,10 @@ const appFixtureFloor = 4
 // per-fixture count below are what fail if that ever stops being true.
 var fixtureKey = regexp.MustCompile(`^\s*([a-z][A-Za-z0-9_]*)\s*:`)
 
-// fixtureString matches a quoted value, blanked before braces are counted so a
-// `{` inside a message is not read as structure.
-var fixtureString = regexp.MustCompile(`"[^"]*"`)
-
-// dataMemberDepth is the brace depth of the members of the envelope's `data`.
-// The literal opens at depth 0, `data:` sits at 1, and its own members at 2.
-const dataMemberDepth = 2
-
 func TestEveryAppViewFixtureMatchesItsToolsOutputSchema(t *testing.T) {
 	t.Parallel()
 	defer fixtureMemberOnlyInTheView.AssertAllMatched(t)
+	defer viewsWithoutAFixture.AssertAllMatched(t)
 
 	checked := 0
 	for _, spec := range compose.NewRegistry(nil, compose.SendPath{}).Specs() {
@@ -98,10 +101,20 @@ func TestEveryAppViewFixtureMatchesItsToolsOutputSchema(t *testing.T) {
 		path := appFixtureDir + "/" + dir + "/fixture.ts"
 		source, err := os.ReadFile(path)
 		if os.IsNotExist(err) {
-			// A view with no fixture is not a finding here: the geo probe
-			// answers no tool's result and renders no record. What would be a
-			// finding is a fixture that disagrees with a schema, and there is
-			// none to disagree.
+			// A FINDING, not a skip. A tool carrying both a view and an output
+			// schema is one whose payload a fixture is supposed to model, and
+			// skipping the missing one means deleting a fixture silently drops
+			// its view out of the check — with the floor still met by the
+			// others, which is a census counting down without saying so.
+			//
+			// The geo probe does not reach here: it declares no output schema
+			// and is excluded above, because it answers no tool's result.
+			if !viewsWithoutAFixture.Waived(t, spec.Name) {
+				t.Errorf("%s carries the view at %s and declares an output schema, but %s does not "+
+					"exist — a view whose payload nothing models is one no test has drawn the real "+
+					"shape of. Add the fixture, or ratify the view in viewsWithoutAFixture[%q]",
+					spec.Name, spec.UI.ResourceURI, path, spec.Name)
+			}
 			continue
 		}
 		if err != nil {
@@ -156,10 +169,7 @@ func compareFixtureToSchema(t *testing.T, tool, dir string, fixture map[string]i
 		if !published[member] {
 			continue
 		}
-		// AT ITS OWN LEVEL. `required` here is what the tool's shape requires
-		// of the payload root, so a member of the same name nested deeper is a
-		// different member and must not answer for it.
-		if at, carried := fixture[member]; carried && at == dataMemberDepth {
+		if _, carried := fixture[member]; carried {
 			continue
 		}
 		t.Errorf("%s REQUIRES %q and %s/fixture.ts does not carry it.\n"+
@@ -215,29 +225,28 @@ func toolShapeMembers(t *testing.T, tool string, raw json.RawMessage) (published
 			"comparing fixtures against the wrong half of it", tool, envelopeDataMember)
 	}
 	published, required = map[string]bool{}, map[string]bool{}
-	collectPublished(shape, published)
-	collectRequired(shape, required)
+	collectPublished(shape, nil, published)
+	collectRequired(shape, nil, required)
 	return published, required
 }
 
 //craft:ignore naked-any a decoded JSON Schema is an arbitrary document, so the node this walks IS any — naming a type here would describe a shape the deriver is free to change
-func collectPublished(node any, out map[string]bool) {
+func collectPublished(node any, at []string, out map[string]bool) {
 	switch n := node.(type) {
 	case map[string]any:
 		if props, isObject := n["properties"].(map[string]any); isObject {
 			for name, child := range props {
-				out[name] = true
-				collectPublished(child, out)
+				here := append(append([]string{}, at...), name)
+				out[strings.Join(here, ".")] = true
+				collectPublished(child, here, out)
 			}
 		}
-		for key, child := range n {
-			if key != "properties" {
-				collectPublished(child, out)
-			}
-		}
+		// An array contributes no segment, matching the fixture side: a row's
+		// members belong to the collection rather than to an index.
+		collectPublished(n["items"], at, out)
 	case []any:
 		for _, child := range n {
-			collectPublished(child, out)
+			collectPublished(child, at, out)
 		}
 	}
 }
@@ -256,54 +265,135 @@ func collectPublished(node any, out map[string]bool) {
 // no longer publishes, and that check is total and reaches every depth.
 //
 //craft:ignore naked-any the same decoded document collectPublished walks, for the same reason
-func collectRequired(node any, out map[string]bool) {
+func collectRequired(node any, at []string, out map[string]bool) {
 	schema, isObject := node.(map[string]any)
 	if !isObject {
 		return
 	}
 	props, _ := schema["properties"].(map[string]any)
-	if names, hasRequired := schema["required"].([]any); hasRequired {
-		for _, name := range names {
-			text, isText := name.(string)
-			if !isText {
-				continue
-			}
-			out[text] = true
-			if child, published := props[text]; published {
-				collectRequired(child, out)
-			}
+	names, hasRequired := schema["required"].([]any)
+	if !hasRequired {
+		return
+	}
+	for _, name := range names {
+		text, isText := name.(string)
+		if !isText {
+			continue
+		}
+		here := append(append([]string{}, at...), text)
+		out[strings.Join(here, ".")] = true
+		if child, published := props[text]; published {
+			collectRequired(child, here, out)
 		}
 	}
 }
 
-// fixtureMembers reads the object-literal keys out of a fixture, with the brace
-// depth each sits at. Comments and string contents are excluded — a `//` note
-// naming a member, or a member name inside a quoted value, is prose.
+// fixtureMembers reads the object-literal keys out of a fixture, each with the
+// PATH it sits at — "items.deal_id" rather than "deal_id".
 //
-// The DEPTH is what makes the required check mean what it says. Without it both
-// sides are flat name sets, and a required member missing from `data` reads as
-// present because something nested carries the same name — the exact drift this
-// gate exists to catch, hidden by a coincidence of vocabulary. Nesting is
-// counted by braces rather than by indentation: a formatter is free to change
-// how it indents and is not free to change what nests inside what.
+// Paths and not names, because a name alone loses which member is meant. The
+// handoff fixture carries a root `name` and a nested `deals[].name`: with names,
+// a schema that dropped the root one while keeping the nested one leaves the
+// stale root field reading as published, which is the drift this gate is for.
+// Arrays contribute no segment — a row's members belong to the collection, and
+// an index would make every fixture's second row a different path.
+//
+// Scanned rather than regex-stripped. A quoted value may contain an escaped
+// quote or a brace, and `"[^"]*"` ends the string at the wrong place for the
+// first and lets the second through — either one corrupts the nesting from that
+// line on and reports valid fixtures as missing required members. Comments are
+// skipped the same way, mid-line ones included.
 func fixtureMembers(source []byte) map[string]int {
 	out := map[string]int{}
-	depth := 0
+	var path []string
 	for _, line := range strings.Split(string(source), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") ||
-			strings.HasPrefix(trimmed, "/*") {
-			continue
-		}
-		code := fixtureString.ReplaceAllString(line, `""`)
-		if m := fixtureKey.FindStringSubmatch(code); m != nil {
-			// The key sits INSIDE the braces open before its line.
-			if prior, seen := out[m[1]]; !seen || depth < prior {
-				out[m[1]] = depth
+		code := fixtureCode(line)
+		if key := fixtureKey.FindStringSubmatch(code); key != nil {
+			if at, under := underData(append(append([]string{}, path...), key[1])); under {
+				out[at] = len(path)
 			}
 		}
-		depth += strings.Count(code, "{") + strings.Count(code, "[")
-		depth -= strings.Count(code, "}") + strings.Count(code, "]")
+		// The key is recorded at the depth it OPENS at, so nesting is updated
+		// after it: `items: [` names items at this level and its rows below.
+		for _, r := range code {
+			switch r {
+			case '{', '[':
+				path = append(path, lastKeyOn(code))
+			case '}', ']':
+				if len(path) > 0 {
+					path = path[:len(path)-1]
+				}
+			}
+		}
 	}
 	return out
+}
+
+// underData answers a fixture path relative to the envelope's `data`, and
+// whether it is under it at all.
+//
+// The fixture models an Envelope, so every path starts inside the literal's
+// outermost brace (an anonymous segment) and then under `data`. The schema side
+// is relative to the tool's own shape, so the two only line up once that prefix
+// is off. A path outside `data` — the envelope's `warnings` — is not the tool's
+// and answers false.
+func underData(path []string) (string, bool) {
+	named := make([]string, 0, len(path))
+	for _, segment := range path {
+		if segment != "" {
+			named = append(named, segment)
+		}
+	}
+	if len(named) == 0 || named[0] != envelopeDataMember {
+		return "", false
+	}
+	return strings.Join(named[1:], "."), len(named) > 1
+}
+
+// lastKeyOn is the member a brace on this line opens under, or "" for an
+// anonymous one — an array's element object, which contributes no segment.
+func lastKeyOn(code string) string {
+	if key := fixtureKey.FindStringSubmatch(code); key != nil {
+		return key[1]
+	}
+	return ""
+}
+
+// fixtureCode is one line with its comments and string CONTENTS removed, so
+// neither can be read as structure or as a key.
+//
+// A hand-rolled scan because the alternatives are wrong in ways that matter
+// here: a regex for a quoted run cannot express "unless the quote is escaped",
+// and a JSON parser cannot read a TypeScript literal at all.
+func fixtureCode(line string) string {
+	var out strings.Builder
+	var quote rune
+	escaped := false
+	runes := []rune(line)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		switch {
+		case quote != 0 && escaped:
+			escaped = false
+		case quote != 0 && r == '\\':
+			escaped = true
+		case quote != 0 && r == quote:
+			quote = 0
+			out.WriteRune('"')
+		case quote != 0:
+			// Inside a string: contributes nothing, whatever it is.
+		case r == '"' || r == '\'' || r == '`':
+			quote = r
+			out.WriteRune('"')
+		case r == '/' && i+1 < len(runes) && (runes[i+1] == '/' || runes[i+1] == '*'):
+			// A comment starts here and this reader is line-wise, so the rest
+			// of the line is prose. A block comment's later lines carry no
+			// key and no brace this cares about — and if one ever did, the
+			// per-fixture count below is what notices the read going wrong.
+			return out.String()
+		default:
+			out.WriteRune(r)
+		}
+	}
+	return out.String()
 }

--- a/backend/gates/appviewfixtures_test.go
+++ b/backend/gates/appviewfixtures_test.go
@@ -206,6 +206,7 @@ func toolShapeMembers(t *testing.T, tool string, raw json.RawMessage) (published
 	return published, required
 }
 
+//craft:ignore naked-any a decoded JSON Schema is an arbitrary document, so the node this walks IS any — naming a type here would describe a shape the deriver is free to change
 func collectPublished(node any, out map[string]bool) {
 	switch n := node.(type) {
 	case map[string]any:
@@ -239,6 +240,8 @@ func collectPublished(node any, out map[string]bool) {
 // Little is lost, because the direction that catches this ticket's defect is the
 // other one: a renamed element member makes the fixture carry a name the schema
 // no longer publishes, and that check is total and reaches every depth.
+//
+//craft:ignore naked-any the same decoded document collectPublished walks, for the same reason
 func collectRequired(node any, out map[string]bool) {
 	schema, isObject := node.(map[string]any)
 	if !isObject {

--- a/backend/gates/appviewfixtures_test.go
+++ b/backend/gates/appviewfixtures_test.go
@@ -77,6 +77,14 @@ const appFixtureFloor = 4
 // per-fixture count below are what fail if that ever stops being true.
 var fixtureKey = regexp.MustCompile(`^\s*([a-z][A-Za-z0-9_]*)\s*:`)
 
+// fixtureString matches a quoted value, blanked before braces are counted so a
+// `{` inside a message is not read as structure.
+var fixtureString = regexp.MustCompile(`"[^"]*"`)
+
+// dataMemberDepth is the brace depth of the members of the envelope's `data`.
+// The literal opens at depth 0, `data:` sits at 1, and its own members at 2.
+const dataMemberDepth = 2
+
 func TestEveryAppViewFixtureMatchesItsToolsOutputSchema(t *testing.T) {
 	t.Parallel()
 	defer fixtureMemberOnlyInTheView.AssertAllMatched(t)
@@ -122,7 +130,7 @@ func TestEveryAppViewFixtureMatchesItsToolsOutputSchema(t *testing.T) {
 }
 
 // compareFixtureToSchema reports both directions of the drift.
-func compareFixtureToSchema(t *testing.T, tool, dir string, fixture, published, required map[string]bool) {
+func compareFixtureToSchema(t *testing.T, tool, dir string, fixture map[string]int, published, required map[string]bool) {
 	t.Helper()
 	for _, member := range slices.Sorted(maps.Keys(fixture)) {
 		if envelopeMembers[member] || published[member] {
@@ -145,7 +153,13 @@ func compareFixtureToSchema(t *testing.T, tool, dir string, fixture, published, 
 	// that matters under every field a payload may omit. A REQUIRED member
 	// missing means the fixture is not an answer the tool could have sealed.
 	for _, member := range slices.Sorted(maps.Keys(required)) {
-		if fixture[member] || !published[member] {
+		if !published[member] {
+			continue
+		}
+		// AT ITS OWN LEVEL. `required` here is what the tool's shape requires
+		// of the payload root, so a member of the same name nested deeper is a
+		// different member and must not answer for it.
+		if at, carried := fixture[member]; carried && at == dataMemberDepth {
 			continue
 		}
 		t.Errorf("%s REQUIRES %q and %s/fixture.ts does not carry it.\n"+
@@ -262,19 +276,34 @@ func collectRequired(node any, out map[string]bool) {
 	}
 }
 
-// fixtureMembers reads the object-literal keys out of a fixture, comments and
-// string contents excluded — a `//` note naming a member, or a member name
-// inside a quoted value, is prose rather than a key.
-func fixtureMembers(source []byte) map[string]bool {
-	out := map[string]bool{}
+// fixtureMembers reads the object-literal keys out of a fixture, with the brace
+// depth each sits at. Comments and string contents are excluded — a `//` note
+// naming a member, or a member name inside a quoted value, is prose.
+//
+// The DEPTH is what makes the required check mean what it says. Without it both
+// sides are flat name sets, and a required member missing from `data` reads as
+// present because something nested carries the same name — the exact drift this
+// gate exists to catch, hidden by a coincidence of vocabulary. Nesting is
+// counted by braces rather than by indentation: a formatter is free to change
+// how it indents and is not free to change what nests inside what.
+func fixtureMembers(source []byte) map[string]int {
+	out := map[string]int{}
+	depth := 0
 	for _, line := range strings.Split(string(source), "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") {
+		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") ||
+			strings.HasPrefix(trimmed, "/*") {
 			continue
 		}
-		if m := fixtureKey.FindStringSubmatch(line); m != nil {
-			out[m[1]] = true
+		code := fixtureString.ReplaceAllString(line, `""`)
+		if m := fixtureKey.FindStringSubmatch(code); m != nil {
+			// The key sits INSIDE the braces open before its line.
+			if prior, seen := out[m[1]]; !seen || depth < prior {
+				out[m[1]] = depth
+			}
 		}
+		depth += strings.Count(code, "{") + strings.Count(code, "[")
+		depth -= strings.Count(code, "}") + strings.Count(code, "]")
 	}
 	return out
 }

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (99)
+## Parity (100)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -26,6 +26,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `airoutingschema_test.go` | H3 | What the EDITOR accepts, checked against what the parser accepts. |
 | `aitaskparity_test.go` | H3 | Every ai\_task an emitter writes into the AI-activity projection must be a task the AI contract declares. |
 | `aitaskrunenum_test.go` | H3 | The ai\_task.state\_changed payload's closed vocabularies must equal the ai\_task\_run column CHECKs they are projected into. |
+| `appviewfixtures_test.go` | H2 | A view's fixture is the tool's answer, and this is what makes that true. |
 | `auditcoherence_test.go` | H3 | The audit\_log enum-coherence gate as a fitness function. |
 | `authwaitparity_test.go` | H3 | How long an in-flight authentication may be held waiting on somebody else's server. |
 | `authzcategories_test.go` | H2 | The outbound category vocabulary is spelled TWICE — once in Go, once as a CHECK constraint on communication\_decision — and the two must agree. |

--- a/frontend/src/mcp-apps/account-brief/fixture.ts
+++ b/frontend/src/mcp-apps/account-brief/fixture.ts
@@ -3,20 +3,31 @@ import type { Envelope } from "../types";
 /**
  * One realistic `read_brief` answer, shaped exactly as the tool seals it.
  *
- * MIRRORED BY HAND from agents.ReadBriefResult / agents.BriefItem, because
- * nothing pins a view's expectation of `structuredContent.data` to what the tool
- * answers — `agents/outputshapes.go` never reaches TypeScript. That gap is filed
- * as a follow-up; until it closes, every member name here is a hand-checked copy
- * and a rename on the Go side will not fail this suite.
+ * Written by hand from agents.ReadBriefResult / agents.BriefItem, and HELD to
+ * them: backend/gates/appviewfixtures_test.go compares every member here against
+ * read_brief's own output schema, which is derived from those structs by
+ * reflection. A rename on the Go side now fails that gate instead of quietly
+ * rendering this view's empty state.
+ *
+ * So a member added here that the tool does not answer is a finding, and a
+ * member the tool REQUIRES and this omits is one too.
  */
 export const accountBriefFixture: Envelope = {
   data: {
     brief_id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
     generated_at: "2026-08-10T06:15:00Z",
     as_of: "2026-08-10T06:00:00Z",
+    // The morning this run is FOR, in the installation's reporting zone. Not
+    // derivable from the two UTC instants above, which is why the tool answers
+    // it and why a fixture without it was not an answer the tool could seal.
+    local_day: "2026-08-10",
     // Seven cleared the honest-short bar; two are queued. The difference is
     // what the ranking left out, and the view says so.
     candidate_count: 7,
+    // Empty: this run had an input for every factor. Never null on the wire —
+    // an agent reading null cannot tell "no factor was omitted" from "nobody
+    // looked".
+    factors_omitted: [],
     items: [
       {
         item_id: "16fd2706-8baf-433b-82eb-8c7fada847da",

--- a/frontend/src/mcp-apps/commitments/fixture.ts
+++ b/frontend/src/mcp-apps/commitments/fixture.ts
@@ -6,7 +6,9 @@ import type { Envelope } from "../types";
  *
  * MIRRORED BY HAND from agents.ReviewCommitmentsResult / agents.CommitmentItem
  * — see the account brief's fixture for why that is hand work rather than
- * generated, and issue 808 for the gate that does not exist yet.
+ * generated. It is HELD to that struct by
+ * backend/gates/appviewfixtures_test.go, which compares every member here
+ * against the tool's own output schema.
  *
  * The four items are the four states this view has to keep apart: badly
  * overdue, overdue by less than a day, upcoming, and a promise nobody dated.

--- a/frontend/src/mcp-apps/handoff/fixture.ts
+++ b/frontend/src/mcp-apps/handoff/fixture.ts
@@ -4,8 +4,9 @@ import type { Envelope } from "../types";
  * One realistic `prepare_handoff` answer, shaped exactly as the tool seals it.
  *
  * MIRRORED BY HAND from agents.PreparedHandoff — see the account brief's
- * fixture for why that is hand work rather than generated, and issue 808 for the
- * gate that does not exist yet.
+ * fixture for why that is hand work rather than generated. It is HELD to that
+ * struct by backend/gates/appviewfixtures_test.go, which compares every member
+ * here against the tool's own output schema.
  *
  * It is a handover that is NOT ready, which is the case worth drawing: two
  * gaps, an untitled seat, an unpriced won deal beside a priced one, and a

--- a/frontend/src/mcp-apps/pipeline-review/fixture.ts
+++ b/frontend/src/mcp-apps/pipeline-review/fixture.ts
@@ -6,7 +6,9 @@ import type { Envelope } from "../types";
  *
  * MIRRORED BY HAND from agents.WhatsSlippingResult / agents.SlippingDealItem —
  * see the account brief's fixture for why that is hand work rather than
- * generated, and issue 808 for the gate that does not exist yet.
+ * generated. It is HELD to that struct by
+ * backend/gates/appviewfixtures_test.go, which compares every member here
+ * against the tool's own output schema.
  *
  * The third deal carries NO amount, which is a real state the view has to keep
  * honest: a deal can be worked before it is priced, and a blank amount


### PR DESCRIPTION
Closes #808, taking the ticket's own option 2 — the fitness test rather than codegen.

### What was open

A view's expectation of `structuredContent.data` was a hand-written mirror of the Go result structs, and a rename on the Go side compiled, shipped, and produced a view rendering its **empty state**. Contained, because the views narrow every field through guards and answer empty rather than throwing — and undetected, because the fixture each view's suite runs against was hand-built from the same reading.

### Why the fixture is the right thing to hold

It is what the view's suite draws. A fixture true to the contract makes those tests true to it, and it is checkable from the backend, where the tool's **output schema** is available — derived from the Go type by reflection (`agents/outputshapes.go`), so a renamed struct member is a renamed schema property.

Running the TypeScript guard against a marshalled Go struct would be closer to the ticket's literal wording, but it needs a TS runtime in a Go gate to prove the same thing this proves statically.

### Derived, not listed

- the tools that carry a view **declare** it (`mcp.ToolUI.ResourceURI`), so the sweep is over `Specs()`;
- the view's directory comes from that URI the same way the document's own file name does (`agents/apps/fetch.go`);
- the members come from the schema and the fixture.

A sixth view inherits the check by existing. A view with no fixture — the geo probe, which answers no tool — is skipped rather than reported: there is nothing to disagree with a schema.

### Two directions, and why only one is total

**Fixture → schema is total, at every depth.** A member the fixture carries that the tool does not publish is the defect this ticket is about, wearing its own name. This is the direction that catches the rename.

**Schema → fixture is limited to what the payload must carry.** A fixture is one realistic answer, so an optional member it does not exercise is a choice rather than drift. Two narrowings got there:

- collecting `required` flatly reported every field of every optional branch — a `required` list inside an optional sub-object says "if you send this object, send these", not that the payload must have them;
- descending into an array's element schema asserted row members against `about: []`, seven findings about an empty list. The walk stops at arrays now, and little is lost because a renamed element member is caught by the total direction anyway.

The subject is the schema's `data` member, not the document: the advertised schema is the envelope's, and the TS `Envelope` type carries only `data` and `warnings` — the seal `Invoke` adds is not hand-written, so comparing against the whole document reported every fixture for lacking a trace id.

### Two findings, fixed

`account-brief/fixture.ts` was missing `local_day` and `factors_omitted`, both required by `read_brief`. Not a payload the tool could have sealed, and no view test had ever drawn either. The four fixture doc comments that pointed at this issue for "the gate that does not exist yet" now name the gate.

### Held

Mutation-checked both ways: renaming `BriefItem.DealID`'s JSON tag to `deal_ref` fails with *"fixture.ts carries `deal_id`, which read_brief does not publish"* — the ticket's defect, now loud; and deleting `local_day` from the fixture fails as a missing required member. `appFixtureFloor` catches the tool-to-view derivation going to zero, and a per-fixture count catches a fixture that stops being read.

`make check-backend` and `make check-fe` both green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account Brief fixtures now include the reporting date and an explicit list of omitted factors, improving consistency in displayed results.

- **Tests**
  - Added automated validation to ensure app view fixtures stay aligned with tool output schemas and identify missing or unexpected fields.

- **Documentation**
  - Updated fixture documentation to reflect schema validation and the current source of truth.
  - Updated the gate inventory to include the new validation gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->