### PR TITLE
test(gates): a test named in a comment exists

### DIFF
--- a/backend/gates/commentnamedtests_test.go
+++ b/backend/gates/commentnamedtests_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H1
+
+//go:build !integration
+
+package gates
+
+// A test named in a comment exists.
+//
+// Naming the gate that holds an invariant — "bound by the census rather than by
+// comment" — is one of the better habits in this tree, and it works only while
+// the name resolves.
+//
+// A stale name is silent in the worst direction. It reads as a decision: the
+// next author greps for it, finds nothing, and cannot tell whether the gate was
+// renamed, deleted, or never written. `craft static` cannot see it, because it
+// is a comment; no compiler sees it, for the same reason. Fifteen accumulated
+// before anybody looked.
+//
+// The corpus is every tracked .go file in the tree, not this module: a comment
+// in an extension or in the tool chain makes the same promise, and a comment
+// here may name a gate that lives there.
+//
+// A name RESOLVES against every identifier the tree declares, not only against
+// test functions — because the question a reader is really asking is whether
+// grepping the name finds anything. `jobs.Config.TestOnly` is a field and
+// `capture.TestMailboxLedger` is a type; prose naming either is telling the
+// truth, and a gate that only knew about `func Test…` would call both stale and
+// teach people to stop naming things.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// commentTestName is a Go test name as prose writes one. `Test` followed by an
+// upper-case letter is what the toolchain itself requires of a test function,
+// so this cannot match an ordinary word.
+var commentTestName = regexp.MustCompile(`\bTest[A-Z][A-Za-z0-9_]*`)
+
+// abbreviated marks a name a comment deliberately cut short — "TestEverySeat…"
+// — which is a reference to a family rather than to one function. Both
+// spellings, because prose here uses each.
+var abbreviated = regexp.MustCompile(`^\s*(?:…|\.\.\.)`)
+
+// runInvocation is a comment telling the reader how to run something. `-run`
+// takes an unanchored regular expression, so a prefix is not a truncated name
+// but the ordinary way to write one — `-run TestEveryPolicyRecordType` selects
+// TestEveryPolicyRecordTypeIsOneItsToolCanSend and is exactly what its author
+// meant. Requiring the full name here would teach people to paste a longer
+// string than the command needs.
+var runInvocation = regexp.MustCompile(`-run\s+$`)
+
+func TestEveryTestNamedInACommentExists(t *testing.T) {
+	t.Parallel()
+
+	declared, testFuncs, comments := goCommentCensus(t)
+
+	// The censusable corpus is asserted before its result is believed. A walk
+	// that found no files reports a clean tree, and a clean tree is exactly
+	// what a broken walk looks like. The test functions are counted separately
+	// from the identifiers they are a subset of: a walk that collected every
+	// `Test`-prefixed field and no test function at all would clear an
+	// identifier floor while having lost the thing this gate is named for.
+	if len(declared) < 1000 {
+		t.Fatalf("collected %d Test-prefixed identifiers across the tree — the walk found far less than this repository holds, so a green result here would mean nothing", len(declared))
+	}
+	if len(testFuncs) < 1000 {
+		t.Fatalf("collected %d declared test functions across the tree — the walk found far less than this repository holds, so a green result here would mean nothing", len(testFuncs))
+	}
+	if len(comments) < 100 {
+		t.Fatalf("collected %d comment groups naming a test — the walk found far less than this repository holds, so a green result here would mean nothing", len(comments))
+	}
+
+	var findings []string
+	for _, c := range comments {
+		for _, name := range c.named {
+			if declared[name] {
+				continue
+			}
+			if c.wraps(name, declared) || c.abbreviates(name) || c.selects(name, declared) {
+				continue
+			}
+			findings = append(findings, c.rel+": "+name)
+		}
+	}
+	sort.Strings(findings)
+
+	for _, f := range findings {
+		rel, name, _ := strings.Cut(f, ": ")
+		t.Errorf("%s names %s, which nothing in the tree declares — rename the reference to what actually holds this, or delete the claim if nothing does",
+			rel, name)
+	}
+}
+
+// commentBlock is one comment group and the three readings of it this gate
+// compares. Prose wraps, and a name broken across two lines is a false hit
+// unless the wrap is read back — but healing the text in place is worse, since
+// an em-dash or a hyphen that belongs to the sentence gets absorbed into the
+// identifier and invents a name nobody wrote. So the text is never rewritten:
+// the alternative readings are built beside it and a name that resolves under
+// ANY of them is a name the comment got right.
+type commentBlock struct {
+	rel string
+	// named is what the comment says line by line, which is how a reader who
+	// has not noticed the wrap reads it too.
+	named []string
+	// joined is the same text with the line breaks closed up, and hyphenJoined
+	// with a trailing hyphen dropped first — the two ways a name is split.
+	joined       string
+	hyphenJoined string
+	// text is the group as written, for the ellipsis lookahead.
+	text string
+}
+
+// wraps reports whether name is the start of a declared test that the comment
+// broke across a line. The name must be a strict prefix of something declared,
+// and that something must appear in one of the closed-up readings — a prefix
+// alone would excuse any truncation.
+func (c commentBlock) wraps(name string, declared map[string]bool) bool {
+	for _, reading := range []string{c.joined, c.hyphenJoined} {
+		for _, candidate := range commentTestName.FindAllString(reading, -1) {
+			if declared[candidate] && strings.HasPrefix(candidate, name) && candidate != name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// selects reports whether the name is a `go test -run` argument that picks out
+// declared tests by prefix.
+func (c commentBlock) selects(name string, declared map[string]bool) bool {
+	segments := strings.Split(c.text, name)
+	for _, before := range segments[:len(segments)-1] {
+		if runInvocation.MatchString(before) && namesAFamily(name, declared) {
+			return true
+		}
+	}
+	return false
+}
+
+// namesAFamily reports whether anything declared begins with this name and is
+// longer than it. A `-run` argument matching nothing is still a stale
+// reference — the command it documents selects no test.
+func namesAFamily(name string, declared map[string]bool) bool {
+	for candidate := range declared {
+		if candidate != name && strings.HasPrefix(candidate, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// abbreviates reports whether the comment cut the name short on purpose, which
+// it signals with an ellipsis immediately after.
+func (c commentBlock) abbreviates(name string) bool {
+	for _, after := range strings.Split(c.text, name)[1:] {
+		if abbreviated.MatchString(after) {
+			return true
+		}
+	}
+	return false
+}
+
+// goCommentCensus parses every tracked .go file once, returning every
+// Test-prefixed identifier the tree declares, the test functions among them,
+// and every comment group naming a candidate.
+//
+// A file the parser cannot read is not skipped quietly. Go source that does not
+// parse is either deliberate test data or a genuine problem, and either way a
+// silent skip shrinks the corpus with nothing to notice — so a partial parse
+// still yields its comments, and its declarations are simply what the parser
+// recovered.
+func goCommentCensus(t *testing.T) (declared, testFuncs map[string]bool, comments []commentBlock) {
+	t.Helper()
+
+	declared, testFuncs = map[string]bool{}, map[string]bool{}
+
+	for _, f := range trackedFiles(t) {
+		if f.symlink || filepath.Ext(f.path) != ".go" {
+			continue
+		}
+		// This file's own prose names the pattern it looks for and nothing
+		// else; the exemption is the exact path, so a second file by this name
+		// elsewhere is scanned like any other.
+		if f.path == "backend/gates/commentnamedtests_test.go" {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(repoRoot, f.path))
+		if err != nil {
+			// Tracked but absent mid-rebase or after `git rm`; not this gate's
+			// business.
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("reading %s: %v", f.path, err)
+		}
+		parsed, _ := parser.ParseFile(token.NewFileSet(), f.path, src, parser.ParseComments|parser.SkipObjectResolution)
+		if parsed == nil {
+			continue
+		}
+		// Every identifier, in any position. A declaration and a use are the
+		// same answer to the reader's question, and telling them apart would
+		// cost the cross-module case: a gate named in one module's comment is
+		// declared in another's file, and both are in this walk either way.
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			if ident, ok := n.(*ast.Ident); ok && commentTestName.MatchString(ident.Name) {
+				declared[ident.Name] = true
+			}
+			return true
+		})
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && fn.Recv == nil && strings.HasPrefix(fn.Name.Name, "Test") {
+				testFuncs[fn.Name.Name] = true
+			}
+		}
+		for _, group := range parsed.Comments {
+			text := group.Text()
+			named := commentTestName.FindAllString(text, -1)
+			if len(named) == 0 {
+				continue
+			}
+			comments = append(comments, commentBlock{
+				rel:          f.path,
+				named:        named,
+				text:         text,
+				joined:       strings.ReplaceAll(text, "\n", ""),
+				hyphenJoined: strings.ReplaceAll(strings.ReplaceAll(text, "-\n", ""), "\n", ""),
+			})
+		}
+	}
+	return declared, testFuncs, comments
+}

--- a/backend/gates/commentnamedtests_test.go
+++ b/backend/gates/commentnamedtests_test.go
@@ -37,6 +37,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -123,13 +124,34 @@ type commentBlock struct {
 }
 
 // wraps reports whether name is the start of a declared test that the comment
-// broke across a line. The name must be a strict prefix of something declared,
-// and that something must appear in one of the closed-up readings — a prefix
-// alone would excuse any truncation.
+// broke across a line.
+//
+// Three conditions, and the third is the one that keeps this from excusing
+// everything. The name must be a strict prefix of something declared; that
+// something must appear in one of the closed-up readings; and it must NOT
+// appear whole in the comment as written. Without the last, "TestFoo is stale;
+// see TestFooBar" excuses TestFoo — the joined reading contains any longer name
+// the comment mentions at all, so a stale reference standing beside a live one
+// would pass, which is this gate's whole subject.
+//
+// A genuine wrap is exactly the case the third condition admits: the full name
+// was split across the line break, so it is absent from the line-by-line
+// reading and present only once the break is closed up.
 func (c commentBlock) wraps(name string, declared map[string]bool) bool {
-	for _, reading := range []string{c.joined, c.hyphenJoined} {
-		for _, candidate := range commentTestName.FindAllString(reading, -1) {
-			if declared[candidate] && strings.HasPrefix(candidate, name) && candidate != name {
+	for candidate := range declared {
+		if candidate == name || !strings.HasPrefix(candidate, name) {
+			continue
+		}
+		if slices.Contains(c.named, candidate) {
+			continue
+		}
+		for _, reading := range []string{c.joined, c.hyphenJoined} {
+			// Substring, not the name pattern. Closing up a break joins the
+			// halves to whatever preceded them — "which\nTestFooBar" becomes
+			// "whichTestFooBar" — so the leading word boundary the pattern
+			// needs is exactly what the wrap destroyed. Searching for a name
+			// already known to be declared has no such problem.
+			if strings.Contains(reading, candidate) {
 				return true
 			}
 		}
@@ -241,4 +263,40 @@ func goCommentCensus(t *testing.T) (declared, testFuncs map[string]bool, comment
 		}
 	}
 	return declared, testFuncs, comments
+}
+
+// The wrap allowance, as a spec, because it is the one that can turn this gate
+// off without failing.
+//
+// Every allowance here trades a false finding for the risk of a missed one, and
+// this is the loosest of the three: it excuses a name on the evidence of a
+// LONGER name nearby. The case that must not pass is a stale reference standing
+// beside a live one — which is the ordinary way a rename leaves a comment
+// behind, so it is not a contrived input.
+func TestAWrappedNameIsExcusedAndAStaleOneBesideALiveOneIsNot(t *testing.T) {
+	t.Parallel()
+
+	declared := map[string]bool{"TestFooBar": true}
+
+	wrapped := commentBlockFor("The refusals need the admit case, which\nTestFoo\nBar provides.")
+	if !wrapped.wraps("TestFoo", declared) {
+		t.Error("a name the comment broke across a line was reported as stale — the wrap reading is what stops this gate from failing on ordinary prose")
+	}
+
+	beside := commentBlockFor("TestFoo is stale; see TestFooBar.")
+	if beside.wraps("TestFoo", declared) {
+		t.Error("a stale name standing beside a live longer one was excused by it — the joined reading contains any longer name the comment mentions, so a prefix test alone excuses every stale reference with a live sibling")
+	}
+}
+
+// commentBlockFor builds the three readings the way the census does, so a spec
+// exercises the same construction production does rather than its own.
+func commentBlockFor(text string) commentBlock {
+	return commentBlock{
+		rel:          "spec.go",
+		named:        commentTestName.FindAllString(text, -1),
+		text:         text,
+		joined:       strings.ReplaceAll(text, "\n", ""),
+		hyphenJoined: strings.ReplaceAll(strings.ReplaceAll(text, "-\n", ""), "\n", ""),
+	}
 }

--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -197,7 +197,7 @@ var piiTables = map[string]piiHandling{
 	// exists to avoid, so the obligation is held where it can be seen whole:
 	//
 	// Held by: TestTheRetentionSweepDestroysTheProviderOriginalToo and
-	// TestTheEraseActionRefusesWithoutItsPurger
+	// TestAPassMissingItsPurgerRefusesBeforeDestroyingAnything
 	// (backend/internal/compose/integration/retentionrawcapture_integration_test.go)
 	"raw_capture": {erasureWrite: true, sarRead: true},
 	"embedding":   {erasureWrite: true, sarRead: false}, // opaque vector: purged, never exported

--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -44,7 +44,7 @@ package gates
 // question about the whole tree, and the tree holds hundreds of them. What it
 // does is make the class stop GROWING, which is the half a test can hold:
 //
-//   - A claim that names its gate is held. `Held by: TestName (path)` in the
+//   - A claim that names its gate is held. `Held by: Test… (path)` in the
 //     same doc comment, and this file checks that test exists.
 //   - Every other claim in the tree today is in `uniquenessclaims.txt`, which
 //     is a DEBT REGISTER and not a permission. It can only shrink: a claim that
@@ -163,7 +163,7 @@ func readRegister(t *testing.T) []string {
 	return keys
 }
 
-// testFunctions returns every `func TestX` in the repo, keyed by name, with the
+// testFunctions returns every `func Test…` in the repo, keyed by name, with the
 // files it is declared in. A `Held by:` is checked against this rather than
 // against a path the author typed, so a rename that leaves the binding behind
 // is a failure rather than a comment nobody reads.
@@ -284,7 +284,7 @@ func declaredInAGateArm(paths []string) (string, bool) {
 // namesTheFile reports whether one of `paths` is the file the binding named.
 //
 // A PATH-SEGMENT suffix, not a string suffix. A bare `strings.HasSuffix`
-// matched inside a FILENAME: `Held by: TestX (claims_test.go)` bound against
+// matched inside a FILENAME: `Held by: Test… (claims_test.go)` bound against
 // `uniquenessclaims_test.go`, a file that does not exist, and `currency_test.go`
 // bound against `employmentcurrency_test.go`. A binding that resolves to a file
 // nobody named is worse than no binding, because it reads as checked.

--- a/backend/gates/uniquenessclaimsdetector_test.go
+++ b/backend/gates/uniquenessclaimsdetector_test.go
@@ -215,7 +215,7 @@ func intensifier(word string) bool {
 // heldBy is the binding a claim carries to say which test holds it. Free text
 // around it, because it sits inside a doc comment a human is also reading:
 //
-//	// Held by: TestEveryFooHasOneWriter (backend/gates/foowriters_test.go)
+//	// Held by: TestEveryFoo… (backend/gates/foowriters_test.go)
 //
 // It may sit ANYWHERE in the doc comment except the first line: revive requires
 // a doc comment to open with the identifier it documents, so a binding written

--- a/backend/gates/unitegress_test.go
+++ b/backend/gates/unitegress_test.go
@@ -29,7 +29,7 @@ package gates
 // resolve. Both defeat a static reader by construction. This is a lint against
 // the shape a unit actually writes — the same posture
 // TestExtensionSQLNamesOnlyTheUnitsOwnTables takes about a unit's SQL, and for
-// reason: the wall is elsewhere and this catches the mistake.
+// the same reason: the wall is elsewhere and this catches the mistake.
 
 import (
 	"go/ast"

--- a/backend/gates/unitegress_test.go
+++ b/backend/gates/unitegress_test.go
@@ -28,7 +28,7 @@ package gates
 // computed strings, or wires a Control hook through a variable this cannot
 // resolve. Both defeat a static reader by construction. This is a lint against
 // the shape a unit actually writes — the same posture
-// TestUnitSQLAddressesItsOwnTables takes about a unit's SQL, and for the same
+// TestExtensionSQLNamesOnlyTheUnitsOwnTables takes about a unit's SQL, and for
 // reason: the wall is elsewhere and this catches the mistake.
 
 import (

--- a/backend/internal/compose/agentcommand_createpatch_test.go
+++ b/backend/internal/compose/agentcommand_createpatch_test.go
@@ -58,7 +58,7 @@ func TestACreateStagesItsRecordTypeWithNoTargetID(t *testing.T) {
 
 // A create OUTSIDE create_record's own served vocabulary still stages,
 // through createResolver like every other registered create — the same shape
-// TestAnArchiveOutsideTheToolSchemaStagesTheRowItNames proves for archive.
+// TestAnArchiveOutsideTheToolSchemaStagesItsOwnTypeAndID proves for archive.
 // custom_field is one of the six create routes whose record type
 // create_record's own Handle cannot write, and createResolver.Guards has no
 // opinion on that (command.go); proving it stages successfully through the
@@ -124,7 +124,7 @@ func TestAMalformedPatchIDAnswersNotFound(t *testing.T) {
 // the seam cannot answer. Staged against a provider that fails EVERY read, so
 // a resolver that consulted the seam anyway fails here rather than passing on
 // a lenient stub — the same proof shape as
-// TestAnArchiveOutsideTheToolSchemaStagesTheRowItNames.
+// TestAnArchiveOutsideTheToolSchemaStagesItsOwnTypeAndID.
 func TestAPatchOutsideTheToolSchemaStagesTheRowItNames(t *testing.T) {
 	staging := &capturingApprovals{}
 	pol := agentPolicy{

--- a/backend/internal/compose/aicert/runner_run_test.go
+++ b/backend/internal/compose/aicert/runner_run_test.go
@@ -218,11 +218,11 @@ func TestRunWritesTaskARecordAndSurfacesTaskBsWriteErrorInTheSameCall(t *testing
 
 // TestRunAnUnrunnableBindingJoinsAnErrorPerTaskAndAbortsNone proves the
 // "heard, never swallowed" contract on the error path every task
-// actually reaches: a malformed MODEL= override fails identically for
-// every task in the corpus (each task's own certifyTask call refuses
-// it independently), and Run reports every one of them — via
-// errors.Join, not just the first — rather than stopping at the first
-// failure.
+// actually reaches: a cloud vendor under a sovereign profile is refused
+// identically for every task in the corpus (each task's own certifyTask
+// call refuses it independently), and Run reports every one of them —
+// via errors.Join, not just the first — rather than stopping at the
+// first failure.
 func TestRunAnUnrunnableBindingJoinsAnErrorPerTaskAndAbortsNone(t *testing.T) {
 	dir := t.TempDir()
 	corpusDir := filepath.Join(dir, "corpus")

--- a/backend/internal/compose/aicert/runner_run_test.go
+++ b/backend/internal/compose/aicert/runner_run_test.go
@@ -170,7 +170,7 @@ func TestRunRejectsAnEvenRepeatsBeforeTouchingAnything(t *testing.T) {
 
 // TestRunWritesTaskARecordAndSurfacesTaskBsWriteErrorInTheSameCall proves
 // the "one task fails, its sibling still gets recorded, in the same
-// Run() call" property that TestRunMalformedOverrideJoinsAnErrorPerTaskAndAbortsNone
+// Run() call" property that TestRunAnUnrunnableBindingJoinsAnErrorPerTaskAndAbortsNone
 // cannot: a malformed override fails every task identically, so it can
 // never show one task succeeding alongside another failing in one Run.
 // Here both tasks certify cleanly, but a plain FILE pre-created at the
@@ -216,7 +216,7 @@ func TestRunWritesTaskARecordAndSurfacesTaskBsWriteErrorInTheSameCall(t *testing
 	}
 }
 
-// TestRunMalformedOverrideJoinsAnErrorPerTaskAndAbortsNone proves the
+// TestRunAnUnrunnableBindingJoinsAnErrorPerTaskAndAbortsNone proves the
 // "heard, never swallowed" contract on the error path every task
 // actually reaches: a malformed MODEL= override fails identically for
 // every task in the corpus (each task's own certifyTask call refuses

--- a/backend/internal/compose/attention/destination.go
+++ b/backend/internal/compose/attention/destination.go
@@ -39,7 +39,7 @@ const (
 
 // destinationOfSource is the whole mapping, and the only one.
 //
-// EXHAUSTIVE over the source enum, held by TestEverySourceHasADestination: a
+// EXHAUSTIVE over the source enum, held by TestEveryWorklistSourceHasADestination: a
 // twenty-second source fails that test until somebody decides where it belongs.
 // The failure is the point. A source added without a destination would default
 // to whatever the zero value is, and the reader would find it on a screen

--- a/backend/internal/compose/attention/unseen.go
+++ b/backend/internal/compose/attention/unseen.go
@@ -30,7 +30,7 @@ import (
 // Under-reporting is the one way this must not fail. A source silently marked
 // complete tells a rep there is no more work of that kind, and there is no
 // failing row to notice — which is why every lane with a bound appears here and
-// `TestEveryBoundedLaneIsNamedInTheBoundsTable` fails when a new one is not.
+// `TestEveryBoundedLaneReportsItsTruncation` fails when a new one does not.
 // The bounds of the lanes whose limit lives behind their seam, where this
 // package cannot reach it. They are MIRRORS: `compose.slippingScanLimit` and
 // `compose.decayCandidateCap` are the real numbers, and

--- a/backend/internal/compose/attention/worklistbuckets_test.go
+++ b/backend/internal/compose/attention/worklistbuckets_test.go
@@ -80,7 +80,7 @@ func TestAJudgementIsNeverUrgentSellerWork(t *testing.T) {
 	}
 }
 
-// TestAnOverdueSellerRowIsCountedOnceHoldsThePrecedence.
+// TestAnOverdueSellerRowIsCountedOnce holds the precedence.
 //
 // `due` beside it is asked of every row whatever its level, so an overdue
 // promise counts twice there — deliberately. The buckets slice instead, so the

--- a/backend/internal/compose/capturepurge.go
+++ b/backend/internal/compose/capturepurge.go
@@ -155,7 +155,9 @@ func (p *CapturePurger) Purge(ctx context.Context, exclusionID ids.UUID, preview
 // second copy of this sequence is how one path would quietly stop auditing a
 // release or stop recomputing an audience.
 //
-// Held by TestBothPurgePathsShareOneExecutor (backend/gates/purgeexecutor_test.go).
+// NOT held by a test. Both call sites are in this file and a reader can see
+// them, which is why the claim is safe to make here and would not be safe
+// three packages away — but a third path added elsewhere would go unnoticed.
 func (p *CapturePurger) carryOut(
 	ctx context.Context, subject capture.PurgeSubject, people []ids.UUID,
 	seat ids.UUID, reason privacy.PurgeReason,

--- a/backend/internal/compose/extingressdrift_test.go
+++ b/backend/internal/compose/extingressdrift_test.go
@@ -257,7 +257,7 @@ func TestTheMergeKeyVocabulariesAgree(t *testing.T) {
 	}
 }
 
-// TestThePublishedActivityTypesMatchTheCoresA published field whose TYPE
+// TestThePublishedActivityTypesMatchTheCores. A published field whose TYPE
 // diverged would compile on both sides and lose meaning in the middle — a
 // string where the core wants a time is the obvious one, and it is the one a
 // hand-written bridge makes possible.

--- a/backend/internal/compose/integration/agentcommandoperand_integration_test.go
+++ b/backend/internal/compose/integration/agentcommandoperand_integration_test.go
@@ -12,7 +12,7 @@ package integration
 //
 // TestAConfirmFirstFactCallAgainstAnUnseeableOrganizationStagesNothing below
 // is the proof that matters: their restCommands entries make Guards run before
-// anything stages. TestTwoFactKeysOnOneOrganizationStageDistinguishableApprovals
+// anything stages. TestTwoStagedCallsDifferingOnlyInArgumentsAreDistinguishable
 // does NOT prove that — diff_hash and summary are both derived from the
 // concrete request path upstream of the resolver (canonicalRESTCall,
 // restSummary), so it holds whether or not a resolver was consulted at all.

--- a/backend/internal/compose/integration/introadvance_integration_test.go
+++ b/backend/internal/compose/integration/introadvance_integration_test.go
@@ -13,8 +13,8 @@ package integration
 // mail the rep sent, a message the contact was merely cc'd on, and the years of
 // backfilled correspondence a first mailbox import delivers all at once.
 //
-// The refusals need the admit case beside them, which TestAContactsAnswer
-// provides: without it a consumer that refused everything would pass every
+// The refusals need the admit case beside them, which
+// TestAContactsAnswerClosesTheIntroduction provides: without it a consumer that refused everything would pass every
 // negative test in this file.
 
 import (

--- a/backend/internal/compose/integration/introadvance_integration_test.go
+++ b/backend/internal/compose/integration/introadvance_integration_test.go
@@ -14,8 +14,8 @@ package integration
 // backfilled correspondence a first mailbox import delivers all at once.
 //
 // The refusals need the admit case beside them, which
-// TestAContactsAnswerClosesTheIntroduction provides: without it a consumer that refused everything would pass every
-// negative test in this file.
+// TestAContactsAnswerClosesTheIntroduction provides: without it a consumer
+// that refused everything would pass every negative test in this file.
 
 import (
 	"context"

--- a/backend/internal/compose/integration/jobfanout/runner_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/runner_integration_test.go
@@ -157,10 +157,11 @@ func setupRunner(t *testing.T) *runnerEnv {
 }
 
 // tick runs ONE workspace's scheduler pass, under the bound context and the
-// clock reading the job worker hands it in production — the fan-out that puts
-// a tenant's pass on its own job row is
-// TestAgentSchedulerFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant's
-// subject, not this suite's.
+// clock reading the job worker hands it in production.
+//
+// There is no fan-out above it to defer to any more: a pass is one row, so
+// what survives is TestAgentSchedulerSeedsAndClaimsWhatIsDue, which asks what
+// one pass does rather than how many rows a tick produces.
 func (re *runnerEnv) tick(t *testing.T) {
 	t.Helper()
 	if err := re.svc.Tick(re.wsCtx, time.Now()); err != nil {

--- a/backend/internal/compose/integration/relationship_seam_integration_test.go
+++ b/backend/internal/compose/integration/relationship_seam_integration_test.go
@@ -172,7 +172,7 @@ func TestAnEmploymentEdgeLivesItsWholeLifeThroughTheToolSurface(t *testing.T) {
 	// ARCHIVE. The caller here is a HUMAN in their own seat, so the 🟡 tier does
 	// not stage — that gate is for agent principals, and the agent half is
 	// proven over REST with a real passport
-	// (TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion).
+	// (TestAFlooredEdgeArchiveStagesWithItsVersionPinned).
 	if _, err := registry.Invoke(ctx, "archive_record", json.RawMessage(fmt.Sprintf(
 		`{"record_type":"relationship","id":%q}`, edgeID))); err != nil {
 		t.Fatalf("archive_record relationship: %v", err)

--- a/backend/internal/compose/onboardingcopy.go
+++ b/backend/internal/compose/onboardingcopy.go
@@ -12,8 +12,8 @@ package compose
 // Vietnamese product, and the only way to find out was to run it.
 //
 // A table instead, keyed by the language, with the shipped set as the census.
-// TestEveryShippedLanguageHasOnboardingCopy fails when the product gains a
-// language this file has not learned — before a reader does.
+// TestTheOnboardingConversationSpeaksEveryShippedLanguage fails when the
+// product gains a language this file has not learned — before a reader does.
 //
 // The model-written half of the conversation needs none of this: it is
 // instructed through promptlang.Rule, which already answers for every shipped

--- a/backend/internal/compose/overlaywebhook_test.go
+++ b/backend/internal/compose/overlaywebhook_test.go
@@ -280,7 +280,7 @@ func TestWebhookReceiverDropsUnmappedSubscription(t *testing.T) {
 	}
 }
 
-// TestOverlayRefetchWorkerRejectsMalformedWorkspace: a job carrying an
+// TestOverlayRefetchWorkerRejectsArgsNamingNoWorkspace: a job carrying an
 // unparseable workspace id is a permanent defect — the worker returns nil (no
 // retry) rather than looping on an unfixable arg. This exercises the guard
 // before any DB access.

--- a/backend/internal/compose/undoabilitypage.go
+++ b/backend/internal/compose/undoabilitypage.go
@@ -241,7 +241,7 @@ func auditSubjectsOf(rows []pageRow) (types []string, subjects []ids.UUID) {
 // from the binding evaluator rather than assembled beside it, so a port added
 // to the write is bound here without anyone remembering — which is how the page
 // came to omit ExternallyGoverned and light a restore button the write refuses.
-// Held by TestTheAdvisoryPathBindsEveryPortTheWriteBinds.
+// Held by TestTheAdvisoryPathAnswersFromThePageFacts.
 //
 // The erasure boundary is the one fact a page cannot hold for every row: a
 // LINK's is its endpoints' and not its own (see pageRow), so an edge row keeps

--- a/backend/internal/modules/automation/audiencegate.go
+++ b/backend/internal/modules/automation/audiencegate.go
@@ -51,7 +51,9 @@ import (
 //     Target. Those can differ by design (gate.go's target-scoped arm says so),
 //     and no shipped handler produces an activity target that differs from its
 //     trigger today — people/leadrouting.go passes ev.Entity straight through.
-//     TestNoHandlerTargetsAnActivityAwayFromItsTrigger fails when one appears.
+//     Nothing holds that, unlike the sibling below: it is a reading of every
+//     shipped handler at the time of writing, and a handler that diverges
+//     later arrives silently.
 //   - A signal carries activity-derived evidence with its own visibility
 //     (platform/auth's SignalScopeClause), and a signal-subject firing skips
 //     this gate. No human-owned signal workflow is registered

--- a/backend/internal/modules/capture/offlinedemo/offlinedemo_test.go
+++ b/backend/internal/modules/capture/offlinedemo/offlinedemo_test.go
@@ -179,7 +179,7 @@ func TestOutboundNamesItsRecipient(t *testing.T) {
 	}
 }
 
-// TestRecordsLinkTheAccount — an activity that links nothing shows on no
+// TestMailRecordsLinkTheAccount — an activity that links nothing shows on no
 // company page, which is the failure the seeder's verify pass exists to catch.
 func TestMailRecordsLinkTheAccount(t *testing.T) {
 	box := demoMailbox()

--- a/backend/internal/modules/identity/passportliveness.go
+++ b/backend/internal/modules/identity/passportliveness.go
@@ -79,7 +79,7 @@ func agentAuthQuery(predicate string) string {
 // asks it again at every tool ADMISSION, because a run authenticates once and
 // then executes for its whole wall clock — so without the second asking, a
 // revoked passport keeps working until the run ends on its own. Held by
-// TestTheLivenessRuleIsAskedTheSameWayTwice.
+// TestBothAgentAuthenticationPathsExecuteTheOneLivenessQuery.
 var agentLivenessWhere = `
 		  AND p.revoked_at IS NULL
 		  AND now() < p.expires_at

--- a/backend/internal/modules/people/sdrhandoff_integration_test.go
+++ b/backend/internal/modules/people/sdrhandoff_integration_test.go
@@ -268,7 +268,7 @@ func (e *promoteConsentEnv) eventReason(t *testing.T, id ids.UUID, status string
 // resets every table before each test — a reader here would be asserting that
 // truncation had not happened, which is a fact about the harness rather than
 // about handoffs. That the migration seeds a usable list is a different claim,
-// and TestTheSeededHandoffReasonsCoverBothTransitions is where it is made.
+// and no test in this tree makes it.
 // The label carries the test's own name because sdr_handoff_reason is a
 // PRESERVED reference table: the migration seeds the system catalogue and the
 // reset leaves it standing, so a fixed label here would collide with the row the

--- a/backend/internal/platform/deployconfig/capture.go
+++ b/backend/internal/platform/deployconfig/capture.go
@@ -72,7 +72,7 @@ type Capture struct {
 // there is one place the default lives and a nil can never panic at a call
 // site that forgot it.
 //
-// Held by: TestOnlyTheResolverDereferencesTracePayloads (capture_test.go)
+// Held by: TestOnlyTheResolverReadsTheTracePayloadsField (capture_test.go)
 func (c Capture) TracesPayloads() bool {
 	return c.TracePayloadsSetting == nil || *c.TracePayloadsSetting
 }

--- a/backend/internal/platform/jobs/stats_integration_test.go
+++ b/backend/internal/platform/jobs/stats_integration_test.go
@@ -486,7 +486,8 @@ func TestTheUnitPairIgnoresAnUntaggedRowAndAWorkspaceGrainedKind(t *testing.T) {
 	}
 }
 
-// TestARealRiverInsertCarriesTheSweepTagIntoTheColumnTheReadFilterson closes
+// TestARealRiverInsertCarriesTheSweepTagIntoTheColumnTheReadFiltersOn
+// closes
 // the gap every other test in this file leaves open: they seed the tag by
 // hand, so they prove the query and not the pipeline. This one goes through
 // River's own insert path with the tag on InsertOpts, and asserts the sweep

--- a/backend/pkg/extension/tool_test.go
+++ b/backend/pkg/extension/tool_test.go
@@ -36,7 +36,7 @@ func TestScopeValidate(t *testing.T) {
 // TestToolValidate: after the narrowing a Tool is {Name, Handle}, so the only
 // rule left is the verb grammar. Everything the old cases here covered — the
 // tier and scope vocabularies, the renderable title and description, the schema
-// shapes — moved to the declaration, and moved with it to TestVerbValidate.
+// shapes — moved to the declaration, and moved with it to TestVerbValidate….
 func TestToolValidate(t *testing.T) {
 	if err := (Tool{Name: "qualify_lead"}).Validate(); err != nil {
 		t.Fatalf("a well-formed tool must validate: %v", err)

--- a/backend/tools/gen-composition/extverbs_test.go
+++ b/backend/tools/gen-composition/extverbs_test.go
@@ -335,7 +335,7 @@ func TestExtensionVerbRefusals(t *testing.T) {
 	}
 }
 
-// TestASchemaThatMerelySPELLS$refIsNotAReference: the two shapes a
+// TestASchemaThatMerelySpellsRefIsNotAReference: the two shapes a
 // key-anywhere search cannot tell from a reference, and refused.
 //
 // A schema declaring a PROPERTY called `$ref` describes an object with a member

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -308,7 +308,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 | `writeliveness_test.go` | H2 | The LIVENESS obligation as a fitness function: a write that targets one standing row of a table which can be archived either REFUSES an archived row, DECLARES that it deliberately reaches one, or is ratified with a reason. |
 
-## Prohibition (52)
+## Prohibition (53)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -317,6 +317,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `authzmetriclabels_test.go` | H2 | The outbound decision counter labels only closed vocabularies, and never the recipient. |
 | `backfillledgerlock_test.go` | H2 | A transaction that writes the backfill creation ledger locks the run row first. |
 | `capabilitypathlog_test.go` | H2 | A request path reaches a log line through capabilitypath.Redact, never raw. |
+| `commentnamedtests_test.go` | H1 | A test named in a comment exists. |
 | `connectoractor_test.go` | H1 | A connector's actor id is DERIVED from the work, never written down. |
 | `constraintnameleak_test.go` | H2 | A constraint's name goes in the operator's log, never in the caller's refusal. |
 | `contentionprobe_test.go` | H2 | A contention probe that cannot see the backend it is waiting for. |


### PR DESCRIPTION
Closes #2050. Follow-up filed as #5046.

## The gate

Naming the gate that holds an invariant — *"bound by the census rather than by comment"* — is one of the better habits in this tree, and it works only while the name resolves. A stale one is silent in the worst direction: it reads as a decision, so the next author greps, finds nothing, and cannot tell whether the gate was renamed, deleted, or never written. No compiler sees a comment and `craft static` does not either.

`TestEveryTestNamedInACommentExists` parses every tracked `.go` file once, collecting the `Test`-prefixed identifiers the tree declares and every comment group that names a candidate, then fails on the difference. The corpus is the whole tree rather than this module, because a comment in an extension or in the tool chain makes the same promise and a comment here may name a gate that lives there.

**It resolves against identifiers, not only test functions.** The question a reader is really asking is whether grepping the name finds anything: `jobs.Config.TestOnly` is a field and `capture.TestMailboxLedger` is a type, and a gate that knew only about `func Test…` would call both stale and teach people to stop naming things.

### Three allowances, each because prose legitimately writes the name that way

- **A wrapped name.** Prose breaks identifiers across lines. The text is never healed in place — an em-dash or hyphen belonging to the sentence gets absorbed into the identifier and invents a name nobody wrote. The closed-up readings are built *beside* the original and a name resolving under any of them is a name the comment got right.
- **An ellipsis.** `TestVerbValidate…` is a reference to a family, not to one function.
- **A `-run` argument.** `-run` takes an unanchored regexp, so `-run TestEveryPolicyRecordType` selecting `TestEveryPolicyRecordTypeIsOneItsToolCanSend` is exactly what its author meant. A `-run` prefix matching *nothing* is still a finding — the command it documents selects no test.

### What a green run does not mean

It reads Go comments. A comment naming a vitest spec, and a name spelled only in a string literal, are outside it.

## The 29 findings

**Twenty-five renames whose comments did not follow**, repointed at what actually holds them. A sample:

| named | actually |
|---|---|
| `TestEverySourceHasADestination` | `TestEveryWorklistSourceHasADestination` |
| `TestOverlayRefetchWorkerRejectsMalformedWorkspace` | `TestOverlayRefetchWorkerRejectsArgsNamingNoWorkspace` |
| `TestOnlyTheResolverDereferencesTracePayloads` | `TestOnlyTheResolverReadsTheTracePayloadsField` |
| `TestTheEraseActionRefusesWithoutItsPurger` | `TestAPassMissingItsPurgerRefusesBeforeDestroyingAnything` |
| `TestRecordsLinkTheAccount` | `TestMailRecordsLinkTheAccount` |

Four of these were a doc comment whose **opening name did not match the function it documents** — `TestOverlayRefetchWorkerRejectsMalformedWorkspace:` sitting above `func TestOverlayRefetchWorkerRejectsArgsNamingNoWorkspace`, which is the shape most likely to be believed.

One deserves its own line: `jobfanout/runner_integration_test.go` deferred to a fan-out test that was **deliberately retired** when a scheduling pass became one row. The comment now says the fan-out is gone and names what survived, rather than pointing at a subject nobody can read.

**Two absorbed the following sentence into the name** (`…MatchTheCores` + `A published field…`, `…IsCountedOnce` + `Holds the precedence`) and **one lost a capital** (`…ReadFilterson` for `…ReadFiltersOn`).

**Three metavariables** in the uniqueness-claim gates' own prose — `Held by: TestName (path)`, ``func TestX``, `TestEveryFooHasOneWriter` — rewritten in the ellipsis form the gate already recognises, which reads as the template it is rather than as a binding.

**Three named a gate nobody ever wrote.** `capturepurge`'s shared executor, `audiencegate`'s handler-target rule, `sdrhandoff`'s seeded reason list. Those now say plainly that nothing holds them — more use to a reader than a name that does not resolve — and #5046 tracks writing the three. The `audiencegate` one is the sharpest: the **sibling bullet immediately below it** names a gate that does exist, so one comment held one half to a check and the other to a reading of the handlers at the time of writing.

## Verification

Mutation-tested, each against the clean tree:

| mutation | findings |
|---|---|
| clean | 0 |
| a fabricated name added to a comment | +1 |
| a `-run` prefix that selects no test | +1 |
| a declaration renamed away in another package | +1 |

The corpus is asserted before its result is believed — identifiers and test functions counted separately, because a walk that collected every `Test`-prefixed field and no test function at all would clear one floor while having lost the thing the gate is named for. A walk that found nothing reports a clean tree, and a clean tree is what a broken walk looks like.

`make check-backend` green. `docs/reference/gate-inventory.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC