### PR TITLE
ci: report the commits a review never covered

### DIFF
--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -1,0 +1,92 @@
+# Did a reviewer read the commit that fixes the review?
+#
+# A branch review reads the branch as it stood when the review was launched, so
+# the fixes for that review's own findings are always outside it. The normal,
+# correct workflow therefore produces an unreviewed commit by construction —
+# and it is the commit carrying changes a reviewer just judged risky enough to
+# flag. Four landed that way in one afternoon across three sessions; the fourth
+# author had just finished explaining the trap to somebody else.
+#
+# It is NOT a gate. `ci` is the one required check and this job is not it, so a
+# red here blocks nothing. Prevention is a branch-protection decision (#2496)
+# and is not this workflow's to make; what it does is make the fact visible on
+# the pull request, at the moment it becomes true, instead of leaving it to be
+# noticed by whoever reads the review timeline carefully enough.
+#
+# It reads what GitHub records. A review carries the commit it was made
+# against, so this speaks precisely for the reviewers that leave one — and says
+# so, because a coverage report read as exhaustive is worse than none: an
+# in-session review posts nothing here and its silence is not coverage.
+name: review-coverage
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+# Per pull request, cancelling in flight: only the tip's answer is worth having,
+# and a report about a commit that has already been superseded is noise on the
+# pull request rather than a finding anybody can act on. The opposite of
+# merge-attest, whose subject is one commit that will never come round again.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: review coverage (reports, never blocks)
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The branch's own commits, which is what a reviewed sha is looked up
+          # in. A shallow clone would make every review older than the fetch
+          # depth read as naming a commit the branch does not have — the report
+          # would be loudest exactly on the longest-lived pull requests.
+          fetch-depth: 0
+      - name: What each reviewer read, and what has landed since
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # A review's `commit_id` is the tree it was made against — the one
+          # thing on a pull request that records WHAT was read rather than that
+          # something was. `--paginate` because a long-running pull request
+          # accumulates more reviews than one page holds, and a report that
+          # read the first page would go quiet on exactly the pull requests
+          # most likely to need it.
+          reviews="$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR}/reviews" \
+            --jq '[.[] | select(.commit_id != null) | {reviewer: .user.login, sha: .commit_id, at: .submitted_at}]' \
+            | jq -s 'add // []')"
+
+          # This branch only. `git rev-list base..head` is the set of commits
+          # the pull request is proposing, which is the set a review of it can
+          # have covered; walking the whole history would let a review of some
+          # ancestor on main read as covering this branch.
+          history="$(git rev-list "${BASE_SHA}..${HEAD_SHA}")"
+
+          # Captured rather than piped into the summary, so the report's own
+          # exit status is what fails the step. Through a pipe it would be
+          # tee's, and the job would stay green while printing the finding.
+          status=0
+          out="$(REVIEW_COVERAGE_HEAD="$HEAD_SHA" \
+                 REVIEW_COVERAGE_HISTORY="$history" \
+                 REVIEW_COVERAGE_REVIEWS="$reviews" \
+                 ./scripts/check-review-coverage.sh 2>&1)" || status=$?
+          printf '%s\n' "$out"
+          {
+            echo '```'
+            printf '%s\n' "$out"
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"
+          exit "$status"

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -22,6 +22,13 @@ name: review-coverage
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+  # A review is half the comparison, so a submission has to refresh it too.
+  # Without this the report goes red on the fix commit and STAYS red through
+  # the re-review that answers it, until somebody happens to push again — a
+  # stale finding that outlives its own cause, which is how a report earns the
+  # habit of being ignored.
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: read
@@ -46,6 +53,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # NAMED, because the two events land somewhere different by default:
+          # a pull_request run checks out the merge ref, a pull_request_review
+          # run checks out the base branch. Neither contains the branch's own
+          # commits reliably, and the walk below is over exactly those.
+          ref: ${{ github.event.pull_request.head.sha }}
           # The branch's own commits, which is what a reviewed sha is looked up
           # in. A shallow clone would make every review older than the fetch
           # depth read as naming a commit the branch does not have — the report
@@ -69,11 +81,17 @@ jobs:
             --jq '[.[] | select(.commit_id != null) | {reviewer: .user.login, sha: .commit_id, at: .submitted_at}]' \
             | jq -s 'add // []')"
 
-          # This branch only. `git rev-list base..head` is the set of commits
-          # the pull request is proposing, which is the set a review of it can
-          # have covered; walking the whole history would let a review of some
-          # ancestor on main read as covering this branch.
-          history="$(git rev-list "${BASE_SHA}..${HEAD_SHA}")"
+          # This branch only, WITH its parent edges. `git rev-list base..head`
+          # is the set of commits the pull request is proposing, which is the
+          # set a review of it can have covered; walking the whole history
+          # would let a review of some ancestor on main read as covering this
+          # branch.
+          #
+          # `--parents` because the report needs ancestry rather than order. A
+          # pull request carrying a merge brings in a side branch whose commits
+          # are older than the reviewed one, and rev-list sorts by date — so
+          # order alone reads them as already covered.
+          history="$(git rev-list --parents "${BASE_SHA}..${HEAD_SHA}")"
 
           # Captured rather than piped into the summary, so the report's own
           # exit status is what fails the step. Through a pipe it would be

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ GO ?= go
 ROOT_SCRIPT_GATES := check-craft-doc craft-test test-dev-isolation \
   test-dev-cleanup \
   test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict \
+  test-review-coverage \
   test-laneorder check-image-pins check-host-ports ci-doc-parity \
   make-target-parity contract-breaking-check contract-frontend-drift \
   test-contract-frontend-drift migration-versions test-migration-versions \
@@ -61,7 +62,7 @@ MINIO_PORT ?= 29000
 # answer lands in its own assignment so `set -e` sees the refusal — a helper
 # called inside another command's argument would fail unnoticed.
 
-.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-laneorder secret-scan test-secret-scan test-sbom-sign test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length fe-file-length rls-store-path no-jurisdiction test-no-jurisdiction pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
+.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-review-coverage test-laneorder secret-scan test-secret-scan test-sbom-sign test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length fe-file-length rls-store-path no-jurisdiction test-no-jurisdiction pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -881,6 +882,14 @@ test-ci-verdict:
 ## "was it green?" reads the same as a pass.
 test-merge-verdict:
 	@./scripts/test-check-merge-verdict.sh
+
+## test-review-coverage — prove the review-coverage report still tells a review
+## of the tip from a review of something older. It is quiet when it is working,
+## so "no complaint" is the signal that cannot be trusted on its own; and the
+## arm with no natural symptom is a force-push, where the approval goes on
+## standing against a tree nobody compared it to.
+test-review-coverage:
+	@./scripts/test-check-review-coverage.sh
 
 ## test-laneorder — prove the integration lane still dispatches its long pole
 ## first. The order is only a scheduling hint, so a regression here never turns

--- a/docs/reference/ci-workflows.md
+++ b/docs/reference/ci-workflows.md
@@ -37,7 +37,8 @@ Eight workflows sit beside the gate, deliberately outside it:
   fixture (`make test-merge-verdict`); a finding is filed as one issue per
   offending pull request through the same reporter the health check uses.
 
-- **`review-coverage.yml`** — on every pull request push. A branch review reads
+- **`review-coverage.yml`** — on `opened`, `reopened`, `synchronize` and
+  `ready_for_review`, and on a submitted review. A branch review reads
   the branch **as it stood when the review was launched**, so the fixes for that
   review's own findings are always outside it: the normal workflow produces an
   unreviewed commit by construction, and it is the one carrying changes a
@@ -49,6 +50,10 @@ Eight workflows sit beside the gate, deliberately outside it:
   naming a commit **the branch no longer has**, which is what a force-push after
   a review leaves behind — the verdict goes on standing against a tree nobody
   compared it to, and nothing else on the pull request says so.
+
+  The review trigger is not decoration: a review is half the comparison, so
+  without it the report would go red on the fix commit and stay red through the
+  re-review that answers it, until somebody happened to push again.
 
   It says nothing about a pull request **nobody has reviewed yet**. That is
   every pull request for most of its life, and it is the same reason

--- a/docs/reference/ci-workflows.md
+++ b/docs/reference/ci-workflows.md
@@ -37,6 +37,31 @@ Eight workflows sit beside the gate, deliberately outside it:
   fixture (`make test-merge-verdict`); a finding is filed as one issue per
   offending pull request through the same reporter the health check uses.
 
+- **`review-coverage.yml`** — on every pull request push. A branch review reads
+  the branch **as it stood when the review was launched**, so the fixes for that
+  review's own findings are always outside it: the normal workflow produces an
+  unreviewed commit by construction, and it is the one carrying changes a
+  reviewer just judged risky enough to flag.
+
+  It reports two things, per reviewer rather than per pull request: commits that
+  landed **after** the newest record that reviewer left, named as a
+  `<reviewed>..<head>` range so re-reviewing is a copyable command; and a record
+  naming a commit **the branch no longer has**, which is what a force-push after
+  a review leaves behind — the verdict goes on standing against a tree nobody
+  compared it to, and nothing else on the pull request says so.
+
+  It says nothing about a pull request **nobody has reviewed yet**. That is
+  every pull request for most of its life, and it is the same reason
+  `merge-attest.yml` stays quiet about an absent verdict.
+
+  **Gates nothing.** `ci` is the required check and this job is not it. It reads
+  what GitHub records — a review carries the commit it was made against — so it
+  speaks only for reviewers that leave one, and **its silence is not coverage**:
+  an in-session review posts no record here at all. Reported by
+  [`scripts/check-review-coverage.sh`](../../scripts/check-review-coverage.sh),
+  which reads its evidence from the environment so every arm is drivable from a
+  fixture (`make test-review-coverage`).
+
 - **`main-health.yml`** — every two hours on `main`: the backend gate, the
   real-Postgres lane, the SPA lane (those two called, not copied — it `uses:`
   `_lane-integration.yml` and `_lane-frontend.yml`), the screen-acceptance UAT,

--- a/scripts/check-review-coverage.sh
+++ b/scripts/check-review-coverage.sh
@@ -92,33 +92,51 @@ fi
 # commit sorts below it and would have been read as already covered — silently,
 # and on exactly the pull requests complicated enough to need this report.
 #
-# commits_after <sha> is everything reachable from the tip that is not the
-# reviewed commit or one of ITS ancestors: reachable(head) minus
-# ancestors(sha), which is the set a re-review would have to read.
-parents_of() {
-	awk -v want="$1" '$1 == want { $1 = ""; print; exit }' <<<"$history"
-}
-
-reachable_from() {
-	local frontier="$1" seen="" next parent
-	while [[ -n "$frontier" ]]; do
-		next=""
-		for parent in $frontier; do
-			grep -qxF "$parent" <<<"$seen" && continue
-			seen+="${parent}"$'\n'
-			next+=" $(parents_of "$parent")"
-		done
-		frontier="$next"
-	done
-	printf '%s' "$seen"
-}
-
+# ONE awk pass, because the obvious shape is quadratic. Walking the graph in
+# shell re-scans the history for every commit visited, and spawns a process to
+# do it: on a long-lived pull request that is the report timing out rather than
+# saying anything, which is worse than the wrong answer it replaced because
+# nothing is left to read at all. awk indexes the edges once and walks them.
+#
+# commits_after <sha> is everything reachable from the tip that is NOT the
+# reviewed commit or one of its ancestors — reachable(head) minus
+# ancestors(reviewed), the set a re-review would have to read.
 commits_after() {
-	local covered
-	covered="$(reachable_from "$1")"
-	# Oldest first is the order the commits were written, which is how the
-	# report lists them; the walk produces no useful order of its own.
-	grep -vxF -f <(printf '%s' "$covered") <<<"$(reachable_from "$head")" || true
+	awk -v head="$head" -v reviewed="$1" '
+		function walk(start,   stack, top, sha, kid, i) {
+			delete reached
+			stack[0] = start
+			top = 1
+			while (top > 0) {
+				sha = stack[--top]
+				if (sha in reached) continue
+				reached[sha] = 1
+				if (!(sha in parents)) continue
+				split(parents[sha], kid, " ")
+				for (i in kid) if (kid[i] != "") stack[top++] = kid[i]
+			}
+		}
+		{
+			order[NR] = $1
+			rows = NR
+			edges = ""
+			for (i = 2; i <= NF; i++) edges = edges " " $i
+			parents[$1] = edges
+		}
+		END {
+			walk(reviewed)
+			for (sha in reached) covered[sha] = 1
+			walk(head)
+			for (sha in reached) fromTip[sha] = 1
+			# Oldest first, which is the order the commits were written: the
+			# history arrives newest first, so it is read back to front. The
+			# walk itself produces no useful order.
+			for (i = rows; i >= 1; i--) {
+				sha = order[i]
+				if ((sha in fromTip) && !(sha in covered)) print sha
+			}
+		}
+	' <<<"$history"
 }
 
 in_history() {

--- a/scripts/check-review-coverage.sh
+++ b/scripts/check-review-coverage.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# check-review-coverage.sh — did a reviewer read the commit that fixes the review?
+#
+# A branch review reads the branch as it stood when the review was launched.
+# Every commit made afterwards falls outside it — and the fixes for that
+# review's own findings are always afterwards. So the normal, correct workflow
+# produces an unreviewed commit by construction:
+#
+#   push  ->  review (commits 1..N)  ->  fix the findings (commit N+1)  ->  merge
+#
+# Commit N+1 carries changes a reviewer just judged risky enough to flag. It is
+# the last commit anybody should want unread, and nothing on the pull request
+# says it was not read. Four instances landed in one afternoon across three
+# sessions; in the fourth, the author had just finished explaining the trap to
+# somebody else and then walked into it on the next commit. Discipline does not
+# fix a default.
+#
+# It is NOT a gate and will never be one. `ci` is the required check; this job
+# is not, so a red here blocks nothing and states a fact. Prevention is a
+# branch-protection decision and is not this script's to make.
+#
+# WHAT IT REPORTS:
+#
+#   - commits after the newest record a reviewer left. The range is named by
+#     sha, so re-reviewing it is a copyable command rather than a guess.
+#   - a record naming a commit this branch no longer has. A force-push after a
+#     review destroys the evidence of what was read, and the reviewer's approval
+#     goes on standing against a tree nobody compared it to.
+#
+# WHAT IT DELIBERATELY DOES NOT REPORT: a pull request nobody has reviewed yet.
+# That is every pull request for most of its life, and an alarm that fires on
+# the expected state is one that gets muted — the lesson check-merge-verdict.sh
+# was written around after seventeen issues in five hours described a bypass
+# working as intended.
+#
+# WHAT IT CANNOT SEE: a review that leaves no record on the pull request. An
+# in-session review posts nothing here, so this speaks only for reviewers that
+# do, and silence from it is not coverage. Said plainly rather than implied,
+# because a coverage report read as exhaustive is worse than none.
+#
+# Reads its evidence from the environment rather than fetching it, so every arm
+# is drivable from a fixture — the same shape check-merge-verdict.sh uses, and
+# for the same reason: a reporter that can only be observed exiting 0 is not
+# evidence of anything.
+set -euo pipefail
+
+head="${REVIEW_COVERAGE_HEAD:-}"
+history="${REVIEW_COVERAGE_HISTORY:-}"
+reviews="${REVIEW_COVERAGE_REVIEWS:-}"
+
+if [[ -z "$head" ]]; then
+	echo "FAIL: REVIEW_COVERAGE_HEAD is empty — there is no tip to compare against." >&2
+	exit 2
+fi
+if [[ -z "$history" ]]; then
+	echo "FAIL: REVIEW_COVERAGE_HISTORY is empty — without the branch's commits, every review would read as naming a commit the branch does not have." >&2
+	exit 2
+fi
+
+# Empty is not the same as `[]`. A fetch that failed and a pull request nobody
+# has reviewed both leave this unset if the caller is careless, and treating the
+# first as the second would report full coverage on the day the API call breaks
+# — which is the one direction this must not fail, since there is no red to
+# notice.
+if [[ -z "$reviews" ]]; then
+	echo "FAIL: REVIEW_COVERAGE_REVIEWS is unset. Pass '[]' for a pull request with no reviews; unset cannot be told from a fetch that failed." >&2
+	exit 2
+fi
+
+if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$reviews"; then
+	echo "FAIL: REVIEW_COVERAGE_REVIEWS is not a JSON array." >&2
+	exit 2
+fi
+
+# The newest record per reviewer. A reviewer who read the branch twice is
+# covered by their later reading, and reporting the earlier one would ask for a
+# re-review that already happened.
+latest="$(jq -c 'group_by(.reviewer) | map(sort_by(.at) | last) | sort_by(.reviewer)' <<<"$reviews")"
+
+if [[ "$(jq 'length' <<<"$latest")" -eq 0 ]]; then
+	echo "OK: no reviewer has left a record on this pull request yet — there is nothing to be behind."
+	echo "    This says nothing about whether the branch was reviewed: a review that posts no record here is invisible to it."
+	exit 0
+fi
+
+# `git rev-list` order, newest first: the commits above a sha are the ones made
+# after it.
+commits_after() {
+	local sha="$1"
+	awk -v want="$sha" '$0 == want { exit } { print }' <<<"$history"
+}
+
+in_history() {
+	grep -qxF "$1" <<<"$history"
+}
+
+findings=0
+while read -r reviewer sha at; do
+	if ! in_history "$sha"; then
+		echo "STALE: ${reviewer} recorded a review of ${sha} at ${at}, and this branch no longer has that commit."
+		echo "       A force-push after a review takes the evidence of what was read with it. The verdict still stands on the pull request against a tree nobody compared it to."
+		findings=$((findings + 1))
+		continue
+	fi
+
+	after="$(commits_after "$sha")"
+	if [[ -z "$after" ]]; then
+		echo "OK: ${reviewer} read ${sha}, which is the tip."
+		continue
+	fi
+
+	count="$(wc -l <<<"$after" | tr -d ' ')"
+	echo "BEHIND: ${count} commit(s) landed after ${reviewer} read ${sha}:"
+	# Oldest first, so the list reads in the order the commits were written.
+	tail -r <<<"$after" 2>/dev/null || tac <<<"$after"
+	echo "       Re-review the range, or say on the pull request why it does not need it:"
+	echo "         ${sha}..${head}"
+	findings=$((findings + 1))
+done < <(jq -r '.[] | "\(.reviewer) \(.sha) \(.at)"' <<<"$latest")
+
+if [[ "$findings" -eq 0 ]]; then
+	echo "OK: every review on this pull request was made against the tip."
+	exit 0
+fi
+
+echo
+echo "This blocks nothing — \`ci\` is the required check and this is not it. It reports that code a reviewer flagged as worth changing was changed afterwards and not read again."
+exit 1

--- a/scripts/check-review-coverage.sh
+++ b/scripts/check-review-coverage.sh
@@ -83,15 +83,46 @@ if [[ "$(jq 'length' <<<"$latest")" -eq 0 ]]; then
 	exit 0
 fi
 
-# `git rev-list` order, newest first: the commits above a sha are the ones made
-# after it.
+# ANCESTRY, not order. The history is `git rev-list --parents`, one commit per
+# line followed by its parents, so what a review did not cover can be computed
+# rather than guessed at from the listing order.
+#
+# Slicing the flat list was wrong the moment a pull request carried a merge:
+# `rev-list` sorts by commit date, so a side branch written before the reviewed
+# commit sorts below it and would have been read as already covered — silently,
+# and on exactly the pull requests complicated enough to need this report.
+#
+# commits_after <sha> is everything reachable from the tip that is not the
+# reviewed commit or one of ITS ancestors: reachable(head) minus
+# ancestors(sha), which is the set a re-review would have to read.
+parents_of() {
+	awk -v want="$1" '$1 == want { $1 = ""; print; exit }' <<<"$history"
+}
+
+reachable_from() {
+	local frontier="$1" seen="" next parent
+	while [[ -n "$frontier" ]]; do
+		next=""
+		for parent in $frontier; do
+			grep -qxF "$parent" <<<"$seen" && continue
+			seen+="${parent}"$'\n'
+			next+=" $(parents_of "$parent")"
+		done
+		frontier="$next"
+	done
+	printf '%s' "$seen"
+}
+
 commits_after() {
-	local sha="$1"
-	awk -v want="$sha" '$0 == want { exit } { print }' <<<"$history"
+	local covered
+	covered="$(reachable_from "$1")"
+	# Oldest first is the order the commits were written, which is how the
+	# report lists them; the walk produces no useful order of its own.
+	grep -vxF -f <(printf '%s' "$covered") <<<"$(reachable_from "$head")" || true
 }
 
 in_history() {
-	grep -qxF "$1" <<<"$history"
+	awk -v want="$1" '$1 == want { found = 1; exit } END { exit !found }' <<<"$history"
 }
 
 findings=0
@@ -109,10 +140,9 @@ while read -r reviewer sha at; do
 		continue
 	fi
 
-	count="$(wc -l <<<"$after" | tr -d ' ')"
+	count="$(grep -c . <<<"$after")"
 	echo "BEHIND: ${count} commit(s) landed after ${reviewer} read ${sha}:"
-	# Oldest first, so the list reads in the order the commits were written.
-	tail -r <<<"$after" 2>/dev/null || tac <<<"$after"
+	printf '%s\n' "$after"
 	echo "       Re-review the range, or say on the pull request why it does not need it:"
 	echo "         ${sha}..${head}"
 	findings=$((findings + 1))

--- a/scripts/test-check-review-coverage.sh
+++ b/scripts/test-check-review-coverage.sh
@@ -128,6 +128,64 @@ else
 	echo "ok: a review of the tip covers every ancestor the merge brought with it"
 fi
 
+# OLDEST FIRST, which the report's own prose promises and a reader relies on:
+# the list reads in the order the commits were written, so the fix commit that
+# needs re-reading is where you expect it. The graph walk produces no order of
+# its own, so this is not a property that survives on its own.
+order_out="$(REVIEW_COVERAGE_HEAD=ccc3333 REVIEW_COVERAGE_HISTORY="$history" \
+	REVIEW_COVERAGE_REVIEWS="[$(review cubic aaa1111 2026-09-01T10:00:00Z)]" "$report" 2>&1 || true)"
+if [[ "$(grep -cE '^(bbb2222|ccc3333)$' <<<"$order_out")" -ne 2 ]] ||
+	[[ "$(grep -nE '^bbb2222$' <<<"$order_out" | cut -d: -f1)" -gt "$(grep -nE '^ccc3333$' <<<"$order_out" | cut -d: -f1)" ]]; then
+	echo "FAIL: the unread commits were not listed oldest first" >&2
+	printf '%s\n' "$order_out" >&2
+	failures=$((failures + 1))
+else
+	echo "ok: the unread commits are listed oldest first"
+fi
+
+# A long branch is where the shape of the walk stops being an aesthetic
+# question. Re-scanning the history per visited commit is quadratic AND spawns
+# a process to do it, so the report times out and says nothing — which is worse
+# than a wrong answer, because nothing is left to read.
+# A long branch is where the shape of the walk stops being an aesthetic
+# question. Re-scanning the history once per visited commit is quadratic AND
+# spawns a process to do it, so a long-lived pull request gets no report at all
+# rather than a wrong one — which is worse, because nothing is left to read.
+#
+# COUNTED, not timed. A wall-clock bound wide enough not to flake on a loaded
+# runner is too wide to separate a quadratic walk from a linear one at any
+# input size a suite can afford; and the property is not "fast", it is "the
+# history is indexed once rather than re-read per commit". So the report runs
+# with a counting shim ahead of awk on PATH, and the count is the assertion.
+shim="$(mktemp -d)"
+trap 'rm -rf "$shim"' EXIT
+real_awk="$(command -v awk)"
+cat >"$shim/awk" <<SHIM
+#!/usr/bin/env bash
+echo . >>"$shim/calls"
+exec "$real_awk" "\$@"
+SHIM
+chmod +x "$shim/awk"
+: >"$shim/calls"
+
+# Built by awk rather than by appending in a loop: bash string concatenation is
+# itself quadratic, and a fixture that cost more to build than to judge would
+# be measuring the wrong thing. (Through the real awk, so it is not counted.)
+long_history="$("$real_awk" 'BEGIN { for (i = 200; i >= 1; i--) printf "c%06d c%06d\n", i, i - 1 }')"
+long_out="$(PATH="$shim:$PATH" REVIEW_COVERAGE_HEAD=c000200 REVIEW_COVERAGE_HISTORY="$long_history" \
+	REVIEW_COVERAGE_REVIEWS="[$(review cubic c000001 2026-09-01T10:00:00Z)]" "$report" 2>&1 || true)"
+awk_calls="$(grep -c . "$shim/calls" || true)"
+if ! grep -qF "199 commit(s) landed after cubic" <<<"$long_out"; then
+	echo "FAIL: a 200-commit branch was not counted correctly" >&2
+	printf '%s\n' "$long_out" | head -3 >&2
+	failures=$((failures + 1))
+elif (( awk_calls > 10 )); then
+	echo "FAIL: the report read the history $awk_calls times for a 200-commit branch — it is re-reading per commit, so a long-lived pull request will get no report at all" >&2
+	failures=$((failures + 1))
+else
+	echo "ok: a 200-commit branch is judged in $awk_calls pass(es) over the history"
+fi
+
 if [[ "$failures" -ne 0 ]]; then
 	echo "FAIL: $failures case(s)" >&2
 	exit 1

--- a/scripts/test-check-review-coverage.sh
+++ b/scripts/test-check-review-coverage.sh
@@ -94,24 +94,30 @@ else
 	echo "ok: an unset review list refuses rather than reading as no reviews"
 fi
 
-# The shape the flat listing got wrong. A merge brings in a side branch whose
-# commits are OLDER than the reviewed one, so `rev-list`'s date order sorts them
-# below it and slicing the list read them as already covered — silently, on
-# exactly the pull requests complicated enough to need this report.
+# The shape the flat listing got wrong. A merge brings in a side branch that
+# diverged BEFORE the reviewed commit, so its commits are older and `rev-list`'s
+# date order sorts them below the review point — slicing the list read them as
+# already covered, silently, on exactly the pull requests complicated enough to
+# need this report.
 #
-#   aaa1111 (reviewed) ... ccc3333 --- mmm4444 (merge)
-#                          sss0001 --/          (older date, never reviewed)
-merge_history=$'mmm4444 ccc3333 sss0001\nccc3333 bbb2222\nsss0001 aaa1111\nbbb2222 aaa1111\naaa1111 base000'
+#   base000 --- aaa1111 (reviewed) --- bbb2222 --- ccc3333 --- mmm4444 (merge)
+#           \-- sss0001 -------------------------------------/
+#
+# The side branch forks from base000, NOT from aaa1111: a child of the reviewed
+# commit is structurally newer and would sort above it, which is the case the
+# flat slice already got right. It is listed after aaa1111 below, because the
+# order of these lines is what stands in for `rev-list`'s date order.
+merge_history=$'mmm4444 ccc3333 sss0001\nccc3333 bbb2222\nbbb2222 aaa1111\naaa1111 base000\nsss0001 base000'
 merge_out=""
 merge_status=0
 merge_out="$(REVIEW_COVERAGE_HEAD=mmm4444 REVIEW_COVERAGE_HISTORY="$merge_history" \
 	REVIEW_COVERAGE_REVIEWS="[$(review cubic aaa1111 2026-09-01T10:00:00Z)]" "$report" 2>&1)" || merge_status=$?
 if [[ "$merge_status" -ne 1 ]] || ! grep -qF "sss0001" <<<"$merge_out"; then
-	echo "FAIL: a side branch merged in after the review was not reported — it is reachable from the tip and is not an ancestor of what was read, so a re-review has to cover it" >&2
+	echo "FAIL: a side branch that forked before the review was not reported — it is reachable from the tip and is not an ancestor of what was read, so a re-review has to cover it" >&2
 	printf '%s\n' "$merge_out" >&2
 	failures=$((failures + 1))
 else
-	echo "ok: a side branch older than the review is still reported as uncovered"
+	echo "ok: a side branch that forked before the review is still reported as uncovered"
 fi
 
 # The other half of ancestry: the reviewed commit's OWN ancestors are covered,

--- a/scripts/test-check-review-coverage.sh
+++ b/scripts/test-check-review-coverage.sh
@@ -14,8 +14,10 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 report="$root/scripts/check-review-coverage.sh"
 failures=0
 
-# The branch, newest first, as `git rev-list` hands it over.
-history=$'ccc3333\nbbb2222\naaa1111'
+# The branch as `git rev-list --parents` hands it over: a commit and its
+# parents, one per line. aaa1111 <- bbb2222 <- ccc3333, with aaa1111's own
+# parent on the base and so outside the range.
+history=$'ccc3333 bbb2222\nbbb2222 aaa1111\naaa1111 base000'
 
 review() { printf '{"reviewer":"%s","sha":"%s","at":"%s"}' "$1" "$2" "$3"; }
 
@@ -79,13 +81,51 @@ case_is "and it says that silence is not coverage" "[]" 0 \
 # which is the one direction with no red to notice.
 unset_out=""
 unset_status=0
-unset_out="$(REVIEW_COVERAGE_HEAD=ccc3333 REVIEW_COVERAGE_HISTORY="$history" "$report" 2>&1)" || unset_status=$?
+# `env -u`, not merely leaving it out of the assignment list: a caller who
+# exports REVIEW_COVERAGE_REVIEWS would otherwise have this case take the `[]`
+# path and pass while proving nothing, which is the one arm whose whole subject
+# is telling unset from empty.
+unset_out="$(env -u REVIEW_COVERAGE_REVIEWS REVIEW_COVERAGE_HEAD=ccc3333 REVIEW_COVERAGE_HISTORY="$history" "$report" 2>&1)" || unset_status=$?
 if [[ "$unset_status" -ne 2 ]] || ! grep -qF "cannot be told from a fetch that failed" <<<"$unset_out"; then
 	echo "FAIL: unset reviews must refuse rather than read as no reviews — got exit $unset_status" >&2
 	printf '%s\n' "$unset_out" >&2
 	failures=$((failures + 1))
 else
 	echo "ok: an unset review list refuses rather than reading as no reviews"
+fi
+
+# The shape the flat listing got wrong. A merge brings in a side branch whose
+# commits are OLDER than the reviewed one, so `rev-list`'s date order sorts them
+# below it and slicing the list read them as already covered — silently, on
+# exactly the pull requests complicated enough to need this report.
+#
+#   aaa1111 (reviewed) ... ccc3333 --- mmm4444 (merge)
+#                          sss0001 --/          (older date, never reviewed)
+merge_history=$'mmm4444 ccc3333 sss0001\nccc3333 bbb2222\nsss0001 aaa1111\nbbb2222 aaa1111\naaa1111 base000'
+merge_out=""
+merge_status=0
+merge_out="$(REVIEW_COVERAGE_HEAD=mmm4444 REVIEW_COVERAGE_HISTORY="$merge_history" \
+	REVIEW_COVERAGE_REVIEWS="[$(review cubic aaa1111 2026-09-01T10:00:00Z)]" "$report" 2>&1)" || merge_status=$?
+if [[ "$merge_status" -ne 1 ]] || ! grep -qF "sss0001" <<<"$merge_out"; then
+	echo "FAIL: a side branch merged in after the review was not reported — it is reachable from the tip and is not an ancestor of what was read, so a re-review has to cover it" >&2
+	printf '%s\n' "$merge_out" >&2
+	failures=$((failures + 1))
+else
+	echo "ok: a side branch older than the review is still reported as uncovered"
+fi
+
+# The other half of ancestry: the reviewed commit's OWN ancestors are covered,
+# whatever their date. A walk that reported them would cry wolf on every merge.
+covered_out=""
+covered_status=0
+covered_out="$(REVIEW_COVERAGE_HEAD=mmm4444 REVIEW_COVERAGE_HISTORY="$merge_history" \
+	REVIEW_COVERAGE_REVIEWS="[$(review cubic mmm4444 2026-09-01T10:00:00Z)]" "$report" 2>&1)" || covered_status=$?
+if [[ "$covered_status" -ne 0 ]] || ! grep -qF "which is the tip" <<<"$covered_out"; then
+	echo "FAIL: a review of the merge itself was reported as behind — everything in the range is an ancestor of it" >&2
+	printf '%s\n' "$covered_out" >&2
+	failures=$((failures + 1))
+else
+	echo "ok: a review of the tip covers every ancestor the merge brought with it"
 fi
 
 if [[ "$failures" -ne 0 ]]; then

--- a/scripts/test-check-review-coverage.sh
+++ b/scripts/test-check-review-coverage.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# test-check-review-coverage.sh — prove the coverage report still tells a review
+# of the tip from a review of something older.
+#
+# It runs beside the reporter for the reason test-check-merge-verdict.sh runs
+# beside the judge: this thing is quiet when it is working, so "no complaint"
+# is exactly the signal that cannot be trusted on its own. The half of this
+# suite that asserts exit 1 is what keeps the quiet half honest — a reporter
+# rewritten to say less is one keystroke from saying nothing, and only a case
+# that fails when it goes quiet can tell those apart.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+report="$root/scripts/check-review-coverage.sh"
+failures=0
+
+# The branch, newest first, as `git rev-list` hands it over.
+history=$'ccc3333\nbbb2222\naaa1111'
+
+review() { printf '{"reviewer":"%s","sha":"%s","at":"%s"}' "$1" "$2" "$3"; }
+
+# case_is <name> <reviews-json> <expected-exit> [substring the output must carry]
+case_is() {
+	local name="$1" reviews="$2" want="$3" must_say="${4:-}"
+	local out status=0
+	out="$(REVIEW_COVERAGE_HEAD=ccc3333 REVIEW_COVERAGE_HISTORY="$history" \
+		REVIEW_COVERAGE_REVIEWS="$reviews" "$report" 2>&1)" || status=$?
+	if [[ "$status" -ne "$want" ]]; then
+		echo "FAIL: $name — expected exit $want, got $status" >&2
+		printf '%s\n' "$out" >&2
+		failures=$((failures + 1))
+		return
+	fi
+	if [[ -n "$must_say" ]] && ! grep -qF -- "$must_say" <<<"$out"; then
+		echo "FAIL: $name — exited $want but never said '$must_say'" >&2
+		printf '%s\n' "$out" >&2
+		failures=$((failures + 1))
+		return
+	fi
+	echo "ok: $name"
+}
+
+# The shape the issue was filed about: reviewed, then fixed, then merged. The
+# range it prints is what makes the finding actionable rather than a scolding.
+case_is "a fix commit after the review is reported, by range" \
+	"[$(review cubic aaa1111 2026-09-01T10:00:00Z)]" 1 "aaa1111..ccc3333"
+case_is "and it names how many commits went unread" \
+	"[$(review cubic aaa1111 2026-09-01T10:00:00Z)]" 1 "2 commit(s) landed after cubic"
+
+# A reviewer who came back is covered by the later reading. Reporting the
+# earlier one would ask for a re-review that already happened, which is how a
+# report earns the mute it then never comes back from.
+case_is "a second review of the tip clears the first" \
+	"[$(review cubic aaa1111 2026-09-01T10:00:00Z),$(review cubic ccc3333 2026-09-01T12:00:00Z)]" 0 \
+	"which is the tip"
+
+# Per reviewer, not per pull request. One reviewer being current says nothing
+# about another, and a report that took the newest record overall would let a
+# fresh bot review paper over a human who read commit one.
+case_is "one reviewer at the tip does not cover another who is behind" \
+	"[$(review coderabbit ccc3333 2026-09-01T12:00:00Z),$(review human aaa1111 2026-09-01T10:00:00Z)]" 1 \
+	"landed after human"
+
+# A force-push destroys the evidence of what was read, and the approval goes on
+# standing. This is the arm with no natural symptom: the reviewer looks current
+# because a verdict is present.
+case_is "a review naming a commit the branch no longer has is stale, not covered" \
+	"[$(review cubic deadbee 2026-09-01T10:00:00Z)]" 1 "no longer has that commit"
+
+# Every pull request is unreviewed for most of its life. Alarming here is how
+# the report gets turned off before it ever catches anything.
+case_is "a pull request nobody has reviewed says so and does not alarm" "[]" 0 \
+	"nothing to be behind"
+case_is "and it says that silence is not coverage" "[]" 0 \
+	"invisible to it"
+
+# Unset is a fetch that failed; `[]` is a pull request with no reviews. Reading
+# the first as the second reports full coverage the day the API call breaks,
+# which is the one direction with no red to notice.
+unset_out=""
+unset_status=0
+unset_out="$(REVIEW_COVERAGE_HEAD=ccc3333 REVIEW_COVERAGE_HISTORY="$history" "$report" 2>&1)" || unset_status=$?
+if [[ "$unset_status" -ne 2 ]] || ! grep -qF "cannot be told from a fetch that failed" <<<"$unset_out"; then
+	echo "FAIL: unset reviews must refuse rather than read as no reviews — got exit $unset_status" >&2
+	printf '%s\n' "$unset_out" >&2
+	failures=$((failures + 1))
+else
+	echo "ok: an unset review list refuses rather than reading as no reviews"
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+	echo "FAIL: $failures case(s)" >&2
+	exit 1
+fi
+echo "OK: test-review-coverage — every arm of the report, including the quiet ones"


### PR DESCRIPTION
Closes #2176.

## The trap

A branch review reads the branch **as it stood when the review was launched**. Every commit made afterwards falls outside it — and the fixes for that review's own findings are always afterwards. So the normal, correct workflow produces an unreviewed commit by construction:

```
push  ->  review (commits 1..N)  ->  fix the findings (commit N+1)  ->  merge
```

Commit N+1 carries changes a reviewer just judged risky enough to flag. It is the last commit anybody should want unread, and nothing on the pull request says it was not read.

The issue recorded four instances in one afternoon across three sessions. The fourth is the argument: that author had just finished explaining this exact failure mode to another session, then walked into it on the next commit. It is not carelessness — it is the tool's default, and it recurs at exactly the moment attention is on the findings rather than on the process.

## What lands

**`review-coverage.yml`**, on every pull request push. It asks GitHub what each review was made against — `commit_id` is the one thing on a pull request that records *what* was read rather than *that* something was — and compares it to the tip.

**Per reviewer, not per pull request.** One reviewer being current says nothing about another, and taking the newest record overall would let a fresh bot review paper over a human who read commit one. A reviewer who came back twice is covered by their later reading.

Two findings:

- **`BEHIND`** — commits after that reviewer's newest record, named as a `<reviewed>..<head>` range so re-reviewing is a copyable command rather than a guess.
- **`STALE`** — a record naming a commit the branch no longer has. This is the arm with no natural symptom: a force-push after a review destroys the evidence of what was read, the approval goes on standing on the pull request, and the reviewer *looks* current because a verdict is present.

## What it deliberately does not do

**It gates nothing, and the issue left that open.** `ci` is the one required check and this job is not it, so a red here blocks nothing. That is the posture `merge-attest.yml` already established here, for the reason stated there: prevention is a branch-protection decision (#2496) and is not a reporter's to make. The issue called this "the cheap form" and noted it would have caught all four instances, since in every case a human or agent would have seen it before merging.

**It says nothing about a pull request nobody has reviewed yet.** That is every pull request for most of its life. Alarming there is how the report gets muted before it ever catches anything — the lesson `check-merge-verdict.sh` was written around after seventeen issues in five hours described a bypass working as intended.

**It cannot see a review that leaves no record**, and it says so in its own output rather than implying otherwise. An in-session review posts nothing on the pull request, so this speaks only for reviewers that do, and **its silence is not coverage**. A coverage report read as exhaustive is worse than none. Making an in-session review post its reviewed SHA remains the prerequisite the issue named; it is not in this change.

**No content exemptions.** The issue floated exempting docs-only or already-covered files. Neither survives contact: two of the four unreviewed ranges carried **contract description changes**, which ship to every client; and "files the review already covered" is exactly what a fix commit touches.

## Verification

`scripts/check-review-coverage.sh` reads its evidence from the environment rather than fetching it, so every arm is drivable from a fixture — the same shape `check-merge-verdict.sh` uses, and for the same reason: a reporter that can only be observed exiting 0 is not evidence of anything.

`make test-review-coverage` (wired into `ROOT_SCRIPT_GATES`, so `make check` runs it) covers eight arms, including the quiet ones:

```
ok: a fix commit after the review is reported, by range
ok: and it names how many commits went unread
ok: a second review of the tip clears the first
ok: one reviewer at the tip does not cover another who is behind
ok: a review naming a commit the branch no longer has is stale, not covered
ok: a pull request nobody has reviewed says so and does not alarm
ok: and it says that silence is not coverage
ok: an unset review list refuses rather than reading as no reviews
```

That last one is the direction with no red to notice: **unset** is a fetch that failed, `[]` is a pull request with no reviews, and reading the first as the second would report full coverage on the day the API call breaks.

Two more shapes the report would otherwise get wrong, handled in the workflow rather than the script: `fetch-depth: 0`, because a shallow clone makes every review older than the fetch depth read as `STALE` — loudest on exactly the longest-lived pull requests; and `--paginate` on the reviews API, because a long-running pull request accumulates more reviews than one page holds and a report reading the first page would go quiet on the pull requests most likely to need it.

Documented in `docs/reference/ci-workflows.md` beside `merge-attest.yml`, whose posture it shares. `make check-backend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC