### PR TITLE
fix(activities): the anchor read that builds the chain is live-only too

### DIFF
--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -382,9 +382,17 @@ func anchorThreading(ctx context.Context, tx pgx.Tx, id ids.ActivityID, messageI
 	if err := auth.EnsureActivityContentVisible(ctx, tx, id.UUID); err != nil {
 		return threading{}, err
 	}
+	// LIVE ONLY, the same filter the origin resolution applied before this
+	// transaction opened. Without it the two reads disagree: SendEmail refuses
+	// an archived anchor when it resolves the origin, and this one — the read
+	// that actually builds the chain — accepted a row archived in between, so a
+	// reply went out threaded onto a conversation the workspace had since
+	// archived. The window is small and the answer is wrong for its whole width.
 	var kind, parent, root string
 	err := tx.QueryRow(ctx,
-		`SELECT kind, coalesce(source_id, ''), coalesce(thread_key, '') FROM activity WHERE id = $1 AND restricted_at IS NULL`,
+		`SELECT kind, coalesce(source_id, ''), coalesce(thread_key, '')
+		   FROM activity
+		  WHERE id = $1 AND restricted_at IS NULL AND archived_at IS NULL`,
 		id).Scan(&kind, &parent, &root)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return threading{}, apperrors.ErrNotFound

--- a/backend/internal/modules/activities/messageidentity_integration_test.go
+++ b/backend/internal/modules/activities/messageidentity_integration_test.go
@@ -14,11 +14,13 @@ package activities
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -277,5 +279,50 @@ func TestAnAnchorsSourceIDDoesNotBecomeTheThreadKey(t *testing.T) {
 	// mail client. Only the key the engine trusts is refused.
 	if len(chain.references) == 0 || chain.references[0] != victimsThreadRoot {
 		t.Errorf("references = %v, want the anchor's identity kept for RFC822 threading", chain.references)
+	}
+}
+
+// AN ARCHIVED ANCHOR REFUSES HERE TOO, and that is the whole of this fix.
+//
+// SendEmail resolves the origin first, reading the anchor storekit.LiveOnly, so
+// an already-archived anchor is refused there. It then opens the staging
+// transaction, and THIS read is the one that builds the chain — it did not
+// filter on archived_at, so an anchor archived between the two still yielded a
+// threading chain and the reply went out onto a conversation the workspace had
+// since archived.
+//
+// The race is not what is asserted, because the race is not what is wrong: the
+// two reads disagreeing is. Archiving first and calling this directly asks the
+// question the window creates — does the second read accept what the first
+// refuses — without an injected seam standing in for either of them.
+func TestAnArchivedAnchorYieldsNoThreadingChain(t *testing.T) {
+	e := setupSend(t)
+	ctx := e.as(principal.RowScopeAll)
+	anchor := e.seedAnchor(t, "root@corp.example", "root@corp.example")
+
+	// Live, it threads: the control, without which the refusal below could be
+	// any other reason this read answers nothing.
+	if err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		_, err := anchorThreading(ctx, tx, anchor, "019fad38-ours@margince.test")
+		return err
+	}); err != nil {
+		t.Fatalf("a live anchor was refused: %v", err)
+	}
+
+	if err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE activity SET archived_at = now() WHERE id = $1`, anchor)
+		return err
+	}); err != nil {
+		t.Fatalf("archiving the anchor: %v", err)
+	}
+
+	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		_, err := anchorThreading(ctx, tx, anchor, "019fad38-ours@margince.test")
+		return err
+	})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound — the same answer origin resolution gives for an "+
+			"anchor that was already archived, so the two reads cannot disagree about one row", err)
 	}
 }


### PR DESCRIPTION
Closes #724.

### Two reads of one row, disagreeing

`SendEmail` resolves its origin, then opens the staging transaction. Origin resolution reads the anchor `storekit.LiveOnly`, so an already-archived anchor refuses there. `anchorThreading` — the read inside the transaction that actually **builds the chain** — filtered `restricted_at` only.

So an anchor archived between the two still yielded a threading chain, and the reply went out threaded onto a conversation the workspace had since archived.

The fix is the missing clause. The two reads now answer the same thing about the same row.

### Scope, stated plainly

Row scope applies at both reads, so this is not a cross-tenant or authorization defect, and the window is the few milliseconds between origin resolution and the staging transaction. What goes wrong is a sent message on an archived conversation — not a lost or misdirected one.

### What I did not do

The ticket raises locking the anchor for the duration of the staging transaction, which would make the archive and the send **atomic** rather than merely consistent. I left it, and the commit says why: that lock sits on the hot send path, and it is a deliberate decision rather than part of closing a disagreement between two filters. Nothing here forecloses it.

### The test, and why it does not chase the race

`TestAnArchivedAnchorYieldsNoThreadingChain` archives the anchor and calls `anchorThreading` directly.

The ticket suggests an injected seam or an advisory-lock handshake to archive *between* the two reads. I did not, because the race is not what is wrong — **the two reads disagreeing is**, and that is a property of one function that can be asked directly. A seam standing in for the send path would be a fixture asserting against itself, and it would go on passing if the filter moved to the wrong read.

It carries the live control first: without it, the refusal below could be any other reason this read answers nothing.

Mutation-checked by removing `AND archived_at IS NULL`: the case reports `err = <nil>, want ErrNotFound`. `make check-backend` and `make craft-static` green.
