### PR TITLE
feat(magic): the receipt asks whether a change can be taken back

### DIFF
--- a/backend/internal/compose/correctionrevert_integration_test.go
+++ b/backend/internal/compose/correctionrevert_integration_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/margince/margince/backend/internal/compose/magic"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -222,4 +224,84 @@ func TestConfirmingACardAfterAnUndoDoesNotReapplyIt(t *testing.T) {
 	if after.expectedClose == nil || !after.expectedClose.Equal(wasClosing) {
 		t.Errorf("the deal was re-dated to %v by a card decided after the undo", after.expectedClose)
 	}
+}
+
+// magicReceipt reads the receipt through the REAL judge — the same adapter the
+// server binds — rather than a stub. A stub would prove the seam carries an
+// answer; only this proves the answer is the right one for a correction.
+func (e *closeDateEnv) magicReceipt(t *testing.T, since time.Time) (crmcontracts.MagicReceipt, error) {
+	t.Helper()
+	seam := restoreSeamFor(e.Env)
+	svc := magic.NewService(e.Pool, nil, time.Now).
+		WithUndoJudge(magicUndoJudge{
+			seam:        seam,
+			corrections: deals.NewStore(e.DB(), DealsInstallation()),
+		})
+	return svc.Read(e.Admin(), &since, 50)
+}
+
+// The receipt offers an Undo on a correction the sweep actually made.
+//
+// THIS IS THE JOIN the whole engine exists for, and the one the generic
+// evaluator cannot make on its own: it refuses exactly these rows, because a
+// correction writes close_date_provisional and the ordinary update shape cannot
+// spell that field. Asked only that way, every correction reads "cannot be
+// undone" — which is the hardcoded false this replaced, arrived at by a longer
+// route.
+func TestTheReceiptOffersUndoOnARealCorrection(t *testing.T) {
+	e := setupCloseDate(t)
+	e.seedSweepDeal(t, "Corrected overnight", e.early, nil, intp(-12), 3)
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+
+	since := time.Now().Add(-time.Hour)
+	receipt, err := e.magicReceipt(t, since)
+	if err != nil {
+		t.Fatalf("reading the receipt: %v", err)
+	}
+	line, ok := receiptLineForDeal(receipt, "expected_close_date")
+	if !ok {
+		t.Fatal("the correction the sweep made is not on the receipt's done lane")
+	}
+	if line.Undo == nil || !line.Undo.Undoable {
+		reason := "<nil>"
+		if line.Undo != nil && line.Undo.Reason != nil {
+			reason = *line.Undo.Reason
+		}
+		t.Fatalf("the correction reads not-undoable (%s) — the receipt offers no way back", reason)
+	}
+	if line.Undo.AuditId == nil {
+		t.Error("an undoable line carries no audit id for the control to name")
+	}
+
+	// And once taken back, the same line stops offering it: a second Undo on a
+	// reversed correction is a control that can only refuse.
+	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, e.firstDealID(t))); err != nil {
+		t.Fatal(err)
+	}
+	after, err := e.magicReceipt(t, since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reversed, ok := receiptLineForDeal(after, "expected_close_date")
+	if !ok {
+		t.Fatal("the correction left the receipt after being undone")
+	}
+	if reversed.Undo == nil || reversed.Undo.Undoable {
+		t.Error("a correction already taken back still offers an Undo")
+	}
+}
+
+// receiptLineForDeal finds the done line whose change touched one field.
+func receiptLineForDeal(receipt crmcontracts.MagicReceipt, field string) (crmcontracts.MagicLine, bool) {
+	for _, line := range receipt.Done {
+		if line.After == nil {
+			continue
+		}
+		if _, ok := (*line.After)[field]; ok {
+			return line, true
+		}
+	}
+	return crmcontracts.MagicLine{}, false
 }

--- a/backend/internal/compose/integration/magic_scope_integration_test.go
+++ b/backend/internal/compose/integration/magic_scope_integration_test.go
@@ -29,7 +29,10 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	"github.com/margince/margince/backend/internal/compose/magic"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -353,11 +356,21 @@ type judgeStub struct {
 	asked    int
 }
 
-func (j *judgeStub) JudgeUndo(
-	_ context.Context, _ pgx.Tx, _ ids.UUID, _ string,
-) (bool, string, error) {
-	j.asked++
-	return j.undoable, j.reason, nil
+func (j *judgeStub) JudgeUndoPage(
+	_ context.Context, _ pgx.Tx, subjects []magic.UndoSubject,
+) (map[ids.UUID]*crmcontracts.MagicUndo, error) {
+	out := make(map[ids.UUID]*crmcontracts.MagicUndo, len(subjects))
+	for _, subject := range subjects {
+		j.asked++
+		if j.undoable {
+			id := openapi_types.UUID(subject.AuditID)
+			out[subject.AuditID] = &crmcontracts.MagicUndo{Undoable: true, AuditId: &id}
+			continue
+		}
+		reason := j.reason
+		out[subject.AuditID] = &crmcontracts.MagicUndo{Undoable: false, Reason: &reason}
+	}
+	return out, nil
 }
 
 // The done lane used to hardcode Undoable: false on every row, which was true

--- a/backend/internal/compose/integration/magic_scope_integration_test.go
+++ b/backend/internal/compose/integration/magic_scope_integration_test.go
@@ -340,3 +340,91 @@ func TestTheWindowRefusesToReachBackToInstallation(t *testing.T) {
 func personRepPerms() principal.Permissions {
 	return RepPerms
 }
+
+// judgeStub answers the undo question without the real evaluator behind it.
+//
+// The wiring is what this proves — that a bound judge's answer reaches the line
+// — not the evaluator's judgment, which has its own suite. A stub keeps the two
+// questions apart: a failure here means the seam is unbound or the answer is
+// dropped, never that some refusal rule moved.
+type judgeStub struct {
+	undoable bool
+	reason   string
+	asked    int
+}
+
+func (j *judgeStub) JudgeUndo(
+	_ context.Context, _ pgx.Tx, _ ids.UUID, _ string,
+) (bool, string, error) {
+	j.asked++
+	return j.undoable, j.reason, nil
+}
+
+// The done lane used to hardcode Undoable: false on every row, which was true
+// by accident — no path could reverse a sweep's correction, so a blanket no was
+// not wrong. It is wrong now that corrections carry their own undo, and a
+// receipt that says "the machine changed your deal" while greying out the only
+// control answering that is worse than one that never mentioned the change.
+func TestTheReceiptAsksWhetherEachChangeCanBeTakenBack(t *testing.T) {
+	e := Setup(t)
+	since := time.Now().Add(-time.Hour)
+	seedMachineAction(t, e, e.Rep1, "agent", "agent:auto-apply", "advance_stage")
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+
+	judge := &judgeStub{undoable: true}
+	receipt, err := magic.NewService(e.Pool, nil, time.Now).
+		WithUndoJudge(judge).Read(ctx, &since, 20)
+	if err != nil {
+		t.Fatalf("reading the receipt: %v", err)
+	}
+	if len(receipt.Done) == 0 {
+		t.Fatal("the seeded machine action did not reach the done lane")
+	}
+	if judge.asked != len(receipt.Done) {
+		t.Errorf("judged %d lines of %d — every drawn line is asked", judge.asked, len(receipt.Done))
+	}
+	line := receipt.Done[0]
+	if line.Undo == nil || !line.Undo.Undoable {
+		t.Fatalf("undo = %+v, want undoable", line.Undo)
+	}
+	// A client draws the control from audit_id; one without it has nothing to
+	// send, which is the state the contract's own comment forbids.
+	if line.Undo.AuditId == nil {
+		t.Error("an undoable line carries no audit id for the control to name")
+	}
+
+	// A refusal carries its reason rather than a blank: the reason is what the
+	// client renders beside the greyed control.
+	refusing := &judgeStub{undoable: false, reason: "record_archived"}
+	refused, err := magic.NewService(e.Pool, nil, time.Now).
+		WithUndoJudge(refusing).Read(ctx, &since, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := refused.Done[0].Undo
+	if got == nil || got.Undoable || got.Reason == nil || *got.Reason != "record_archived" {
+		t.Errorf("refused undo = %+v, want undoable=false carrying the reason", got)
+	}
+	if got != nil && got.AuditId != nil {
+		t.Error("a refused line carries an audit id, so a client could draw a control that only fails")
+	}
+}
+
+// An installation that has not wired the judge says so, rather than reading as
+// "this cannot be undone" — the product did not look, which is a different
+// thing and must not be presented as the same.
+func TestAnUnwiredUndoJudgeSaysItDidNotLook(t *testing.T) {
+	e := Setup(t)
+	since := time.Now().Add(-time.Hour)
+	seedMachineAction(t, e, e.Rep1, "agent", "agent:auto-apply", "advance_stage")
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+
+	receipt, err := magic.NewService(e.Pool, nil, time.Now).Read(ctx, &since, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	undo := receipt.Done[0].Undo
+	if undo == nil || undo.Undoable || undo.Reason == nil || *undo.Reason != "undo_not_evaluated" {
+		t.Errorf("unwired undo = %+v, want a stated not-evaluated reason", undo)
+	}
+}

--- a/backend/internal/compose/magic/couldnot.go
+++ b/backend/internal/compose/magic/couldnot.go
@@ -36,6 +36,10 @@ type TroubledRuns interface {
 	TroubledRuns(ctx context.Context, since time.Time, limit int) ([]automation.TroubledAutomationRun, error)
 }
 
+// nothingToUndo is the reason a could-not-complete line carries: the action did
+// not happen, so its absence is not a change to reverse.
+var nothingToUndo = "no_completed_change"
+
 // couldNotComplete reads the work that did not land.
 //
 // A REFUSED read is named to the caller rather than folded into an empty lane:
@@ -101,6 +105,9 @@ func troubledLine(run automation.TroubledAutomationRun) crmcontracts.MagicLine {
 		// A firing that did not happen has nothing to take back. Saying so
 		// explicitly beats leaving the field absent, which a client would have
 		// to guess about.
-		Undo: &crmcontracts.MagicUndo{Undoable: false},
+		// Never undoable, and not for want of asking: this lane is what the
+		// machine could NOT do. A failed run and an undecided approval have no
+		// committed change behind them, so there is nothing to put back.
+		Undo: &crmcontracts.MagicUndo{Undoable: false, Reason: &nothingToUndo},
 	}
 }

--- a/backend/internal/compose/magic/lines.go
+++ b/backend/internal/compose/magic/lines.go
@@ -66,7 +66,8 @@ func lineOf(e entry) (crmcontracts.MagicLine, bool) {
 			Type: crmcontracts.MagicActorType(e.ActorType),
 			Id:   e.ActorID,
 		},
-		Undo: &crmcontracts.MagicUndo{Undoable: false},
+		// Undo is filled by judgeUndoOn once the page is drawn — it needs the
+		// transaction and the record, neither of which this dressing has.
 	}
 	if meaning.consequence != "" {
 		line.Consequence = &meaning.consequence

--- a/backend/internal/compose/magic/service.go
+++ b/backend/internal/compose/magic/service.go
@@ -116,7 +116,9 @@ func (s *Service) Read(
 		// transaction: the judge reads the record each line names, and a
 		// second connection inside this one can deadlock against a lock it
 		// holds.
-		s.judgeUndoOn(ctx, tx, receipt.Done)
+		if err := s.judgeUndoOn(ctx, tx, receipt.Done); err != nil {
+			return err
+		}
 		receipt.NotShown = notShownOf(notShown)
 		failed, refused, err := s.couldNotComplete(ctx, from, limit)
 		if err != nil {

--- a/backend/internal/compose/magic/service.go
+++ b/backend/internal/compose/magic/service.go
@@ -39,7 +39,10 @@ type Service struct {
 	// because a seam was not wired would look exactly like one with nothing in
 	// it.
 	troubled TroubledRuns
-	now      func() time.Time
+	// undo is OPTIONAL for the same reason: unbound, every done line reads
+	// not-undoable with a stated reason rather than the page refusing.
+	undo UndoJudge
+	now  func() time.Time
 }
 
 // NewService binds the read.
@@ -109,6 +112,11 @@ func (s *Service) Read(
 			return err
 		}
 		receipt.Done = linesOf(entries, limit)
+		// Asked after the lines are drawn and inside the page's own
+		// transaction: the judge reads the record each line names, and a
+		// second connection inside this one can deadlock against a lock it
+		// holds.
+		s.judgeUndoOn(ctx, tx, receipt.Done)
 		receipt.NotShown = notShownOf(notShown)
 		failed, refused, err := s.couldNotComplete(ctx, from, limit)
 		if err != nil {

--- a/backend/internal/compose/magic/undojudge.go
+++ b/backend/internal/compose/magic/undojudge.go
@@ -21,7 +21,6 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -35,10 +34,20 @@ import (
 // refusal; one that answered no to a reversal the writer would allow hides the
 // feature entirely, which is why this is asked at all rather than defaulted.
 type UndoJudge interface {
-	// JudgeUndo reports whether the entry may be reversed, and why not when it
-	// may not. The reason is compose/undoability's own vocabulary — the same
-	// words the refusal would carry — rather than a second set written here.
-	JudgeUndo(ctx context.Context, tx pgx.Tx, auditID ids.UUID, entityType string) (undoable bool, reason string, err error)
+	// JudgeUndoPage answers for a whole page at once, keyed by audit id.
+	//
+	// The page rather than the line, because the judgment reads more than the
+	// entry: an omitted answer is read as not-evaluated, so a judge may decline
+	// a subject it does not serve without inventing a verdict for it. The
+	// reasons are compose/undoability's own vocabulary rather than a second set
+	// written here.
+	JudgeUndoPage(ctx context.Context, tx pgx.Tx, subjects []UndoSubject) (map[ids.UUID]*crmcontracts.MagicUndo, error)
+}
+
+// UndoSubject is one entry a page asks about.
+type UndoSubject struct {
+	AuditID    ids.UUID
+	EntityType string
 }
 
 // WithUndoJudge binds the undoability read. An option for the reason
@@ -65,27 +74,48 @@ const unwiredUndoReason = "undo_not_evaluated"
 // happened and who did it, which is most of its value, and one unreadable entry
 // must not cost a rep the whole morning's receipt — the same reasoning fieldsOf
 // applies to an unreadable audit blob.
-func (s *Service) judgeUndoOn(ctx context.Context, tx pgx.Tx, lines []crmcontracts.MagicLine) {
-	for i := range lines {
-		lines[i].Undo = s.judgeOne(ctx, tx, lines[i])
+func (s *Service) judgeUndoOn(ctx context.Context, tx pgx.Tx, lines []crmcontracts.MagicLine) error {
+	if s.undo == nil || len(lines) == 0 {
+		for i := range lines {
+			lines[i].Undo = refusedUndo(unwiredUndoReason)
+		}
+		return nil
 	}
+	// ONE call for the page, not one per line. The judgment behind a single
+	// answer reads the record, its history and the installation's own posture,
+	// and asking it a hundred times over is a hundred round trips for a page
+	// that already knows every id it needs. The per-page shape also lets the
+	// judge resolve what is constant — the overlay posture is a property of the
+	// workspace, not of the line — exactly once.
+	answers, err := s.undo.JudgeUndoPage(ctx, tx, entriesOf(lines))
+	if err != nil {
+		return err
+	}
+	for i := range lines {
+		answer, ok := answers[ids.UUID(lines[i].Id)]
+		if !ok {
+			lines[i].Undo = refusedUndo(unwiredUndoReason)
+			continue
+		}
+		lines[i].Undo = answer
+	}
+	return nil
 }
 
-// judgeOne answers for a single line.
-func (s *Service) judgeOne(ctx context.Context, tx pgx.Tx, line crmcontracts.MagicLine) *crmcontracts.MagicUndo {
-	if s.undo == nil || line.Entity == nil {
-		return refusedUndo(unwiredUndoReason)
+// entriesOf names what the page needs judged: the audit entry each line is
+// about, and the record type that entry sits on.
+func entriesOf(lines []crmcontracts.MagicLine) []UndoSubject {
+	out := make([]UndoSubject, 0, len(lines))
+	for _, line := range lines {
+		if line.Entity == nil {
+			continue
+		}
+		out = append(out, UndoSubject{
+			AuditID:    ids.UUID(line.Id),
+			EntityType: line.Entity.Type,
+		})
 	}
-	auditID := ids.UUID(line.Id)
-	undoable, reason, err := s.undo.JudgeUndo(ctx, tx, auditID, line.Entity.Type)
-	if err != nil {
-		return refusedUndo(unwiredUndoReason)
-	}
-	if !undoable {
-		return refusedUndo(reason)
-	}
-	id := openapi_types.UUID(auditID)
-	return &crmcontracts.MagicUndo{Undoable: true, AuditId: &id}
+	return out
 }
 
 // refusedUndo is the shape a client draws as a greyed control with a reason

--- a/backend/internal/compose/magic/undojudge.go
+++ b/backend/internal/compose/magic/undojudge.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package magic
+
+// Whether a line the receipt draws can actually be taken back.
+//
+// The done lane used to answer `Undoable: false` for every row, which was true
+// by accident: the sweep's corrections could not be reversed by any path, so a
+// hardcoded no was not wrong. It is wrong now, and a receipt that says "the
+// machine changed your deal" while greying out the only control that answers
+// that is worse than one that does not mention the change.
+//
+// A SEAM rather than a call, for the reason every other lane here is one: the
+// evaluator lives in compose, compose imports this package, and a direct
+// dependency would be a cycle. Unbound, every line reads not-undoable with a
+// stated reason — the same answer this file replaces, but declared rather than
+// assumed.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// UndoJudge answers whether one audit entry can be reversed, for a reader.
+//
+// Advisory, not binding: a line saying "you can take this back" is an offer to
+// open the control, and the write re-asks under its own lock. A judge that
+// answered yes to a reversal the writer would refuse costs a rep one clear
+// refusal; one that answered no to a reversal the writer would allow hides the
+// feature entirely, which is why this is asked at all rather than defaulted.
+type UndoJudge interface {
+	// JudgeUndo reports whether the entry may be reversed, and why not when it
+	// may not. The reason is compose/undoability's own vocabulary — the same
+	// words the refusal would carry — rather than a second set written here.
+	JudgeUndo(ctx context.Context, tx pgx.Tx, auditID ids.UUID, entityType string) (undoable bool, reason string, err error)
+}
+
+// WithUndoJudge binds the undoability read. An option for the reason
+// WithTroubledRuns is one: an installation that has not wired it gets a receipt
+// that names its own limitation instead of a page that refuses.
+func (s *Service) WithUndoJudge(j UndoJudge) *Service {
+	s.undo = j
+	return s
+}
+
+// unwiredUndoReason is what a line says when no judge is bound.
+//
+// Named rather than blank, because the client draws the reason beside a greyed
+// control: "not evaluated" tells a rep the product did not look, which is a
+// different thing from "this cannot be undone" and should not read as it.
+const unwiredUndoReason = "undo_not_evaluated"
+
+// judgeUndoOn fills the undo answer on every line of a page.
+//
+// Bounded by the page, which is bounded by maxLimit: at most 100 evaluations,
+// each short-circuiting on the cheap refusals before it reads the record.
+//
+// A judge that errors takes NO line down with it. The page still says what
+// happened and who did it, which is most of its value, and one unreadable entry
+// must not cost a rep the whole morning's receipt — the same reasoning fieldsOf
+// applies to an unreadable audit blob.
+func (s *Service) judgeUndoOn(ctx context.Context, tx pgx.Tx, lines []crmcontracts.MagicLine) {
+	for i := range lines {
+		lines[i].Undo = s.judgeOne(ctx, tx, lines[i])
+	}
+}
+
+// judgeOne answers for a single line.
+func (s *Service) judgeOne(ctx context.Context, tx pgx.Tx, line crmcontracts.MagicLine) *crmcontracts.MagicUndo {
+	if s.undo == nil || line.Entity == nil {
+		return refusedUndo(unwiredUndoReason)
+	}
+	auditID := ids.UUID(line.Id)
+	undoable, reason, err := s.undo.JudgeUndo(ctx, tx, auditID, line.Entity.Type)
+	if err != nil {
+		return refusedUndo(unwiredUndoReason)
+	}
+	if !undoable {
+		return refusedUndo(reason)
+	}
+	id := openapi_types.UUID(auditID)
+	return &crmcontracts.MagicUndo{Undoable: true, AuditId: &id}
+}
+
+// refusedUndo is the shape a client draws as a greyed control with a reason
+// beside it. The reason is always present, because a refusal without one is the
+// blank the contract's own comment says this field exists to replace.
+func refusedUndo(reason string) *crmcontracts.MagicUndo {
+	if reason == "" {
+		reason = unwiredUndoReason
+	}
+	return &crmcontracts.MagicUndo{Undoable: false, Reason: &reason}
+}

--- a/backend/internal/compose/magicseam.go
+++ b/backend/internal/compose/magicseam.go
@@ -15,12 +15,15 @@ import (
 	"errors"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose/briefs"
 	"github.com/margince/margince/backend/internal/compose/magic"
 	"github.com/margince/margince/backend/internal/modules/automation"
+	"github.com/margince/margince/backend/internal/modules/privacy"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // newMagicService assembles the receipt's read.
@@ -59,4 +62,76 @@ func (m magicBriefCutoff) CutoffFor(ctx context.Context) (time.Time, bool, error
 		return time.Time{}, false, err
 	}
 	return run.AsOf, true, nil
+}
+
+// magicUndoJudge answers the receipt's "can this be taken back" from the SAME
+// evaluator the restore route itself uses.
+//
+// One evaluator, deliberately. The receipt's offer and the write's refusal have
+// to agree — a line promising an Undo the writer then declines is worse than no
+// line at all — and two constructions of the same judgment drift the moment
+// somebody adds a rule to one of them.
+type magicUndoJudge struct {
+	seam RestoreSeam
+}
+
+// JudgeUndo reads the audit row and asks the evaluator in ADVISORY mode.
+//
+// Advisory because this is a page being drawn, not a change being made: the
+// binding answer is taken again inside the reversal's own transaction, under
+// the row lock, where it can refuse a caller who lost a race this read could
+// not have seen.
+func (j magicUndoJudge) JudgeUndo(
+	ctx context.Context, tx pgx.Tx, auditID ids.UUID, entityType string,
+) (bool, string, error) {
+	if !servesRecordType(entityType) {
+		return false, string(ReasonUnsupportedRecordType), nil
+	}
+	// Read IN THE CALLER'S transaction. RestoreSeam.readRow opens its own,
+	// which nested inside the page's would take a second connection while this
+	// one holds locks — the deadlock every reader in this tree is written to
+	// avoid.
+	var row AuditRow
+	err := tx.QueryRow(ctx, `
+		SELECT id, entity_type, entity_id, action, before, after, occurred_at
+		  FROM audit_log
+		 WHERE id = $1`, auditID).
+		Scan(&row.ID, &row.EntityType, &row.EntityID, &row.Action,
+			&row.Before, &row.After, &row.OccurredAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, string(ReasonUnsupportedRecordType), nil
+	}
+	if err != nil {
+		return false, "", err
+	}
+	// The same two gates readRow takes, in the same order: the record's own row
+	// scope first, then membership of its history. A line the reader may not
+	// see must not learn it exists from the shape of an undo answer — and the
+	// done lane is already scoped, so this is belt and braces rather than the
+	// only guard.
+	// A scope MISS is an answer — no control for a record this reader cannot
+	// change — while a broken read is not, and the two must not collapse into
+	// the same silent "no". Swallowing both would hide a failing gate behind a
+	// greyed button nobody questions.
+	if err := j.seam.visible(ctx, tx, row.EntityType, row.EntityID); err != nil {
+		if errors.Is(err, apperrors.ErrNotFound) || errors.Is(err, apperrors.ErrPermissionDenied) {
+			return false, string(ReasonUnsupportedRecordType), nil
+		}
+		return false, "", err
+	}
+	served, err := privacy.HistoryServesEntry(ctx, tx, row.EntityType, row.EntityID, auditID)
+	if err != nil {
+		return false, "", err
+	}
+	if !served {
+		return false, string(ReasonUnsupportedRecordType), nil
+	}
+	answer, err := j.seam.evaluator.Evaluate(ctx, tx, row, Advisory)
+	if err != nil {
+		return false, "", err
+	}
+	if answer.Undoable {
+		return true, "", nil
+	}
+	return false, string(answer.Reason), nil
 }

--- a/backend/internal/compose/magicseam.go
+++ b/backend/internal/compose/magicseam.go
@@ -17,13 +17,18 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/margince/margince/backend/internal/compose/briefs"
 	"github.com/margince/margince/backend/internal/compose/magic"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/automation"
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/privacy"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // newMagicService assembles the receipt's read.
@@ -64,74 +69,164 @@ func (m magicBriefCutoff) CutoffFor(ctx context.Context) (time.Time, bool, error
 	return run.AsOf, true, nil
 }
 
-// magicUndoJudge answers the receipt's "can this be taken back" from the SAME
-// evaluator the restore route itself uses.
+// magicUndoJudge answers the receipt's "can this be taken back".
 //
-// One evaluator, deliberately. The receipt's offer and the write's refusal have
-// to agree — a line promising an Undo the writer then declines is worse than no
-// line at all — and two constructions of the same judgment drift the moment
-// somebody adds a rule to one of them.
+// TWO PATHS, asked in this order, because the product has two reversals and the
+// generic one cannot see the other. A close-date correction is refused by
+// undoability — it writes close_date_provisional, which the ordinary update
+// shape cannot spell — while deals.RevertCorrection restores it perfectly. Ask
+// only the generic evaluator and every correction this receipt exists to
+// surface reads "cannot be undone", which is the exact defect the hardcoded
+// false already was.
+//
+// The generic evaluator is still asked for everything else, from the SAME seam
+// the restore route uses: the line offering an Undo and the write performing it
+// must agree, and two constructions of one judgment drift.
 type magicUndoJudge struct {
 	seam RestoreSeam
+	// corrections answers whether an audit row is a machine correction with its
+	// own reversal. Nil is a real state — an installation wired without it
+	// simply has no corrections to offer.
+	corrections *deals.Store
 }
 
-// JudgeUndo reads the audit row and asks the evaluator in ADVISORY mode.
+// JudgeUndoPage answers a whole page.
 //
-// Advisory because this is a page being drawn, not a change being made: the
-// binding answer is taken again inside the reversal's own transaction, under
-// the row lock, where it can refuse a caller who lost a race this read could
-// not have seen.
-func (j magicUndoJudge) JudgeUndo(
-	ctx context.Context, tx pgx.Tx, auditID ids.UUID, entityType string,
-) (bool, string, error) {
-	if !servesRecordType(entityType) {
-		return false, string(ReasonUnsupportedRecordType), nil
+// The workspace-level questions are asked ONCE here rather than per line: the
+// object grant and the installation's overlay posture are properties of the
+// caller and the workspace, and asking them a hundred times over is a hundred
+// round trips for one answer. isOverlayUncached in particular opens its own
+// transaction, so per-line it would take a second connection while this one
+// holds the page — the deadlock shape every reader here is written to avoid.
+func (j magicUndoJudge) JudgeUndoPage(
+	ctx context.Context, tx pgx.Tx, subjects []magic.UndoSubject,
+) (map[ids.UUID]*crmcontracts.MagicUndo, error) {
+	out := make(map[ids.UUID]*crmcontracts.MagicUndo, len(subjects))
+	if len(subjects) == 0 {
+		return out, nil
 	}
-	// Read IN THE CALLER'S transaction. RestoreSeam.readRow opens its own,
-	// which nested inside the page's would take a second connection while this
-	// one holds locks — the deadlock every reader in this tree is written to
-	// avoid.
+	// The object grant the WRITE takes. Without it a rep who owns the row but
+	// holds no update permission is offered a control that can only 403 —
+	// row authority alone is not the question the writer asks.
+	posture := undoPosture{mayWrite: auth.Require(ctx, "deal", principal.ActionUpdate) == nil}
+	external, err := j.seam.evaluator.ExternallyGoverned(ctx)
+	if err != nil {
+		return nil, err
+	}
+	posture.externallyGoverned = external
+	for _, subject := range subjects {
+		answer, err := j.judgeOne(ctx, tx, subject, posture)
+		if err != nil {
+			return nil, err
+		}
+		if answer != nil {
+			out[subject.AuditID] = answer
+		}
+	}
+	return out, nil
+}
+
+// undoPosture is what the page resolved once for every line on it: facts about
+// the CALLER and the WORKSPACE rather than about any one entry.
+type undoPosture struct {
+	// mayWrite is the object grant the write itself takes. Row authority alone
+	// is not the question: a rep who owns the row but holds no update
+	// permission would be offered a control that can only 403.
+	mayWrite bool
+	// externallyGoverned marks a workspace whose records live in another
+	// system, where no reversal this server makes can reach them.
+	externallyGoverned bool
+}
+
+// judgeOne answers for one entry, or declines to answer at all.
+//
+// A nil answer means "not judged" and the page reads it as not-evaluated. That
+// is deliberate for a subject this path does not serve: inventing a verdict for
+// an entry it never looked at is how a greyed control acquires a reason that is
+// not true.
+func (j magicUndoJudge) judgeOne(
+	ctx context.Context, tx pgx.Tx, subject magic.UndoSubject, posture undoPosture,
+) (*crmcontracts.MagicUndo, error) {
+	if !servesRecordType(subject.EntityType) {
+		return magicRefusal(string(ReasonUnsupportedRecordType)), nil
+	}
+	if posture.externallyGoverned {
+		return magicRefusal(string(ReasonNotRestorableByThisPath)), nil
+	}
+	if !posture.mayWrite {
+		return magicRefusal(string(ReasonNotWritableByCaller)), nil
+	}
 	var row AuditRow
 	err := tx.QueryRow(ctx, `
 		SELECT id, entity_type, entity_id, action, before, after, occurred_at
 		  FROM audit_log
-		 WHERE id = $1`, auditID).
+		 WHERE id = $1`, subject.AuditID).
 		Scan(&row.ID, &row.EntityType, &row.EntityID, &row.Action,
 			&row.Before, &row.After, &row.OccurredAt)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return false, string(ReasonUnsupportedRecordType), nil
+		return magicRefusal(string(ReasonUnsupportedRecordType)), nil
 	}
 	if err != nil {
-		return false, "", err
+		return nil, err
 	}
-	// The same two gates readRow takes, in the same order: the record's own row
-	// scope first, then membership of its history. A line the reader may not
-	// see must not learn it exists from the shape of an undo answer — and the
-	// done lane is already scoped, so this is belt and braces rather than the
-	// only guard.
 	// A scope MISS is an answer — no control for a record this reader cannot
-	// change — while a broken read is not, and the two must not collapse into
-	// the same silent "no". Swallowing both would hide a failing gate behind a
-	// greyed button nobody questions.
+	// change — while a broken read is not. Collapsing both into a silent "no"
+	// would hide a failing gate behind a greyed button nobody questions.
 	if err := j.seam.visible(ctx, tx, row.EntityType, row.EntityID); err != nil {
 		if errors.Is(err, apperrors.ErrNotFound) || errors.Is(err, apperrors.ErrPermissionDenied) {
-			return false, string(ReasonUnsupportedRecordType), nil
+			return magicRefusal(string(ReasonUnsupportedRecordType)), nil
 		}
-		return false, "", err
+		return nil, err
 	}
-	served, err := privacy.HistoryServesEntry(ctx, tx, row.EntityType, row.EntityID, auditID)
+	served, err := privacy.HistoryServesEntry(ctx, tx, row.EntityType, row.EntityID, subject.AuditID)
 	if err != nil {
-		return false, "", err
+		return nil, err
 	}
 	if !served {
-		return false, string(ReasonUnsupportedRecordType), nil
+		return magicRefusal(string(ReasonUnsupportedRecordType)), nil
 	}
-	answer, err := j.seam.evaluator.Evaluate(ctx, tx, row, Advisory)
+	// THE CORRECTION PATH FIRST. A machine correction has its own reversal, and
+	// the generic evaluator refuses exactly those rows — so asking it first
+	// would answer "cannot be undone" for the changes this receipt exists to
+	// show.
+	if answer, decided, err := j.judgeCorrection(ctx, tx, subject.AuditID); err != nil || decided {
+		return answer, err
+	}
+	verdict, err := j.seam.evaluator.Evaluate(ctx, tx, row, Advisory)
 	if err != nil {
-		return false, "", err
+		return nil, err
 	}
-	if answer.Undoable {
-		return true, "", nil
+	if verdict.Undoable {
+		return magicOffer(subject.AuditID), nil
 	}
-	return false, string(answer.Reason), nil
+	return magicRefusal(string(verdict.Reason)), nil
+}
+
+// judgeCorrection answers for a machine correction, and says whether it was one.
+func (j magicUndoJudge) judgeCorrection(
+	ctx context.Context, tx pgx.Tx, auditID ids.UUID,
+) (*crmcontracts.MagicUndo, bool, error) {
+	if j.corrections == nil {
+		return nil, false, nil
+	}
+	correction, err := j.corrections.CorrectionForAudit(ctx, tx, auditID)
+	if errors.Is(err, apperrors.ErrNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if correction.Reversed() {
+		return magicRefusal(string(ReasonAlreadyUndone)), true, nil
+	}
+	return magicOffer(auditID), true, nil
+}
+
+func magicOffer(auditID ids.UUID) *crmcontracts.MagicUndo {
+	id := openapi_types.UUID(auditID)
+	return &crmcontracts.MagicUndo{Undoable: true, AuditId: &id}
+}
+
+func magicRefusal(reason string) *crmcontracts.MagicUndo {
+	return &crmcontracts.MagicUndo{Undoable: false, Reason: &reason}
 }

--- a/backend/internal/compose/recordrestoreseam.go
+++ b/backend/internal/compose/recordrestoreseam.go
@@ -266,4 +266,16 @@ func (s *Server) wireReversal(pool *pgxpool.Pool) {
 	s.privacyHandlers = s.privacyHandlers.
 		WithChangeRestorer(seam).
 		WithUndoabilityReader(NewUndoabilityPage(seam))
+	// The receipt's undo answer comes from THIS seam, not a second one built
+	// for it: the line offering an Undo and the write performing it must agree,
+	// and one evaluator is how they stay agreed. It also inherits the server's
+	// own dispatcher, so the overlay question is answered once.
+	//
+	// Assembly order is load-bearing here and stated rather than assumed: the
+	// receipt is built before this runs, and a nil service would leave every
+	// line reading "not evaluated" with nothing failing to say so.
+	if s.magicService == nil {
+		panic("compose: the receipt must be assembled before its undo judge is bound")
+	}
+	s.magicService.WithUndoJudge(magicUndoJudge{seam: seam})
 }

--- a/backend/internal/compose/recordrestoreseam.go
+++ b/backend/internal/compose/recordrestoreseam.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/privacy"
 	"github.com/margince/margince/backend/internal/platform/auth"
@@ -277,5 +278,11 @@ func (s *Server) wireReversal(pool *pgxpool.Pool) {
 	if s.magicService == nil {
 		panic("compose: the receipt must be assembled before its undo judge is bound")
 	}
-	s.magicService.WithUndoJudge(magicUndoJudge{seam: seam})
+	s.magicService.WithUndoJudge(magicUndoJudge{
+		seam: seam,
+		// The corrections store is what lets a machine close-date change read
+		// as undoable at all: the generic evaluator refuses exactly those rows,
+		// because they write a field the ordinary update shape cannot spell.
+		corrections: deals.NewStore(InstallationDB(pool), DealsInstallation()),
+	})
 }

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -288,7 +288,8 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 	// The machinery's receipt: what ran without being asked, in the window since
 	// the reader last looked. It reads the same clock the rest of the surface
 	// does, so "since your brief" means the same instant everywhere.
-	srv.magicHandlers = magic.NewHandlers(newMagicService(pool, time.Now))
+	srv.magicService = newMagicService(pool, time.Now)
+	srv.magicHandlers = magic.NewHandlers(srv.magicService)
 	srv.wireAnalyticsSurface(pool)
 	srv.wireCaptureSettingsSurface(pool)
 	srv.wireExportSurface(pool, log)

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -81,6 +81,10 @@ type Server struct {
 	// than a decision anybody made.
 	attentionHandlers attention.Handlers
 	magicHandlers     magic.Handlers
+	// magicService is held so wireReversal can bind the undo judge to the SAME
+	// restore seam the reversal route uses — the receipt's offer and the write's
+	// refusal have to be one judgment.
+	magicService *magic.Service
 	// The relationship-graph reads (ADR-0078): who knows this contact, and
 	// how a deal is covered.
 	network.Reads


### PR DESCRIPTION
Every line in the receipt's done lane answered `Undoable: false`, hardcoded. That was true by accident — no path could reverse a sweep's correction, so a blanket no wasn't wrong. It is wrong now that corrections carry their own undo (#5049), and a receipt that says "the machine changed your deal" while greying out the only control answering that is worse than one that never mentioned the change.

## What changed

The undo answer comes from the **same evaluator the restore route uses**, bound in `wireReversal` off the seam that route already builds. One evaluator, deliberately: the line offering an Undo and the write performing it have to agree, and two constructions of one judgment drift the moment somebody adds a rule to either.

Advisory rather than binding — the page is being drawn, not changed, and the writer re-asks under its own lock where it can refuse a caller who lost a race this read could not have seen. An installation that hasn't wired a judge reads "not evaluated" rather than "cannot be undone": the product not having looked is a different thing from the answer being no.

## From the review

Four blocking defects, and **the first one made the feature pointless**:

- **Corrections still read as not-undoable.** The generic evaluator refuses exactly those rows, because a correction writes `close_date_provisional` and the ordinary update shape cannot spell that field. Asking only that authority meant every change this receipt exists to surface said "cannot be undone" — the hardcoded `false`, reached by a longer route. The correction path is now asked first.
- **Up to ~1,100 queries per page.** The judgment ran per line, ~11 queries each, and `isOverlayUncached` opens its own transaction — so the page took a second connection while holding its own. Now one call per page, with the caller's grant and workspace posture resolved once, since neither varies by line.
- **An offer could be made to a reader who couldn't take it.** The port took row authority alone; the write also requires the `deal:update` object grant.
- **Every failure collapsed into "not evaluated"**, so a database error read as a greyed button rather than a fault. Real errors propagate now; a scope miss, which is genuinely an answer, still reads as one.

Codex confirmed no privacy/scoping leak and no missing index.

## Verification

- `make check-backend` green; `internal/compose` and `internal/compose/integration` lanes green.
- The end-to-end test is mutation-checked, and the mutation reproduces exactly the defect above: disabling the correction path makes the seeded correction read `not_restorable_by_this_path`.
- `TestTheReceiptOffersUndoOnARealCorrection` runs the whole journey through the real adapter — sweep corrects, receipt offers Undo, reversal withdraws the offer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Magic receipts determine whether each completed change can be undone instead of hardcoding every line as `Undoable: false`. It uses the same restore evaluator as the undo route, including correction reversals from #5049, so receipts can offer Undo when the write can actually succeed.

- Evaluates a whole receipt page in one call and resolves workspace posture and `deal:update` permission once.
- Propagates evaluator errors, distinguishes scope refusals from failures, and reports an unwired judge as `undo_not_evaluated`.
- Marks failed or incomplete actions as `no_completed_change`.
- Adds integration coverage for the real correction, receipt, and reversal flow.

<sup>Written for commit d137f7760c4a5916ddc54f05a449023496c9ea76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added undo availability details to correction receipts.
  - Receipts now indicate which completed changes can be undone.
  - Non-undoable changes display a clear reason, including when undo evaluation is unavailable.
  - Undo decisions now account for permissions, record visibility, privacy history, and supported correction types.

- **Bug Fixes**
  - Undo offers now disappear after a correction has been reversed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->