### PR TITLE
fix(briefs): the morning queue ranks the reader's own work

### DIFF
--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -23,39 +23,6 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
 
-// sourceWaiting names the who-is-waiting producer. A named constant rather
-// than the literal at each site: the classifier, the dedupe and the
-// source-unavailable report all reach for it, and a typo in any of them would
-// produce a lane nothing joins up — silently, because each half would still
-// compile.
-const sourceWaiting = "customer_waiting"
-
-// sourceTask names the open-task producer. Named for the reason sourceWaiting
-// is: the owner filter asks whether a row came from the lane that narrowed to
-// one person in its own query, and a typo there would silently drop every task
-// out of the queue it was asked for.
-const sourceTask = "task"
-
-// sourceClaim names the rep's own promises. keepUnowned reads it: a claim has
-// no assignee column, so the row arrives ownerless while already belonging to
-// the rep whose query produced it.
-const sourceClaim = "conversation_claim"
-
-// sourceAtRisk names the quiet-deal producer. Three readers spell it — the
-// bounds table, the category map and the classifier — which is two more than a
-// literal survives.
-const sourceAtRisk = "deal_at_risk"
-
-// subjectDeal is the subject type a deal-shaped row names.
-const subjectDeal = "deal"
-
-// subjectPerson is the subject type a person-shaped row names.
-//
-// A constant for the reason sourceDecay is one: the suppressor pairing the
-// decay lane against a waiting row matches on it, and a misspelt literal there
-// fails silently — it matches nothing, drops nothing, and reads green.
-const subjectPerson = "person"
-
 // classifyDay turns the assembled lanes into ranked candidates.
 //
 // Order of appearance does not matter — rankAll decides the order — so the lanes

--- a/backend/internal/compose/attention/scope.go
+++ b/backend/internal/compose/attention/scope.go
@@ -214,7 +214,7 @@ func keepReadersOwn(ctx context.Context, rows []ranked) []ranked {
 	}
 	kept := make([]ranked, 0, len(rows))
 	for _, row := range rows {
-		if narrowedByItsOwnLane(row) || ownedByReader(row, actor) {
+		if boundToTheActingReader(row) || ownedByReader(row, actor) {
 			kept = append(kept, row)
 		}
 	}
@@ -247,6 +247,14 @@ func keepOwnedBy(rows []ranked, owner ids.UUID) []ranked {
 	for _, row := range rows {
 		if narrowedByItsOwnLane(row) {
 			kept = append(kept, row)
+			continue
+		}
+		// The overnight brief is the ACTING reader's, whoever the page names.
+		// It ranks against that person's own responsibility, so its rows say
+		// nothing about the owner asked for here — and a row that happens to
+		// name them is a coincidence of the deal's owner column, not evidence
+		// the night picked it for them.
+		if row.item.Source == sourceBriefItem {
 			continue
 		}
 		if named, ok := answersTo(row); ok && named == owner {
@@ -285,6 +293,23 @@ func keepOwnedBy(rows []ranked, owner ids.UUID) []ranked {
 func narrowedByItsOwnLane(row ranked) bool {
 	return row.item.Source == sourceTask || row.item.Source == sourceLeadResponse ||
 		row.item.Source == sourceMeeting || row.item.Source == sourceMeetingOutcome
+}
+
+// boundToTheActingReader marks the lanes that narrowed to the person ASKING,
+// as opposed to the ones that narrowed to a named person.
+//
+// The overnight brief is the case that needs the distinction. It ranks against
+// the acting reader's own responsibility — their deal, or one they hold an open
+// assigned task on — so under `mine` a brief row is theirs whatever the deal's
+// owner column says, and judging it by owner drops exactly the assist the
+// ranking admitted.
+//
+// But it is bound to the READER, not to whoever the page names. A manager
+// opening a rep's queue must not inherit their own overnight picks under
+// somebody else's heading, which is the failure keepOwnedBy exists to prevent —
+// so that filter deliberately does not consult this.
+func boundToTheActingReader(row ranked) bool {
+	return narrowedByItsOwnLane(row) || row.item.Source == sourceBriefItem
 }
 
 // keepUnowned keeps the rows that answer to nobody.

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -452,3 +452,39 @@ func (teammatesFailing) SharesLiveTeamWithCaller(context.Context, ids.UUID) (boo
 func (teammatesFailing) LiveTeammatesOfCaller(context.Context) ([]TeamMember, bool, error) {
 	return nil, false, errors.New("reading team membership")
 }
+
+// An assist survives the owner filter, and does not follow the reader onto
+// somebody else's page.
+//
+// The overnight brief ranks against the acting reader's own responsibility —
+// their deal, or one they hold an open assigned task on. So a brief row is
+// already bound to the person asking, and judging it afterwards by DEAL OWNER
+// drops exactly the assist the ranking admitted: the night picks a colleague's
+// deal because this rep has work on it, and the filter removes it before they
+// ever see it. That is the starvation the ranking fix closed, one layer down.
+//
+// The second half is the limit. `mine` is the acting reader; a named owner is
+// somebody else, and a manager opening a rep's queue must not inherit their own
+// overnight picks under that rep's heading.
+func TestAnAssistedDealSurvivesMineAndStaysOffANamedOwnersPage(t *testing.T) {
+	reader := ids.MustParse("01a05500-0000-7000-8000-000000000001")
+	colleague := ids.MustParse("01a05500-0000-7000-8000-0000000000ff")
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, UserID: reader,
+		Permissions: principal.Permissions{RowScope: principal.RowScopeAll},
+	})
+	// A brief row on a deal somebody else owns: the night admitted it because
+	// this reader has an open assigned task on it.
+	assist := ownedDeal("assist", colleague)
+	assist.Source = "brief_item"
+	rows := []ranked{{item: assist}}
+
+	if kept := keepReadersOwn(ctx, rows); len(kept) != 1 {
+		t.Errorf("the reader's own overnight pick was dropped by the owner filter (%d kept)", len(kept))
+	}
+	// The same row under a NAMED owner is not that person's work: it is the
+	// acting reader's, and this is not their page.
+	if kept := keepOwnedBy(rows, colleague); len(kept) != 0 {
+		t.Errorf("a named owner's page inherited the reader's own overnight pick (%d kept)", len(kept))
+	}
+}

--- a/backend/internal/compose/attention/sources.go
+++ b/backend/internal/compose/attention/sources.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The words a queue row carries for WHICH LANE produced it, and which subject
+// it names.
+//
+// Named rather than written as literals at each site, because the readers are
+// spread: the classifier sets them, the scope filters ask about them, the
+// bounds table and the category map read them. A misspelt literal in any of
+// those fails silently — it matches nothing, drops nothing, and reads green.
+
+// sourceWaiting names the who-is-waiting producer. A named constant rather
+// than the literal at each site: the classifier, the dedupe and the
+// source-unavailable report all reach for it, and a typo in any of them would
+// produce a lane nothing joins up — silently, because each half would still
+// compile.
+const sourceWaiting = "customer_waiting"
+
+// sourceTask names the open-task producer. Named for the reason sourceWaiting
+// is: the owner filter asks whether a row came from the lane that narrowed to
+// one person in its own query, and a typo there would silently drop every task
+// out of the queue it was asked for.
+const sourceTask = "task"
+
+// sourceClaim names the rep's own promises. keepUnowned reads it: a claim has
+// no assignee column, so the row arrives ownerless while already belonging to
+// the rep whose query produced it.
+const sourceClaim = "conversation_claim"
+
+// sourceAtRisk names the quiet-deal producer. Three readers spell it — the
+// bounds table, the category map and the classifier — which is two more than a
+// literal survives.
+const sourceAtRisk = "deal_at_risk"
+
+// sourceBriefItem names the overnight queue's own producer.
+//
+// The brief ranks against the reader's OWN responsibility — their deal, or one
+// they hold an open assigned task on — so a row from this lane is already
+// bound to the person asking, exactly as a task or a meeting row is. Judging it
+// afterwards by DEAL OWNER would drop the assist case the ranking admitted: the
+// night picks a colleague's deal because this rep has work on it, and the owner
+// filter then removes it before they ever see it. That is the same starvation
+// the ranking fix closed, one layer down.
+const sourceBriefItem = "brief_item"
+
+// subjectDeal is the subject type a deal-shaped row names.
+const subjectDeal = "deal"
+
+// subjectPerson is the subject type a person-shaped row names.
+//
+// A constant for the reason sourceDecay is one: the suppressor pairing the
+// decay lane against a waiting row matches on it, and a misspelt literal there
+// fails silently — it matches nothing, drops nothing, and reads green.
+const subjectPerson = "person"

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -343,6 +343,27 @@ func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.T
 	if scope != "" {
 		q += " AND " + scope
 	}
+	// RESPONSIBILITY, not merely visibility — and it belongs HERE rather than
+	// after the ranking, which is the whole defect.
+	//
+	// A deal is workspace-readable in this product: auth.ScopeClauseFor renders
+	// no predicate for a rep on `deal`, so every seat that may read one may read
+	// them all. The overnight queue then takes the top seven by score and the
+	// worklist narrows to "mine" afterwards — so a rep whose colleagues carry
+	// larger deals watched all seven slots fill with deals that were never
+	// theirs to act on, and their own work never entered the ranking at all.
+	// One observed morning selected six colleague deals out of seven.
+	//
+	// Applied before the cap, the ranking competes among the deals this person
+	// can actually move. Access to a colleague's deal is not responsibility for
+	// it; the team view is where breadth belongs.
+	q += fmt.Sprintf(`
+		  AND (d.owner_id = $%d
+		       OR EXISTS (
+			SELECT 1 FROM activity a
+			JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = d.id
+			WHERE a.kind = 'task' AND NOT a.is_done
+			  AND a.archived_at IS NULL AND a.assignee_id = $%d))`, userPos, userPos)
 	q += " ORDER BY d.id"
 
 	rows, err := tx.Query(ctx, q, args...)

--- a/backend/internal/compose/briefs/briefrank_integration_test.go
+++ b/backend/internal/compose/briefs/briefrank_integration_test.go
@@ -342,10 +342,17 @@ func TestBriefActedAndDismissedItemsLeaveTheNextQueue(t *testing.T) {
 		t.Fatalf("post-mark queue = %v (candidates %d), want empty", queueDeals(next.Queue), next.CandidateCount)
 	}
 
-	// The marks bind for OTHER runs of the same user too, not just the
-	// run they were made in — and for another user not at all: rep2's
-	// own brief still ranks both deals (owned by rep1, visible under
-	// row_scope=all).
+	// The marks bind for OTHER runs of the same user too, not just the run they
+	// were made in — and for another user not at all.
+	//
+	// Rep2 needs a REASON to carry these deals, not merely permission to read
+	// them: the queue is scoped to the person's own responsibility, so an open
+	// task assigned to them is what puts somebody else's deal in their morning.
+	// That is the assist case the scope admits, and it is exactly what makes
+	// this a test about marks rather than about ownership.
+	for _, item := range run.Items {
+		assignTaskTo(t, owner, item.DealID, b.Rep2)
+	}
 	rep2 := b.As(b.Rep2, []ids.UUID{b.Team1}, integration.AdminPerms)
 	rep2Ranking, err := b.engine.Rank(rep2, nextClock)
 	if err != nil {
@@ -380,29 +387,66 @@ func TestBriefActedAndDismissedItemsLeaveTheNextQueue(t *testing.T) {
 // ranks another team's deal exactly as an all-scope principal does. The
 // candidate query still composes the deal read predicate, so this is the
 // place that proves it widens nothing beyond what read_record answers.
-func TestBriefRankRanksEveryDealTheReadModelShows(t *testing.T) {
+// The morning queue is the reader's OWN work, not everything they may read.
+//
+// A deal is workspace-readable here: ScopeClauseFor renders no predicate for a
+// rep on `deal`, so every seat may read every deal. The queue used to take its
+// top seven from that whole population and let the worklist narrow to "mine"
+// afterwards — so a rep whose colleagues carried larger deals watched all seven
+// slots fill with work that was never theirs, and their own deals never entered
+// the ranking. One observed morning selected six colleague deals out of seven.
+//
+// A big colleague deal is still VISIBLE; the team view is where breadth
+// belongs. What it may no longer do is consume a slot in this rep's morning.
+func TestTheQueueRanksTheReadersOwnWorkRatherThanEverythingVisible(t *testing.T) {
 	b := setupBrief(t)
 	owner := integration.OwnerConn(t)
 
+	// Deliberately the most attractive deal in the fixture: if value alone
+	// still decided the queue, this would take the top slot.
 	foreign := b.seedBriefDeal(t, owner, "Foreign", b.stageA, int64Ptr(90_000_00), closeOn(briefClock, 3), &b.Rep3)
 
 	scoped, err := b.engine.Rank(b.As(b.Rep1, []ids.UUID{b.Team1}, integration.RepPerms), briefClock)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !queueHasDeal(scoped.Queue, foreign) {
-		t.Fatalf("team-scoped queue = %v misses another team's deal, which every seat reads", queueDeals(scoped.Queue))
+	if queueHasDeal(scoped.Queue, foreign) {
+		t.Errorf("queue = %v carries a deal owned by somebody else and unassigned to this rep",
+			queueDeals(scoped.Queue))
 	}
-	if len(scoped.Queue) != 3 {
-		t.Fatalf("scoped queue = %v, want rep1's two candidates plus the foreign deal", queueDeals(scoped.Queue))
+	if len(scoped.Queue) != 2 {
+		t.Fatalf("queue = %v, want rep1's own two candidates", queueDeals(scoped.Queue))
 	}
 
-	all, err := b.engine.Rank(b.repCtx, briefClock)
+	// An ASSIST puts it back: an open task assigned to this rep is a reason to
+	// carry somebody else's deal, which permission alone is not.
+	assignTaskTo(t, owner, foreign, b.Rep1)
+	withAssist, err := b.engine.Rank(b.As(b.Rep1, []ids.UUID{b.Team1}, integration.RepPerms), briefClock)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !queueHasDeal(all.Queue, foreign) {
-		t.Fatalf("all-scope queue = %v misses the foreign deal", queueDeals(all.Queue))
+	if !queueHasDeal(withAssist.Queue, foreign) {
+		t.Errorf("queue = %v drops a colleague's deal this rep has an open task on",
+			queueDeals(withAssist.Queue))
+	}
+}
+
+// assignTaskTo gives one person an open task on a deal — the assist that makes
+// somebody else's deal their responsibility for the morning.
+func assignTaskTo(t *testing.T, owner *pgx.Conn, dealID, assignee ids.UUID) {
+	t.Helper()
+	activity := ids.NewV7()
+	ctx := context.Background()
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO activity (id, kind, subject, assignee_id, is_done, occurred_at, source, captured_by)
+		VALUES ($1, 'task', 'Assist', $2, false, now(), 'manual', 'human:x')`, activity, assignee); err != nil {
+		t.Fatalf("seeding the assist task: %v", err)
+	}
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO activity_link (activity_id, entity_type, deal_id)
+		VALUES ($1, 'deal', $2)`,
+		activity, dealID); err != nil {
+		t.Fatalf("linking the assist task: %v", err)
 	}
 }
 


### PR DESCRIPTION
A deal is workspace-readable in this product: `auth.ScopeClauseFor` renders no predicate for a rep on `deal`, so every seat may read every deal. The overnight queue took its top seven from that whole population, and the worklist narrowed to "mine" only afterwards.

So a rep whose colleagues carried larger deals watched all seven slots fill with work that was never theirs to act on, and their own deals never entered the ranking at all. **The audited morning selected six colleague deals out of seven.** Narrowing afterwards cannot undo that — the cap has already been spent.

## What changed

Responsibility now bounds the candidates *before* they are scored: the deal is this person's, or they hold an open task assigned on it. The second half is the assist case, and it is why this isn't simply an ownership filter — a colleague handing you a task is a reason to carry their deal for the morning, where permission alone is not.

## From the review

Codex caught that the fix recreated the same bug one layer down. The worklist attaches and filters on **deal owner**, so an assist deal could win a slot in the stored brief and then be dropped from `scope=mine` before the rep saw it — and my test only checked the ranking, not the downstream filter.

The overnight lane narrows to the acting reader's own responsibility, so a brief row is already bound to the person asking, exactly as a task or meeting row is. It now survives `mine` on that basis.

**A second problem I found while fixing the first:** the obvious fix was to add the brief source to `narrowedByItsOwnLane`, which both scope filters share. But `keepOwnedBy` has the opposite default for a documented reason — a manager opening a rep's queue must not inherit their own rows under somebody else's heading. Sharing the predicate would have leaked exactly that. The two filters now answer differently, and the test asserts both directions.

Codex also confirmed the indexes serve the new predicate (`idx_activity_tasks`, `idx_alink_deal`), that a schema constraint makes joining on `deal_id` alone safe, and that the team board is unaffected — it doesn't go through `briefCandidates`.

## Verification

- `make check-backend` green; `compose/briefs`, `compose`, and `compose/integration` lanes green.
- Both halves mutation-checked: reverting the ranking predicate makes the queue carry a colleague's deal again; reverting the filter predicate drops the assist.
- Two existing tests asserted the old behaviour and now state the new rule. The per-rep-marks test needed its bystander to have an actual reason to see the deals — the assist case again.

One thing Codex raised that I did **not** change: an unowned deal with no assist now enters nobody's personal brief. Other lanes still surface it, and "nobody's morning" seems right for a deal nobody owns, but flagging it as a deliberate call rather than an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The morning brief now ranks the reader's own work instead of every visible deal. The queue previously scored all workspace-readable deals, so a rep's seven slots could fill with colleagues' larger deals while their own never entered the ranking — one observed morning picked six colleague deals out of seven. Candidates are now filtered by responsibility before scoring: the deal is the reader's, or they hold an open task assigned on it.

**Bug Fixes**
- Assist deals (open tasks on a colleague's deal) now survive the worklist's `mine` filter, which previously dropped them by deal owner.
- A named owner's page still won't inherit the acting reader's brief picks; the filter excludes brief rows outright.
- An unowned deal with no assist now enters nobody's personal brief; other lanes still surface it.

<sup>Written for commit 81f458eaa3d958cff4abfd91a6e14b439d90c500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

