### PR TITLE
fix(people): the LinkedIn apply binds its connection, and lands in one transaction

### DIFF
--- a/backend/internal/compose/linkedinmatchproposal.go
+++ b/backend/internal/compose/linkedinmatchproposal.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/modules/approvals"
@@ -219,11 +220,6 @@ func employerOrPlaceholder(s string) string {
 // path performs, released by a human instead of by a string comparison.
 func linkedInMatchAcceptEffect(svc *approvals.Service, store *people.Store) approvals.ApprovedEffect {
 	return func(ctx context.Context, approvalID ids.ApprovalID, proposedChange json.RawMessage, diffHash string) error {
-		// The single-use redemption IS the idempotency claim: whoever consumes
-		// the approval executes, anyone else finds it consumed.
-		if _, _, err := svc.Redeem(ctx, approvalID, linkedInMatchKind, diffHash); err != nil {
-			return err
-		}
 		var p linkedInMatchProposal
 		if err := json.Unmarshal(proposedChange, &p); err != nil {
 			return fmt.Errorf("compose: unreadable LinkedIn match proposal: %w", err)
@@ -231,9 +227,22 @@ func linkedInMatchAcceptEffect(svc *approvals.Service, store *people.Store) appr
 		if _, ok := principal.Actor(ctx); !ok {
 			return fmt.Errorf("compose: LinkedIn match effect without a deciding principal")
 		}
+		// ONE TRANSACTION, which is what RedeemAndApply is for. Redeem-then-apply
+		// was two: the redemption committed, and a failure in the apply left the
+		// approval consumed and the connection never linked — unrecoverable
+		// through the API, because the row is decided and re-deciding answers
+		// 409. Redeem's own doc says callers should use this and have no window
+		// at all, and every other accept effect in compose already does.
+		//
+		// The single-use redemption is still the idempotency claim: whoever
+		// consumes the approval executes, anyone else finds it consumed. What
+		// changes is that a consumed approval now implies the write landed.
+		//
 		// Executed as the DECIDER, not as a machine: a member approving a match
 		// is making the claim themselves, and the write must be gated by their
 		// grants and recorded against them.
-		return store.ApplyLinkedInMatch(ctx, p.ConnectionID, p.OwnerUserID, p.PersonID)
+		return svc.RedeemAndApply(ctx, approvalID, linkedInMatchKind, diffHash, func(tx pgx.Tx) error {
+			return people.ApplyLinkedInMatchTx(ctx, tx, p.ConnectionID, p.OwnerUserID, p.PersonID)
+		})
 	}
 }

--- a/backend/internal/compose/linkedinmatchproposal.go
+++ b/backend/internal/compose/linkedinmatchproposal.go
@@ -50,7 +50,12 @@ const linkedInMatchKind = "linkedin_match"
 // decide it.
 type linkedInMatchProposal struct {
 	ConnectionID ids.UUID `json:"connection_id"`
-	PersonID     ids.UUID `json:"person_id"`
+	// OwnerUserID is the member whose network produced the pair, stamped at
+	// staging from the ghost row. The apply binds on it: without it the write
+	// gated the PERSON and nothing tied the CONNECTION, so a payload naming
+	// another member's connection applied to it.
+	OwnerUserID ids.UUID `json:"owner_user_id"`
+	PersonID    ids.UUID `json:"person_id"`
 	// ConnectionName and ConnectionCompany are the export's own spelling. The
 	// folded forms the matcher compared on are deliberately absent: nobody can
 	// decide "andreas muller · simio".
@@ -166,7 +171,8 @@ func stagePendingLinkedInMatches(
 
 func stageOneLinkedInMatch(ctx context.Context, svc *approvals.Service, m people.PendingLinkedInMatch) (bool, error) {
 	canonical, hash, err := diffhash.Object(map[string]any{
-		"connection_id": m.ConnectionID.String(), "person_id": m.PersonID.String(),
+		"connection_id": m.ConnectionID.String(), "owner_user_id": m.OwnerUserID.String(),
+		"person_id":       m.PersonID.String(),
 		"connection_name": m.ConnectionName, "connection_company": m.ConnectionCompany,
 		"person_name": m.PersonName,
 	})
@@ -228,6 +234,6 @@ func linkedInMatchAcceptEffect(svc *approvals.Service, store *people.Store) appr
 		// Executed as the DECIDER, not as a machine: a member approving a match
 		// is making the claim themselves, and the write must be gated by their
 		// grants and recorded against them.
-		return store.ApplyLinkedInMatch(ctx, p.ConnectionID, p.PersonID)
+		return store.ApplyLinkedInMatch(ctx, p.ConnectionID, p.OwnerUserID, p.PersonID)
 	}
 }

--- a/backend/internal/compose/linkedinmatchproposal_integration_test.go
+++ b/backend/internal/compose/linkedinmatchproposal_integration_test.go
@@ -407,3 +407,59 @@ func onlyLinkedInConnection(t *testing.T, e *integration.Env) ids.UUID {
 	}
 	return id
 }
+
+// A FAILED APPLY TAKES THE REDEMPTION WITH IT.
+//
+// The effect redeemed the approval and then applied it in a SECOND
+// transaction. A failure in the apply left the approval consumed and the
+// connection never linked — and unrecoverable through the API, because the row
+// is decided and re-deciding answers 409. Redeem's own doc says callers should
+// use RedeemAndApply and have no window at all.
+//
+// The failure is produced by tombstoning the connection between staging and
+// deciding, which is a thing that actually happens: a re-import supersedes the
+// row a proposal is about. The apply then refuses, and what this pins is that
+// the approval is left UNCONSUMED — so a consumed approval implies the write
+// landed, which is the property the two transactions did not have.
+func TestAFailedLinkedInApplyLeavesTheApprovalUnconsumed(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	linkedInMatchFixture(ctx, t, e)
+	grantReadPeopleRole(t, e, e.Rep1, "all")
+
+	store := people.NewStore(e.DB())
+	if _, err := store.MatchLinkedInConnections(ctx, e.Rep1); err != nil {
+		t.Fatalf("matching: %v", err)
+	}
+	svc := approvalsServiceWithEffects(e.Pool)
+	if _, err := StageLinkedInMatches(ctx, svc, store); err != nil {
+		t.Fatalf("staging: %v", err)
+	}
+	approval := onlyPendingLinkedInMatch(t, e)
+
+	// The row the proposal is about goes away, exactly as a re-import would
+	// take it away.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE linkedin_connection SET tombstoned_at = now()`)
+		return err
+	}); err != nil {
+		t.Fatalf("tombstoning the connection: %v", err)
+	}
+
+	if _, err := svc.Decide(ctx, approval, true, nil); err == nil {
+		t.Fatal("approving reported success while the connection it names was gone")
+	}
+
+	var consumed *string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT consumed_at::text FROM approval WHERE id = $1`, approval).Scan(&consumed)
+	}); err != nil {
+		t.Fatalf("reading the approval back: %v", err)
+	}
+	if consumed != nil {
+		t.Errorf("the approval is consumed at %s while its apply failed — the redemption committed "+
+			"on its own, so the member's yes is spent and the connection was never linked", *consumed)
+	}
+}

--- a/backend/internal/compose/linkedinmatchproposal_test.go
+++ b/backend/internal/compose/linkedinmatchproposal_test.go
@@ -29,12 +29,12 @@ func TestTheProposalCarriesTheExportsSpellingAndNotTheFoldedForms(t *testing.T) 
 	// legal-suffix stripped — cannot be judged by anybody and must not travel:
 	// nobody can decide "andreas muller · simio".
 	m := people.PendingLinkedInMatch{
-		ConnectionID: ids.NewV7(), PersonID: ids.NewV7(),
+		ConnectionID: ids.NewV7(), OwnerUserID: ids.NewV7(), PersonID: ids.NewV7(),
 		ConnectionName: "André Schultewolter", ConnectionCompany: "SIMIO GmbH & Co. KG",
 		PersonName: "Andre Schultewolter",
 	}
 	payload, err := json.Marshal(linkedInMatchProposal{
-		ConnectionID: m.ConnectionID, PersonID: m.PersonID,
+		ConnectionID: m.ConnectionID, OwnerUserID: m.OwnerUserID, PersonID: m.PersonID,
 		ConnectionName: m.ConnectionName, ConnectionCompany: m.ConnectionCompany,
 		PersonName: m.PersonName,
 	})
@@ -45,7 +45,14 @@ func TestTheProposalCarriesTheExportsSpellingAndNotTheFoldedForms(t *testing.T) 
 	if err := json.Unmarshal(payload, &fields); err != nil {
 		t.Fatalf("unreadable proposal: %v", err)
 	}
-	want := []string{"connection_id", "person_id", "connection_name", "connection_company", "person_name"}
+	// owner_user_id is on the wire and is NOT a ghost's detail: it names the
+	// member whose network produced the pair, which is what the apply binds on
+	// so a payload cannot land on somebody else's connection. Nothing about the
+	// third party travels with it.
+	want := []string{
+		"connection_id", "owner_user_id", "person_id",
+		"connection_name", "connection_company", "person_name",
+	}
 	for _, key := range want {
 		if _, ok := fields[key]; !ok {
 			t.Errorf("the proposal omits %s — the inbox cannot render the question without it", key)

--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -158,65 +158,87 @@ func (s *Store) ApplyLinkedInMatch(ctx context.Context, connectionID, ownerID, p
 		return err
 	}
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {
-		if err := auth.HoldWritableLive(ctx, tx, entityPerson, personID); err != nil {
-			return err
-		}
-		// And HELD, before the connection row below. person_social is a declared
-		// PII table Art. 17 erasure deletes, so a handle written after that
-		// commit puts the erased person's public profile straight back.
-		//
-		// Taken HERE rather than beside that write, because the erasure goes
-		// person-then-linkedin_connection and this transaction locks the
-		// connection two statements down. Person second would close a cycle
-		// against it — the same ordering the DOI issuer takes, and for the same
-		// reason.
-		// The prior values come from the write itself, through a pre-write
-		// self-join: a separate read would be a different look at the same row,
-		// and the audit row would attest to something other than what this
-		// statement replaced.
-		var wasStatus string
-		var wasPerson *ids.UUID
-		// BOUND to the connection this proposal was staged for, on all three
-		// axes the payload names. The guards above gate the PERSON — the update
-		// grant and the target's visibility — and nothing tied the connection:
-		// an apply would re-point an already-confirmed row to a different
-		// contact, and would land on another member's connection, if the payload
-		// said so.
-		//
-		// owner_user_id, because a member decides about their OWN imported
-		// network and nobody else's. match_status = 'suggested', because a
-		// confirmed row is a link somebody already has and this is not the verb
-		// that moves one. matched_person_id, because the pair is the claim: an
-		// approval released against this contact must not apply to whatever the
-		// row points at now if the matcher moved it.
-		err := tx.QueryRow(ctx, `
-			UPDATE linkedin_connection c
-			   SET match_status = 'confirmed', updated_at = now()
-			  FROM linkedin_connection was
-			 WHERE c.id = $1 AND was.id = c.id AND c.tombstoned_at IS NULL
-			   AND c.owner_user_id = $3
-			   AND c.match_status = 'suggested'
-			   AND c.matched_person_id = $2
-			 RETURNING was.match_status, was.matched_person_id`,
-			connectionID, personID, ownerID).Scan(&wasStatus, &wasPerson)
-		if errors.Is(err, pgx.ErrNoRows) {
-			// Every way the predicate misses is the same answer, and it is the
-			// honest one: this approval does not describe a suggestion that is
-			// still there to confirm. The connection was tombstoned or erased,
-			// or it belongs to another member, or it has already been confirmed,
-			// or the pair it names has moved. Silently succeeding would report a
-			// link that does not exist.
-			return apperrors.ErrNotFound
-		}
-		if err != nil {
-			return fmt.Errorf("people: applying an approved LinkedIn match: %w", err)
-		}
-		wrote, err := writeLinkedInHandle(ctx, tx, connectionID, personID)
-		if err != nil {
-			return err
-		}
-		return auditLinkedInMatch(ctx, tx, connectionID, personID, matchImages(wasStatus, wasPerson, personID), wrote)
+		return applyLinkedInMatchInTx(ctx, tx, connectionID, ownerID, personID)
 	})
+}
+
+// ApplyLinkedInMatchTx is ApplyLinkedInMatch inside a transaction the CALLER
+// owns, for the accept effect.
+//
+// It exists so redeeming the approval and applying it are ONE transaction. They
+// were two: the redemption committed, and a failure in the apply left the
+// approval consumed and the connection never linked — with no way back through
+// the API, because the row is decided and re-deciding answers 409. Redeem's own
+// doc says callers should use RedeemAndApply and have no window at all, which
+// every other accept effect in compose already does.
+//
+// The object gate is the caller's to apply, as it is for every other Tx-shaped
+// entry point here: the approvals service checks the decider's authority before
+// any effect runs, and ApplyLinkedInMatch applies it above for the direct path.
+func ApplyLinkedInMatchTx(ctx context.Context, tx pgx.Tx, connectionID, ownerID, personID ids.UUID) error {
+	return applyLinkedInMatchInTx(ctx, tx, connectionID, ownerID, personID)
+}
+
+// applyLinkedInMatchInTx is the write both entry points land on.
+func applyLinkedInMatchInTx(ctx context.Context, tx pgx.Tx, connectionID, ownerID, personID ids.UUID) error {
+	if err := auth.HoldWritableLive(ctx, tx, entityPerson, personID); err != nil {
+		return err
+	}
+	// And HELD, before the connection row below. person_social is a declared
+	// PII table Art. 17 erasure deletes, so a handle written after that
+	// commit puts the erased person's public profile straight back.
+	//
+	// Taken HERE rather than beside that write, because the erasure goes
+	// person-then-linkedin_connection and this transaction locks the
+	// connection two statements down. Person second would close a cycle
+	// against it — the same ordering the DOI issuer takes, and for the same
+	// reason.
+	// The prior values come from the write itself, through a pre-write
+	// self-join: a separate read would be a different look at the same row,
+	// and the audit row would attest to something other than what this
+	// statement replaced.
+	var wasStatus string
+	var wasPerson *ids.UUID
+	// BOUND to the connection this proposal was staged for, on all three
+	// axes the payload names. The guards above gate the PERSON — the update
+	// grant and the target's visibility — and nothing tied the connection:
+	// an apply would re-point an already-confirmed row to a different
+	// contact, and would land on another member's connection, if the payload
+	// said so.
+	//
+	// owner_user_id, because a member decides about their OWN imported
+	// network and nobody else's. match_status = 'suggested', because a
+	// confirmed row is a link somebody already has and this is not the verb
+	// that moves one. matched_person_id, because the pair is the claim: an
+	// approval released against this contact must not apply to whatever the
+	// row points at now if the matcher moved it.
+	err := tx.QueryRow(ctx, `
+		UPDATE linkedin_connection c
+		   SET match_status = 'confirmed', updated_at = now()
+		  FROM linkedin_connection was
+		 WHERE c.id = $1 AND was.id = c.id AND c.tombstoned_at IS NULL
+		   AND c.owner_user_id = $3
+		   AND c.match_status = 'suggested'
+		   AND c.matched_person_id = $2
+		 RETURNING was.match_status, was.matched_person_id`,
+		connectionID, personID, ownerID).Scan(&wasStatus, &wasPerson)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Every way the predicate misses is the same answer, and it is the
+		// honest one: this approval does not describe a suggestion that is
+		// still there to confirm. The connection was tombstoned or erased,
+		// or it belongs to another member, or it has already been confirmed,
+		// or the pair it names has moved. Silently succeeding would report a
+		// link that does not exist.
+		return apperrors.ErrNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("people: applying an approved LinkedIn match: %w", err)
+	}
+	wrote, err := writeLinkedInHandle(ctx, tx, connectionID, personID)
+	if err != nil {
+		return err
+	}
+	return auditLinkedInMatch(ctx, tx, connectionID, personID, matchImages(wasStatus, wasPerson, personID), wrote)
 }
 
 // matchImagePair is the connection's own columns on either side of a confirmed

--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -180,7 +180,25 @@ func ApplyLinkedInMatchTx(ctx context.Context, tx pgx.Tx, connectionID, ownerID,
 }
 
 // applyLinkedInMatchInTx is the write both entry points land on.
+//
+// A ZERO ownerID means the proposal predates the field, and it is resolved from
+// the connection row rather than refused. A pending approval staged before this
+// shipped carries no owner_user_id, so binding on the zero value would match no
+// row — and the member could never decide it: the effect fails, and re-deciding
+// a decided row answers 409. Reading the owner off the row is what staging does
+// anyway, so a legacy payload gets exactly the behaviour it had, and a new one
+// gets the guard. The fallback goes when no pending proposal predates the field.
 func applyLinkedInMatchInTx(ctx context.Context, tx pgx.Tx, connectionID, ownerID, personID ids.UUID) error {
+	if ownerID == ids.Nil {
+		if err := tx.QueryRow(ctx,
+			`SELECT owner_user_id FROM linkedin_connection WHERE id = $1 AND tombstoned_at IS NULL`,
+			connectionID).Scan(&ownerID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return apperrors.ErrNotFound
+			}
+			return fmt.Errorf("people: reading a legacy proposal's connection owner: %w", err)
+		}
+	}
 	if err := auth.HoldWritableLive(ctx, tx, entityPerson, personID); err != nil {
 		return err
 	}

--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -42,7 +42,11 @@ const (
 // terms they judge it on: the export's own spelling of the connection, and the
 // contact the matcher thinks it is.
 type PendingLinkedInMatch struct {
-	ConnectionID      ids.UUID
+	ConnectionID ids.UUID
+	// OwnerUserID is the member whose imported network produced this pair. It
+	// travels because the APPLY has to bind the connection it was staged for:
+	// the guards on that path gate the person, and nothing tied the row.
+	OwnerUserID       ids.UUID
 	ConnectionName    string
 	ConnectionCompany string
 	PersonID          ids.UUID
@@ -116,7 +120,7 @@ func (s *Store) suggestedMatches(ctx context.Context, forPerson ids.UUID) ([]Pen
 		// second copy of the row-scope join to keep in step with this one.
 		personPos := arg(optionalPerson(forPerson))
 		rows, err := tx.Query(ctx, storekit.SQLf(`
-			SELECT c.id, c.full_name, coalesce(c.company_name, ''), p.id, p.full_name
+			SELECT c.id, c.owner_user_id, c.full_name, coalesce(c.company_name, ''), p.id, p.full_name
 			  FROM linkedin_connection c
 			  JOIN person p ON p.id = c.matched_person_id AND p.archived_at IS NULL AND (%s)
 			 WHERE c.owner_user_id = $%d
@@ -130,7 +134,7 @@ func (s *Store) suggestedMatches(ctx context.Context, forPerson ids.UUID) ([]Pen
 		defer rows.Close()
 		for rows.Next() {
 			var m PendingLinkedInMatch
-			if err := rows.Scan(&m.ConnectionID, &m.ConnectionName, &m.ConnectionCompany,
+			if err := rows.Scan(&m.ConnectionID, &m.OwnerUserID, &m.ConnectionName, &m.ConnectionCompany,
 				&m.PersonID, &m.PersonName); err != nil {
 				return err
 			}
@@ -146,7 +150,7 @@ func (s *Store) suggestedMatches(ctx context.Context, forPerson ids.UUID) ([]Pen
 //
 // It is the same write the automatic exact-name path performs. The difference
 // is only who released it: a string comparison there, a person here.
-func (s *Store) ApplyLinkedInMatch(ctx context.Context, connectionID, personID ids.UUID) error {
+func (s *Store) ApplyLinkedInMatch(ctx context.Context, connectionID, ownerID, personID ids.UUID) error {
 	// Writing to a contact takes the person update grant. The approvals engine
 	// checked the decider's authority before calling this; taking it again here
 	// keeps the store's own entry point gated rather than trusting a caller.
@@ -172,18 +176,36 @@ func (s *Store) ApplyLinkedInMatch(ctx context.Context, connectionID, personID i
 		// statement replaced.
 		var wasStatus string
 		var wasPerson *ids.UUID
+		// BOUND to the connection this proposal was staged for, on all three
+		// axes the payload names. The guards above gate the PERSON — the update
+		// grant and the target's visibility — and nothing tied the connection:
+		// an apply would re-point an already-confirmed row to a different
+		// contact, and would land on another member's connection, if the payload
+		// said so.
+		//
+		// owner_user_id, because a member decides about their OWN imported
+		// network and nobody else's. match_status = 'suggested', because a
+		// confirmed row is a link somebody already has and this is not the verb
+		// that moves one. matched_person_id, because the pair is the claim: an
+		// approval released against this contact must not apply to whatever the
+		// row points at now if the matcher moved it.
 		err := tx.QueryRow(ctx, `
 			UPDATE linkedin_connection c
-			   SET matched_person_id = $2, match_status = 'confirmed', updated_at = now()
+			   SET match_status = 'confirmed', updated_at = now()
 			  FROM linkedin_connection was
 			 WHERE c.id = $1 AND was.id = c.id AND c.tombstoned_at IS NULL
+			   AND c.owner_user_id = $3
+			   AND c.match_status = 'suggested'
+			   AND c.matched_person_id = $2
 			 RETURNING was.match_status, was.matched_person_id`,
-			connectionID, personID).Scan(&wasStatus, &wasPerson)
+			connectionID, personID, ownerID).Scan(&wasStatus, &wasPerson)
 		if errors.Is(err, pgx.ErrNoRows) {
-			// The connection went away between the proposal and the decision —
-			// a re-import that tombstoned it, or an erasure. Not found is the
-			// honest answer; silently succeeding would report a link that does
-			// not exist.
+			// Every way the predicate misses is the same answer, and it is the
+			// honest one: this approval does not describe a suggestion that is
+			// still there to confirm. The connection was tombstoned or erased,
+			// or it belongs to another member, or it has already been confirmed,
+			// or the pair it names has moved. Silently succeeding would report a
+			// link that does not exist.
 			return apperrors.ErrNotFound
 		}
 		if err != nil {

--- a/backend/internal/modules/people/linkedinreview_integration_test.go
+++ b/backend/internal/modules/people/linkedinreview_integration_test.go
@@ -14,10 +14,12 @@ package people
 // that the reach read counts what it says it counts.
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -97,7 +99,7 @@ func TestApplyingAnApprovedMatchPutsTheLinkedInURLOnTheContact(t *testing.T) {
 	e.employ(t, andreas, org)
 	e.importAndMatch(t)
 
-	if err := e.store.ApplyLinkedInMatch(e.as(), e.ghostID(t), andreas.UUID); err != nil {
+	if err := e.store.ApplyLinkedInMatch(e.as(), e.ghostID(t), e.rep, andreas.UUID); err != nil {
 		t.Fatalf("applying the approved match: %v", err)
 	}
 	if status, person := e.ghostStatus(t, suggestedGhost); status != "confirmed" || person == nil || *person != andreas.UUID {
@@ -132,7 +134,7 @@ func TestApplyingAMatchNeverOverwritesAHandleTheContactAlreadyHad(t *testing.T) 
 	}
 	e.importAndMatch(t)
 
-	if err := e.store.ApplyLinkedInMatch(e.as(), e.ghostID(t), andreas.UUID); err != nil {
+	if err := e.store.ApplyLinkedInMatch(e.as(), e.ghostID(t), e.rep, andreas.UUID); err != nil {
 		t.Fatalf("applying the approved match: %v", err)
 	}
 	// The link still stands — only the copy did not happen.
@@ -297,5 +299,73 @@ func TestAConnectionNeverMatchesAContactItsOwnerMayNotSee(t *testing.T) {
 
 	if status, person := e.ghostStatus(t, "Andreas Müller"); status != "unmatched" || person != nil {
 		t.Errorf("a ghost matched a contact its owner may not see: %q → %v", status, person)
+	}
+}
+
+// The apply is BOUND to the connection its proposal was staged for, on every
+// axis the payload names.
+//
+// The guards on this path gate the PERSON — the update grant and the target's
+// visibility — and nothing tied the CONNECTION. So an apply would re-point an
+// already-confirmed row to a different contact, and would land on another
+// member's connection, if the payload said so. Each case here is one of the
+// three predicates, and each must change zero rows and answer not-found rather
+// than reporting a link it did not make.
+func TestApplyingAMatchRefusesAConnectionTheProposalDoesNotDescribe(t *testing.T) {
+	e := setupDedupe(t)
+	org := e.seedOrgNamed(t, "Acme GmbH")
+	andreas := e.seedContact(t, "Andreas Muller")
+	e.employ(t, andreas, org)
+	e.importAndMatch(t)
+	ghost := e.ghostID(t)
+
+	other := e.seedContact(t, "Someone Else")
+
+	for _, tc := range []struct {
+		name          string
+		owner, person ids.UUID
+		what          string
+	}{
+		{
+			name: "another member's connection", owner: ids.NewV7(), person: andreas.UUID,
+			what: "a member decides about their own imported network and nobody else's",
+		},
+		{
+			name: "a pair the row does not name", owner: e.rep, person: other.UUID,
+			what: "the pair IS the claim, so an approval released against one contact must not " +
+				"apply to whoever the row points at now",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := e.store.ApplyLinkedInMatch(e.as(), ghost, tc.owner, tc.person); !errors.Is(err, apperrors.ErrNotFound) {
+				t.Fatalf("err = %v, want ErrNotFound — %s", err, tc.what)
+			}
+			if status, _ := e.ghostStatus(t, suggestedGhost); status != "suggested" {
+				t.Errorf("the connection is %q, want it untouched at suggested", status)
+			}
+		})
+	}
+
+	// The outcome the three clauses exist for, asserted as an outcome: a
+	// confirmed row is never re-pointed.
+	//
+	// NOT claimed as a test of the state clause. I could not build a case where
+	// `match_status = 'suggested'` is the operative refusal through this entry
+	// point — every route to an apply carrying a non-suggested row is turned
+	// away earlier, by the pair clause or by the person lock — and neutralising
+	// the state clause alone fails nothing here. It stays because the ticket
+	// asks for it and because it is true, and it is defence in depth on this
+	// path rather than the guard that holds. The owner and pair clauses ARE
+	// load-bearing, and each fails this case when neutralised.
+	if err := e.store.ApplyLinkedInMatch(e.as(), ghost, e.rep, andreas.UUID); err != nil {
+		t.Fatalf("the correct apply was refused: %v", err)
+	}
+	if err := e.store.ApplyLinkedInMatch(e.as(), ghost, e.rep, other.UUID); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound — a confirmed row is a link somebody already has", err)
+	}
+	if status, person := e.ghostStatus(t, suggestedGhost); status != "confirmed" ||
+		person == nil || *person != andreas.UUID {
+		t.Errorf("the connection is %q → %v, want it left confirmed to the contact it names",
+			status, person)
 	}
 }

--- a/backend/internal/modules/people/linkedinreview_integration_test.go
+++ b/backend/internal/modules/people/linkedinreview_integration_test.go
@@ -369,3 +369,32 @@ func TestApplyingAMatchRefusesAConnectionTheProposalDoesNotDescribe(t *testing.T
 			status, person)
 	}
 }
+
+// A proposal staged BEFORE owner_user_id existed still applies.
+//
+// The payload gained the field, and a pending approval minted before this
+// shipped carries none — so its OwnerUserID decodes to the zero value. Binding
+// on that would match no row, the effect would fail, and the member could never
+// decide it: re-deciding a decided row answers 409. So a zero owner is resolved
+// from the connection, which is where staging reads it from anyway.
+//
+// The zero id is passed directly rather than through a stored payload: what is
+// under test is the store's handling of a proposal that names no owner, and
+// building a legacy approval row to carry one there would be asserting against
+// a fixture of the old format rather than against the behaviour.
+func TestAProposalWithNoOwnerStillAppliesAgainstItsConnection(t *testing.T) {
+	e := setupDedupe(t)
+	org := e.seedOrgNamed(t, "Acme GmbH")
+	andreas := e.seedContact(t, "Andreas Muller")
+	e.employ(t, andreas, org)
+	e.importAndMatch(t)
+
+	if err := e.store.ApplyLinkedInMatch(e.as(), e.ghostID(t), ids.Nil, andreas.UUID); err != nil {
+		t.Fatalf("a proposal predating owner_user_id was refused: %v", err)
+	}
+	if status, person := e.ghostStatus(t, suggestedGhost); status != "confirmed" ||
+		person == nil || *person != andreas.UUID {
+		t.Errorf("the connection is %q → %v, want it confirmed to the contact the proposal named",
+			status, person)
+	}
+}


### PR DESCRIPTION
Closes #681.

`ApplyLinkedInMatch` updated the connection row on `id` and `tombstoned_at` alone. The guards it does have — `person:update` and `EnsureVisibleLive` — gate the **person**. Nothing tied the **connection** to the owner the proposal was staged for, so it would re-point an already-`confirmed` row to a different contact, and would apply to another member's connection, if the payload said so.

### Three axes, because the payload names three things

- **owner_user_id** — a member decides about their own imported network and nobody else's. Added to the proposal payload, stamped at staging from the ghost row (`PendingLinkedInMatch` now carries it, read straight from `c.owner_user_id`).
- **match_status = 'suggested'** — a confirmed row is a link somebody already has, and this is not the verb that moves one.
- **matched_person_id** — the pair IS the claim. An approval released against one contact must not apply to whoever the row points at now if the matcher has moved it.

Zero rows is `ErrNotFound` for all of them, and the comment says why one answer serves: every way the predicate misses means the same thing — this approval does not describe a suggestion that is still there to confirm.

`matched_person_id` also leaves the SET clause. The predicate now requires it to already be the proposed person, so writing it was a no-op that made the audit image describe an update that never happened.

### The payload grew by one field, and the exact-count test agrees

`TestTheProposalCarriesTheExportsSpellingAndNotTheFoldedForms` pins the payload's fields exactly, so it names `owner_user_id` now — with the reason, because that test's whole point is that a ghost's details are nobody's business who is only deciding an identity. `owner_user_id` is not a ghost's detail: it names the member whose network produced the pair.

### What is held, and what is not

`TestApplyingAMatchRefusesAConnectionTheProposalDoesNotDescribe` covers another member's connection, a pair the row does not name, and the outcome that a confirmed row is never re-pointed.

**The state clause is not independently held, and the test says so** instead of implying otherwise. I could not construct a route through this entry point where `match_status = 'suggested'` is the operative refusal — a non-suggested row is turned away earlier by the pair clause or the person lock, and neutralising the state clause alone fails nothing. It stays because it is true, because the ticket asks for it, and because a later caller may not be so lucky; it is defence in depth on this path rather than the guard that holds.

Two earlier versions of that case *did* pass while claiming otherwise — one refused by the pair clause, one by something upstream — which is why it now says what it covers rather than what it is about.

Mutation-checked: neutralising the **owner** clause fails three assertions, the **pair** clause two. `make check-backend` and `make craft-static` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LinkedIn match approvals now apply connection changes atomically, preventing approvals from being consumed when application fails.
  * Match applications now verify the specified owner and person before updating a connection.
  * Legacy proposals without owner details continue to resolve the owner automatically.

* **Documentation**
  * Updated the gate inventory to reflect 101 parity gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->