### PR TITLE
fix(desktop): the macOS floor is pinned by the step that builds the Go half

### DIFF
--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -26,6 +26,24 @@ on:
     paths:
       - desktop/**
       - .github/workflows/desktop-macos.yml
+  # And again on main once the merge has happened, for the same paths.
+  #
+  # A pull-request run judges the MERGE ref, so it is a prediction about a main
+  # that does not exist yet; two lanes landing in the same window each pass
+  # against a main without the other. Nothing re-asked the question afterwards,
+  # and because this lane is path-scoped nothing asked it on the next ordinary
+  # pull request either — so a broken bundle waited for the next change to
+  # desktop/ to discover it, which was three weeks the first time. This is the
+  # cheapest arrangement that gives main its own answer.
+  #
+  # It does NOT make this lane a merge gate: it reports after the fact, the way
+  # main-health does, and the standing decision about what blocks a merge is
+  # unaffected.
+  push:
+    branches: [main]
+    paths:
+      - desktop/**
+      - .github/workflows/desktop-macos.yml
   # On demand, once this workflow is on the default branch — GitHub resolves a
   # dispatch against the default branch only.
   workflow_dispatch:

--- a/backend/gates/desktopmacosfloor_test.go
+++ b/backend/gates/desktopmacosfloor_test.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H1
+
+package gates
+
+// Every macOS build script pins the bundle's OS floor before it compiles
+// anything.
+//
+// A compiler on macOS stamps its output with the deployment target it was
+// given, and clang's default is the OS of the machine doing the build. A build
+// step that does not source desktop/build/macos-target.sh therefore produces
+// binaries that refuse to launch on any Mac older than the builder's — a floor
+// nobody chose, that moves whenever the build machine takes an OS update, and
+// that is invisible to the builder, whose own Mac always satisfies it.
+//
+// This gate exists because the desktop bundle shipped for three weeks with its
+// Go half unpinned and looked correct the whole time. Go's own linker stamps
+// the floor its toolchain supports, which is the same number macos-target.sh
+// declares, so the omission was masked — until a dependency arrived carrying a
+// darwin-only cgo file, which handed the link to clang and let clang's default
+// through. The bundle's floor had been resting on a transitive dependency's
+// build tags rather than on a decision.
+//
+// The lane that would have caught it runs only on a macOS runner, and only for
+// pull requests touching desktop/**. The change that broke it touched
+// backend/go.mod. This gate is the cheap half of the answer: it runs on every
+// pull request, on Linux, and reads the scripts rather than their output.
+//
+// WHAT IT CANNOT SEE, and why H1 rather than H3. The corpus is a total list —
+// every *.sh in the directory, no skip-list — but whether a script pins the
+// floor is decided by a regex over shell text, and text can lie about what
+// runs. Three ways this passes something it should not:
+//
+//   a script that sources the floor and then clears or overrides
+//   MACOSX_DEPLOYMENT_TARGET before compiling; a top-level source placed AFTER
+//   a top-level compiler call; and any spelling of the source command this
+//   regex does not cover, which shows up as a false FAILURE rather than a false
+//   pass and is the safe direction to be wrong in.
+//
+// The source must sit in column ONE, which is what rules out the near misses
+// worth ruling out: a source buried in a function body or a conditional branch
+// is indented in this tree, so it cannot satisfy this. Combined with the shape
+// every script here has — compilers inside functions, one `main "$@"` on the
+// last line — a column-one source necessarily runs before any compiler. That
+// shape is not itself gated, which is the residual hole and the reason for the
+// paragraph above.
+//
+// It also judges only the macOS lane: the Windows .ps1 scripts carry no
+// equivalent stamp, so they have nothing to pin.
+//
+// None of this is the last line of defence. What the scripts actually PRODUCE
+// is held by assert_min_os inside the bundle build, reading the Mach-O of every
+// binary on a real Mac — an H3 check on the output, which this one only tries to
+// beat to the answer by twenty minutes and one macOS runner.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	// The script that declares the floor, and the directory holding the lane
+	// that sources it — relative to the module root TestMain lands every gate
+	// at. macos-target.sh is excluded from the corpus below because it is the
+	// subject, not a subscriber.
+	macOSFloorScript = "macos-target.sh"
+	macOSBuildDir    = "../desktop/build"
+
+	// Below the four scripts present when this gate was written, so a glob that
+	// stops matching after a rename fails here rather than certifying an empty
+	// directory. It is a floor on the SCAN, not a claim about how many build
+	// steps the lane ought to have.
+	macOSBuildScriptFloor = 3
+)
+
+// sourcesFloor matches a shell source of the floor script, in either spelling
+// bash accepts, anchored to COLUMN ONE.
+//
+// The anchor is the check's teeth: an indented source is inside a function body
+// or a branch, and either can go unexecuted while reading exactly like a script
+// that pins the floor. Every script in this lane sources at column one already,
+// so the anchor costs nothing and closes the near miss.
+//
+// The path is deliberately loose: which variable holds the script's directory is
+// the script's business, and pinning it here would fail on a rename that changed
+// nothing that matters.
+var sourcesFloor = regexp.MustCompile(`^(\.|source)\s+\S*` + regexp.QuoteMeta(macOSFloorScript))
+
+// exportsDeploymentTarget matches the floor script's own export. Checked so
+// that gutting macos-target.sh cannot leave every script dutifully sourcing a
+// file that no longer sets anything — the failure this gate would otherwise
+// certify as clean.
+var exportsDeploymentTarget = regexp.MustCompile(`(?m)^export MACOSX_DEPLOYMENT_TARGET=`)
+
+func TestEveryMacOSBuildScriptPinsTheDeploymentTarget(t *testing.T) {
+	t.Parallel()
+
+	floor, err := os.ReadFile(filepath.Join(macOSBuildDir, macOSFloorScript))
+	if err != nil {
+		t.Fatalf("reading the script that declares the macOS floor: %v", err)
+	}
+	if !exportsDeploymentTarget.Match(floor) {
+		t.Fatalf("%s/%s no longer exports MACOSX_DEPLOYMENT_TARGET, so every script that sources "+
+			"it is pinning nothing and the bundle's OS floor is again the build machine's",
+			macOSBuildDir, macOSFloorScript)
+	}
+
+	scripts, err := filepath.Glob(filepath.Join(macOSBuildDir, "*.sh"))
+	if err != nil {
+		t.Fatalf("listing the macOS build scripts: %v", err)
+	}
+
+	// Two lists, both read from the tree: every script in the lane, and those
+	// that pin the floor. There is no waiver map and no compiler-detection
+	// heuristic — a heuristic is what goes short when the next script compiles
+	// by a spelling it does not recognise, and sourcing costs a script that
+	// ships nothing exactly nothing. Every script in this directory pins the
+	// floor; that an exemption has never been needed is why none exists.
+	var inLane, pinned []string
+	for _, script := range scripts {
+		name := filepath.Base(script)
+		if name == macOSFloorScript {
+			continue
+		}
+		inLane = append(inLane, name)
+
+		body, err := os.ReadFile(script)
+		if err != nil {
+			t.Fatalf("reading %s: %v", script, err)
+		}
+		if pinsFloor(string(body)) {
+			pinned = append(pinned, name)
+		}
+	}
+
+	if len(inLane) < macOSBuildScriptFloor {
+		t.Fatalf("found %d script(s) under %s, fewer than the %d this gate was written against — "+
+			"the glob has stopped matching the lane it judges, and an empty scan reports clean",
+			len(inLane), macOSBuildDir, macOSBuildScriptFloor)
+	}
+
+	// missingFrom is this package's shared list diff, and takes what is HELD
+	// first: the scripts that pin, then the lane they are drawn from.
+	unpinned := missingFrom(pinned, inLane)
+	if len(unpinned) > 0 {
+		t.Fatalf("%d of %d macOS build script(s) do not source %s: %s\n"+
+			"Anything a script in this directory compiles is stamped with the build machine's OS "+
+			"unless the floor is sourced first, and will then refuse to launch on an older Mac. "+
+			"Add `. \"$HERE/%s\"` near the top, the way build-postgres.sh and build-valkey.sh do.",
+			len(unpinned), len(inLane), macOSFloorScript, strings.Join(unpinned, ", "), macOSFloorScript)
+	}
+}
+
+// pinsFloor reports whether a script sources the floor from a line bash runs on
+// the way in.
+//
+// Comment lines go first, because this file's own failure message spells the
+// source command and several of these scripts explain the target in prose — a
+// gate that read either would certify a script that only talks about pinning.
+// The column-one anchor in sourcesFloor does the rest; pinsFloorCases covers
+// the near misses.
+func pinsFloor(body string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if sourcesFloor.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// pinsFloorCases are the near misses, each a line that reads like a script
+// pinning the floor and is not one. They exist because the predicate is a regex
+// and a regex is exactly the thing that quietly says yes: the gate's value is
+// what it REFUSES, and nothing else in this file demonstrates a refusal.
+var pinsFloorCases = []struct {
+	name string
+	body string
+	want bool
+}{
+	{"a top-level source pins it", ". \"$HERE/macos-target.sh\"", true},
+	{"and so does the source keyword", "source \"$HERE/macos-target.sh\"", true},
+	{"a bare relative path is still a source", ". ./macos-target.sh", true},
+	{
+		// The case that made the anchor worth having: bash runs this only if
+		// something calls the function, and nothing here checks that anything
+		// does.
+		name: "a source inside a function body is not a pin",
+		body: "setup() {\n  . \"$HERE/macos-target.sh\"\n}\n",
+		want: false,
+	},
+	{
+		name: "nor is one inside a branch that may never be taken",
+		body: "if [[ -n \"${RELEASE:-}\" ]]; then\n  . \"$HERE/macos-target.sh\"\nfi\n",
+		want: false,
+	},
+	{
+		// Every script in this lane discusses the deployment target, and this
+		// file's own failure message spells the command.
+		name: "a comment describing the pin is not a pin",
+		body: "# Source it first: . \"$HERE/macos-target.sh\"\n",
+		want: false,
+	},
+	{"an indented comment is not a pin either", "  # . \"$HERE/macos-target.sh\"\n", false},
+	{"naming the file without sourcing it is not a pin", "echo macos-target.sh\n", false},
+	{"a script that never mentions it does not pin it", "set -euo pipefail\ngo build ./...\n", false},
+}
+
+func TestPinsFloorRefusesASourceBashMayNeverRun(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range pinsFloorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := pinsFloor(tc.body); got != tc.want {
+				t.Errorf("pinsFloor(%q) = %t, want %t", tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/desktop/build/build-app.sh
+++ b/desktop/build/build-app.sh
@@ -9,6 +9,18 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Pins the deployment target before any compiler runs, so every binary here is
+# stamped with the bundle's declared floor instead of the build machine's OS.
+#
+# Go needs this as much as the C halves do, and far less obviously. With no cgo
+# anywhere in the graph Go links internally and stamps its own supported floor,
+# which is the same number this file declares — so omitting it produced a
+# correct bundle by coincidence rather than by decision. The coincidence ended
+# when one dependency arrived carrying a darwin-only cgo file: that hands the
+# link to clang, clang defaults the target to the builder's OS, and every
+# binary in the bundle then demanded the macOS the runner happened to be on.
+# shellcheck source=desktop/build/macos-target.sh
+. "$HERE/macos-target.sh"
 ROOT="$(cd "$HERE/../.." && pwd)"
 OUT="$ROOT/build/desktop/.stage"
 
@@ -33,6 +45,9 @@ build_server_binaries() {
   done
 }
 
+# The signed binaries, in build order. Read by verify_runnable_os below.
+BUILT=()
+
 # sign_binary ad-hoc signs one executable, HERE in the staging directory
 # rather than after assembly.
 #
@@ -42,8 +57,14 @@ build_server_binaries() {
 # starter script it cannot sign as a subcomponent. Staging paths cannot
 # collide that way. Signatures are embedded in the Mach-O, so they survive
 # the copy into the folder.
+#
+# It also records what it signed, in BUILT. Every executable this script ships
+# is signed, so this is the one place that already knows the whole list —
+# assembling a second one, by globbing the staging directory or by naming the
+# roles again, is how a census comes to check fewer binaries than were built.
 sign_binary() {
   codesign --force --sign - --timestamp=none "$1"
+  BUILT+=("$1")
 }
 
 # build_frontend builds the COMPOSED SPA, for the same reason the server
@@ -125,12 +146,39 @@ build_launcher() {
   sign_binary "$OUT/bin/margince"
 }
 
+# verify_runnable_os holds THIS step's output to the bundle's floor, the way the
+# Postgres and bus steps hold theirs.
+#
+# build-dist.sh checks the assembled folder too, and that check is the one that
+# constrains what a user copies. This one names the step that stamped a binary
+# wrong while the build log still shows which compiler ran, and main() calls it
+# before the frontend so the answer does not wait on a build that cannot change
+# it.
+verify_runnable_os() {
+  # An empty census would pass while examining nothing, which is how a
+  # verification step most often fails.
+  if [[ ${#BUILT[@]} -eq 0 ]]; then
+    echo "FAIL: no binaries were built, so there is nothing to hold to the macOS floor" >&2
+    exit 1
+  fi
+  if ! assert_min_os "${BUILT[@]}"; then
+    exit 1
+  fi
+  log "every binary runs on macOS $MACOS_MIN or newer"
+}
+
 main() {
+  # Every binary, then the floor, then the frontend. The frontend is the
+  # expensive half — a dependency install and two vite builds — and it produces
+  # no Mach-O, so nothing in it can affect the answer. Paying for it before
+  # asking is how the earlier order reported a stamped binary several minutes
+  # after it could have.
   build_server_binaries
+  build_launcher
+  verify_runnable_os
   if [[ "${SKIP_FRONTEND:-0}" != "1" ]]; then
     build_frontend
   fi
-  build_launcher
   log "binaries in $OUT/bin"
 }
 

--- a/desktop/build/macos-target.sh
+++ b/desktop/build/macos-target.sh
@@ -11,6 +11,14 @@
 # fail for everyone else — with a floor nobody chose, nobody wrote down, and
 # that moves every time the builder takes an OS update.
 #
+# GO IS NOT EXEMPT, and looks it. Go's own linker stamps the floor its toolchain
+# supports, which is the number below — so a Go binary built with this variable
+# unset can come out correctly stamped and prove nothing. It stays correct only
+# while nothing in the module graph uses cgo: one darwin-only cgo file anywhere
+# among the dependencies hands the link to clang, and clang applies the rule in
+# the paragraph above. Whether this bundle has a floor at all then depends on a
+# transitive dependency's build tags, which is not a decision anyone made.
+#
 # 12.0 is not arbitrary: it is Go's own floor for this toolchain, so the C
 # halves (Postgres, the bus) and the Go halves (api, worker, migrate, the
 # launcher) agree on one number instead of disagreeing silently. Raising it
@@ -26,22 +34,36 @@ export MACOSX_DEPLOYMENT_TARGET="$MACOS_MIN"
 # A check rather than a comment, because the failure it guards is invisible on
 # the machine that causes it: the builder's own Mac always satisfies whatever
 # floor the builder's own Mac produced.
+#
+# It names EVERY offender rather than stopping at the first. One unpinned build
+# step and one stray binary are different faults with different fixes, and a
+# check that reports a single file cannot tell them apart — the file it reports
+# is whichever one the caller happened to pass first, which reads as a difference
+# between binaries when the cause is common to all of them. The count is the
+# diagnosis, so the count has to survive to the message.
 assert_min_os() {
-  local file minos newest
+  local file minos newest offenders=0
   for file in "$@"; do
     minos="$(vtool -show-build "$file" 2>/dev/null | awk '/^ *minos/ {print $2; exit}')"
     if [[ -z "$minos" ]]; then
       echo "FAIL: $file declares no macOS build version, so the OS it needs cannot be known" >&2
-      return 1
+      offenders=$((offenders + 1))
+      continue
     fi
     # sort -V so 9.0 sorts below 12.0 the way a version does, not the way a
     # string does.
     newest="$(printf '%s\n%s\n' "$MACOS_MIN" "$minos" | sort -V | tail -1)"
     if [[ "$newest" != "$MACOS_MIN" ]]; then
       echo "FAIL: $file requires macOS $minos but this bundle declares $MACOS_MIN" >&2
-      echo "      It was built without MACOSX_DEPLOYMENT_TARGET, so it inherited the build machine's OS" >&2
-      echo "      and would refuse to launch on any older Mac." >&2
-      return 1
+      offenders=$((offenders + 1))
     fi
   done
+
+  if [[ "$offenders" -gt 0 ]]; then
+    echo "      $offenders of $# checked binaries cannot be shown to run on macOS $MACOS_MIN." >&2
+    echo "      A binary inherits the build machine's OS unless MACOSX_DEPLOYMENT_TARGET is exported" >&2
+    echo "      before the compiler runs, so it launches for the builder and for nobody older;" >&2
+    echo "      source macos-target.sh in the build step that produced them." >&2
+    return 1
+  fi
 }

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -121,7 +121,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (132)
+## Census (133)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -159,6 +159,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `dealtargettype_test.go` | H2 | Every deal-scoped staging names its target type through one constant. |
 | `decisioncoverage_test.go` | H2 | A message that reaches the send queue carries a decision saying why, written in the transaction that staged it. |
 | `declaredfilters_test.go` | H2 | A declared narrowing parameter is read by the handler it is declared on, or it is not declared. |
+| `desktopmacosfloor_test.go` | H1 | Every macOS build script pins the bundle's OS floor before it compiles anything. |
 | `directmailbypass_test.go` | H2 | Who may hand a message straight to the SMTP relay, bypassing comms\_outbound. |
 | `docscodepaths_test.go` | H3 | Every source file a prose page names in backticks still exists. |
 | `docslinktargets_test.go` | H3 | Every relative link under docs/ points at a file that exists. |


### PR DESCRIPTION
Fixes https://github.com/margince/margince/issues/5033.

`desktop-macos` is red on `main`. `desktop/build/build-app.sh` never sourced
`macos-target.sh`, so not one of the four Go binaries it produces was given
`MACOSX_DEPLOYMENT_TARGET`. The C halves source it and always passed; the Go
half was never pinned at all.

## The issue's diagnosis was wrong, in a way worth recording

The issue reads the failure as `migrate` alone being mis-stamped and infers a
linker difference between the roles — `api` and `worker` "pass the same check
in the same loop". They do not pass it. They were never reached.

`assert_min_os` returned at its first offender, and `verify_runnable_os` feeds
it a list built by `find`, which returned `runtime/migrate` first. Built at
`origin/main` on macOS 15.7.7, go1.26.6, through the composition the bundle
actually ships:

| binary | `minos`, target unset | with the target set |
|---|---|---|
| `api` | 15.0 (the host) | 12.0 |
| `worker` | 15.0 | 12.0 |
| `migrate` | 15.0 | 12.0 |
| `margince` (launcher) | 15.0 | 12.0 |

All four, identically. There is no difference between the roles to explain.

## Why it went red now, three weeks after the omission landed

Not the runner. The last green run and the first red one are the same image
(`macos-26-arm64`), the same Xcode 26.6, the same MacOSX26.5 SDK. And the
green bundle is downloadable: every Mach-O in the artifact from
https://github.com/margince/margince/actions/runs/34177065200 reports
`minos 12.0`, Go binaries included, built by a `build-app.sh` that pinned
nothing.

The determinant is the module graph:

| build | link | `minos` |
|---|---|---|
| `CGO_ENABLED=0` | internal | **12.0** — Go's own supported floor |
| `CGO_ENABLED=1`, a cgo package present | external, via clang | **the host's** |

`prometheus/client_golang` carries `process_collector_mem_cgo_darwin.go`. It
became a direct dependency in
https://github.com/margince/margince/commit/e9994ff9d (PR
https://github.com/margince/margince/pull/4972), which merged after that last
green run. One darwin-only cgo file moved the link from Go's linker to clang,
and clang defaults the deployment target to the OS of the machine doing the
build.

So the bundle's OS floor had been resting on a transitive dependency's build
tags. It was correct by coincidence, and the coincidence was worth exactly what
coincidences are worth.

## What changed

1. **`build-app.sh` sources `macos-target.sh`** and holds its own output to the
   floor, the way `build-postgres.sh` and `build-valkey.sh` already do. The
   stamp no longer depends on which linker Go picks — measured 12.0 under both.
   The census is the list `sign_binary` accumulates, because every shipped
   executable is signed, so nothing built can drop out of it.
2. **`assert_min_os` names every offender** and prints the count. One unpinned
   build step and one stray binary are different faults with different fixes,
   and a check that reports one file cannot tell them apart — as this one's
   report demonstrated.
3. **A gate**, `desktopmacosfloor_test.go` (census, H3): every script in
   `desktop/build/` sources the floor, and the floor still exports the variable.
   This is the part that actually closes the hole. The bundle lane needs a macOS
   runner and is path-scoped to `desktop/**`; the change that broke it touched
   `backend/go.mod`. The gate runs on every pull request, on Linux, in
   milliseconds. Corpus is a glob with no skip-list and a count floor, so it
   cannot fail short.
4. **The lane runs on `main`** for the paths it guards — the issue's "done looks
   like". A pull-request run judges the merge ref, which is a prediction about a
   `main` that does not exist yet.

## What I did not do, and why

**I did not add `backend/go.mod` to the lane's paths.** It is the file that
broke it, so the case is obvious — but with the target exported the link mode no
longer changes the stamp, which is what made the dependency graph load-bearing
in the first place. Paying an 8-minute macOS bundle build on every `main` push
that touches `go.mod` would be buying a guard against a mechanism this PR
removes, when item 3 already answers the general case for free. Happy to add it
if you would rather have the belt as well as the braces.

## Verification

- `desktop/build/build-app.sh` at this branch: `every binary runs on macOS 12.0
  or newer`, all four at `minos 12.0`.
- The new message, on binaries built with the target unset — three named where
  the old code named one:
  ```
  FAIL: .../api requires macOS 15.0 but this bundle declares 12.0
  FAIL: .../worker requires macOS 15.0 but this bundle declares 12.0
  FAIL: .../migrate requires macOS 15.0 but this bundle declares 12.0
        3 of 4 checked binaries cannot be shown to run on macOS 12.0.
  ```
- Gate mutation-tested, four mutants, each killed by the right assertion:
  `build-app.sh` stops sourcing → names `build-app.sh`; the export is removed →
  the floor-script message; a real source line becomes a comment → named, so
  prose does not count as pinning; the glob stops matching → the count floor.
This PR touches `desktop/**`, so `desktop-macos` runs on it, which is the only
place the whole bundle is proved.

Locally, and stated precisely because the machine would not give me the whole
lane:

| lane | result |
|---|---|
| `check-backend` (root script gates, vet, lint, arch-lint, unit, `./gates`) | **pass**, whole thing |
| `fe-typecheck-composed`, `fe-ds-gates`, `fe-drift`, `fe-file-length`, `fe-lint`, `fe-build` | **pass**, each with its own exit code |
| `craft static --strict` on the changed Go file | **pass**, 0 findings |
| `fe-unit` | **not completed here** |
| `test-integration` | **not run here** |

`fe-unit` was killed three times by this machine's low-memory watchdog, at
default parallelism and at `--maxWorkers=2`; single-threaded it was still going
after 35 minutes, so I stopped it rather than keep the branch parked. I did not
stop the shared Docker Postgres to free the memory, because parallel sessions
are using it.

I am not claiming those two are green. Neither is affected by this diff: there
is no frontend source, no `crm.yaml`, no design-system file, no runtime Go, no
migration and no store code in it — the only Go file is a new gate, and
`./gates` passed in full (102 s).

CI agrees about the frontend half and says so out loud: the `frontend` check on
this PR is **SKIPPED**, by the lane's own path scoping, so `fe-unit` is not run
here by CI either. That is the evidence, rather than my assurance, that this
diff cannot reach it. The integration lane **does** run on this PR, so that one
gets a real verdict — and I will read it rather than assume it.

## Filed, not fixed

https://github.com/margince/margince/issues/5052 — Go's build cache does not
key on `MACOSX_DEPLOYMENT_TARGET`, so a warm cache from a build that did not set
it supplies objects compiled for a newer SDK while the link still stamps 12.0.
`assert_min_os` passes either way. Cold cache: 0 `ld` warnings. Warm from a
no-target build: 42, and they do not clear on rebuild. The fix is a cost
decision about the release lane's caching, which is why it is a separate issue
rather than the tail of this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - macOS desktop builds now consistently use the bundle’s declared minimum macOS version, regardless of the build machine.
  - Build verification now checks that produced binaries can run on the supported macOS versions and reports all compatibility issues together.

- **Tests**
  - Added automated coverage to ensure every macOS build path applies the required deployment target.

- **Chores**
  - macOS desktop workflow now runs after qualifying pushes to `main` as a post-merge health check.
  - Updated the gate inventory to include the new macOS compatibility check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->