### PR TITLE
test(compose): two sibling tests catch up with the rules they assert

### DIFF
--- a/backend/internal/compose/attentionleads_integration_test.go
+++ b/backend/internal/compose/attentionleads_integration_test.go
@@ -151,23 +151,46 @@ func TestAnOwedLeadReachesItsOwnersQueueAndNobodyElses(t *testing.T) {
 	}
 }
 
-// The lane claims nothing when the installation measures no first response.
+// A lead still owes a reply where nothing measures how late it is, and the row
+// says so by carrying no deadline.
 //
-// Not merely "no rows": an absent source must publish no reach row either, or
-// the page reports a bound on a source it never consulted.
-func TestWithTheTargetOffTheLaneIsAbsentFromThePage(t *testing.T) {
+// This replaced an earlier decision that read almost alike on screen: with no
+// first-response target the lane used to be ABSENT rather than empty, on the
+// grounds that "nothing is late" and "nothing measures late" are different
+// answers. They are — but whether a lead has been replied to is a fact about
+// the lead, and whether anyone states a time for it is a fact about the
+// installation's policy. Withholding the row made the second answer the rep's
+// problem. So the row stands whatever the policy says, and a deadline appears
+// only where one is set.
+func TestWithTheTargetOffALeadIsOwedButCarriesNoDeadline(t *testing.T) {
 	e := integration.Setup(t)
 	// Deliberately NOT calling measureFirstResponse: this is the default.
 	seedOwedLead(t, e, "Nobody Is Counting", &e.Rep1, 48*time.Hour)
 
 	page := ownQueue(e.As(e.Rep1, []ids.UUID{e.Team1}, leadRepPerms), t, e)
-	if got := leadRows(page); len(got) != 0 {
-		t.Errorf("the queue carries %v with the target switched off", got)
+	if got := leadRows(page); len(got) != 1 || got[0] != "Nobody Is Counting" {
+		t.Fatalf("the queue carries %v with the target switched off, want the one lead "+
+			"still owed a reply", got)
 	}
+	// Silent about WHEN, which is the half the policy owns. A deadline here
+	// would be one this installation never stated.
+	for _, item := range page.Queue {
+		if string(item.Source) == "lead_response" && item.DueAt != nil {
+			t.Errorf("the row carries a deadline of %v where no policy states one", *item.DueAt)
+		}
+	}
+	// And the source publishes its reach, because it WAS read. This is what
+	// tells a read source with nothing to show from one the page never
+	// consulted, and it is the assertion the retired decision inverted.
+	var published bool
 	for _, reach := range page.Reach {
 		if string(reach.Source) == "lead_response" {
-			t.Errorf("the page publishes a reach row for a source it never read: %+v", reach)
+			published = true
 		}
+	}
+	if !published {
+		t.Error("the page publishes no reach row for lead_response, so a source it did read " +
+			"reports no bound at all")
 	}
 }
 

--- a/backend/internal/compose/briefmail_integration_test.go
+++ b/backend/internal/compose/briefmail_integration_test.go
@@ -28,18 +28,25 @@ import (
 // lane must survive without failing the assembly around it.
 var errRelayRefused = errors.New("the relay refused the envelope")
 
-// seedWorkFor puts one open deal on a rep's plate, so their morning has
-// something in it.
+// seedWorkFor puts one open deal on each named rep's plate, so their morning
+// has something in it.
 //
 // A run with an EMPTY queue is a quiet morning, and a quiet morning is
 // deliberately not mailed to anybody who did not ask to hear about it — so a
 // fixture without this seeds the case where nothing is sent, and every
 // assertion about sending passes vacuously. It did, on the first run of these
 // tests, and the two that then failed were the ones honest enough to say so.
-func seedWorkFor(t *testing.T, e *integration.Env, owner ids.UUID) {
+//
+// The reps share ONE pipeline because DealFixture seeds the installation's
+// pipeline defaults, which refuses a second run — so calling this helper twice
+// in a test fails with a bare "conflict" that names nothing. Take the owners
+// together instead.
+func seedWorkFor(t *testing.T, e *integration.Env, owners ...ids.UUID) {
 	t.Helper()
 	pipeline, open, _ := integration.DealFixture(t, e)
-	e.SeedDeal(t, "Globex Renewal", pipeline, open, &owner)
+	for _, owner := range owners {
+		e.SeedDeal(t, "Globex Renewal", pipeline, open, &owner)
+	}
 }
 
 // withMailer wires this env's worker to a relay that counts.
@@ -70,6 +77,22 @@ func mailAttemptOf(t *testing.T, user ids.UUID, day time.Time) (*time.Time, *str
 		t.Fatal(err)
 	}
 	return at, cause
+}
+
+// waitingItemsOf counts what a rep's run still has to report. A run with
+// nothing waiting is skipped by the mail pass rather than sent, so a test that
+// means to exercise the mail has to establish this and not assume it.
+func waitingItemsOf(t *testing.T, user ids.UUID, day time.Time) int {
+	t.Helper()
+	var waiting int
+	if err := integration.OwnerConn(t).QueryRow(context.Background(),
+		`SELECT count(*) FROM brief_item i
+		   JOIN brief_run r ON r.id = i.brief_run_id
+		  WHERE r.user_id = $1 AND r.local_day = $2 AND i.state = 'new'`,
+		user, day.Format(time.DateOnly)).Scan(&waiting); err != nil {
+		t.Fatal(err)
+	}
+	return waiting
 }
 
 func TestTheMorningBriefIsMailedOncePerRepPerDay(t *testing.T) {
@@ -366,7 +389,13 @@ func TestARepWithNoChosenHourIsMailedByTheAssemblingPass(t *testing.T) {
 func TestADepartedSeatDoesNotCostTheOthersTheirMorning(t *testing.T) {
 	relay := &countingMailer{}
 	b := setupBriefJob(t).withMailer(relay)
-	seedWorkFor(t, b.Env, b.Rep1)
+	// Work for BOTH, each on their own plate. The queue ranks the deals a rep is
+	// responsible for rather than every deal their row scope lets them read, so
+	// a colleague holding nothing of their own has an empty brief — and an empty
+	// brief is not mailed at all unless the rep asked to hear about quiet days.
+	// Seeding one rep would leave this test asserting the departure guard while
+	// actually exercising a quiet morning.
+	seedWorkFor(t, b.Env, b.Rep1, b.Rep2)
 	setDeliveryHour(t, b.Rep1, 9)
 	setDeliveryHour(t, b.Rep2, 9)
 
@@ -375,11 +404,20 @@ func TestADepartedSeatDoesNotCostTheOthersTheirMorning(t *testing.T) {
 	if err := b.run(t); err != nil {
 		t.Fatalf("the seven o'clock pass failed: %v", err)
 	}
-	// The premise: both runs exist and neither has spent its attempt, so the
-	// nine o'clock pass has two to mail rather than one.
+	// The premise, checked rather than assumed: both runs exist, each has
+	// something waiting, and neither has spent its attempt — so the nine
+	// o'clock pass has two to mail rather than one.
+	//
+	// The waiting count is the half that went stale once responsibility replaced
+	// visibility, and it failed silently: a rep with an empty brief is never
+	// mailed, which reads exactly like the departure this test is about.
 	for _, rep := range []ids.UUID{b.Rep1, b.Rep2} {
 		if at, _ := mailAttemptOf(t, rep, morning); at != nil {
 			t.Fatalf("a run was mailed at seven for a rep who asked for nine")
+		}
+		if waiting := waitingItemsOf(t, rep, morning); waiting == 0 {
+			t.Fatalf("the run for %s has nothing waiting, so this pass would skip it as a "+
+				"quiet morning and the departure guard would go untested", rep)
 		}
 	}
 


### PR DESCRIPTION
Fixes both reds this claimed, in one pull request.

`main` has been red on two independent integration tests, both in
`backend/internal/compose`. They are here together deliberately: separately,
each PR inherits the other's red and neither can show a green `ci`, so the pair
would have to be merged past a failing verdict. Together they produce a real
one.

Between them they account for
https://github.com/margince/margince/issues/5057 and
https://github.com/margince/margince/issues/5062, and they were the only reason
https://github.com/margince/margince/pull/5061 could not go green.

## Both are the same failure mode

A deliberate behaviour change updated its own tests and missed a sibling in
`internal/compose`. **The product is right in both cases. The fixtures were
asserting the old world.**

### 1. `TestADepartedSeatDoesNotCostTheOthersTheirMorning`

https://github.com/margince/margince/pull/5058 narrowed the morning queue from
**visibility** to **responsibility**:

```sql
AND (d.owner_id = $me
     OR EXISTS (SELECT 1 FROM activity a
                JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = d.id
                WHERE a.kind = 'task' AND NOT a.is_done
                  AND a.archived_at IS NULL AND a.assignee_id = $me))
```

The fixture gave its one deal to `Rep1` and asked whether `Rep2` still received
their own morning after `Rep1`'s seat was deactivated. `Rep2` used to qualify
because `brief_reader` carries `row_scope: all`, so they saw `Rep1`'s deal.
Owning nothing, `Rep2`'s brief is now empty — and an empty brief is correctly
not mailed, because `quiet_day_notice` fails closed. `Rep2` receiving nothing is
now right.

`seedWorkFor` takes several owners and gives each their own deal. One pipeline
for all of them, because `DealFixture` seeds the installation's pipeline
defaults and refuses a second run — calling the helper twice fails with a bare
`conflict` that names nothing, which cost me a round.

**The part worth more than the fix.** The test claimed a premise it never
checked. Its comment said the nine o'clock pass "has two to mail rather than
one"; it verified only that neither attempt had been spent. So the premise went
false in silence, and the failure surfaced three assertions later as
`the colleague received 0 message(s)` — which reads as a broken departure guard
and sent me into the mail loop's `continue` before the fixture. Now:

```
briefmail_integration_test.go:419: the run for 01a0821e-… has nothing waiting,
so this pass would skip it as a quiet morning and the departure guard would go
untested
```

Had that assertion existed, #5058 would have been told what it broke.

### 2. `TestWithTheTargetOffTheLaneIsAbsentFromThePage`

https://github.com/margince/margince/pull/5064 retired the decision this test
was named after — it removed the early return that made the lead-response lane
absent when no first-response target is set:

```diff
-	if !tracked {
-		return nil, false, nil
-	}
```

The reasoning is in the lane's own comment now: whether a lead has been replied
to is a fact about the lead, and whether anyone states a time for it is a fact
about the installation's policy. Withholding the row made the second answer the
rep's problem. So the row stands whatever the policy says, and carries a
deadline only where one is set.

The test is renamed and inverted to assert the rule that replaced it: the row is
present, `due_at` is absent, and the source publishes its reach *because it was
read* — which is what still tells a read source with nothing to show from one
the page never consulted. That last assertion is the one the retired decision
had backwards, and it is worth keeping in the new form rather than deleting.

## Verification

Each fix reproduced on plain `main` first, in a dedicated worktree, so both reds
are inherited and neither is a branch's:

| | |
|---|---|
| departed-seat, at `e105c37e4` | fails |
| target-off, at `747389b1f` | fails |

Mutation-tested, each killed by the assertion that should catch it:

- fixture back to one owner → `has nothing waiting, so this pass would skip it as a quiet morning and the departure guard would go untested`
- the retired `if !tracked` early return restored → `the queue carries [] with the target switched off, want the one lead still owed a reply`

And the whole `backend/internal/compose` package run **whole**, which CI never
does — it shards by test, so cross-test state and the package budget are
invisible to a green `ci`. With only the first fix it was 3294 pass / 1 fail,
the remaining failure being the second red; with both, clean.

`craft static --strict` on both changed files: 0 findings.
