### PR TITLE
fix(briefs): a future activity is not momentum, and a lead owes a reply without a policy

### DIFF
--- a/backend/internal/compose/attention/lead.go
+++ b/backend/internal/compose/attention/lead.go
@@ -30,9 +30,9 @@ import (
 // while the queue that claims to be "what should I do next" said nothing about
 // it.
 //
-// `tracked` is the installation's first-response policy, and false is not an
-// empty list: with the target switched off no lead owes a reply at a stated
-// time, so the lane renders ABSENT rather than empty. Saying "no leads are
+// `tracked` is the installation's first-response policy. It decides whether a
+// row can carry a DEADLINE, not whether the row exists: a lead owes a reply
+// either way. Saying "no leads are
 // overdue" where nothing measures overdue would be a claim the product cannot
 // support.
 type LeadResponses interface {
@@ -196,13 +196,10 @@ func dropEscalationTasksAlreadyOwed(rows []ranked) []ranked {
 type leadRead struct {
 	rows []OwedLead
 	// read is false when no lead source is bound, or when the read was refused
-	// or failed. NOT when the installation measures no first response: leads
-	// still owe replies there, and reporting none is the defect this lane had.
+	// or failed — never because the installation measures no first response,
+	// which is a fact about deadlines rather than about whether leads owe
+	// replies.
 	read bool
-	// tracked says whether a first-response target exists. False means every
-	// row's deadline and state are absent — the reply is owed, and nothing
-	// measures when it was owed by.
-	tracked bool
 }
 
 // bounded reports whether the read stopped at its cap, so the page can say
@@ -214,22 +211,20 @@ func (l leadRead) bounded() bool {
 
 // owedLeads reads the leads still owed a first reply, or names why it could not.
 //
-// A lead owing a reply is a fact about the LEAD; whether that reply is late is a
-// fact about the installation's policy. The lane used to conflate them and drop
-// itself entirely where no first-response target was configured — so a rep with
-// five unanswered leads read "0 owed a first answer", which is not a cautious
-// answer but a wrong one.
-//
-// Now the rows come back either way, and only the deadline and its state depend
-// on a policy. `tracked` still rides along so the surface can say a reply is
-// owed without claiming to know when it was owed by.
+// A lead owing a reply is a fact about the LEAD; whether that reply is LATE is a
+// fact about the installation's policy. So the lane reports the rows whether or
+// not a first-response target exists, and a row carries a deadline only where
+// one is set.
 func (s *Service) owedLeads(
 	ctx context.Context,
 ) (leadRead, *crmcontracts.WorklistSourceUnavailable) {
 	if s.leads == nil {
 		return leadRead{}, nil
 	}
-	owed, tracked, err := s.leads.Owed(ctx, s.taskScope, s.taskOwner, leadResponseBound)
+	// The policy answer is deliberately unused: a deadline belongs on the row
+	// that has one, and every row already carries its own. Reading it here
+	// would be a second place deciding what the lane may say.
+	owed, _, err := s.leads.Owed(ctx, s.taskScope, s.taskOwner, leadResponseBound)
 	switch {
 	case errors.Is(err, apperrors.ErrPermissionDenied):
 		return leadRead{}, &crmcontracts.WorklistSourceUnavailable{
@@ -241,6 +236,6 @@ func (s *Service) owedLeads(
 			Source: sourceLeadResponse, Reason: crmcontracts.WorklistSourceUnavailableReasonFailed,
 		}
 	default:
-		return leadRead{rows: owed, read: true, tracked: tracked}, nil
+		return leadRead{rows: owed, read: true}, nil
 	}
 }

--- a/backend/internal/compose/attention/lead.go
+++ b/backend/internal/compose/attention/lead.go
@@ -195,9 +195,14 @@ func dropEscalationTasksAlreadyOwed(rows []ranked) []ranked {
 // row for a source the page never consulted.
 type leadRead struct {
 	rows []OwedLead
-	// read is false when no lead source is bound, when the installation
-	// measures no first response, or when the read was refused or failed.
+	// read is false when no lead source is bound, or when the read was refused
+	// or failed. NOT when the installation measures no first response: leads
+	// still owe replies there, and reporting none is the defect this lane had.
 	read bool
+	// tracked says whether a first-response target exists. False means every
+	// row's deadline and state are absent — the reply is owed, and nothing
+	// measures when it was owed by.
+	tracked bool
 }
 
 // bounded reports whether the read stopped at its cap, so the page can say
@@ -209,10 +214,15 @@ func (l leadRead) bounded() bool {
 
 // owedLeads reads the leads still owed a first reply, or names why it could not.
 //
-// An installation with no first-response target has no leads that are LATE, so
-// the source is absent from the page entirely. Reporting zero overdue leads
-// where nothing measures overdue would be a number the product cannot stand
-// behind.
+// A lead owing a reply is a fact about the LEAD; whether that reply is late is a
+// fact about the installation's policy. The lane used to conflate them and drop
+// itself entirely where no first-response target was configured — so a rep with
+// five unanswered leads read "0 owed a first answer", which is not a cautious
+// answer but a wrong one.
+//
+// Now the rows come back either way, and only the deadline and its state depend
+// on a policy. `tracked` still rides along so the surface can say a reply is
+// owed without claiming to know when it was owed by.
 func (s *Service) owedLeads(
 	ctx context.Context,
 ) (leadRead, *crmcontracts.WorklistSourceUnavailable) {
@@ -230,9 +240,7 @@ func (s *Service) owedLeads(
 		return leadRead{}, &crmcontracts.WorklistSourceUnavailable{
 			Source: sourceLeadResponse, Reason: crmcontracts.WorklistSourceUnavailableReasonFailed,
 		}
-	case !tracked:
-		return leadRead{}, nil
 	default:
-		return leadRead{rows: owed, read: true}, nil
+		return leadRead{rows: owed, read: true, tracked: tracked}, nil
 	}
 }

--- a/backend/internal/compose/attention/leadlane_test.go
+++ b/backend/internal/compose/attention/leadlane_test.go
@@ -173,12 +173,19 @@ func TestAnAtRiskLeadWithNoDeadlineNamesNoMoment(t *testing.T) {
 	}
 }
 
-// The policy question is not a filter. With no target set nothing is late, so
-// the source is ABSENT — a page reporting zero overdue leads would be stating a
-// number nothing measures.
-func TestWithNoFirstResponseTargetTheLaneClaimsNothing(t *testing.T) {
+// A reply is owed whether or not anything measures when it was owed by.
+//
+// The lane used to drop itself entirely with no first-response target set, on
+// the reasoning that nothing is LATE without one. But "owed" and "late" are
+// different questions: a rep with five unanswered leads read "0 owed a first
+// answer", which is not a cautious answer, it is a wrong one. The policy
+// decides the deadline; the lead decides whether a reply is outstanding.
+//
+// So the rows appear, carrying no deadline and no state — the lane says a reply
+// is owed without inventing a time it was owed by.
+func TestLeadsOweAReplyEvenWithNoFirstResponseTarget(t *testing.T) {
 	svc := leadLaneService(&stubLeads{tracked: false, rows: []OwedLead{
-		{ID: ids.NewV7(), Name: "a lead", State: "breached", DeadlineAt: readInstant.Add(-time.Hour)},
+		{ID: ids.NewV7(), Name: "a lead"},
 	}})
 
 	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
@@ -186,19 +193,23 @@ func TestWithNoFirstResponseTargetTheLaneClaimsNothing(t *testing.T) {
 		t.Fatalf("worklist: %v", err)
 	}
 
+	var found int
 	for _, row := range day.Queue {
-		if row.Source == sourceLeadResponse {
-			t.Fatalf("a lead row reached the queue with the first-response target switched off")
+		if row.Source != sourceLeadResponse {
+			continue
 		}
+		found++
+		// No invented SLA: the row must not claim a deadline nothing set.
+		if row.DueAt != nil {
+			t.Errorf("the row carries a deadline (%v) with nothing measuring one", *row.DueAt)
+		}
+	}
+	if found != 1 {
+		t.Fatalf("lead rows on the queue = %d, want the one unanswered lead", found)
 	}
 	for _, missing := range day.SourcesUnavailable {
 		if missing.Source == sourceLeadResponse {
 			t.Fatalf("the lane reported itself unavailable; an unmeasured target is not a failed read")
-		}
-	}
-	for _, count := range day.Counts {
-		if count.Category == "leads" && count.Considered > 0 {
-			t.Fatalf("the leads category counted %d rows nothing measured", count.Considered)
 		}
 	}
 }
@@ -241,11 +252,13 @@ func TestANamedOwnersQueueKeepsTheirOwedLeads(t *testing.T) {
 	rowFor(t, day, "their lead")
 }
 
-// With the target switched off the source must be ABSENT, and a reach row is
-// not absence: reachOf emits one for every bounded-source key, so recording the
-// lane unconditionally published a zero-valued entry that reads as "read, and
-// there was nothing".
-func TestAnUntrackedLanePublishesNoReachRow(t *testing.T) {
+// A read that happened and found nothing publishes its reach row.
+//
+// The lane no longer disappears when no first-response target is set — it reads
+// the leads either way — so the reach row is now the honest record of a read
+// that ran: considered zero, shown zero. Suppressing it would put the lane back
+// in the state where "nothing to report" and "nobody looked" are the same page.
+func TestAnUntrackedLaneWithNoLeadsStillReportsItsReach(t *testing.T) {
 	svc := leadLaneService(&stubLeads{tracked: false})
 
 	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
@@ -255,10 +268,14 @@ func TestAnUntrackedLanePublishesNoReachRow(t *testing.T) {
 
 	for _, reach := range day.Reach {
 		if reach.Source == sourceLeadResponse {
-			t.Fatalf("the lane published a reach row (considered=%d shown=%d) with nothing measuring first response",
-				reach.Considered, reach.Shown)
+			if reach.Considered != 0 || reach.Shown != 0 {
+				t.Errorf("reach = considered %d shown %d, want an honest empty read",
+					reach.Considered, reach.Shown)
+			}
+			return
 		}
 	}
+	t.Fatal("the lane published no reach row, so the page cannot tell an empty read from an absent one")
 }
 
 // One late reply is ONE row.

--- a/backend/internal/compose/attention/leadlane_test.go
+++ b/backend/internal/compose/attention/leadlane_test.go
@@ -175,14 +175,10 @@ func TestAnAtRiskLeadWithNoDeadlineNamesNoMoment(t *testing.T) {
 
 // A reply is owed whether or not anything measures when it was owed by.
 //
-// The lane used to drop itself entirely with no first-response target set, on
-// the reasoning that nothing is LATE without one. But "owed" and "late" are
-// different questions: a rep with five unanswered leads read "0 owed a first
-// answer", which is not a cautious answer, it is a wrong one. The policy
-// decides the deadline; the lead decides whether a reply is outstanding.
-//
-// So the rows appear, carrying no deadline and no state — the lane says a reply
-// is owed without inventing a time it was owed by.
+// Owed and late are different questions: the policy decides the deadline, the
+// lead decides whether a reply is outstanding. So the rows appear with no
+// first-response target set, carrying no deadline and no state — the lane says
+// a reply is owed without inventing a time it was owed by.
 func TestLeadsOweAReplyEvenWithNoFirstResponseTarget(t *testing.T) {
 	svc := leadLaneService(&stubLeads{tracked: false, rows: []OwedLead{
 		{ID: ids.NewV7(), Name: "a lead"},
@@ -252,30 +248,38 @@ func TestANamedOwnersQueueKeepsTheirOwedLeads(t *testing.T) {
 	rowFor(t, day, "their lead")
 }
 
-// A read that happened and found nothing publishes its reach row.
+// A read that happened and found nothing publishes its reach row — and it does
+// so whether or not a first-response target exists.
 //
-// The lane no longer disappears when no first-response target is set — it reads
-// the leads either way — so the reach row is now the honest record of a read
-// that ran: considered zero, shown zero. Suppressing it would put the lane back
-// in the state where "nothing to report" and "nobody looked" are the same page.
-func TestAnUntrackedLaneWithNoLeadsStillReportsItsReach(t *testing.T) {
-	svc := leadLaneService(&stubLeads{tracked: false})
+// Both positions are asserted because the lane's behaviour must NOT differ
+// between them: a page that suppressed the row when nothing measured deadlines
+// would make "nothing to report" and "nobody looked" the same page. Asserting
+// only the untracked case would pass even with the policy plumbing deleted.
+func TestTheLeadLaneReportsItsReachWithOrWithoutATarget(t *testing.T) {
+	for _, tracked := range []bool{false, true} {
+		svc := leadLaneService(&stubLeads{tracked: tracked})
 
-	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
-	if err != nil {
-		t.Fatalf("worklist: %v", err)
-	}
+		day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
+		if err != nil {
+			t.Fatalf("tracked=%v: worklist: %v", tracked, err)
+		}
 
-	for _, reach := range day.Reach {
-		if reach.Source == sourceLeadResponse {
-			if reach.Considered != 0 || reach.Shown != 0 {
-				t.Errorf("reach = considered %d shown %d, want an honest empty read",
-					reach.Considered, reach.Shown)
+		var found bool
+		for _, reach := range day.Reach {
+			if reach.Source != sourceLeadResponse {
+				continue
 			}
-			return
+			found = true
+			if reach.Considered != 0 || reach.Shown != 0 {
+				t.Errorf("tracked=%v: reach = considered %d shown %d, want an honest empty read",
+					tracked, reach.Considered, reach.Shown)
+			}
+		}
+		if !found {
+			t.Errorf("tracked=%v: the lane published no reach row, so the page cannot tell "+
+				"an empty read from an absent one", tracked)
 		}
 	}
-	t.Fatal("the lane published no reach row, so the page cannot tell an empty read from an absent one")
 }
 
 // One late reply is ONE row.

--- a/backend/internal/compose/attentionleadseam.go
+++ b/backend/internal/compose/attentionleadseam.go
@@ -54,9 +54,6 @@ func (l attentionLeadResponses) Owed(
 	if err != nil {
 		return nil, false, err
 	}
-	if !tracked {
-		return nil, false, nil
-	}
 
 	in := people.ListLeadsInput{Limit: &limit}
 	// Narrowed in the QUERY, the way the task lane is: filtering afterwards
@@ -108,19 +105,33 @@ func (l attentionLeadResponses) Owed(
 	}
 	owed := make([]attention.OwedLead, 0, len(keep))
 	for _, row := range keep {
-		// A lead that has been answered, or that never owed a reply, is not
-		// this lane's work. The store ranks those last rather than dropping
-		// them, because the same queue answers other questions.
-		if row.SlaState == nil {
+		// UNANSWERED is the question, and the SLA state is not it.
+		//
+		// leadSLAFields returns a nil state for every lead when the
+		// installation sets no first-response target — so selecting on the
+		// state dropped the whole lane wherever nobody had configured one, and
+		// the tile read "0 owed a first answer" beside five leads nobody had
+		// replied to. A policy decides whether a reply is LATE; whether one is
+		// owed at all is a property of the lead.
+		//
+		// An archived lead owes nothing, and neither does an answered one.
+		if row.ArchivedAt != nil || row.FirstResponseAt != nil {
 			continue
 		}
-		owed = append(owed, attention.OwedLead{
-			ID:         ids.UUID(row.Id),
-			Name:       leadDisplayName(row),
-			OwnerID:    ownerOfLead(row),
-			DeadlineAt: deadlineOfLead(row),
-			State:      string(*row.SlaState),
-		})
+		lead := attention.OwedLead{
+			ID:      ids.UUID(row.Id),
+			Name:    leadDisplayName(row),
+			OwnerID: ownerOfLead(row),
+		}
+		// The deadline and its state exist only where a policy states one.
+		// Left zero and empty otherwise, which OwedLead declares as the
+		// untracked case: the lane says a reply is owed without inventing a
+		// time it was owed by.
+		if row.SlaState != nil {
+			lead.DeadlineAt = deadlineOfLead(row)
+			lead.State = string(*row.SlaState)
+		}
+		owed = append(owed, lead)
 	}
 	return owed, tracked, nil
 }

--- a/backend/internal/compose/attentionleadseam.go
+++ b/backend/internal/compose/attentionleadseam.go
@@ -42,8 +42,9 @@ func (l attentionLeadResponses) Owed(
 	ctx context.Context, scope attention.TaskScope, owner ids.UUID, limit int,
 ) ([]attention.OwedLead, bool, error) {
 	// Asked FIRST, and the answer is not a filter. With no target set no lead
-	// owes a reply at a stated time, so the lane is absent rather than empty —
-	// the difference between "nothing is late" and "nothing measures late".
+	// owes a reply at a stated TIME, which is why the answer rides back to the
+	// caller rather than filtering here: it decides whether a row can carry a
+	// deadline, not whether the row exists.
 	//
 	// It is asked WITHOUT the lead grant, deliberately. Whether this
 	// installation measures first response is a property of the installation,
@@ -55,7 +56,11 @@ func (l attentionLeadResponses) Owed(
 		return nil, false, err
 	}
 
-	in := people.ListLeadsInput{Limit: &limit}
+	// Narrowed in the QUERY, for the reason stated below about the task lane:
+	// the page is bounded, so cutting answered leads out of it afterwards loses
+	// the unanswered ones behind them and reports the shortfall as none owed.
+	owed := true
+	in := people.ListLeadsInput{Limit: &limit, OwedAReply: &owed}
 	// Narrowed in the QUERY, the way the task lane is: filtering afterwards
 	// would let a colleague's leads fill the bound and hide the reader's own
 	// overdue one behind a cut that had already happened.
@@ -103,37 +108,24 @@ func (l attentionLeadResponses) Owed(
 	if err != nil {
 		return nil, false, err
 	}
-	owed := make([]attention.OwedLead, 0, len(keep))
+	owedLeads := make([]attention.OwedLead, 0, len(keep))
 	for _, row := range keep {
-		// UNANSWERED is the question, and the SLA state is not it.
-		//
-		// leadSLAFields returns a nil state for every lead when the
-		// installation sets no first-response target — so selecting on the
-		// state dropped the whole lane wherever nobody had configured one, and
-		// the tile read "0 owed a first answer" beside five leads nobody had
-		// replied to. A policy decides whether a reply is LATE; whether one is
-		// owed at all is a property of the lead.
-		//
-		// An archived lead owes nothing, and neither does an answered one.
-		if row.ArchivedAt != nil || row.FirstResponseAt != nil {
-			continue
-		}
 		lead := attention.OwedLead{
 			ID:      ids.UUID(row.Id),
 			Name:    leadDisplayName(row),
 			OwnerID: ownerOfLead(row),
 		}
-		// The deadline and its state exist only where a policy states one.
-		// Left zero and empty otherwise, which OwedLead declares as the
-		// untracked case: the lane says a reply is owed without inventing a
-		// time it was owed by.
+		// A deadline and its state exist only where a policy states one: with
+		// the target off leadSLAFields returns nil for every lead. Left zero
+		// and empty, which OwedLead declares as that case — a reply is owed,
+		// and nothing measures by when.
 		if row.SlaState != nil {
 			lead.DeadlineAt = deadlineOfLead(row)
 			lead.State = string(*row.SlaState)
 		}
-		owed = append(owed, lead)
+		owedLeads = append(owedLeads, lead)
 	}
-	return owed, tracked, nil
+	return owedLeads, tracked, nil
 }
 
 // leadDisplayName is what the row calls the lead, or NOTHING.

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -143,7 +143,7 @@ func (e *BriefEngine) gather(ctx context.Context, now time.Time, userID ids.UUID
 		if err := briefCandidates(ctx, tx, userID, now, base, out.facts, &out.order); err != nil {
 			return err
 		}
-		out.seatsReadable, err = briefEvidenceRows(ctx, tx, lastView, out.facts, out.order, out.stakeholders)
+		out.seatsReadable, err = briefEvidenceRows(ctx, tx, lastView, now, out.facts, out.order, out.stakeholders)
 		if err != nil {
 			return err
 		}
@@ -391,7 +391,7 @@ func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.T
 // factor on every deal, which reorders the queue; the caller has to be told, or
 // they read an order that is wrong rather than one that is short.
 func briefEvidenceRows(
-	ctx context.Context, tx pgx.Tx, lastView *time.Time,
+	ctx context.Context, tx pgx.Tx, lastView *time.Time, asOf time.Time,
 	facts map[ids.UUID]briefDealFacts, order []ids.UUID, stakeholders map[ids.UUID][]ids.UUID,
 ) (seatsReadable bool, err error) {
 	// The seat edge's admission is resolved ONCE, ahead of the loop: it is a
@@ -409,8 +409,16 @@ func briefEvidenceRows(
 			JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = $1
 			WHERE a.archived_at IS NULL
 			  AND ($2::timestamptz IS NULL OR a.occurred_at > $2)
+			  -- BOUNDED AT THE CUTOFF, the way the dismissal filter beside it is
+			  -- and for the same reason: a future-dated row has not happened, so
+			  -- counting it as "the deal moved overnight" is a claim about
+			  -- something still to come. A task dated next Tuesday, written days
+			  -- ago, kept lifting momentum from its 0.4 baseline to 1.0 on every
+			  -- morning in between — the audit found three of the seven selected
+			  -- deals riding evidence dated after the brief's own cutoff.
+			  AND a.occurred_at <= $3
 			ORDER BY a.occurred_at DESC, a.id DESC
-			LIMIT $3`, dealID, lastView, briefOvernightEvidenceCap))
+			LIMIT $4`, dealID, lastView, asOf.UTC(), briefOvernightEvidenceCap))
 		if err != nil {
 			return false, err
 		}

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -409,13 +409,9 @@ func briefEvidenceRows(
 			JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = $1
 			WHERE a.archived_at IS NULL
 			  AND ($2::timestamptz IS NULL OR a.occurred_at > $2)
-			  -- BOUNDED AT THE CUTOFF, the way the dismissal filter beside it is
-			  -- and for the same reason: a future-dated row has not happened, so
-			  -- counting it as "the deal moved overnight" is a claim about
-			  -- something still to come. A task dated next Tuesday, written days
-			  -- ago, kept lifting momentum from its 0.4 baseline to 1.0 on every
-			  -- morning in between — the audit found three of the seven selected
-			  -- deals riding evidence dated after the brief's own cutoff.
+			  -- Bounded at the cutoff, the way the dismissal filter above is: a
+			  -- future-dated row has not happened, so counting it as overnight
+			  -- movement claims the deal moved for something still to come.
 			  AND a.occurred_at <= $3
 			ORDER BY a.occurred_at DESC, a.id DESC
 			LIMIT $4`, dealID, lastView, asOf.UTC(), briefOvernightEvidenceCap))

--- a/backend/internal/compose/briefs/briefrank_integration_test.go
+++ b/backend/internal/compose/briefs/briefrank_integration_test.go
@@ -678,14 +678,10 @@ func TestALaterActRetiresTheDismissalLineage(t *testing.T) {
 
 // A future-dated activity is not overnight momentum.
 //
-// The evidence read had a lower bound and no upper one, so a row dated ahead of
-// the brief's own cutoff counted as "the deal moved". A task written days ago
-// and dated next Tuesday therefore lifted momentum from its 0.4 baseline to 1.0
-// on every morning in between — the audit found three of seven selected deals
-// riding evidence dated after the cutoff that produced them.
-//
-// The dismissal filter in the same query already bounds itself this way, and
-// says why: a future-dated activity has not happened. The two reads disagreed.
+// Momentum folds any evidence in the window to 1.0 against a 0.4 baseline, so a
+// task dated next week would say the deal moved — on every morning until that
+// date arrives. Evidence of movement is bounded by the cutoff it is evidence
+// for.
 func TestAFutureDatedActivityIsNotOvernightMomentum(t *testing.T) {
 	b := setupBrief(t)
 	owner := integration.OwnerConn(t)

--- a/backend/internal/compose/briefs/briefrank_integration_test.go
+++ b/backend/internal/compose/briefs/briefrank_integration_test.go
@@ -675,3 +675,43 @@ func TestALaterActRetiresTheDismissalLineage(t *testing.T) {
 		}
 	}
 }
+
+// A future-dated activity is not overnight momentum.
+//
+// The evidence read had a lower bound and no upper one, so a row dated ahead of
+// the brief's own cutoff counted as "the deal moved". A task written days ago
+// and dated next Tuesday therefore lifted momentum from its 0.4 baseline to 1.0
+// on every morning in between — the audit found three of seven selected deals
+// riding evidence dated after the cutoff that produced them.
+//
+// The dismissal filter in the same query already bounds itself this way, and
+// says why: a future-dated activity has not happened. The two reads disagreed.
+func TestAFutureDatedActivityIsNotOvernightMomentum(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	// Dated a week past the clock this run judges against, so it cannot have
+	// happened by the time the queue is built.
+	ahead := briefClock.Add(7 * 24 * time.Hour)
+	scheduled := integration.SeedIDRow(t, owner, `
+		INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'task', 'prepare the renewal deck', $2, 'manual', 'human:x')`,
+		ahead)
+	integration.LinkActivity(t, owner, scheduled, "deal", b.dealB)
+
+	ranking, err := b.engine.Rank(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range ranking.Queue {
+		if item.DealID != b.dealB {
+			continue
+		}
+		if item.Features.Momentum != briefMomentumUnchanged {
+			t.Errorf("momentum = %v, want the %v baseline — nothing has happened on this deal yet",
+				item.Features.Momentum, briefMomentumUnchanged)
+		}
+		return
+	}
+	t.Fatal("deal B left the queue entirely; this test can say nothing about its momentum")
+}

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -383,6 +383,14 @@ type ListLeadsInput struct {
 	// rows first, so a reader asking for a score keeps the colder rows off
 	// the page rather than scanning past them.
 	MinScore *int
+	// OwedAReply keeps only the leads nobody has answered.
+	//
+	// A QUERY dial rather than something a caller filters afterwards, and the
+	// difference is the whole point: the page is bounded, so a caller cutting
+	// answered rows off the end of it loses the unanswered leads that were
+	// behind them — and reports the shortfall as "none owed" rather than as a
+	// page that was cut.
+	OwedAReply *bool
 	// Source narrows to one capture source (inbound, webform, referral,
 	// import, crawl, manual, ...): the exact stored value, no prefix match.
 	Source *string

--- a/backend/internal/modules/people/lead_list.go
+++ b/backend/internal/modules/people/lead_list.go
@@ -90,6 +90,9 @@ func (s *Store) ListLeads(ctx context.Context, in ListLeadsInput) ([]crmcontract
 			if in.Status != nil {
 				where = append(where, storekit.SQLf(leadStatusColumn+" = $%d", arg(*in.Status)))
 			}
+			if in.OwedAReply != nil && *in.OwedAReply {
+				where = append(where, leadOwesAReplySQL)
+			}
 			if in.MinScore != nil {
 				where = append(where, storekit.SQLf(leadScoreColumn+" >= $%d", arg(*in.MinScore)))
 			}

--- a/backend/internal/modules/people/leadowedqueue_integration_test.go
+++ b/backend/internal/modules/people/leadowedqueue_integration_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// The owed-a-reply dial belongs in the QUERY, and this is why.
+//
+// A caller reading this queue takes a bounded page. Answered leads sort by the
+// same keys as unanswered ones when no first-response target is set, so a
+// caller filtering after the cut loses every unanswered lead that sat behind an
+// answered one — and reports the shortfall as "none owed" rather than as a page
+// that was cut.
+//
+// TWO GUARDS hold this and the test proves the outcome rather than either one:
+// the dial puts `first_response_at IS NULL` in the WHERE clause, and the band
+// in leadQueueRank sorts answered leads last even with no target set. Removing
+// one alone leaves this green; removing both returns an answered lead here.
+// Both exist deliberately — the dial is what a caller asks for, the band is
+// what every other reader of this queue gets without asking.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestTheOwedDialKeepsAnsweredLeadsOutOfTheBoundedPage(t *testing.T) {
+	e := setupPromoteConsent(t)
+
+	// Answered leads first, so an unfiltered read of one row returns one of
+	// them and the unanswered lead is the one that would be lost.
+	var answered []ids.UUID
+	for _, name := range []string{"Answered A", "Answered B"} {
+		lead, _, err := e.store.CreateLead(e.ctx, CreateLeadInput{
+			FullName: strPtr(name), Source: "manual",
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		answered = append(answered, ids.UUID(lead.Id))
+	}
+	replied := time.Now().UTC()
+	for _, id := range answered {
+		if _, err := e.owner.Exec(e.ctx,
+			`UPDATE lead SET first_response_at = $2 WHERE id = $1`, id, replied); err != nil {
+			t.Fatalf("stamping a first response: %v", err)
+		}
+	}
+	owedLead, _, err := e.store.CreateLead(e.ctx, CreateLeadInput{
+		FullName: strPtr("Nobody has answered this one"), Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A page smaller than the answered set: without the dial this returns only
+	// answered leads and the caller concludes nothing is owed.
+	one := 1
+	owed := true
+	rows, _, err := e.store.ListLeads(e.ctx, ListLeadsInput{Limit: &one, OwedAReply: &owed})
+	if err != nil {
+		t.Fatalf("listing owed leads: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("owed page = %d rows, want the one unanswered lead", len(rows))
+	}
+	if ids.UUID(rows[0].Id) != ids.UUID(owedLead.Id) {
+		t.Errorf("the bounded page returned %q, want the unanswered lead — an answered one "+
+			"filled the cut", *rows[0].FullName)
+	}
+}

--- a/backend/internal/modules/people/leadowespelling_test.go
+++ b/backend/internal/modules/people/leadowespelling_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// "This lead still owes a first reply" is spelled once.
+//
+// Four readers ask it — the SLA state filter, the breach scan, the work
+// queue's band, and the list's owed dial — and a fifth writing the predicate by
+// hand is how a queue starts disagreeing with the filter that feeds it. The
+// figures then differ by rows nobody can account for, which is precisely the
+// defect this predicate was extracted to end.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Held by: this test, named in leadOwesAReplySQL's own doc comment.
+func TestTheOwesAReplyPredicateHasOneSpelling(t *testing.T) {
+	t.Parallel()
+	// The shape a hand-written second spelling takes: the two column tests
+	// together, in either order, however spaced.
+	handWritten := regexp.MustCompile(
+		`first_response_at\s+IS\s+NULL[\s\S]{0,80}archived_at\s+IS\s+NULL|` +
+			`archived_at\s+IS\s+NULL[\s\S]{0,80}first_response_at\s+IS\s+NULL`)
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package: %v", err)
+	}
+	var scanned int
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		scanned++
+		for _, hit := range handWritten.FindAllString(string(body), -1) {
+			// The constant's own declaration is the one permitted spelling.
+			if strings.Contains(hit, leadOwesAReplySQL) && name == "leadsla.go" {
+				continue
+			}
+			t.Errorf("%s writes the owes-a-reply predicate by hand (%q) — "+
+				"use leadOwesAReplySQL so every reader asks one question",
+				name, strings.Join(strings.Fields(hit), " "))
+		}
+	}
+	// A census that reads nothing reports PASS with nothing to notice.
+	if scanned < 20 {
+		t.Fatalf("scanned %d files of this package, far below its size — the walk lost its source", scanned)
+	}
+}

--- a/backend/internal/modules/people/leadsla.go
+++ b/backend/internal/modules/people/leadsla.go
@@ -69,12 +69,28 @@ func leadSLAFields(policy leadSLAPolicy, routedAt *time.Time, createdAt time.Tim
 //
 // With the target switched off no lead is in any SLA state, so the filter
 // matches nothing rather than pretending a default target.
+// leadOwesAReplySQL is the one spelling of "this lead still owes a first
+// reply": live, and nobody has answered it.
+//
+// FOUR readers ask it — the SLA state filter, the breach scan, the work
+// queue's band, and the list's own unanswered dial — and the question is one.
+// Spelled separately they drift, and a queue that disagrees with the filter
+// feeding it reports a count nobody can reconcile.
+//
+// Deliberately NOT a statement about the status ladder. A lead the system moved
+// to `contacted` because a cold outbound went out has had no genuine response,
+// and §18.1 is explicit that an auto-touch does not satisfy first response — so
+// the rung a lead sits on says nothing about whether somebody replied to it.
+//
+// Held by: TestTheOwesAReplyPredicateHasOneSpelling (leadowespelling_test.go)
+const leadOwesAReplySQL = "archived_at IS NULL AND first_response_at IS NULL"
+
 func slaStateClause(policy leadSLAPolicy, state crmcontracts.ListLeadsParamsSlaState, arg func(any) int) string {
 	if !policy.enabled {
 		return "FALSE"
 	}
 	deadline := "COALESCE(routed_at, created_at) + $%d * interval '1 minute'"
-	open := "archived_at IS NULL AND first_response_at IS NULL AND "
+	open := leadOwesAReplySQL + " AND "
 	minutes := policy.targetMinutes()
 	now := leadSLAClock().UTC()
 	switch crmcontracts.LeadSlaState(state) {
@@ -141,7 +157,7 @@ func (s *Store) ScanLeadSLA(ctx context.Context, now time.Time) ([]SLABreach, er
 			SELECT id, owner_id, COALESCE(routed_at, created_at) + $1 * interval '1 minute',
 			       COALESCE(NULLIF(btrim(full_name), ''), email::text, '')
 			FROM lead
-			WHERE archived_at IS NULL AND first_response_at IS NULL AND sla_breached_at IS NULL
+			WHERE `+leadOwesAReplySQL+` AND sla_breached_at IS NULL
 			  AND COALESCE(routed_at, created_at) + $1 * interval '1 minute' < $2
 			ORDER BY created_at
 			FOR UPDATE SKIP LOCKED`,

--- a/backend/internal/modules/people/leadworkqueue.go
+++ b/backend/internal/modules/people/leadworkqueue.go
@@ -137,6 +137,9 @@ func leadQueueWhere(ctx context.Context, in ListLeadsInput, active []fieldcatalo
 	if in.Status != nil {
 		where = append(where, storekit.SQLf(leadStatusColumn+" = $%d", arg(*in.Status)))
 	}
+	if in.OwedAReply != nil && *in.OwedAReply {
+		where = append(where, leadOwesAReplySQL)
+	}
 	if in.MinScore != nil {
 		where = append(where, storekit.SQLf(leadScoreColumn+" >= $%d", arg(*in.MinScore)))
 	}
@@ -154,7 +157,15 @@ func leadQueueWhere(ctx context.Context, in ListLeadsInput, active []fieldcatalo
 // falls through to score, then age.
 func leadQueueRank(policy leadSLAPolicy, arg func(any) int, asOf time.Time) string {
 	if !policy.enabled {
-		return fmt.Sprintf("%d", leadQueueRankInactive)
+		// No target, so no lead is LATE — but a lead still owes a first reply,
+		// and the queue's job is to put the ones that do in front of the ones
+		// that do not. Ranking every row the same made an answered lead with a
+		// high score outrank an unanswered one, which is the queue's whole
+		// question answered backwards. within_target is the honest band for
+		// "owed, with nothing measuring by when".
+		return fmt.Sprintf(`CASE
+			WHEN archived_at IS NOT NULL OR first_response_at IS NOT NULL THEN %d
+			ELSE %d END`, leadQueueRankInactive, leadQueueRankWithinTarget)
 	}
 	minutes := policy.targetMinutes()
 	risk := int(policy.atRisk() / time.Minute)

--- a/backend/internal/modules/people/leadworkqueue_test.go
+++ b/backend/internal/modules/people/leadworkqueue_test.go
@@ -5,6 +5,7 @@ package people
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,5 +48,32 @@ func TestLeadQueueCursorRejectsMalformedAndImpossibleValues(t *testing.T) {
 		if _, err := decodeLeadQueueCursor(token); !errors.As(err, new(*storekit.MalformedCursorError)) {
 			t.Errorf("decode %q error = %v, want MalformedCursorError", token, err)
 		}
+	}
+}
+
+// With no first-response target, an unanswered lead still outranks an answered
+// one.
+//
+// The rank used to collapse to a single constant when the policy was off, so
+// every lead shared a band and the ordering fell through to score. An answered
+// lead with a high score then sorted above an unanswered one — and because the
+// queue's readers take a bounded page, a page of answered leads could fill the
+// limit and hide the leads that actually owe a reply. The queue's own question
+// answered backwards.
+func TestTheLeadQueueRanksUnansweredFirstWithNoTarget(t *testing.T) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	rank := leadQueueRank(leadSLAPolicy{}, arg, time.Now())
+
+	// It must still DISCRIMINATE: a bare constant is what let score decide.
+	if !strings.Contains(rank, "first_response_at IS NOT NULL") {
+		t.Errorf("rank with no target = %q, which cannot tell an answered lead from an owed one", rank)
+	}
+	if !strings.Contains(rank, "archived_at IS NOT NULL") {
+		t.Error("an archived lead is not owed a reply and must not be ranked as if it were")
+	}
+	// And it reads nothing from the policy it does not have.
+	if len(args) != 0 {
+		t.Errorf("the no-target rank bound %d arguments, want none", len(args))
 	}
 }

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (100)
+## Parity (101)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Two signals the morning brief reported wrongly, both making a number say something the record does not support.

**A future-dated activity counted as overnight momentum.** The evidence read had a lower bound and no upper one, so a task written days ago and dated next Tuesday lifted momentum from its 0.4 baseline to 1.0 on every morning in between. The audit found three of seven selected deals riding evidence dated after the cutoff that produced them. The dismissal filter in the same query already bounds itself this way and says why — the two reads disagreed.

**A lead owed a reply, and the tile said zero.** The lane dropped itself entirely when no first-response target was configured, on the reasoning that nothing is *late* without one. But owed and late are different questions: a rep with five unanswered leads read "0 owed a first answer", and the tile linked to an empty list to confirm it.

## From the review

The Codex run failed mid-command, so per protocol I fell back to the repo's own `security-redteam` and `craft-reviewer`. **Both independently found the same defect, and it was the fix reproducing the bug it was fixing.**

The seam took 50 leads and filtered answered ones *afterwards*. With no target set, `leadQueueRank` collapsed to a single constant, so answered and unanswered leads sorted alike on score — a workspace whose top scorers had all been replied to reported an empty lane while unanswered leads sat behind the cut, and `bounded()` read false because the page was short rather than truncated. The seam's own comment forty lines up already says narrowing belongs in the query for exactly this reason.

So `ListLeadsInput` carries an `OwedAReply` dial and the band ranks answered leads last regardless of policy. Both hold it, and the test says so rather than implying either alone is load-bearing — I verified that removing one leaves it green and removing both returns an answered lead.

Three more from craft review, all applied: `leadRead.tracked` had no reader and is gone rather than shipped speculative; two interface comments still described the lane rendering absent; and the reach test asserted only the untracked case, passing identically with the policy on.

Security found no isolation, authz or injection issue: `lead` is an identity table whose read predicate is already `TRUE` for every grant holder, so removing the early return widens nothing, and the evidence cutoff comes from the run's own clock with no caller influence.

## One spelling

The predicate now exists once. Four readers ask "does this lead still owe a first reply", and a fifth writing it by hand is how a queue starts disagreeing with the filter feeding it. `leadOwesAReplySQL` is that spelling — and because the repo refuses a uniqueness claim without a test, it is held by one rather than by a comment asserting it.

## Verification

- `make check-backend` green; `modules/people`, `compose/briefs`, `compose` lanes green.
- Both fixes mutation-checked: reverting the cutoff gives momentum 1.0 on a deal where nothing happened; reverting both lead guards returns an answered lead in a one-row page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two wrong numbers in the morning brief: future-dated activity counted as overnight momentum, and leads owed a reply read zero when no first-response target was set. Both now report what the record supports.

**Bug Fixes**
- Overnight evidence is bounded at the run's cutoff, so a task dated next week no longer lifts a deal's momentum on the mornings before it.
- The lead lane renders owed leads whether or not a first-response target exists; a row carries a deadline only where a policy sets one.
- `ListLeadsInput` gains an `OwedAReply` dial, and the queue ranks answered leads last even without a target, so bounded pages don't lose unanswered leads behind answered ones.

**Refactors**
- The owes-a-reply predicate is now spelled once as `leadOwesAReplySQL`, held by a test instead of a comment.

<sup>Written for commit 16ac9fbdec73b5753c7e6b80ff959a334e66c90a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unanswered leads now appear in lead-response views even when no first-response target is configured.
  * Lead lists prioritize unanswered leads and prevent answered leads from occupying limited result slots.
  * Lead reach reporting now remains available regardless of response-target tracking.
  * Future-dated activity no longer counts as overnight momentum.

* **Documentation**
  * Updated the gate inventory parity count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->