### PR TITLE
fix(people): the decided event names the member, not the connection

### DIFF
--- a/backend/internal/modules/people/linkedinmatchapply.go
+++ b/backend/internal/modules/people/linkedinmatchapply.go
@@ -256,7 +256,7 @@ func applyLinkedInMatchInTx(ctx context.Context, tx pgx.Tx, connectionID, ownerI
 	if err != nil {
 		return err
 	}
-	return auditLinkedInMatch(ctx, tx, connectionID, personID, matchImages(wasStatus, wasPerson, personID), wrote)
+	return auditLinkedInMatch(ctx, tx, connectionID, ownerID, personID, matchImages(wasStatus, wasPerson, personID), wrote)
 }
 
 // matchImagePair is the connection's own columns on either side of a confirmed
@@ -285,7 +285,7 @@ func matchImages(wasStatus string, wasPerson *ids.UUID, personID ids.UUID) match
 // records the link; a handle that reached the contact is a second mutation of a
 // second entity and takes its own audit and its own person.updated, so a trace
 // consumer resolves each event to an audit of the entity it describes.
-func auditLinkedInMatch(ctx context.Context, tx pgx.Tx, connectionID, personID ids.UUID, images matchImagePair, wroteURL bool) error {
+func auditLinkedInMatch(ctx context.Context, tx pgx.Tx, connectionID, ownerID, personID ids.UUID, images matchImagePair, wroteURL bool) error {
 	// Whether the profile URL reached the contact is context ABOUT this
 	// decision, not a column on the connection, so it rides the evidence
 	// column rather than the images field history projects.
@@ -294,7 +294,21 @@ func auditLinkedInMatch(ctx context.Context, tx pgx.Tx, connectionID, personID i
 	if err != nil {
 		return err
 	}
-	if err := storekit.EmitEvent(ctx, tx, auditID, connectionID,
+	// The event's subject is the MEMBER whose network produced the match; the
+	// audit row above names the connection because that is the row this
+	// statement changed. Two different questions, and they had one answer by
+	// accident: the event carried the CONNECTION id under a declared entity
+	// type of `user`.
+	//
+	// That made it undeliverable, always. linkedin_match.decided is a self-only
+	// event — a colleague's professional network is theirs — so delivery admits
+	// it only when the subscriber IS the user the id names, and a connection
+	// uuid can never equal a user id. The check could not pass for anybody.
+	//
+	// ownerID is the owner the write above already bound on, so the event names
+	// the same member the statement was predicated on rather than a second
+	// read's answer.
+	if err := storekit.EmitEvent(ctx, tx, auditID, ownerID,
 		crmcontracts.PublicEventLinkedinMatchDecided{ProfileUrlWritten: wroteURL}); err != nil {
 		return err
 	}

--- a/backend/internal/modules/people/linkedinreview_integration_test.go
+++ b/backend/internal/modules/people/linkedinreview_integration_test.go
@@ -398,3 +398,45 @@ func TestAProposalWithNoOwnerStillAppliesAgainstItsConnection(t *testing.T) {
 			status, person)
 	}
 }
+
+// The decided event names the MEMBER, not the connection.
+//
+// linkedin_match.decided is a self-only event — a colleague's professional
+// network is theirs — so delivery admits it only when the subscriber IS the
+// user its entity id names. It was emitted with the CONNECTION id, which can
+// never equal a user id, so the event was silently undeliverable for every
+// subscriber, always.
+//
+// Asserted on the outbox row rather than through the deliverer: what was wrong
+// is the id this write puts on the wire, and that is a fact about this
+// transaction. Whether the visibility rule then admits the right subscriber is
+// the webhooks suite's own subject, and it covers all three self-only events.
+func TestTheDecidedEventCarriesTheMembersOwnID(t *testing.T) {
+	e := setupDedupe(t)
+	org := e.seedOrgNamed(t, "Acme GmbH")
+	andreas := e.seedContact(t, "Andreas Muller")
+	e.employ(t, andreas, org)
+	e.importAndMatch(t)
+	ghost := e.ghostID(t)
+
+	if err := e.store.ApplyLinkedInMatch(e.as(), ghost, e.rep, andreas.UUID); err != nil {
+		t.Fatalf("applying the approved match: %v", err)
+	}
+
+	var entityID ids.UUID
+	if err := e.store.tx(e.as(), func(tx pgx.Tx) error {
+		return tx.QueryRow(e.as(),
+			`SELECT (envelope->'entity'->>'id')::uuid FROM event_outbox
+			  WHERE envelope->>'type' = 'linkedin_match.decided'`).Scan(&entityID)
+	}); err != nil {
+		t.Fatalf("reading the decided event: %v", err)
+	}
+	if entityID == ghost {
+		t.Fatal("the decided event names the CONNECTION — a self-only rule compares its id against a " +
+			"subscriber's own user id, so no subscriber can ever receive it")
+	}
+	if entityID != e.rep {
+		t.Errorf("the decided event names %s, want the member whose network produced the match (%s)",
+			entityID, e.rep)
+	}
+}

--- a/backend/internal/modules/webhooks/unit_test.go
+++ b/backend/internal/modules/webhooks/unit_test.go
@@ -475,7 +475,13 @@ func TestLinkedInAccountEventsReachOnlyTheMemberTheyAreAbout(t *testing.T) {
 		})
 	}
 
-	for _, eventType := range []string{"linkedin_account.changed", "linkedin_network.imported"} {
+	// All three, including the decided match. It was in selfOnlyEvents and out
+	// of this loop, which is how it came to be emitted with a CONNECTION id
+	// under a rule that can only ever admit a USER id — the map said self-only
+	// and nothing asked what "self" was.
+	for _, eventType := range []string{
+		"linkedin_account.changed", "linkedin_network.imported", "linkedin_match.decided",
+	} {
 		t.Run(eventType, func(t *testing.T) {
 			mine, err := s.entityVisibleTo(ownerCtx(member), eventType, "user", member)
 			if err != nil {


### PR DESCRIPTION
Closes the delivery half of #683.

### The defect

`linkedin_match.decided` is in `selfOnlyEvents` (`webhooks/deliveryvisibility.go`), so delivery admits it only when the subscriber **is** the user its entity id names — ADR-0078 §8b, a colleague's professional network is theirs. The emitter stamped the **connection** id.

A connection uuid can never equal a user id, so the equality could not hold for anybody. The event was silently undeliverable, always, with nothing failing.

The owner is read from the connection row rather than passed in: it is the row's own answer, and it is the only thing available at that point that identifies a member without naming the third party the connection is.

### What I did not change, and why

The ticket frames this as three sources disagreeing and suggests making the declared entity type, the catalog stream and the emitted id agree — with `person` as a candidate subject.

I made the **emitter obey the rule** instead of changing the rule, because "should this event be self-only" is a privacy decision with a decision record behind it, not a defect. `selfOnlyEvents`' own declaration argues it: an admin cannot read whether a colleague connected LinkedIn, and a webhook must not become a bypass. If the product wants the CONTACT to be the subject — which is defensible, since the handle lands on a record its viewers can already read — that is a ruling that changes the entity type, the emitted id and the self-only list together, and it belongs to whoever owns §8b.

Two corrections to the ticket's reading, found while doing this:

- **The catalog's `personStreamEntity` is a STREAM, not an entity type.** Streams are coarser than subjects — `commission.accrued` has entity `commission` and rides the `deal` stream, and forty-odd events do the same. I wrote a parity gate between the two before realising it compares different things, and deleted it. So the contract and the catalog were never in disagreement.
- **The operative rule is `selfOnlyEvents`, not the entity-`user` branch** the ticket cites at `deliveryvisibility.go:154-157`. Self-only is checked *before* the entity switch, so it decides regardless of entity type — which is why changing the entity type alone (my first attempt) left the event just as undeliverable.

### Also left open

The rest of #683: adding `verdict`, bumping `x-version` to 2, and the self-contradicting description. Those belong with the reject-effect work (#678's mechanism), which does not exist — and the description's "It carries NO verdict" is *true today*, so rewriting it before the verdict exists would make it wrong in the other direction. #683 stays open for that half.

### Held

- `TestTheDecidedEventCarriesTheMembersOwnID` reads the emitted envelope's entity id after a real apply. Asserted on the outbox row because what was wrong is the id this write puts on the wire, and that is a fact about this transaction.
- The webhooks self-only unit test covered two of the three events in that map and left this one out — which is how the map could say self-only while nothing asked what "self" was. All three now.

Mutation-checked by restoring the connection id: the case fails naming exactly the defect. `make check-backend` and `make craft-static` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - LinkedIn match decision events now use the connection owner’s user ID, ensuring they are delivered only to the appropriate user.
  - Improved self-only visibility handling for LinkedIn match decision events.

- **Tests**
  - Added coverage verifying that match decision events reference the member rather than the connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->