### PR TITLE
fix(attention): the decisions count is what this reader can settle

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -43158,10 +43158,15 @@ components:
           type: integer
           minimum: 0
           description: |
-            How much routine work is queued behind a decision. Counted before the fold, so
-            a hundred alike approvals read as a hundred here even where the queue draws
+            How many decisions THIS reader can settle. Counted before the fold, so a
+            hundred alike approvals read as a hundred here even where the queue draws
             them as one row — the strip says how much work there is, and the queue says
             how much reading it costs.
+
+            Only rows carrying a verb the reader may press. A duplicate pair whose two
+            records the reader cannot both write is somebody else's decision, and
+            counting it here tells them a person is blocked on an answer they are not
+            able to give.
         more_available:
           type: boolean
           description: |

--- a/backend/internal/compose/attention/readings.go
+++ b/backend/internal/compose/attention/readings.go
@@ -84,9 +84,19 @@ func readingsOf(
 			// duplicateItem with a merge action only when the reader could write
 			// BOTH records, and an approval carries its verbs only where the
 			// inbox admits them. Counting the rest tells somebody a person is
-			// blocked on an answer they are not able to give — the headline read
-			// "10 decisions waiting" over two the rep could take and eight only
-			// an admin could.
+			// blocked on an answer they are not able to give.
+			//
+			// KNOWN NARROWING, and it is the safe direction rather than an
+			// oversight. A duplicate pair the reader may write but nobody may
+			// MERGE — two organizations each carrying live projects — can still
+			// be dismissed as not-a-duplicate, and reaches here with no verb
+			// because the surface offers no dismiss control for this source
+			// yet (issue 5066). Such a pair is missing from this count until it
+			// does. The
+			// alternative was counting every undecidable row, which is the
+			// defect: a headline naming work the reader cannot do teaches them
+			// to distrust the number, while one that is short by a case nobody
+			// can currently action from this page stays true to what it claims.
 			if len(row.item.Actions) == 0 {
 				continue
 			}

--- a/backend/internal/compose/attention/readings.go
+++ b/backend/internal/compose/attention/readings.go
@@ -77,6 +77,19 @@ func readingsOf(
 			// hundred alike approvals read as a hundred here even where the queue
 			// draws them as one row. The strip says how much work there is; the
 			// queue says how much reading it costs.
+			//
+			// A row this reader cannot settle is not their decision. The verb is
+			// the test, because the producers already resolved authority to
+			// decide whether to offer one: a duplicate pair reaches
+			// duplicateItem with a merge action only when the reader could write
+			// BOTH records, and an approval carries its verbs only where the
+			// inbox admits them. Counting the rest tells somebody a person is
+			// blocked on an answer they are not able to give — the headline read
+			// "10 decisions waiting" over two the rep could take and eight only
+			// an admin could.
+			if len(row.item.Actions) == 0 {
+				continue
+			}
 			out.Review++
 		case crmcontracts.WorklistItemCategoryDealsAtRisk:
 			if !row.hasExpected {

--- a/backend/internal/compose/attention/readings_test.go
+++ b/backend/internal/compose/attention/readings_test.go
@@ -55,9 +55,11 @@ func TestTheReadingsDoNotShrinkAsAReaderPagesThroughTheQueue(t *testing.T) {
 // decisions pill must not report the buyers waiting as gone.
 func TestAFilterDoesNotEmptyTheOtherReadings(t *testing.T) {
 	day := crmcontracts.Attention{
-		AsOf:     rankInstant,
-		NeedsYou: []crmcontracts.AttentionItem{item("a1", "approval", withKind("capture_counterparty"))},
-		AtRisk:   lane(item("d1", "deal_at_risk", withDeal(500_00))),
+		AsOf: rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{
+			item("a1", "approval", withKind("capture_counterparty"), decidable()),
+		},
+		AtRisk: lane(item("d1", "deal_at_risk", withDeal(500_00))),
 	}
 	considered := classifyDay(day, rankInstant, dayMoney{})
 
@@ -248,7 +250,8 @@ func TestPricedRowsThatDisagreeAboutUnitsNameNoCurrency(t *testing.T) {
 func TestReviewCountsTheFoldedWorkRatherThanTheRowsDrawn(t *testing.T) {
 	needs := make([]crmcontracts.AttentionItem, 0, 12)
 	for i := range 12 {
-		needs = append(needs, item(string(rune('a'+i)), "approval", withKind("capture_counterparty")))
+		needs = append(needs, item(string(rune('a'+i)), "approval",
+			withKind("capture_counterparty"), decidable()))
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: needs}
 	considered := classifyDay(day, rankInstant, dayMoney{})
@@ -389,9 +392,11 @@ func TestThePermanentlyWithheldPrivacyLaneDoesNotMarkEveryDayAFloor(t *testing.T
 // a count would pass while the strip put buyer replies under prospecting.
 func TestEachReadingCountsItsOwnCategory(t *testing.T) {
 	day := crmcontracts.Attention{
-		AsOf:     rankInstant,
-		NeedsYou: []crmcontracts.AttentionItem{item("a1", "approval", withKind("capture_counterparty"))},
-		AtRisk:   lane(item("d1", "deal_at_risk", withDeal(100_00))),
+		AsOf: rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{
+			item("a1", "approval", withKind("capture_counterparty"), decidable()),
+		},
+		AtRisk: lane(item("d1", "deal_at_risk", withDeal(100_00))),
 	}
 
 	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil, nil)
@@ -404,5 +409,36 @@ func TestEachReadingCountsItsOwnCategory(t *testing.T) {
 	}
 	if got.Prospecting != 0 {
 		t.Fatalf("counted %d prospecting on a day with none", got.Prospecting)
+	}
+}
+
+// A decision this reader cannot settle is not counted as waiting on them.
+//
+// The headline says somebody is blocked until you answer. Counting a duplicate
+// pair whose two records the reader may not both write tells them a person is
+// waiting on an answer they are unable to give — the audited page read "10
+// decisions waiting" over two the rep could take and eight only an admin could,
+// each of which said in its own card that a lead or admin had to settle it.
+//
+// The verb is the test rather than a second authority lookup: the producers
+// already resolved it. duplicateItem offers `merge` only to a reader who could
+// write both sides, and an approval carries its verbs only where the inbox
+// admits them, so a row with no action is one somebody else has to settle.
+func TestTheDecisionCountLeavesOutWhatThisReaderCannotSettle(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{
+			item("mine", "approval", withKind("capture_counterparty"), decidable()),
+			// Pairs the reader can see and cannot merge: duplicateItem offered
+			// no verb because they may not write both records.
+			item("dup1", "dedupe_candidate", withKind("person")),
+			item("dup2", "dedupe_candidate", withKind("person")),
+		},
+	}
+
+	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil, nil)
+
+	if got.Review != 1 {
+		t.Errorf("counted %d decisions, want the one this reader can actually take", got.Review)
 	}
 }

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -38,6 +38,15 @@ func withKind(kind string) func(*crmcontracts.AttentionItem) {
 	return func(i *crmcontracts.AttentionItem) { i.Kind = &kind }
 }
 
+// decidable gives a row the verb its producer offers only to a reader who could
+// press it. A decision fixture without one models a row somebody else has to
+// settle, which is a real case but not the one most tests mean.
+func decidable() func(*crmcontracts.AttentionItem) {
+	return func(i *crmcontracts.AttentionItem) {
+		i.Actions = []crmcontracts.AttentionItemActions{"decide"}
+	}
+}
+
 func withDue(at time.Time) func(*crmcontracts.AttentionItem) {
 	return func(i *crmcontracts.AttentionItem) { i.DueAt = &at }
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -37245,10 +37245,15 @@ type WorklistReadings struct {
 	// error the conversion seam exists to prevent.
 	RevenueCurrency *string `json:"revenue_currency,omitempty"`
 
-	// Review How much routine work is queued behind a decision. Counted before the fold, so
-	// a hundred alike approvals read as a hundred here even where the queue draws
+	// Review How many decisions THIS reader can settle. Counted before the fold, so a
+	// hundred alike approvals read as a hundred here even where the queue draws
 	// them as one row — the strip says how much work there is, and the queue says
 	// how much reading it costs.
+	//
+	// Only rows carrying a verb the reader may press. A duplicate pair whose two
+	// records the reader cannot both write is somebody else's decision, and
+	// counting it here tells them a person is blocked on an answer they are not
+	// able to give.
 	Review int `json:"review"`
 }
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -32639,10 +32639,15 @@ export interface components {
             /** @description How much new business is in hand and owed a first response. */
             prospecting: number;
             /**
-             * @description How much routine work is queued behind a decision. Counted before the fold, so
-             *     a hundred alike approvals read as a hundred here even where the queue draws
+             * @description How many decisions THIS reader can settle. Counted before the fold, so a
+             *     hundred alike approvals read as a hundred here even where the queue draws
              *     them as one row — the strip says how much work there is, and the queue says
              *     how much reading it costs.
+             *
+             *     Only rows carrying a verb the reader may press. A duplicate pair whose two
+             *     records the reader cannot both write is somebody else's decision, and
+             *     counting it here tells them a person is blocked on an answer they are not
+             *     able to give.
              */
             review: number;
             /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8753,7 +8753,7 @@ export const de = {
     "Neugeschäft, das eine erste Antwort schuldet",
   "worklist.readings.review": "Prüfung",
   "worklist.readings.review.detail":
-    "Routinearbeit, die hinter einer Entscheidung wartet",
+    "Entscheidungen, die nur Sie treffen können",
   "worklist.readings.truncated":
     "Es gibt mehr Arbeit, als hier gezählt werden konnte. Das sind Untergrenzen, keine Gesamtzahlen.",
   "worklist.hidden.title": "Was die Liste nicht zeigt",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8889,7 +8889,7 @@ export const en = {
   "worklist.readings.prospecting": "Prospecting",
   "worklist.readings.prospecting.detail": "New business owed a first reply",
   "worklist.readings.review": "Review",
-  "worklist.readings.review.detail": "Routine work queued behind a decision",
+  "worklist.readings.review.detail": "Decisions only you can settle",
   "worklist.readings.truncated":
     "There is more work than this could count. These are floors, not totals.",
   "worklist.hidden.title": "What the queue is not showing",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8646,8 +8646,7 @@ export const vi = {
   "worklist.readings.prospecting.detail":
     "Cơ hội mới đang chờ phản hồi đầu tiên",
   "worklist.readings.review": "Xem xét",
-  "worklist.readings.review.detail":
-    "Việc thường lệ đang chờ sau một quyết định",
+  "worklist.readings.review.detail": "Quyết định chỉ bạn mới xử lý được",
   "worklist.readings.truncated":
     "Có nhiều việc hơn số đếm được ở đây. Đây là mức tối thiểu, không phải tổng số.",
   "worklist.hidden.title": "Những gì danh sách không hiển thị",


### PR DESCRIPTION
The headline says somebody is blocked until you answer. The number under it counted every decision on the page — the audited morning read **"10 decisions waiting"** over two the rep could take and eight duplicate pairs that each said, in their own card, that only an admin or a sales lead could settle them.

## What changed

The verb is the test rather than a second authority lookup, because the producers already resolved it: `duplicateItem` offers `merge` only to a reader who could write both records, and an approval carries its verbs only where the inbox admits them. A row with no action is one somebody else has to answer.

The contract said "how much work there is"; it now says how much of it this reader can settle, which is the question the headline was already asking. The reading's own copy said "routine work queued behind a decision" — accurate before this change, not after — and now names what it counts, in all three languages.

## From the review

Codex found a real under-count, and chasing it turned up something better.

A pair whose two organizations each carry live projects **cannot be merged by anybody**, but a reader who may write both can still dismiss it as not-a-duplicate — `DisposeDedupeCandidate` takes write authority for that arm and applies no project restriction. So my proxy conflated "cannot merge" with "cannot act", and dropped a real decision.

I tried sending a `dismiss` verb for that case. **A gate refused it**, correctly: `TestNoLaneAdvertisesAVerbTheClientCannotPerform` holds that no lane may advertise a verb the client cannot perform, and `worklist.row.tsx` has no dismiss control for a dedupe candidate. Wiring one is a frontend change that belongs with its backend half, so it is [#5066](https://github.com/margince/margince/issues/5066) rather than scope creep here.

The narrowing is now stated where the count is taken, pointing at that issue. It is the safe direction: a headline naming work the reader cannot do teaches them to distrust the number, while one short by a case nobody can action from that page stays true to what it claims.

Codex's second finding — that the Decisions pill and this reading would now differ with nothing explaining why — is what the copy change addresses.

## Verification

- `make check-backend` and `make check-fe` green; `compose` integration lane green.
- Mutation-checked: removing the guard makes the test count 3 decisions where 1 is actionable.
- Three existing fixtures built decision rows with no actions, so they described undecidable work while asserting it was counted. They carry the verb now, which is what a real approval reaching that count has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the attention decisions count so it shows only what this reader can settle, not every decision on the page. Rows with no action are ones the producers already resolved as somebody else's to answer, so they're skipped; the contract copy and the reading's label in all three languages were updated to say exactly what the count includes.

**Known narrowing**
- A duplicate pair the reader may write but nobody can merge (two organizations with live projects) has no dismiss control on this surface yet, so it's missing from the count until that lands ([#5066](https://github.com/margince/margince/issues/5066)).
- That is the safe direction: a headline counting work the reader cannot do teaches distrust, while one short by an unactionable case stays true.

<sup>Written for commit 0dcd1d999b207ca0f1592f3a61931bf89d9a4dd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

