### PR TITLE
fix(attention): main is red — the lead lane's test still asks the old question

### DIFF
--- a/backend/internal/compose/attentionleads_integration_test.go
+++ b/backend/internal/compose/attentionleads_integration_test.go
@@ -151,22 +151,50 @@ func TestAnOwedLeadReachesItsOwnersQueueAndNobodyElses(t *testing.T) {
 	}
 }
 
-// The lane claims nothing when the installation measures no first response.
+// With no first-response target the lane still reports what is owed, and claims
+// no deadline for it.
 //
-// Not merely "no rows": an absent source must publish no reach row either, or
-// the page reports a bound on a source it never consulted.
-func TestWithTheTargetOffTheLaneIsAbsentFromThePage(t *testing.T) {
+// Owing a reply is a fact about the LEAD; being LATE is a fact about the
+// installation's policy. The lane used to drop itself entirely when no target
+// was set, which hid the work rather than the deadline — an installation that
+// measures no first response has leads owed replies exactly like any other, and
+// a queue that showed none of them was answering a question nobody asked.
+//
+// Both halves, because they fail in opposite directions. Reporting nothing hides
+// the work; reporting a due date the policy never set would put a deadline on
+// the screen that the record cannot stand behind, which is the failure the old
+// shape was avoiding and the reason it is worth pinning rather than deleting.
+func TestWithNoTargetTheLaneReportsWhatIsOwedAndClaimsNoDeadline(t *testing.T) {
 	e := integration.Setup(t)
 	// Deliberately NOT calling measureFirstResponse: this is the default.
 	seedOwedLead(t, e, "Nobody Is Counting", &e.Rep1, 48*time.Hour)
 
 	page := ownQueue(e.As(e.Rep1, []ids.UUID{e.Team1}, leadRepPerms), t, e)
-	if got := leadRows(page); len(got) != 0 {
-		t.Errorf("the queue carries %v with the target switched off", got)
+	if got := leadRows(page); len(got) != 1 || got[0] != "Nobody Is Counting" {
+		t.Fatalf("the queue carries %v with no first-response target, want the owed lead — the work is owed whether or not anything measures how late it is", got)
 	}
+
+	var seen bool
 	for _, reach := range page.Reach {
 		if string(reach.Source) == "lead_response" {
-			t.Errorf("the page publishes a reach row for a source it never read: %+v", reach)
+			seen = true
+		}
+	}
+	if !seen {
+		t.Error("the page publishes no reach row for lead_response — a source it read and drew from must say what it considered")
+	}
+
+	for _, item := range page.Queue {
+		if string(item.Source) != "lead_response" {
+			continue
+		}
+		if item.DueAt != nil {
+			t.Errorf("the row carries a due date of %v where the installation sets no target — a deadline on the screen the record cannot stand behind", *item.DueAt)
+		}
+		for _, because := range item.Because {
+			if kind := string(because.Kind); kind == "response_overdue" || kind == "response_due_soon" {
+				t.Errorf("the row says %q with no target set — overdue against what?", kind)
+			}
 		}
 	}
 }


### PR DESCRIPTION
**main is red.** Two tests, independently:

- `TestWithTheTargetOffTheLaneIsAbsentFromThePage` — this PR.
- `TestADepartedSeatDoesNotCostTheOthersTheirMorning` — #5063's subject, not touched here. That PR is green so far and its auto-merge was never armed, which is why it had not landed; I have armed it.

Reproduced on a detached worktree at main's tip with nothing else in it, so neither is a merge artefact.

## What happened

#5064 changed the rule on purpose, and said so:

> A lead owing a reply is a fact about the LEAD; whether that reply is LATE is a fact about the installation's policy. So the lane reports the rows whether or not a first-response target exists, and a row carries a deadline only where one is set.

The test that characterised the *old* behaviour — the lane drops itself entirely when nothing measures first response — was not moved with it. It has been failing on `main` ever since:

```
attentionleads_integration_test.go:165: the queue carries [Nobody Is Counting] with the target switched off
attentionleads_integration_test.go:169: the page publishes a reach row for a source it never read:
    {Considered:1 MoreAvailable:false Shown:1 Source:lead_response}
```

## The fix

Rewritten to the new rule rather than deleted, because the concern the old shape carried is still real and would otherwise have nowhere to live. The old test was guarding against *a number the product cannot stand behind* — reporting zero overdue leads where nothing measures overdue. Under the new rule that concern moves rather than disappears: the lane may report the work, but a row must not claim a **due date the policy never set**.

So `TestWithNoTargetTheLaneReportsWhatIsOwedAndClaimsNoDeadline` holds both halves, and they fail in opposite directions:

- the owed lead **is** carried, and the source publishes its reach row — reporting nothing hides work that is genuinely owed;
- the row carries **no `DueAt`**, and says neither `response_overdue` nor `response_due_soon` — a deadline on the screen the record cannot stand behind is what the old shape existed to prevent.

A test asserting only the first would pass against a lane that invented deadlines; only the second, against one that reports nothing at all.

## Verification

Restoring the drop-the-lane behaviour (reading the policy answer back and returning an empty `leadRead` when it is false) fails it:

```
attentionleads_integration_test.go:174: the queue carries [] with no first-response target,
    want the owed lead — the work is owed whether or not anything measures how late it is
```

`make check-backend` green. `make test-it DIR=backend/internal/compose` leaves only `TestADepartedSeatDoesNotCostTheOthersTheirMorning`, which is #5063's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC