### PR TITLE
fix(weekly): a week of leads and meetings is not a quiet week

### DIFF
--- a/backend/internal/compose/aicert/corpus/weekly_review/a_week_of_leads_is_not_an_empty_week.yaml
+++ b/backend/internal/compose/aicert/corpus/weekly_review/a_week_of_leads_is_not_an_empty_week.yaml
@@ -1,0 +1,42 @@
+name: a_week_of_leads_and_meetings_is_described_rather_than_called_quiet
+task: weekly_review
+site: narrative
+source: hand_authored
+sanitized_by: hand_authored/claude-fable-5
+fixture:
+  week_start: "2026-07-13"
+  counts:
+    tasks_due: 0
+    tasks_done: 0
+    tasks_carried_over: 0
+    deals_moved: 0
+    deals_won: 0
+    deals_lost: 0
+    proposals_accepted: 0
+    proposals_rejected: 0
+    brief_items_acted: 0
+    brief_items_dismissed: 0
+    leads_routed: 6
+    leads_answered_in_target: 5
+    leads_breached: 1
+    meetings_held: 3
+    meetings_with_next_step: 2
+  deals: []
+expect:
+  outcome: accepted
+  answer:
+    must_mention: []
+    # The failure this case exists for: reading a row of zeroed DEAL counts as
+    # an empty week. This rep answered five of six new leads inside the target
+    # and sat in three meetings — a full week by any reading, and the one shape
+    # an SDR's week most often takes. Calling it quiet tells them their work
+    # did not count.
+    must_not_mention: ["quiet", "nothing happened", "uneventful", "slow week"]
+  bands: { certified_min: 70, degraded_min: 50, floor: 40 }
+  rubric: >
+    The week held real work: six leads routed, five answered inside the target,
+    one missed, three meetings held and two of them producing a next step. A
+    good sentence says what was done — the lead responses, the meetings, or
+    both. It must not call the week quiet or empty, because the deal counts
+    being zero is not the same as nothing happening. Saying that no deal moved
+    or closed is TRUE and welcome; saying the week was quiet is not.

--- a/backend/internal/compose/weekly/narrative/narrative.go
+++ b/backend/internal/compose/weekly/narrative/narrative.go
@@ -86,6 +86,12 @@ func (c Counts) quiet() bool {
 		c.MeetingsHeld == 0 && c.MeetingsWithNextStep == 0
 }
 
+// dealsQuiet reports whether no deal did anything this week — the fact that
+// settles a claim about deals, as against one about the whole week.
+func (c Counts) dealsQuiet() bool {
+	return c.DealsMoved == 0 && c.DealsWon == 0 && c.DealsLost == 0
+}
+
 // Deal is one line from the week, by the name it carried then.
 type Deal struct {
 	Label   string `json:"label"`
@@ -228,13 +234,22 @@ func Parse(reply string, in Input) (string, error) {
 // against the one fact that settles it. English only, matching the corpus this
 // prompt is certified against — a sentence written in another language is not
 // caught here, which is why the prompt states the rule as well.
-var quietClaims = []string{
+// wholeWeekClaims say the WEEK held nothing. Any count settles them.
+var wholeWeekClaims = []string{
 	"quiet week",
 	"a quiet one",
+	"nothing happened",
+}
+
+// dealClaims say no DEAL did anything, which lead and meeting work does not
+// contradict. Split from the whole-week claims because the counts widened: a
+// week of nothing but answered leads is genuinely one where nothing closed,
+// and refusing that sentence would reject the truth for agreeing with the
+// numbers beside it.
+var dealClaims = []string{
 	"nothing closed",
 	"nothing moved",
 	"nothing slipped",
-	"nothing happened",
 }
 
 // refuseContradiction rejects a sentence that says the week held nothing when
@@ -251,14 +266,23 @@ var quietClaims = []string{
 // wrote about; a week whose prose contradicts its own numbers reads as a
 // product that does not know what happened.
 func refuseContradiction(sentence string, in Input) error {
-	if in.Counts.quiet() {
-		return nil
-	}
 	folded := strings.ToLower(sentence)
-	for _, claim := range quietClaims {
-		if strings.Contains(folded, claim) {
-			return fmt.Errorf(
-				"weekly narrative: the sentence says %q about a week that was not quiet", claim)
+	if !in.Counts.quiet() {
+		for _, claim := range wholeWeekClaims {
+			if strings.Contains(folded, claim) {
+				return fmt.Errorf(
+					"weekly narrative: the sentence says %q about a week that was not quiet", claim)
+			}
+		}
+	}
+	// Checked against the DEALS alone. A rep whose week was four routed leads
+	// and no pipeline movement is owed a sentence that can say so.
+	if !in.Counts.dealsQuiet() {
+		for _, claim := range dealClaims {
+			if strings.Contains(folded, claim) {
+				return fmt.Errorf(
+					"weekly narrative: the sentence says %q about a week whose deals moved", claim)
+			}
 		}
 	}
 	return nil

--- a/backend/internal/compose/weekly/narrative/narrative.go
+++ b/backend/internal/compose/weekly/narrative/narrative.go
@@ -59,6 +59,15 @@ type Counts struct {
 	ProposalsRejected   int `json:"proposals_rejected"`
 	BriefItemsActed     int `json:"brief_items_acted"`
 	BriefItemsDismissed int `json:"brief_items_dismissed"`
+	// The lead and meeting outcomes the scorecard already reports. Without
+	// them a week spent answering new business and sitting in meetings — real
+	// work, and often the whole of an SDR's week — reached the narrator as a
+	// row of zeros, and it wrote that nothing happened.
+	LeadsRouted           int `json:"leads_routed"`
+	LeadsAnsweredInTarget int `json:"leads_answered_in_target"`
+	LeadsBreached         int `json:"leads_breached"`
+	MeetingsHeld          int `json:"meetings_held"`
+	MeetingsWithNextStep  int `json:"meetings_with_next_step"`
 }
 
 // quiet reports whether the week did nothing worth a sentence.
@@ -72,7 +81,9 @@ func (c Counts) quiet() bool {
 	return c.TasksDue == 0 && c.TasksDone == 0 && c.TasksCarriedOver == 0 &&
 		c.DealsMoved == 0 && c.DealsWon == 0 && c.DealsLost == 0 &&
 		c.ProposalsAccepted == 0 && c.ProposalsRejected == 0 &&
-		c.BriefItemsActed == 0 && c.BriefItemsDismissed == 0
+		c.BriefItemsActed == 0 && c.BriefItemsDismissed == 0 &&
+		c.LeadsRouted == 0 && c.LeadsAnsweredInTarget == 0 && c.LeadsBreached == 0 &&
+		c.MeetingsHeld == 0 && c.MeetingsWithNextStep == 0
 }
 
 // Deal is one line from the week, by the name it carried then.

--- a/backend/internal/compose/weekly/narrative/narrative_test.go
+++ b/backend/internal/compose/weekly/narrative/narrative_test.go
@@ -236,3 +236,36 @@ func TestAWeekOfLeadsAndMeetingsIsNotQuiet(t *testing.T) {
 		t.Error("a week with nothing in it no longer reads as quiet")
 	}
 }
+
+// "Nothing closed" is a claim about DEALS, and a week of answered leads does
+// not contradict it.
+//
+// The contradiction guard fires on any non-quiet week. Once lead and meeting
+// work made a week non-quiet, a truthful sentence about a rep who routed four
+// leads and moved no pipeline — "Four leads answered; nothing closed" — was
+// refused by the guard meant to stop the opposite lie. The claim and the fact
+// that settles it have to match.
+func TestASentenceAboutDealsIsJudgedByTheDeals(t *testing.T) {
+	leadsOnly := Input{Counts: Counts{LeadsRouted: 4, LeadsAnsweredInTarget: 4}}
+
+	// TRUE, and it must survive: no deal did anything.
+	if err := refuseContradiction("Four leads answered in time; nothing closed.", leadsOnly); err != nil {
+		t.Errorf("a truthful sentence was refused: %v", err)
+	}
+	// FALSE, and it must still be caught: the week was not empty.
+	if err := refuseContradiction("A quiet week.", leadsOnly); err == nil {
+		t.Error("a week of four routed leads was allowed to call itself quiet")
+	}
+
+	// And the original guard is intact where it belongs: a week that closed
+	// deals may not say nothing closed.
+	won := Input{Counts: Counts{DealsWon: 3}}
+	if err := refuseContradiction("Nothing closed this week.", won); err == nil {
+		t.Error("a week with three won deals was allowed to say nothing closed")
+	}
+
+	// A genuinely empty week may say so.
+	if err := refuseContradiction("A quiet week — nothing closed.", Input{}); err != nil {
+		t.Errorf("an empty week was refused its own description: %v", err)
+	}
+}

--- a/backend/internal/compose/weekly/narrative/narrative_test.go
+++ b/backend/internal/compose/weekly/narrative/narrative_test.go
@@ -206,3 +206,33 @@ func TestTheQuietWeekExemplarIsOfferedOnlyToAQuietWeek(t *testing.T) {
 		t.Error("a busy week is not told that it was busy")
 	}
 }
+
+// A week of leads and meetings is not a quiet week.
+//
+// The narrative's counts held tasks, deals, proposals and brief interactions —
+// but not the lead and meeting outcomes the scorecard reports on the same page.
+// So a rep who spent the week answering new business and sitting in meetings
+// reached the narrator as a row of zeros, and it wrote that nothing happened,
+// beside a scorecard saying otherwise.
+func TestAWeekOfLeadsAndMeetingsIsNotQuiet(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Counts
+	}{
+		{"leads were routed", Counts{LeadsRouted: 4}},
+		{"leads were answered in time", Counts{LeadsAnsweredInTarget: 2}},
+		{"a lead's target was missed", Counts{LeadsBreached: 1}},
+		{"meetings were held", Counts{MeetingsHeld: 3}},
+		{"a meeting produced a next step", Counts{MeetingsWithNextStep: 1}},
+	}
+	for _, c := range cases {
+		if c.in.quiet() {
+			t.Errorf("%s: the week reads as quiet, so the narrator is told nothing happened", c.name)
+		}
+	}
+	// The genuinely empty week still reads as one — the point is not to make
+	// every week loud, it is to stop calling a busy one silent.
+	if !(Counts{}).quiet() {
+		t.Error("a week with nothing in it no longer reads as quiet")
+	}
+}

--- a/backend/internal/compose/weeklyjobs.go
+++ b/backend/internal/compose/weeklyjobs.go
@@ -283,6 +283,13 @@ func (w *weeklyGenerateWorker) narrate(ctx context.Context, review weekly.Review
 			ProposalsRejected:   review.Counts.ProposalsRejected,
 			BriefItemsActed:     review.Counts.BriefItemsActed,
 			BriefItemsDismissed: review.Counts.BriefItemsDismissed,
+			// The scorecard reports these; without them a week of answering
+			// leads and holding meetings reaches the narrator as zeros.
+			LeadsRouted:           review.Counts.LeadsRouted,
+			LeadsAnsweredInTarget: review.Counts.LeadsAnsweredInTarget,
+			LeadsBreached:         review.Counts.LeadsBreached,
+			MeetingsHeld:          review.Counts.MeetingsHeld,
+			MeetingsWithNextStep:  review.Counts.MeetingsWithNextStep,
 		},
 	}
 	for _, line := range review.Deals {

--- a/docs/reference/ai-certification.json
+++ b/docs/reference/ai-certification.json
@@ -5177,9 +5177,19 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": "3 scenarios it scored have changed since (the case): a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count",
+          "stale_reason": "3 scenarios it scored have changed since (the case and the prompt this build sends and the grader): a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count",
           "stale_cause": {
             "case_changed": [
+              "a_deal_named_like_an_instruction_is_read_as_a_name",
+              "a_quiet_week_is_reported_as_quiet_rather_than_dressed_up",
+              "the_sentence_leads_with_what_changed_not_with_a_count"
+            ],
+            "prompt_changed": [
+              "a_deal_named_like_an_instruction_is_read_as_a_name",
+              "a_quiet_week_is_reported_as_quiet_rather_than_dressed_up",
+              "the_sentence_leads_with_what_changed_not_with_a_count"
+            ],
+            "grader_changed": [
               "a_deal_named_like_an_instruction_is_read_as_a_name",
               "a_quiet_week_is_reported_as_quiet_rather_than_dressed_up",
               "the_sentence_leads_with_what_changed_not_with_a_count"
@@ -5207,9 +5217,19 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": "3 scenarios it scored have changed since (the case): a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count",
+          "stale_reason": "3 scenarios it scored have changed since (the case and the prompt this build sends and the grader): a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count",
           "stale_cause": {
             "case_changed": [
+              "a_deal_named_like_an_instruction_is_read_as_a_name",
+              "a_quiet_week_is_reported_as_quiet_rather_than_dressed_up",
+              "the_sentence_leads_with_what_changed_not_with_a_count"
+            ],
+            "prompt_changed": [
+              "a_deal_named_like_an_instruction_is_read_as_a_name",
+              "a_quiet_week_is_reported_as_quiet_rather_than_dressed_up",
+              "the_sentence_leads_with_what_changed_not_with_a_count"
+            ],
+            "grader_changed": [
               "a_deal_named_like_an_instruction_is_read_as_a_name",
               "a_quiet_week_is_reported_as_quiet_rather_than_dressed_up",
               "the_sentence_leads_with_what_changed_not_with_a_count"

--- a/docs/reference/ai-certification.json
+++ b/docs/reference/ai-certification.json
@@ -5,7 +5,7 @@
     "sites_best_partial": 0,
     "sites_best_stale": 41,
     "sites_absent": 1,
-    "scenarios": 157,
+    "scenarios": 158,
     "records": 74,
     "bindings": 10
   },
@@ -5150,6 +5150,11 @@
           "file": "backend/internal/compose/aicert/corpus/weekly_review/a_quiet_week_is_said_to_be_quiet.yaml"
         },
         {
+          "name": "a_week_of_leads_and_meetings_is_described_rather_than_called_quiet",
+          "expects": "accepted",
+          "file": "backend/internal/compose/aicert/corpus/weekly_review/a_week_of_leads_is_not_an_empty_week.yaml"
+        },
+        {
           "name": "the_sentence_leads_with_what_changed_not_with_a_count",
           "expects": "accepted",
           "file": "backend/internal/compose/aicert/corpus/weekly_review/a_week_with_one_thing_worth_saying.yaml"
@@ -5165,7 +5170,7 @@
           "state": "stale",
           "band": "not_supported",
           "scenarios_measured": 0,
-          "scenarios_total": 3,
+          "scenarios_total": 4,
           "runs": 9,
           "passed": 6,
           "reliability": 0.6666666666666666,
@@ -5205,7 +5210,7 @@
           "state": "stale",
           "band": "not_supported",
           "scenarios_measured": 0,
-          "scenarios_total": 3,
+          "scenarios_total": 4,
           "runs": 9,
           "passed": 6,
           "reliability": 0.6666666666666666,

--- a/docs/reference/ai-certification.md
+++ b/docs/reference/ai-certification.md
@@ -40,8 +40,8 @@ Counted per record — one (task, binding) pair — over the 55 stale record(s) 
 | What moved | Records | What it means |
 |---|---:|---|
 | the case | 55 | Somebody rewrote the test. Re-certify: the old number measured a different question. |
-| **the prompt this build sends** | 12 | The product changed. The band describes the NEW prompt, so a drop is the cost of that change and not the model. |
-| the grader | 0 | The judge's own request moved. A band can shift with neither the test nor the product touched. |
+| **the prompt this build sends** | 14 | The product changed. The band describes the NEW prompt, so a drop is the cost of that change and not the model. |
+| the grader | 2 | The judge's own request moved. A band can shift with neither the test nor the product touched. |
 
 A site's *best* state is the strongest state any of its bindings reached. A
 site `current` on one model and `stale` on three is counted once, as
@@ -299,8 +299,8 @@ model, real network).
 | `voice_build/eval_scores` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | the case changed under scenario judge_ranks_the_author_rhythm_above_generic_ai_prose since the record scored it |
 | `weekly_learnings/learn` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since (the case): a_deal_named_like_an_instruction_teaches_no_lesson, a_pattern_across_three_deals_is_drawn_and_cited, a_week_that_invites_a_lesson_it_cannot_support_yields_none |
 | `weekly_learnings/learn` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since (the case): a_deal_named_like_an_instruction_teaches_no_lesson, a_pattern_across_three_deals_is_drawn_and_cited, a_week_that_invites_a_lesson_it_cannot_support_yields_none |
-| `weekly_review/narrative` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since (the case): a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count |
-| `weekly_review/narrative` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since (the case): a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count |
+| `weekly_review/narrative` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since (the case and the prompt this build sends and the grader): a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count |
+| `weekly_review/narrative` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since (the case and the prompt this build sends and the grader): a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count |
 
 ## Sites, their scenarios and their records
 

--- a/docs/reference/ai-certification.md
+++ b/docs/reference/ai-certification.md
@@ -29,7 +29,7 @@ How to certify a model: [certify-an-ai-model.md](../how-to/certify-an-ai-model.m
 | … best state `partial` | 0 |
 | … best state `stale` | 41 |
 | … `absent` on every binding | 1 |
-| Scenarios in the corpus | 157 |
+| Scenarios in the corpus | 158 |
 | Committed records | 74 |
 | Bindings measured | 10 |
 
@@ -132,7 +132,7 @@ Which model to run each site on, and what that choice rests on.
 | [`voice_build/eval_draft`](#voice_buildeval_draft) | - | - | - | `stale` | 1 | 3 |
 | [`voice_build/eval_scores`](#voice_buildeval_scores) | - | - | - | `stale` | 1 | 3 |
 | [`weekly_learnings/learn`](#weekly_learningslearn) | - | - | - | `stale` | 3 | 2 |
-| [`weekly_review/narrative`](#weekly_reviewnarrative) | - | - | - | `stale` | 3 | 2 |
+| [`weekly_review/narrative`](#weekly_reviewnarrative) | - | - | - | `stale` | 4 | 2 |
 
 **Best model tested** is the strongest result that still describes what ships.
 Only a `current` or `partial` record is eligible; among those the pick is the
@@ -1238,18 +1238,19 @@ Records (2):
 
 Scope a run of it can claim: `full_invocation`.
 
-Scenarios (3):
+Scenarios (4):
 
 | Scenario | Expects | Case |
 |---|---|---|
 | `a_deal_named_like_an_instruction_is_read_as_a_name` | `accepted` | [a_deal_name_is_not_an_instruction.yaml](../../backend/internal/compose/aicert/corpus/weekly_review/a_deal_name_is_not_an_instruction.yaml) |
 | `a_quiet_week_is_reported_as_quiet_rather_than_dressed_up` | `accepted` | [a_quiet_week_is_said_to_be_quiet.yaml](../../backend/internal/compose/aicert/corpus/weekly_review/a_quiet_week_is_said_to_be_quiet.yaml) |
+| `a_week_of_leads_and_meetings_is_described_rather_than_called_quiet` | `accepted` | [a_week_of_leads_is_not_an_empty_week.yaml](../../backend/internal/compose/aicert/corpus/weekly_review/a_week_of_leads_is_not_an_empty_week.yaml) |
 | `the_sentence_leads_with_what_changed_not_with_a_count` | `accepted` | [a_week_with_one_thing_worth_saying.yaml](../../backend/internal/compose/aicert/corpus/weekly_review/a_week_with_one_thing_worth_saying.yaml) |
 
 Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 6 | 0.67 | 997ms | 1239ms | 6 | 3 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 6 | 0.67 | 879ms | 1619ms | 6 | 3 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/4 | `not_supported` | 9 | 6 | 0.67 | 997ms | 1239ms | 6 | 3 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/4 | `not_supported` | 9 | 6 | 0.67 | 879ms | 1619ms | 6 | 3 | 0 | 0 |
 

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2609,7 +2609,7 @@ export const de = {
   "brief.weekly.scorecard.multiThreaded": "Mehr als ein Kontakt",
   "brief.weekly.scorecard.multiThreadedBasis":
     "von {total} offenen Deals, in den letzten 30 Tagen",
-  "brief.weekly.scorecard.closeDateSound": "Bestätigtes Abschlussdatum",
+  "brief.weekly.scorecard.closeDateSound": "Festes Abschlussdatum hinterlegt",
   "brief.weekly.scorecard.forecastMoves": "Forecast hochgestuft",
   "brief.weekly.scorecard.forecastMovesBasis": "{down} herabgestuft",
   // Die kommende Woche. Der eingefrorene Rückblick sagt, was war; dies ist der

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2609,7 +2609,7 @@ export const de = {
   "brief.weekly.scorecard.multiThreaded": "Mehr als ein Kontakt",
   "brief.weekly.scorecard.multiThreadedBasis":
     "von {total} offenen Deals, in den letzten 30 Tagen",
-  "brief.weekly.scorecard.closeDateSound": "Abschlussdatum trägt",
+  "brief.weekly.scorecard.closeDateSound": "Bestätigtes Abschlussdatum",
   "brief.weekly.scorecard.forecastMoves": "Forecast hochgestuft",
   "brief.weekly.scorecard.forecastMovesBasis": "{down} herabgestuft",
   // Die kommende Woche. Der eingefrorene Rückblick sagt, was war; dies ist der

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2701,7 +2701,7 @@ export const en = {
   "brief.weekly.scorecard.multiThreaded": "More than one contact",
   "brief.weekly.scorecard.multiThreadedBasis":
     "of {total} open deals, in the last 30 days",
-  "brief.weekly.scorecard.closeDateSound": "Confirmed close date",
+  "brief.weekly.scorecard.closeDateSound": "Firm close date recorded",
   "brief.weekly.scorecard.forecastMoves": "Forecast upgrades",
   "brief.weekly.scorecard.forecastMovesBasis": "{down} downgraded",
   // The week ahead. The frozen review says what happened; this is the only part

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2701,7 +2701,7 @@ export const en = {
   "brief.weekly.scorecard.multiThreaded": "More than one contact",
   "brief.weekly.scorecard.multiThreadedBasis":
     "of {total} open deals, in the last 30 days",
-  "brief.weekly.scorecard.closeDateSound": "Close date holds up",
+  "brief.weekly.scorecard.closeDateSound": "Confirmed close date",
   "brief.weekly.scorecard.forecastMoves": "Forecast upgrades",
   "brief.weekly.scorecard.forecastMovesBasis": "{down} downgraded",
   // The week ahead. The frozen review says what happened; this is the only part

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2582,7 +2582,7 @@ export const vi = {
   "brief.weekly.scorecard.multiThreaded": "Nhiều hơn một liên hệ",
   "brief.weekly.scorecard.multiThreadedBasis":
     "trên {total} cơ hội đang mở, trong 30 ngày qua",
-  "brief.weekly.scorecard.closeDateSound": "Ngày chốt đáng tin",
+  "brief.weekly.scorecard.closeDateSound": "Ngày chốt đã xác nhận",
   "brief.weekly.scorecard.forecastMoves": "Nâng dự báo",
   "brief.weekly.scorecard.forecastMovesBasis": "{down} hạ dự báo",
   // Tuần tới. Bản tổng kết đã đóng băng nói điều đã xảy ra; đây là phần duy nhất

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2582,7 +2582,7 @@ export const vi = {
   "brief.weekly.scorecard.multiThreaded": "Nhiều hơn một liên hệ",
   "brief.weekly.scorecard.multiThreadedBasis":
     "trên {total} cơ hội đang mở, trong 30 ngày qua",
-  "brief.weekly.scorecard.closeDateSound": "Ngày chốt đã xác nhận",
+  "brief.weekly.scorecard.closeDateSound": "Đã ghi ngày chốt cố định",
   "brief.weekly.scorecard.forecastMoves": "Nâng dự báo",
   "brief.weekly.scorecard.forecastMovesBasis": "{down} hạ dự báo",
   // Tuần tới. Bản tổng kết đã đóng băng nói điều đã xảy ra; đây là phần duy nhất


### PR DESCRIPTION
Two weekly-review defects, both making the page say something the record does not support.

**The narrative could not see lead or meeting work.** Its counts held tasks, deals, proposals and brief interactions — but not the lead and meeting outcomes the scorecard reports on the same page. So a rep who spent the week answering new business and sitting in meetings reached the narrator as a row of zeros, and it wrote that nothing happened, beside a scorecard saying otherwise. The counts were already on the review row; the narrative simply could not read them. `quiet()` now reads all fifteen, which is what its own comment already claimed.

**"Close date holds up" described a field, not a judgement.** The rule is: a date is set, not provisional, and not in the past. It says nothing about whether the buyer agreed or whether the deal has gone silent — and the same audited morning that showed 7 of 7 sound was asking the rep to correct one of those dates because nothing had moved on it.

## From the review

Three findings, and the first was caused by my own fix:

**A truthful sentence would have been refused.** Widening the counts made every lead-only week non-quiet, which armed the contradiction guard against "nothing closed" — a sentence that is exactly right for a rep who routed four leads and moved no pipeline. The guard meant to stop the opposite lie would have rejected the truth. Whole-week claims and deal claims are now judged by the facts that settle each.

**"Confirmed close date" was a smaller version of the same overclaim.** `close_date_provisional` defaults to false, so a deal imported with a future date and never touched by anyone satisfies the rule. Nobody confirmed anything. It now reads "Firm close date recorded", which is what the rule measures.

**The certification corpus had no scenario for the week this change exists to describe.** Added one: six leads routed, five answered in target, three meetings, no deal movement — the shape that used to reach the narrator as zeros. It asserts the sentence may say no deal closed and may not call the week quiet.

## Verification

- `make check-backend` and `make check-fe` green (8453 frontend tests); `compose/weekly` lane green.
- Mutation-checked: reverting the widened `quiet()` fails all five lead/meeting cases.
- The new guard is tested in both directions — the truthful lead-only sentence is accepted, the false "quiet week" and the false "nothing closed" on a week with three wins are both still refused.
- `ai-certification` regenerated: the prompt moved, so the scores that certified the old one no longer certify this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The weekly review used to call a week of only leads and meetings "quiet" because its counts ignored those outcomes; it now reads all fifteen counts, so an SDR's busy week is described as the work it was. The scorecard label "Close date holds up" is now "Firm close date recorded" in all three locales, since the date rule measures field state, not buyer agreement.

- Deal-only claims like "nothing closed" are now judged against deal counts alone, so a lead-only week with no pipeline movement can truthfully say so.
- Whole-week claims like "quiet week" remain judged by every count, including the newly visible lead and meeting outcomes.
- Added a certification corpus scenario for a lead-and-meeting week; the narrative prompt moved, so the affected certification records are stale and need re-certification.

<sup>Written for commit 63512d2f32223b2c5ab624467a645ecb8473d063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly narratives now include routed leads, response performance, meetings held, and meetings with next steps.
  * Weeks with lead or meeting activity are no longer incorrectly described as quiet.
  * Narratives can distinguish between no deals closing and no activity occurring.

* **Documentation**
  * Added certification coverage for weeks with lead and meeting activity.

* **Style**
  * Refined the weekly scorecard’s “firm close date” wording in English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->