### PR TITLE
fix(weeklyplan): the capacity line prices the week the plan is about

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -36129,7 +36129,9 @@ components:
             Null and empty carry the same distinction as `risks`.
         capacity:
           description: |
-            What next week's calendar already holds, counted rather than authored.
+            What the PLANNED week's calendar already holds, counted rather than authored —
+            the same seven days `local_week_start` names, so the figure and the plan cannot
+            describe different weeks.
 
             ABSENT when the installation composed no calendar reader. Absent is NOT zero: a
             week nobody has looked at is unknown, and drawing it as "nothing booked" would

--- a/backend/internal/compose/integration/weeklyplancontract_integration_test.go
+++ b/backend/internal/compose/integration/weeklyplancontract_integration_test.go
@@ -119,7 +119,7 @@ func TestAnAbsentCapacitySeamLeavesCapacityAbsentNotZero(t *testing.T) {
 // exactly one thing: whether a reader is composed at all.
 type stubCapacity struct{ committed weeklyplan.Committed }
 
-func (s stubCapacity) NextWeek(_ context.Context, _ ids.UUID, _ time.Time) (weeklyplan.Committed, error) {
+func (s stubCapacity) ForWeek(_ context.Context, _ ids.UUID, _ time.Time) (weeklyplan.Committed, error) {
 	return s.committed, nil
 }
 

--- a/backend/internal/compose/integration/weeklyplancontract_integration_test.go
+++ b/backend/internal/compose/integration/weeklyplancontract_integration_test.go
@@ -117,9 +117,20 @@ func TestAnAbsentCapacitySeamLeavesCapacityAbsentNotZero(t *testing.T) {
 
 // stubCapacity answers a fixed load, so the test above and this one differ in
 // exactly one thing: whether a reader is composed at all.
-type stubCapacity struct{ committed weeklyplan.Committed }
+//
+// It RECORDS the week it was asked about. A stub that ignored the argument
+// would answer the same figure whichever week the store named, so a call site
+// passing the wrong one — the defect this seam was reshaped to end — would run
+// green through every test here.
+type stubCapacity struct {
+	committed weeklyplan.Committed
+	askedFor  *time.Time
+}
 
-func (s stubCapacity) ForWeek(_ context.Context, _ ids.UUID, _ time.Time) (weeklyplan.Committed, error) {
+func (s stubCapacity) ForWeek(_ context.Context, _ ids.UUID, weekStart time.Time) (weeklyplan.Committed, error) {
+	if s.askedFor != nil {
+		*s.askedFor = weekStart
+	}
 	return s.committed, nil
 }
 
@@ -202,8 +213,10 @@ func TestAClearedRiskIsTellableFromOneNeverWritten(t *testing.T) {
 // told it otherwise.
 func TestASavedContractStillCarriesTheCountedCapacity(t *testing.T) {
 	e := setupPlan(t)
+	var priced time.Time
 	e.store = e.store.WithCapacity(stubCapacity{
 		committed: weeklyplan.Committed{Meetings: 3, Tasks: 2},
+		askedFor:  &priced,
 	})
 
 	plan, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{
@@ -211,6 +224,12 @@ func TestASavedContractStillCarriesTheCountedCapacity(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	// The week PRICED is the week STORED. Read from the clock instead, the
+	// capacity line described a different seven days from the plan it sat on.
+	if !priced.Equal(plan.LocalWeekStart) {
+		t.Errorf("capacity priced the week of %s for a plan stored against %s",
+			priced.Format(time.DateOnly), plan.LocalWeekStart.Format(time.DateOnly))
 	}
 	if plan.Capacity == nil {
 		t.Fatal("a save must answer with the capacity a read would give, not omit it")

--- a/backend/internal/compose/weeklyplancapacity_integration_test.go
+++ b/backend/internal/compose/weeklyplancapacity_integration_test.go
@@ -31,7 +31,7 @@ var capacityClock = time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)
 // held meeting inside the window, which must not count: the week has not
 // happened, so a meeting with an outcome there is one somebody backdated, and
 // counting it would inflate a figure a rep plans against.
-func TestCapacityCountsOnlyBookedMeetingsInNextWeeksLocalWindow(t *testing.T) {
+func TestCapacityCountsOnlyBookedMeetingsInTheNamedWeeksLocalWindow(t *testing.T) {
 	e := integration.Setup(t)
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 
@@ -51,11 +51,53 @@ func TestCapacityCountsOnlyBookedMeetingsInNextWeeksLocalWindow(t *testing.T) {
 	// attributed to them; asking about Rep1 would count a week nobody booked
 	// and pass at zero whatever the window did.
 	seam := weeklyPlanCapacity{pool: e.Pool}
-	got, err := seam.NextWeek(rep, e.AdminUser, capacityClock)
+	// The week is NAMED by the caller, which is the plan's own
+	// local_week_start in production. Derived from the clock instead, the
+	// heading, the stored row and this line answered about three different
+	// sets of seven days.
+	nextWeek := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	got, err := seam.ForWeek(rep, e.AdminUser, nextWeek)
 	if err != nil {
-		t.Fatalf("reading next week's capacity: %v", err)
+		t.Fatalf("reading the named week's capacity: %v", err)
 	}
 	if got.Meetings != 1 {
 		t.Fatalf("one booked meeting falls in next week, got %d", got.Meetings)
+	}
+}
+
+// The seam prices the week it is GIVEN, not the one after today.
+//
+// The fixture is asymmetric on purpose: two meetings in the current week and
+// one in the next. A seam that ignored its argument and computed "next week"
+// would answer 1 whichever week it was asked about, and the assertion could not
+// tell the two apart — which is how the original defect survived, with the plan
+// stored against one week and priced against another.
+func TestCapacityPricesTheWeekItIsGiven(t *testing.T) {
+	e := integration.Setup(t)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+
+	bookMeeting(t, e, "This week — one", capacityClock.AddDate(0, 0, 1), "booked")
+	bookMeeting(t, e, "This week — two", capacityClock.AddDate(0, 0, 2), "booked")
+	bookMeeting(t, e, "Next week — one", time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC), "booked")
+
+	seam := weeklyPlanCapacity{pool: e.Pool}
+	thisWeek := time.Date(2026, 6, 8, 0, 0, 0, 0, time.UTC)
+	nextWeek := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+
+	current, err := seam.ForWeek(rep, e.AdminUser, thisWeek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Meetings != 2 {
+		t.Errorf("asked about the week of the 8th, counted %d meetings, want its two",
+			current.Meetings)
+	}
+	coming, err := seam.ForWeek(rep, e.AdminUser, nextWeek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if coming.Meetings != 1 {
+		t.Errorf("asked about the week of the 15th, counted %d meetings, want its one",
+			coming.Meetings)
 	}
 }

--- a/backend/internal/compose/weeklyplanseam.go
+++ b/backend/internal/compose/weeklyplanseam.go
@@ -57,8 +57,13 @@ type weeklyPlanCapacity struct{ pool *pgxpool.Pool }
 
 var _ weeklyplan.Capacity = weeklyPlanCapacity{}
 
-// NextWeek counts booked meetings and open tasks due in NEXT week's local
-// window — the week the plan being written is about, not the one being lived.
+// ForWeek counts booked meetings and open tasks due in ONE named week's local
+// window — the week the plan is about, which the caller names.
+//
+// Named rather than derived: this seam used to compute "next week" from the
+// clock, so a plan stored against the current week was priced against the week
+// after it, and the heading, the stored row and this line each answered about a
+// different seven days.
 //
 // Booked only, never held: this is a question about a week that has not
 // happened, so a meeting's outcome cannot be known and `held` there would mean
@@ -67,20 +72,15 @@ var _ weeklyplan.Capacity = weeklyPlanCapacity{}
 // The window is the LOCAL week resolved to instants, through weekly's own
 // WeekStartOf, so the plan and the review beside it agree about which seven
 // days these are.
-func (c weeklyPlanCapacity) NextWeek(
-	ctx context.Context, owner ids.UUID, now time.Time,
+func (c weeklyPlanCapacity) ForWeek(
+	ctx context.Context, owner ids.UUID, weekStart time.Time,
 ) (weeklyplan.Committed, error) {
 	var out weeklyplan.Committed
 	err := database.WithWorkspaceTx(ctx, c.pool, func(tx pgx.Tx) error {
-		thisWeek, err := weekly.WeekStartOf(ctx, tx, now)
-		if err != nil {
-			return err
-		}
 		zone, err := identity.TimezoneOf(ctx, tx)
 		if err != nil {
 			return err
 		}
-		nextWeek := thisWeek.AddDate(0, 0, 7)
 		// A calendar date carried as midnight UTC is the wrong shape for a
 		// range: comparing timestamptz against it measures a week offset by the
 		// installation's UTC offset, and across a DST change a fixed 168 hours
@@ -88,7 +88,7 @@ func (c weeklyPlanCapacity) NextWeek(
 		var start, end time.Time
 		if err := tx.QueryRow(ctx, `
 			SELECT ($1::date)::timestamp AT TIME ZONE $2,
-			       ($1::date + 7)::timestamp AT TIME ZONE $2`, nextWeek, zone).
+			       ($1::date + 7)::timestamp AT TIME ZONE $2`, weekStart, zone).
 			Scan(&start, &end); err != nil {
 			return fmt.Errorf("compose: bounding next week: %w", err)
 		}

--- a/backend/internal/compose/weeklyplanseam.go
+++ b/backend/internal/compose/weeklyplanseam.go
@@ -65,9 +65,11 @@ var _ weeklyplan.Capacity = weeklyPlanCapacity{}
 // after it, and the heading, the stored row and this line each answered about a
 // different seven days.
 //
-// Booked only, never held: this is a question about a week that has not
-// happened, so a meeting's outcome cannot be known and `held` there would mean
-// somebody backdated it. Canceled and no_show are absent for the same reason.
+// Booked only, never held. The question is what is COMMITTED — what a rep must
+// leave room for — and an outcome is not a commitment: a held meeting is time
+// already spent rather than time still owed, and counting it would price a week
+// against work that is finished. Canceled and no_show are absent for the same
+// reason, from the other side.
 //
 // The window is the LOCAL week resolved to instants, through weekly's own
 // WeekStartOf, so the plan and the review beside it agree about which seven

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -35673,7 +35673,9 @@ type WeeklyLearningCitationSubjectType string
 // WeeklyPlan One rep's week as they meant it to go — the forward counterpart to the frozen
 // WeeklyReview beside it.
 type WeeklyPlan struct {
-	// Capacity What next week's calendar already holds, counted rather than authored.
+	// Capacity What the PLANNED week's calendar already holds, counted rather than authored —
+	// the same seven days `local_week_start` names, so the figure and the plan cannot
+	// describe different weeks.
 	//
 	// ABSENT when the installation composed no calendar reader. Absent is NOT zero: a
 	// week nobody has looked at is unknown, and drawing it as "nothing booked" would

--- a/backend/internal/modules/weeklyplan/contract.go
+++ b/backend/internal/modules/weeklyplan/contract.go
@@ -124,7 +124,7 @@ func (s *Store) SetContract(ctx context.Context, now time.Time, in ContractEdit)
 	// own tables and the seam reads other modules'. Without this a successful
 	// save answers with no capacity at all, which a client reads as "no
 	// calendar composed" moments after a GET told it otherwise.
-	out.Capacity, err = s.capacityFor(ctx, owner, now)
+	out.Capacity, err = s.capacityFor(ctx, owner, out.LocalWeekStart)
 	if err != nil {
 		return Plan{}, err
 	}
@@ -200,9 +200,14 @@ func boundedOptional(field string, value *string) (*string, error) {
 // composed no calendar has an UNKNOWN week ahead, and drawing that as "no
 // meetings booked" would tell a rep their week is free when nothing has looked.
 type Capacity interface {
-	// NextWeek reports how much of the coming week is already committed, for
-	// the given rep, in the installation's reporting zone.
-	NextWeek(ctx context.Context, owner ids.UUID, now time.Time) (Committed, error)
+	// ForWeek reports how much of ONE week is already committed, for the given
+	// rep, in the installation's reporting zone.
+	//
+	// The week is named by the caller rather than derived here, and that is the
+	// whole point: the plan's own local_week_start is the week being planned,
+	// and a seam that computed "next week" for itself described a different
+	// seven days from the ones the plan was stored against.
+	ForWeek(ctx context.Context, owner ids.UUID, weekStart time.Time) (Committed, error)
 }
 
 // Committed is the count behind the capacity line.
@@ -226,19 +231,26 @@ func (s *Store) WithCapacity(c Capacity) *Store {
 	return s
 }
 
-// capacityFor reads next week's load, or reports it unknown.
+// capacityFor reads the load of the week the PLAN is about, or reports it
+// unknown.
+//
+// The week comes from the plan rather than from the clock. Read as "next week"
+// instead, the heading, the stored row and the capacity line answered about
+// three different sets of seven days: a plan created on Tuesday was stored
+// against the current week, called "next week" on the page, and priced against
+// the week after it.
 //
 // An unbound seam answers nil, and every caller must carry that through as
 // absent. This is the one place that decides it, so a surface cannot
 // accidentally substitute a zero.
-func (s *Store) capacityFor(ctx context.Context, owner ids.UUID, now time.Time) (*Committed, error) {
+func (s *Store) capacityFor(ctx context.Context, owner ids.UUID, weekStart time.Time) (*Committed, error) {
 	if s.capacity == nil {
-		//nolint:nilnil // no capacity seam composed means the week ahead is UNKNOWN, which a zero would misreport as free.
+		//nolint:nilnil // no capacity seam composed means the week is UNKNOWN, which a zero would misreport as free.
 		return nil, nil
 	}
-	committed, err := s.capacity.NextWeek(ctx, owner, now)
+	committed, err := s.capacity.ForWeek(ctx, owner, weekStart)
 	if err != nil {
-		return nil, fmt.Errorf("weeklyplan: reading next week's capacity: %w", err)
+		return nil, fmt.Errorf("weeklyplan: reading the planned week's capacity: %w", err)
 	}
 	return &committed, nil
 }

--- a/backend/internal/modules/weeklyplan/store.go
+++ b/backend/internal/modules/weeklyplan/store.go
@@ -248,7 +248,7 @@ func (s *Store) planForOwner(ctx context.Context, owner ids.UUID, now time.Time)
 	// Outside the transaction above: the seam reads other modules' tables and
 	// opens its own, and holding this one open across it would make a read of
 	// the plan wait on a read of the calendar.
-	plan.Capacity, err = s.capacityFor(ctx, owner, now)
+	plan.Capacity, err = s.capacityFor(ctx, owner, plan.LocalWeekStart)
 	if err != nil {
 		return Plan{}, err
 	}

--- a/backend/internal/platform/mailcopy/catalog.go
+++ b/backend/internal/platform/mailcopy/catalog.go
@@ -204,9 +204,9 @@ func weeklyMovementLines(line writeLine) {
 // list is written in.
 func weeklyClosingLines(line writeLine) {
 	line(func(c *Copy) *string { return &c.WeeklyPlanAhead },
-		"Plan next week",
-		"Nächste Woche planen",
-		"Lập kế hoạch tuần tới")
+		"Plan your week",
+		"Ihre Woche planen",
+		"Lập kế hoạch tuần của bạn")
 	line(func(c *Copy) *string { return &c.WeeklyFullWeek },
 		"The full week, and the ones before it:",
 		"Die ganze Woche, und die davor:",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -26486,7 +26486,9 @@ export interface components {
              */
             capacity_note?: string | null;
             /**
-             * @description What next week's calendar already holds, counted rather than authored.
+             * @description What the PLANNED week's calendar already holds, counted rather than authored —
+             *     the same seven days `local_week_start` names, so the figure and the plan cannot
+             *     describe different weeks.
              *
              *     ABSENT when the installation composed no calendar reader. Absent is NOT zero: a
              *     week nobody has looked at is unknown, and drawing it as "nothing booked" would

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2614,7 +2614,7 @@ export const de = {
   "brief.weekly.scorecard.forecastMovesBasis": "{down} herabgestuft",
   // Die kommende Woche. Der eingefrorene Rückblick sagt, was war; dies ist der
   // einzige Teil dieser Seite, den noch jemand ändern kann.
-  "plan.title": "Nächste Woche planen",
+  "plan.title": "Ihre Woche planen",
   // Der Kopf der sortierten Liste, auf der Seite, die zuerst geöffnet wird —
   // dieselben Zeilen wie in der Arbeitsliste, in der Reihenfolge des Servers.
   // Der Eröffnungssatz des Briefings, aus den Zeilen zusammengesetzt, die die
@@ -2753,8 +2753,8 @@ export const de = {
   "plan.contract.save": "Speichern",
   "plan.contract.cancel": "Abbrechen",
   "plan.contract.capacityLine":
-    "Nächste Woche hält bereits {meetings} Termine und {tasks} Aufgaben.",
-  "plan.contract.crowded": "Nächste Woche ist schon voll",
+    "Diese Woche hält bereits {meetings} Termine und {tasks} Aufgaben.",
+  "plan.contract.crowded": "Diese Woche ist schon voll",
   "plan.contract.crowdedBody":
     "{committed} Dinge sind bereits gebucht und Sie haben {commitments} Vorhaben notiert. Etwas wird weichen müssen.",
   "plan.help.ask": "Um Hilfe bitten",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2706,7 +2706,7 @@ export const en = {
   "brief.weekly.scorecard.forecastMovesBasis": "{down} downgraded",
   // The week ahead. The frozen review says what happened; this is the only part
   // of that page anybody can still change.
-  "plan.title": "Plan next week",
+  "plan.title": "Plan your week",
   // The head of the ranked queue, on the page a rep opens first. The same rows
   // the Worklist draws, in the order the server decided.
   // The Brief's opening sentence, composed from the rows the page is showing —
@@ -2847,8 +2847,8 @@ export const en = {
   "plan.contract.save": "Save",
   "plan.contract.cancel": "Cancel",
   "plan.contract.capacityLine":
-    "Next week already holds {meetings} meetings and {tasks} tasks.",
-  "plan.contract.crowded": "Next week is already full",
+    "That week already holds {meetings} meetings and {tasks} tasks.",
+  "plan.contract.crowded": "That week is already full",
   "plan.contract.crowdedBody":
     "{committed} things are already booked and you have written {commitments} commitments. Something will have to give.",
   "plan.help.ask": "Ask for help",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2587,7 +2587,7 @@ export const vi = {
   "brief.weekly.scorecard.forecastMovesBasis": "{down} hạ dự báo",
   // Tuần tới. Bản tổng kết đã đóng băng nói điều đã xảy ra; đây là phần duy nhất
   // của trang đó mà vẫn còn ai đó thay đổi được.
-  "plan.title": "Lập kế hoạch tuần tới",
+  "plan.title": "Lập kế hoạch tuần của bạn",
   // Phần đầu của danh sách đã xếp hạng, trên trang mở đầu tiên — cùng những
   // dòng mà Danh sách công việc hiển thị, theo thứ tự máy chủ đã quyết định.
   // Câu mở đầu của bản tóm tắt, ghép từ chính những dòng trang đang hiển thị —
@@ -2724,8 +2724,8 @@ export const vi = {
   "plan.contract.save": "Lưu",
   "plan.contract.cancel": "Hủy",
   "plan.contract.capacityLine":
-    "Tuần tới đã có {meetings} cuộc họp và {tasks} công việc.",
-  "plan.contract.crowded": "Tuần tới đã kín",
+    "Tuần đó đã có {meetings} cuộc họp và {tasks} công việc.",
+  "plan.contract.crowded": "Tuần đó đã kín",
   "plan.contract.crowdedBody":
     "{committed} việc đã được đặt và bạn đã ghi {commitments} cam kết. Sẽ phải bỏ bớt điều gì đó.",
   "plan.help.ask": "Nhờ giúp đỡ",


### PR DESCRIPTION
Three signals disagreed about which seven days a rep was planning. The panel said **"Plan next week"**. Clicking it stored a plan against the **current** week. The capacity line beside it counted meetings and tasks in the week **after that**.

## What changed

The seam computed "next week" from the clock, so it could only ever describe a week nobody had named. It now takes the week as an argument, and both callers pass the plan's own `local_week_start` — the row already knows which week it is about, and that is the only answer that cannot drift from the one being stored.

The copy stops naming a week the page does not choose: "Plan your week", and a capacity line saying "that week" rather than asserting which one. The page shows the plan's dates, so the words need not guess at them.

**A gate caught the mail copy**, which is paired to the panel's own wording — a reader with both open would have been told about their week in two vocabularies.

## From the review

No blocking findings. Codex confirmed the half I deliberately left alone: the weekly plan is the **current running week** per both the contract and the module reference, so keeping `weekStart(now)` in the writer — rather than advancing it — is correct, and making the capacity agree with it is the right direction of fix.

Three real-but-minor issues, all applied:

- The contract description still promised "next week's calendar", and the seam's comment still explained itself as a question about a week that has not happened. Both described what the change stopped being true. The comment now gives the reason that actually holds — a commitment is time still owed, and a held meeting is time already spent.
- **The store-level stub ignored its week argument**, so either call site could have passed the wrong one and run green through every test in that file. It records the week now, and the saved-contract test asserts the week priced is the week stored.

## Verification

- `make check-backend` and `make check-fe` green (8453 frontend tests); `compose` and `compose/integration` lanes green.
- Both guards mutation-checked. The seam test uses an asymmetric fixture — two meetings in one week, one in the other — so a seam ignoring its argument answers the same number for both, which is how the original defect survived. Mutating the call site to add seven days fails the store test with the exact original shape: a plan stored against the 8th, priced against the 15th.

Codex noted it could not run the integration suite from its sandbox, so its boundary-case observations are static; the lanes above were run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the weekly plan capacity line so it prices the same seven days the plan is stored against. Previously the heading said "Plan next week", the plan saved against the current week, and the capacity line counted the week after that; the seam now takes the week as an argument, both callers pass the plan's own `local_week_start`, and UI copy no longer names a week the page doesn't choose.

**Tests**
- The store-level stub now records the week it was asked about, and the saved-contract test asserts the priced week equals the stored week.
- A new asymmetric-fixture test catches a seam that ignores its argument.

<sup>Written for commit be27a5287e897c3d5d5e57e00307df257da5ee7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Weekly plan capacity is now calculated for the specific week being planned, ensuring stored plans show the correct booked meetings and open tasks.

* **Copy Updates**
  * Planning labels and capacity messages in English, German, and Vietnamese now refer to “your week” or the selected week instead of automatically referring to next week.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->