### PR TITLE
fix(compose): a settlement names the attempt that took the claim

### DIFF
--- a/backend/internal/compose/agentidempotency.go
+++ b/backend/internal/compose/agentidempotency.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -79,13 +81,17 @@ func (c agentClaims) Claim(ctx context.Context, tool, key, digest string) (agent
 	if err != nil {
 		return agents.Claim{}, err
 	}
-	outcome, stored, err := claimKey(ctx, c.pool, holder, key, mcpClaimEndpoint(tool), digest)
+	outcome, hold, stored, err := claimKey(ctx, c.pool, holder, key, mcpClaimEndpoint(tool), digest)
 	if err != nil {
 		return agents.Claim{}, err
 	}
 	switch outcome {
 	case claimFresh:
-		return agents.Claim{State: agents.ClaimFresh}, nil
+		// The attempt token travels back to the caller, which hands it to
+		// whichever settling verb ends the call. Only a FRESH claim carries
+		// one: every other verdict read somebody else's row and has nothing of
+		// its own to settle.
+		return agents.Claim{State: agents.ClaimFresh, Attempt: hold.attempt.String()}, nil
 	case claimInProgress:
 		return agents.Claim{State: agents.ClaimInFlight}, nil
 	case claimMismatch:
@@ -103,35 +109,58 @@ func (c agentClaims) Claim(ctx context.Context, tool, key, digest string) (agent
 
 // Settle records the sealed result, and what it cost the caller's read bound,
 // so a repeat of the same key answers with it at the same price.
-func (c agentClaims) Settle(ctx context.Context, tool, key string, result json.RawMessage, records int) error {
-	holder, err := claimHolder(ctx, "settling")
-	if err != nil {
+func (c agentClaims) Settle(ctx context.Context, tool, key, attempt string, result json.RawMessage, records int) error {
+	hold, err := c.holdFor(ctx, "settling", tool, key, attempt)
+	if err != nil || !hold.holdsClaim() {
 		return err
 	}
-	return recordClaimOutcome(ctx, c.pool, holder, key, mcpClaimEndpoint(tool),
+	return recordClaimOutcome(ctx, c.pool, hold,
 		mcpClaimSucceeded, string(result), mcpClaimContentType, records)
+}
+
+// holdFor rebuilds the hold a settling verb was handed.
+//
+// The attempt is the caller's token from Claim, and an unparseable or absent
+// one answers a hold that owns nothing — which the settling verbs treat as
+// "nothing to settle" rather than falling back to (principal, key, tool). That
+// fallback is the defect: those three do not name an attempt, because a key
+// past its replay window is re-claimed in place under the same three.
+func (c agentClaims) holdFor(ctx context.Context, verb, tool, key, attempt string) (claimHold, error) {
+	holder, err := claimHolder(ctx, verb)
+	if err != nil {
+		return claimHold{}, err
+	}
+	id, err := ids.Parse(attempt)
+	if err != nil {
+		// Not an error to the caller: a settlement naming no attempt has
+		// nothing to land on, and refusing the CALL over its bookkeeping would
+		// turn a lost claim into a lost result.
+		slog.WarnContext(ctx, "an idempotency settlement named no usable attempt; nothing was recorded",
+			"tool", tool, "verb", verb, "err", err)
+		return claimHold{}, nil
+	}
+	return claimHold{principalID: holder, key: key, endpoint: mcpClaimEndpoint(tool), attempt: id}, nil
 }
 
 // Fail records that the tool ran under this key and produced no result. The
 // reason is stored where a result would be, and a later attempt is told it
 // rather than being allowed to run again — see agents.Idempotency for why a
 // failed run is not a free key.
-func (c agentClaims) Fail(ctx context.Context, tool, key, reason string) error {
-	holder, err := claimHolder(ctx, "failing")
-	if err != nil {
+func (c agentClaims) Fail(ctx context.Context, tool, key, attempt, reason string) error {
+	hold, err := c.holdFor(ctx, "failing", tool, key, attempt)
+	if err != nil || !hold.holdsClaim() {
 		return err
 	}
 	// No records: nothing was handed over, so there is nothing a replay of it
 	// could cost — and it will never be replayed in any case.
-	return recordClaimOutcome(ctx, c.pool, holder, key, mcpClaimEndpoint(tool),
-		mcpClaimFailed, reason, mcpClaimContentType, 0)
+	return recordClaimOutcome(ctx, c.pool, hold, mcpClaimFailed, reason, mcpClaimContentType, 0)
 }
 
 // Release gives back a key whose call never ran.
-func (c agentClaims) Release(ctx context.Context, tool, key string) error {
-	holder, err := claimHolder(ctx, "releasing")
-	if err != nil {
+func (c agentClaims) Release(ctx context.Context, tool, key, attempt string) error {
+	hold, err := c.holdFor(ctx, "releasing", tool, key, attempt)
+	if err != nil || !hold.holdsClaim() {
 		return err
 	}
-	return releaseClaim(ctx, c.pool, holder, key, mcpClaimEndpoint(tool))
+	return releaseClaim(ctx, c.pool, hold)
 }

--- a/backend/internal/compose/agentidempotency_integration_test.go
+++ b/backend/internal/compose/agentidempotency_integration_test.go
@@ -50,15 +50,19 @@ func TestAToolsRetryKeyRunsItsCallOnceAndReplaysTheResult(t *testing.T) {
 	ctx := agentCtxAs(e, "agent:"+ids.NewV7().String())
 	recorded := json.RawMessage(`{"schema_version":"1.0.0","evidence":[],"data":{"sent":true}}`)
 
-	if first := claimState(ctx, t, claims, "send_email", "k-1", "digest-a"); first.State != agents.ClaimFresh {
+	first := claimState(ctx, t, claims, "send_email", "k-1", "digest-a")
+	if first.State != agents.ClaimFresh {
 		t.Fatalf("the first claim = %v, want fresh", first.State)
+	}
+	if first.Attempt == "" {
+		t.Fatal("a fresh claim named no attempt, so nothing can settle it")
 	}
 	// Before the first attempt settles, a concurrent retry must not run: the
 	// claim row is written insert-first precisely so the loser sees it.
 	if inFlight := claimState(ctx, t, claims, "send_email", "k-1", "digest-a"); inFlight.State != agents.ClaimInFlight {
 		t.Fatalf("a retry mid-flight = %v, want in-flight", inFlight.State)
 	}
-	if err := claims.Settle(ctx, "send_email", "k-1", recorded, 3); err != nil {
+	if err := claims.Settle(ctx, "send_email", "k-1", first.Attempt, recorded, 3); err != nil {
 		t.Fatalf("settle: %v", err)
 	}
 
@@ -81,10 +85,11 @@ func TestAToolsRetryKeyRefusesADifferentCall(t *testing.T) {
 	claims := toolIdempotency(e.Pool)
 	ctx := agentCtxAs(e, "agent:"+ids.NewV7().String())
 
-	if first := claimState(ctx, t, claims, "update_record", "k-2", "digest-a"); first.State != agents.ClaimFresh {
+	first := claimState(ctx, t, claims, "update_record", "k-2", "digest-a")
+	if first.State != agents.ClaimFresh {
 		t.Fatalf("the first claim = %v, want fresh", first.State)
 	}
-	if err := claims.Settle(ctx, "update_record", "k-2", json.RawMessage(`{"data":{}}`), 1); err != nil {
+	if err := claims.Settle(ctx, "update_record", "k-2", first.Attempt, json.RawMessage(`{"data":{}}`), 1); err != nil {
 		t.Fatalf("settle: %v", err)
 	}
 	// Same key, different arguments. Replaying the first result here would
@@ -107,10 +112,11 @@ func TestAReleasedKeyIsClaimableAgain(t *testing.T) {
 	claims := toolIdempotency(e.Pool)
 	ctx := agentCtxAs(e, "agent:"+ids.NewV7().String())
 
-	if first := claimState(ctx, t, claims, "archive_record", "k-3", "digest-a"); first.State != agents.ClaimFresh {
+	first := claimState(ctx, t, claims, "archive_record", "k-3", "digest-a")
+	if first.State != agents.ClaimFresh {
 		t.Fatalf("the first claim = %v, want fresh", first.State)
 	}
-	if err := claims.Release(ctx, "archive_record", "k-3"); err != nil {
+	if err := claims.Release(ctx, "archive_record", "k-3", first.Attempt); err != nil {
 		t.Fatalf("release: %v", err)
 	}
 	if again := claimState(ctx, t, claims, "archive_record", "k-3", "digest-a"); again.State != agents.ClaimFresh {
@@ -127,11 +133,11 @@ func TestReleasingASettledKeyDoesNotDiscardItsResult(t *testing.T) {
 	ctx := agentCtxAs(e, "agent:"+ids.NewV7().String())
 	recorded := json.RawMessage(`{"schema_version":"1.0.0","evidence":[],"data":{"sent":true}}`)
 
-	claimState(ctx, t, claims, "send_email", "k-4", "digest-a")
-	if err := claims.Settle(ctx, "send_email", "k-4", recorded, 2); err != nil {
+	held := claimState(ctx, t, claims, "send_email", "k-4", "digest-a")
+	if err := claims.Settle(ctx, "send_email", "k-4", held.Attempt, recorded, 2); err != nil {
 		t.Fatalf("settle: %v", err)
 	}
-	if err := claims.Release(ctx, "send_email", "k-4"); err != nil {
+	if err := claims.Release(ctx, "send_email", "k-4", held.Attempt); err != nil {
 		t.Fatalf("release: %v", err)
 	}
 	replay := claimState(ctx, t, claims, "send_email", "k-4", "digest-a")
@@ -167,7 +173,7 @@ func TestOneKeyIsThreeDifferentClaims(t *testing.T) {
 	// And the REST door. The endpoint spelling is what keeps a tool's key out of
 	// a request path's; this proves the two really do write different rows.
 	actor, _ := principal.Actor(agentA)
-	outcome, _, err := claimKey(agentA, e.Pool, actor.ID, key, "POST /v1/offer-templates", "digest-a")
+	outcome, _, _, err := claimKey(agentA, e.Pool, actor.ID, key, "POST /v1/offer-templates", "digest-a")
 	if err != nil {
 		t.Fatalf("the REST claim failed: %v", err)
 	}
@@ -184,10 +190,11 @@ func TestAFailedRunIsRecordedAndItsKeyIsNotReusable(t *testing.T) {
 	claims := toolIdempotency(e.Pool)
 	ctx := agentCtxAs(e, "agent:"+ids.NewV7().String())
 
-	if first := claimState(ctx, t, claims, "create_record", "k-5", "digest-a"); first.State != agents.ClaimFresh {
-		t.Fatalf("the first claim = %v, want fresh", first.State)
+	ran := claimState(ctx, t, claims, "create_record", "k-5", "digest-a")
+	if ran.State != agents.ClaimFresh {
+		t.Fatalf("the first claim = %v, want fresh", ran.State)
 	}
-	if err := claims.Fail(ctx, "create_record", "k-5", "it conflicted with another change"); err != nil {
+	if err := claims.Fail(ctx, "create_record", "k-5", ran.Attempt, "it conflicted with another change"); err != nil {
 		t.Fatalf("fail: %v", err)
 	}
 
@@ -219,13 +226,13 @@ func TestAClaimWithNoPrincipalIsRefused(t *testing.T) {
 			if _, err := claims.Claim(tc.ctx, "send_email", "k-6", "digest-a"); err == nil {
 				t.Fatal("the claim was taken")
 			}
-			if err := claims.Settle(tc.ctx, "send_email", "k-6", json.RawMessage(`{}`), 0); err == nil {
+			if err := claims.Settle(tc.ctx, "send_email", "k-6", ids.NewV7().String(), json.RawMessage(`{}`), 0); err == nil {
 				t.Fatal("the settlement was written")
 			}
-			if err := claims.Fail(tc.ctx, "send_email", "k-6", "why"); err == nil {
+			if err := claims.Fail(tc.ctx, "send_email", "k-6", ids.NewV7().String(), "why"); err == nil {
 				t.Fatal("the failure was written")
 			}
-			if err := claims.Release(tc.ctx, "send_email", "k-6"); err == nil {
+			if err := claims.Release(tc.ctx, "send_email", "k-6", ids.NewV7().String()); err == nil {
 				t.Fatal("the release ran")
 			}
 		})

--- a/backend/internal/compose/idempotency.go
+++ b/backend/internal/compose/idempotency.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -116,7 +117,7 @@ func idempotency(pool *pgxpool.Pool, probes map[string]replayProbe) func(http.Ha
 			// key per request-path, so /deals/A and /deals/B never collide.
 			endpoint := r.Method + " " + r.URL.Path
 
-			outcome, stored, err := claimKey(r.Context(), pool, actor.ID, key, endpoint, digest)
+			outcome, hold, stored, err := claimKey(r.Context(), pool, actor.ID, key, endpoint, digest)
 			if err != nil {
 				// Degraded, not refused: idempotency is a retry-safety layer,
 				// and refusing the request because the layer itself hiccupped
@@ -124,7 +125,10 @@ func idempotency(pool *pgxpool.Pool, probes map[string]replayProbe) func(http.Ha
 				// all. The tool surface REFUSES instead, and the two are
 				// reasoned about together in claimKey's own comment.
 				slog.ErrorContext(r.Context(), "idempotency claim failed; executing without replay protection", "err", err)
-				outcome, stored = claimFresh, storedResponse{}
+				// And no hold: executing without replay protection means there
+				// is nothing to settle, so the settle below writes nothing
+				// rather than writing under three columns it does not own.
+				outcome, hold, stored = claimFresh, claimHold{}, storedResponse{}
 			}
 			if outcome != claimFresh {
 				writeClaimOutcome(w, r, pool, probes, route, outcome, stored)
@@ -139,7 +143,7 @@ func idempotency(pool *pgxpool.Pool, probes map[string]replayProbe) func(http.Ha
 			next.ServeHTTP(rec, r.WithContext(ctx))
 			// Zero records: this door charges no read bound, so its claims carry
 			// no cost to record (0198).
-			if err := settleClaim(r.Context(), pool, actor.ID, key, endpoint,
+			if err := settleClaim(r.Context(), pool, hold,
 				rec.status, rec.buf.String(), rec.Header().Get("Content-Type"), 0, effect.committed); err != nil {
 				slog.ErrorContext(r.Context(), "idempotency claim settlement failed", "err", err)
 			}
@@ -219,39 +223,79 @@ type storedResponse struct {
 // (agents.Registry.claimFor). A caller reading claimFresh from this function
 // must therefore check err first: fresh with an error means no claim was
 // acquired.
-func claimKey(ctx context.Context, pool *pgxpool.Pool, principalID, key, endpoint, digest string) (claimOutcome, storedResponse, error) {
+func claimKey(ctx context.Context, pool *pgxpool.Pool, principalID, key, endpoint, digest string) (claimOutcome, claimHold, storedResponse, error) {
 	outcome := claimFresh
+	var hold claimHold
 	var stored storedResponse
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
-		claimed, err := insertClaim(ctx, tx, principalID, key, endpoint, digest)
+		attempt, claimed, err := insertClaim(ctx, tx, principalID, key, endpoint, digest)
 		if err != nil {
 			return err
 		}
 		if claimed {
+			hold = claimHold{principalID: principalID, key: key, endpoint: endpoint, attempt: attempt}
 			return nil // fresh claim
 		}
-		outcome, stored, err = resolveExistingClaim(ctx, tx, principalID, key, endpoint, digest)
+		var reclaimed ids.UUID
+		outcome, reclaimed, stored, err = resolveExistingClaim(ctx, tx, principalID, key, endpoint, digest)
+		hold = claimHold{principalID: principalID, key: key, endpoint: endpoint, attempt: reclaimed}
 		return err
 	})
 	if err != nil {
-		return claimFresh, storedResponse{}, err
+		return claimFresh, claimHold{}, storedResponse{}, err
 	}
-	return outcome, stored, nil
+	return outcome, hold, stored, nil
 }
+
+// claimHold names the ATTEMPT that took a claim, and is what every settlement
+// is predicated on.
+//
+// The row is identified by (principal, key, endpoint), and that was the whole
+// identity a settle or a release matched. But the row is RE-CLAIMED in place
+// once past the replay window — new digest, cleared response, same three
+// columns — so an attempt still in flight when its claim expired could settle
+// the replacement's row: overwriting a result a later replay serves for the
+// wrong call, or deleting a live claim and letting a third attempt run beside
+// the second.
+//
+// A zero attempt means this caller holds nothing to settle: it read somebody
+// else's claim rather than taking one. Every settle and release refuses such a
+// hold outright rather than falling back to the three columns, because falling
+// back is the behaviour being removed.
+type claimHold struct {
+	principalID string
+	key         string
+	endpoint    string
+	attempt     ids.UUID
+}
+
+// holdsClaim reports whether this hold names an attempt of its own.
+func (h claimHold) holdsClaim() bool { return h.attempt != ids.Nil }
 
 // insertClaim writes the claim row insert-first and reports whether THIS
 // attempt is the one that claimed the key: false means a row for the same
 // (workspace, principal, key, endpoint) already exists.
-func insertClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string) (bool, error) {
-	tag, err := tx.Exec(ctx, `
+func insertClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string) (ids.UUID, bool, error) {
+	// RETURNING, so the attempt id comes from the row rather than from a value
+	// this function chose and hoped matched. A settlement is predicated on it,
+	// and a predicate compared against something the writer only believes was
+	// stored is not a predicate.
+	var attempt ids.UUID
+	err := tx.QueryRow(ctx, `
 		INSERT INTO idempotency_key (principal_id, key, endpoint, request_digest)
 		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (principal_id, key, endpoint) DO NOTHING`,
-		principalID, key, endpoint, digest)
-	if err != nil {
-		return false, err
+		ON CONFLICT (principal_id, key, endpoint) DO NOTHING
+		RETURNING attempt_id`,
+		principalID, key, endpoint, digest).Scan(&attempt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// DO NOTHING fired: a row for this key already exists and this attempt
+		// did not claim it.
+		return ids.Nil, false, nil
 	}
-	return tag.RowsAffected() == 1, nil
+	if err != nil {
+		return ids.Nil, false, err
+	}
+	return attempt, true, nil
 }
 
 // resolveExistingClaim decides what an already-claimed key means for this
@@ -259,7 +303,7 @@ func insertClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, dig
 // the same key reused for a different body, or — past the replay window — a
 // re-claim in place. The row is read FOR UPDATE inside the caller's
 // transaction, so two concurrent attempts under one key cannot both execute.
-func resolveExistingClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string) (claimOutcome, storedResponse, error) {
+func resolveExistingClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string) (claimOutcome, ids.UUID, storedResponse, error) {
 	return resolveClaimRow(ctx, tx, principalID, key, endpoint, digest, true)
 }
 
@@ -267,7 +311,7 @@ func resolveExistingClaim(ctx context.Context, tx pgx.Tx, principalID, key, endp
 // second pass — the one that reads back what a rival left after this attempt
 // lost the re-claim — so a row that vanishes twice inside one transaction
 // cannot loop.
-func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string, mayReclaim bool) (claimOutcome, storedResponse, error) {
+func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string, mayReclaim bool) (claimOutcome, ids.UUID, storedResponse, error) {
 	var storedDigest, contentType string
 	var status *int
 	var respBody *string
@@ -290,14 +334,14 @@ func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint,
 			// The row went twice inside one transaction. Nothing is left to
 			// read, and in-flight is the answer that costs least if wrong:
 			// it tells the caller to retry rather than inventing a result.
-			return claimInProgress, storedResponse{}, nil
+			return claimInProgress, ids.Nil, storedResponse{}, nil
 		}
-		claimed, err := insertClaim(ctx, tx, principalID, key, endpoint, digest)
+		attempt, claimed, err := insertClaim(ctx, tx, principalID, key, endpoint, digest)
 		if err != nil {
-			return claimFresh, storedResponse{}, err
+			return claimFresh, ids.Nil, storedResponse{}, err
 		}
 		if claimed {
-			return claimFresh, storedResponse{}, nil
+			return claimFresh, attempt, storedResponse{}, nil
 		}
 		// A rival re-created it in the same instant. What they left is not
 		// necessarily in flight — it may already carry a stored response, or a
@@ -312,18 +356,23 @@ func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint,
 		return resolveClaimRow(ctx, tx, principalID, key, endpoint, digest, false)
 	}
 	if err != nil {
-		return claimFresh, storedResponse{}, err
+		return claimFresh, ids.Nil, storedResponse{}, err
 	}
 	if expired {
-		// Past the retention window the key means nothing anymore:
-		// re-claim it in place for this attempt.
-		_, err := tx.Exec(ctx, `
+		// Past the retention window the key means nothing anymore: re-claim it
+		// in place for this attempt, under a NEW attempt id. That id is what
+		// stops the previous holder — still in flight, or it would not be
+		// returning — from settling the row it no longer owns.
+		var reclaimed ids.UUID
+		err := tx.QueryRow(ctx, `
 			UPDATE idempotency_key
 			SET request_digest = $4, response_status = NULL, response_body = NULL,
-			    response_content_type = DEFAULT, response_records = DEFAULT, created_at = now()
-			WHERE principal_id = $1 AND key = $2 AND endpoint = $3`,
-			principalID, key, endpoint, digest)
-		return claimFresh, storedResponse{}, err
+			    response_content_type = DEFAULT, response_records = DEFAULT,
+			    created_at = now(), attempt_id = uuidv7()
+			WHERE principal_id = $1 AND key = $2 AND endpoint = $3
+			RETURNING attempt_id`,
+			principalID, key, endpoint, digest).Scan(&reclaimed)
+		return claimFresh, reclaimed, storedResponse{}, err
 	}
 	stored := storedResponse{contentType: contentType, records: records}
 	if respBody != nil {
@@ -331,9 +380,9 @@ func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint,
 	}
 	switch {
 	case storedDigest != digest:
-		return claimMismatch, storedResponse{}, nil
+		return claimMismatch, ids.Nil, storedResponse{}, nil
 	case status == nil:
-		return claimInProgress, storedResponse{}, nil
+		return claimInProgress, ids.Nil, storedResponse{}, nil
 	case *status < 200 || *status >= 300:
 		// A RECORDED failure — the attempt reached its handler and answered a
 		// refusal it could not take back. The tool surface writes one for a run
@@ -343,10 +392,10 @@ func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint,
 		// the recording could not determine, so the body carries the reason and
 		// the caller decides.
 		stored.status = *status
-		return claimFailed, stored, nil
+		return claimFailed, ids.Nil, stored, nil
 	default:
 		stored.status = *status
-		return claimReplay, stored, nil
+		return claimReplay, ids.Nil, stored, nil
 	}
 }
 
@@ -364,13 +413,20 @@ func resolveClaimRow(ctx context.Context, tx pgx.Tx, principalID, key, endpoint,
 //
 // Only one door reports a write today (the per-field split's staging half), so
 // the released path is still what every other refusal takes.
-func settleClaim(ctx context.Context, pool *pgxpool.Pool, principalID, key, endpoint string,
+func settleClaim(ctx context.Context, pool *pgxpool.Pool, hold claimHold,
 	status int, body, contentType string, records int, wrote bool,
 ) error {
-	if claimIsReleased(status, wrote) {
-		return releaseClaim(ctx, pool, principalID, key, endpoint)
+	// A caller that took no claim settles nothing. It reached here after
+	// reading somebody else's row — a replay, a mismatch, or an infrastructure
+	// failure the door degraded past — and writing under those three columns
+	// would be settling an attempt that is not this one.
+	if !hold.holdsClaim() {
+		return nil
 	}
-	return recordClaimOutcome(ctx, pool, principalID, key, endpoint, status, body, contentType, records)
+	if claimIsReleased(status, wrote) {
+		return releaseClaim(ctx, pool, hold)
+	}
+	return recordClaimOutcome(ctx, pool, hold, status, body, contentType, records)
 }
 
 // claimIsReleased is the rule a refusal is judged by: a key goes back only for
@@ -386,15 +442,19 @@ func claimIsReleased(status int, wrote bool) bool {
 // recordClaimOutcome writes a settled response onto a held claim, whatever that
 // response says. settleClaim reaches it for a success; failClaim reaches it for
 // a run that produced none.
-func recordClaimOutcome(ctx context.Context, pool *pgxpool.Pool, principalID, key, endpoint string,
+func recordClaimOutcome(ctx context.Context, pool *pgxpool.Pool, hold claimHold,
 	status int, body, contentType string, records int,
 ) error {
 	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		// attempt_id, so a settlement lands only on the attempt that made it.
+		// Without it a holder whose claim expired mid-flight would overwrite
+		// the REPLACEMENT's recorded result, and a later replay would serve the
+		// wrong call's document under a key that looks settled.
 		_, err := tx.Exec(ctx, `
 			UPDATE idempotency_key
-			SET response_status = $4, response_body = $5, response_content_type = $6, response_records = $7
-			WHERE principal_id = $1 AND key = $2 AND endpoint = $3`,
-			principalID, key, endpoint, status, body, contentType, records)
+			SET response_status = $5, response_body = $6, response_content_type = $7, response_records = $8
+			WHERE principal_id = $1 AND key = $2 AND endpoint = $3 AND attempt_id = $4`,
+			hold.principalID, hold.key, hold.endpoint, hold.attempt, status, body, contentType, records)
 		return err
 	})
 }
@@ -403,12 +463,17 @@ func recordClaimOutcome(ctx context.Context, pool *pgxpool.Pool, principalID, ke
 // claim with no recorded response is released: a settled one is a result
 // somebody may still replay, and deleting it here would turn a completed call
 // into one that executes a second time.
-func releaseClaim(ctx context.Context, pool *pgxpool.Pool, principalID, key, endpoint string) error {
+func releaseClaim(ctx context.Context, pool *pgxpool.Pool, hold claimHold) error {
 	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		// attempt_id here for the harder half of the same reason: a stale
+		// release DELETES a live claim, and the key is then free while the
+		// attempt holding it is still running — so a third attempt executes
+		// beside the second, which is the one thing the key exists to prevent.
 		_, err := tx.Exec(ctx, `
 			DELETE FROM idempotency_key
-			WHERE principal_id = $1 AND key = $2 AND endpoint = $3 AND response_status IS NULL`,
-			principalID, key, endpoint)
+			WHERE principal_id = $1 AND key = $2 AND endpoint = $3 AND attempt_id = $4
+			  AND response_status IS NULL`,
+			hold.principalID, hold.key, hold.endpoint, hold.attempt)
 		return err
 	})
 }

--- a/backend/internal/compose/idempotencyreclaim_integration_test.go
+++ b/backend/internal/compose/idempotencyreclaim_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // reclaimVerdict runs the read-back pass — the one that reports what a rival
@@ -34,7 +35,7 @@ func reclaimVerdict(t *testing.T, e *integration.Env, principalID, key, digest s
 	t.Helper()
 	var got claimOutcome
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		outcome, _, err := resolveClaimRow(context.Background(), tx, principalID, key, "POST /v1/people", digest, false)
+		outcome, _, _, err := resolveClaimRow(context.Background(), tx, principalID, key, "POST /v1/people", digest, false)
 		got = outcome
 		return err
 	}); err != nil {
@@ -96,5 +97,75 @@ func TestAClaimThatVanishesTwiceStopsRatherThanLooping(t *testing.T) {
 	e := integration.Setup(t)
 	if got := reclaimVerdict(t, e, "human:"+ids.NewV7().String(), ids.NewV7().String(), "digest"); got != claimInProgress {
 		t.Errorf("a claim with no row at all reports %v, want claimInProgress", got)
+	}
+}
+
+// A settlement from an attempt whose claim EXPIRED writes nothing.
+//
+// The claim row is identified by (principal, key, endpoint), and that was the
+// whole identity a settle or a release matched. But the row is re-claimed in
+// place once past the replay window — new digest, cleared response, same three
+// columns — so a first attempt still in flight when its claim expired could
+// return and settle the replacement's row. Two harms, and both are asserted
+// here: it would overwrite a result a later replay serves for the wrong call,
+// and it would delete a live claim, letting a third attempt run beside the
+// second.
+//
+// The window is narrow — an attempt has to outlive the replay window, and both
+// transports are bounded far below it — which is why the fix is a predicate
+// rather than a lock. attempt_id is stamped fresh on the claim and on the
+// re-claim, so a settlement names the attempt that made it or names nothing.
+func TestASettlementFromAnExpiredAttemptWritesNothing(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+	actor, _ := principal.Actor(ctx)
+	const key, endpoint, digest = "k-expired", "POST /v1/people", "digest-first"
+
+	// The first attempt takes the key and is still running.
+	_, stale, _, err := claimKey(ctx, e.Pool, actor.ID, key, endpoint, digest)
+	if err != nil {
+		t.Fatalf("the first claim failed: %v", err)
+	}
+
+	// Its claim ages past the replay window while it runs.
+	e.WsExec(t, `UPDATE idempotency_key SET created_at = now() - interval '48 hours' WHERE key = $1`, key)
+
+	// A second attempt re-claims the key in place, under a new attempt id.
+	outcome, live, _, err := claimKey(ctx, e.Pool, actor.ID, key, endpoint, "digest-second")
+	if err != nil {
+		t.Fatalf("the re-claim failed: %v", err)
+	}
+	if outcome != claimFresh {
+		t.Fatalf("re-claiming an expired key = %v, want fresh", outcome)
+	}
+	if live.attempt == stale.attempt {
+		t.Fatal("the re-claim kept the previous attempt's id, so the two are indistinguishable")
+	}
+
+	// Now the FIRST attempt returns and settles. It must write nothing.
+	if err := settleClaim(ctx, e.Pool, stale, 200, `{"stale":true}`, "application/json", 0, true); err != nil {
+		t.Fatalf("the stale settlement errored: %v", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM idempotency_key WHERE key = $1 AND response_status IS NULL`, key); n != 1 {
+		t.Error("a stale settlement recorded a result on the replacement's claim — a later replay would " +
+			"answer the wrong call's document under a key that looks settled")
+	}
+
+	// And its release must not free the live claim either.
+	if err := settleClaim(ctx, e.Pool, stale, 409, `{"code":"conflict"}`, "application/json", 0, false); err != nil {
+		t.Fatalf("the stale release errored: %v", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM idempotency_key WHERE key = $1`, key); n != 1 {
+		t.Error("a stale release deleted the replacement's live claim — the key is free while the " +
+			"attempt holding it is still running, so a third attempt executes beside it")
+	}
+
+	// The live attempt still settles, which is what makes the above a
+	// predicate rather than a lock.
+	if err := settleClaim(ctx, e.Pool, live, 200, `{"live":true}`, "application/json", 0, true); err != nil {
+		t.Fatalf("the live settlement errored: %v", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM idempotency_key WHERE key = $1 AND response_status = 200`, key); n != 1 {
+		t.Error("the attempt that holds the claim could not settle it")
 	}
 }

--- a/backend/internal/modules/agents/idempotency.go
+++ b/backend/internal/modules/agents/idempotency.go
@@ -73,6 +73,16 @@ const (
 type Claim struct {
 	State  ClaimState
 	Result json.RawMessage
+	// Attempt names THIS attempt's hold on the key, opaque here and meaningful
+	// to the store. It travels back on every settlement so a settle or a
+	// release lands on the attempt that made it: a key past its replay window
+	// is re-claimed in place, so the same (principal, key, tool) can name a
+	// DIFFERENT attempt by the time a slow caller returns.
+	//
+	// Empty for every state but Fresh: a caller that did not take the key has
+	// nothing to settle, and the store refuses a settlement that names no
+	// attempt rather than falling back to the key.
+	Attempt string
 	// Records is what the recorded answer was charged against the read bound
 	// when it was produced. A replay of it costs the same (see chargeReplay).
 	Records int
@@ -94,11 +104,17 @@ type Idempotency interface {
 	Claim(ctx context.Context, tool, key, digest string) (Claim, error)
 	// Settle records a successful result, and the number of records it hands
 	// over, so a replay of it costs the caller what the call cost.
-	Settle(ctx context.Context, tool, key string, result json.RawMessage, records int) error
+	//
+	// attempt is the token Claim answered with. The three settling verbs take
+	// it rather than re-deriving the row from (tool, key), because that triple
+	// does not name an attempt: a key past its replay window is re-claimed in
+	// place, and a settlement matched on the triple alone can land on somebody
+	// else's live claim.
+	Settle(ctx context.Context, tool, key, attempt string, result json.RawMessage, records int) error
 	// Fail records that the tool ran under this key and produced no result.
-	Fail(ctx context.Context, tool, key, reason string) error
+	Fail(ctx context.Context, tool, key, attempt, reason string) error
 	// Release gives an unrun key back, so the caller may retry it.
-	Release(ctx context.Context, tool, key string) error
+	Release(ctx context.Context, tool, key, attempt string) error
 }
 
 // WithIdempotency installs the claim store that makes `idempotency_key` mean
@@ -130,12 +146,12 @@ func WithReplayReader(reader ReplayReader) RegistryOption {
 // `send_email` — the exact call whose response was lost, and the most
 // irreversible act on this surface — dies on the consumed approval and never
 // reaches the result the first attempt recorded.
-func (r *Registry) claimFor(ctx context.Context, spec mcp.ToolSpec, res reserved) (fresh bool, out json.RawMessage, records int, err error) {
+func (r *Registry) claimFor(ctx context.Context, spec mcp.ToolSpec, res reserved) (fresh bool, attempt string, out json.RawMessage, records int, err error) {
 	if res.RetryKey == "" {
-		return true, nil, 0, nil
+		return true, "", nil, 0, nil
 	}
 	if err := r.refuseUnkeyableCall(spec); err != nil {
-		return false, nil, 0, err
+		return false, "", nil, 0, err
 	}
 	claim, err := r.claims.Claim(ctx, spec.Name, res.RetryKey, res.DiffHash)
 	if err != nil {
@@ -144,22 +160,22 @@ func (r *Registry) claimFor(ctx context.Context, spec mcp.ToolSpec, res reserved
 		// promise the retry then discovers was never kept.
 		slog.ErrorContext(ctx, "the idempotency claim failed; refusing the call rather than running it unprotected",
 			"tool", spec.Name, "err", err)
-		return false, nil, 0, fmt.Errorf(
+		return false, "", nil, 0, fmt.Errorf(
 			"%s could not be made safe to retry just now, so it was not run; retry the identical call: %w",
 			spec.Name, apperrors.ErrConflict)
 	}
 	switch claim.State {
 	case ClaimFresh:
-		return true, nil, 0, nil
+		return true, claim.Attempt, nil, 0, nil
 	case ClaimReplay:
 		out, err := r.replay(ctx, spec, claim)
-		return false, out, claim.Records, err
+		return false, "", out, claim.Records, err
 	case ClaimInFlight:
-		return false, nil, 0, fmt.Errorf(
+		return false, "", nil, 0, fmt.Errorf(
 			"an earlier %s call with this idempotency_key has not finished yet; wait for it rather than "+
 				"repeating it: %w", spec.Name, apperrors.ErrConflict)
 	case ClaimMismatch:
-		return false, nil, 0, fmt.Errorf(
+		return false, "", nil, 0, fmt.Errorf(
 			"this idempotency_key was already used for a DIFFERENT %s call; send a new key to make this "+
 				"call, or repeat the original arguments to read its result: %w", spec.Name, apperrors.ErrConflict)
 	case ClaimFailed:
@@ -167,14 +183,14 @@ func (r *Registry) claimFor(ctx context.Context, spec mcp.ToolSpec, res reserved
 		// attempt reached the tool, so whether it took effect is exactly what
 		// this surface does not know — and a fresh key here would be a second
 		// attempt at something that may already have happened.
-		return false, nil, 0, fmt.Errorf(
+		return false, "", nil, 0, fmt.Errorf(
 			"an earlier %s call with this idempotency_key failed after it had already started, so it may or "+
 				"may not have taken effect (%s); check the record before retrying under a NEW key: %w",
 			spec.Name, claim.Reason, apperrors.ErrConflict)
 	default:
 		// A state this switch does not know cannot be resolved into "safe to
 		// run", so it is refused rather than guessed at.
-		return false, nil, 0, fmt.Errorf("crmagents: unknown idempotency claim state %d: %w", claim.State, apperrors.ErrConflict)
+		return false, "", nil, 0, fmt.Errorf("crmagents: unknown idempotency claim state %d: %w", claim.State, apperrors.ErrConflict)
 	}
 }
 
@@ -238,20 +254,20 @@ func (r *Registry) unitOwnedTool(name string) bool {
 // committed — create_record commits the row and then reads it back — so "the
 // call returned an error" is not "nothing happened", and freeing the key there
 // is how one key creates two records.
-func (r *Registry) settleRun(ctx context.Context, spec mcp.ToolSpec, res reserved, out json.RawMessage, records int, runErr error) {
+func (r *Registry) settleRun(ctx context.Context, spec mcp.ToolSpec, res reserved, attempt string, out json.RawMessage, records int, runErr error) {
 	if res.RetryKey == "" {
 		return
 	}
 	book := context.WithoutCancel(ctx)
 	if runErr != nil {
-		if err := r.claims.Fail(book, spec.Name, res.RetryKey, safeFailureReason(runErr)); err != nil {
+		if err := r.claims.Fail(book, spec.Name, res.RetryKey, attempt, safeFailureReason(runErr)); err != nil {
 			slog.ErrorContext(book, "recording a failed call against its idempotency key failed; a retry of "+
 				"this key will report it as still in flight",
 				"tool", spec.Name, "err", err)
 		}
 		return
 	}
-	if err := r.claims.Settle(book, spec.Name, res.RetryKey, out, records); err != nil {
+	if err := r.claims.Settle(book, spec.Name, res.RetryKey, attempt, out, records); err != nil {
 		slog.ErrorContext(book, "recording a completed call for replay failed; a retry of this key will "+
 			"report it as still in flight rather than answering",
 			"tool", spec.Name, "err", err)
@@ -288,12 +304,12 @@ func safeFailureReason(err error) string {
 // BEFORE the tool ran — today, a refused approval redemption. Nothing else may
 // use it: for any failure at or after the handler, whether an effect landed is
 // exactly what this surface cannot know.
-func (r *Registry) releaseUnrunKey(ctx context.Context, spec mcp.ToolSpec, res reserved) {
+func (r *Registry) releaseUnrunKey(ctx context.Context, spec mcp.ToolSpec, res reserved, attempt string) {
 	if res.RetryKey == "" {
 		return
 	}
 	book := context.WithoutCancel(ctx)
-	if err := r.claims.Release(book, spec.Name, res.RetryKey); err != nil {
+	if err := r.claims.Release(book, spec.Name, res.RetryKey, attempt); err != nil {
 		slog.ErrorContext(book, "releasing an unrun call's idempotency claim failed; the key stays held "+
 			"until the retention sweep reaches it", "tool", spec.Name, "err", err)
 	}

--- a/backend/internal/modules/agents/idempotency_test.go
+++ b/backend/internal/modules/agents/idempotency_test.go
@@ -42,6 +42,12 @@ type recordingClaims struct {
 	failCtxLive   bool
 }
 
+// freshAttempt is the token a fresh claim answers with in these cases. Named
+// because every settlement below asserts on it: the point of the token is that
+// a settlement can name the WRONG attempt, so a case that did not say which one
+// it named would prove nothing about it.
+const freshAttempt = "01a08000-0000-7000-8000-00000000beef"
+
 func (c *recordingClaims) Claim(_ context.Context, tool, key, digest string) (Claim, error) {
 	c.claimed = append(c.claimed, tool+"/"+key+"/"+digest)
 	if c.claimErr != nil {
@@ -50,21 +56,24 @@ func (c *recordingClaims) Claim(_ context.Context, tool, key, digest string) (Cl
 	return c.verdict, nil
 }
 
-func (c *recordingClaims) Settle(ctx context.Context, tool, key string, result json.RawMessage, records int) error {
-	c.settled = append(c.settled, tool+"/"+key)
+func (c *recordingClaims) Settle(ctx context.Context, tool, key, attempt string, result json.RawMessage, records int) error {
+	// The attempt rides the recorded string, so every case below states which
+	// attempt a settlement named — the whole point of the token is that a
+	// settlement can name the wrong one.
+	c.settled = append(c.settled, tool+"/"+key+"@"+attempt)
 	c.stored, c.storedRecords = result, records
 	c.settleCtxLive = ctx.Err() == nil
 	return c.settleErr
 }
 
-func (c *recordingClaims) Fail(ctx context.Context, tool, key, reason string) error {
-	c.failed = append(c.failed, tool+"/"+key+": "+reason)
+func (c *recordingClaims) Fail(ctx context.Context, tool, key, attempt, reason string) error {
+	c.failed = append(c.failed, tool+"/"+key+"@"+attempt+": "+reason)
 	c.failCtxLive = ctx.Err() == nil
 	return c.failErr
 }
 
-func (c *recordingClaims) Release(_ context.Context, tool, key string) error {
-	c.released = append(c.released, tool+"/"+key)
+func (c *recordingClaims) Release(_ context.Context, tool, key, attempt string) error {
+	c.released = append(c.released, tool+"/"+key+"@"+attempt)
 	return c.releaseErr
 }
 
@@ -163,7 +172,7 @@ func (f *retryFixture) invoke(t *testing.T, args string) (json.RawMessage, error
 
 func TestAFreshClaimRunsTheToolAndRecordsItsResult(t *testing.T) {
 	f := newRetryFixture(t)
-	f.claims.verdict = Claim{State: ClaimFresh}
+	f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 
 	out, err := f.invoke(t, `{"idempotency_key":"k-1","note":"hi"}`)
 	if err != nil {
@@ -172,7 +181,7 @@ func TestAFreshClaimRunsTheToolAndRecordsItsResult(t *testing.T) {
 	if f.tool.runs != 1 {
 		t.Fatalf("the tool ran %d times, want 1", f.tool.runs)
 	}
-	if len(f.claims.settled) != 1 || f.claims.settled[0] != "send_email/k-1" {
+	if len(f.claims.settled) != 1 || f.claims.settled[0] != "send_email/k-1@"+freshAttempt {
 		t.Fatalf("settled = %v", f.claims.settled)
 	}
 	if len(f.claims.released) != 0 {
@@ -429,7 +438,7 @@ func TestAClaimStoreFailureRefusesTheCallRatherThanRunningItUnprotected(t *testi
 // happened", and giving the key back there is how one key creates two records.
 func TestAFailedRunKeepsItsKeyRatherThanInvitingASecondAttempt(t *testing.T) {
 	f := newRetryFixture(t)
-	f.claims.verdict = Claim{State: ClaimFresh}
+	f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 	f.tool.fail = fmt.Errorf("the provider refused the write: %w", apperrors.ErrConflict)
 
 	if _, err := f.invoke(t, `{"idempotency_key":"k-1"}`); err == nil {
@@ -446,7 +455,7 @@ func TestAFailedRunKeepsItsKeyRatherThanInvitingASecondAttempt(t *testing.T) {
 	}
 	// The recorded reason is the SENTINEL's words, not the refusal's own prose:
 	// it is stored for the window and handed to whoever presents the key next.
-	if got := f.claims.failed[0]; got != "send_email/k-1: it conflicted with another change" {
+	if got := f.claims.failed[0]; got != "send_email/k-1@"+freshAttempt+": it conflicted with another change" {
 		t.Fatalf("recorded %q — a stored reason must not carry the refusal's own text", got)
 	}
 }
@@ -479,7 +488,7 @@ func TestARetryOfAFailedRunIsToldToCheckBeforeUsingANewKey(t *testing.T) {
 func TestBookkeepingFailuresNeverChangeWhatTheCallerIsTold(t *testing.T) {
 	t.Run("settling fails after a successful call", func(t *testing.T) {
 		f := newRetryFixture(t)
-		f.claims.verdict = Claim{State: ClaimFresh}
+		f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 		f.claims.settleErr = errors.New("the update failed")
 		out, err := f.invoke(t, `{"idempotency_key":"k-1"}`)
 		if err != nil {
@@ -491,7 +500,7 @@ func TestBookkeepingFailuresNeverChangeWhatTheCallerIsTold(t *testing.T) {
 	})
 	t.Run("recording a failed run fails", func(t *testing.T) {
 		f := newRetryFixture(t)
-		f.claims.verdict = Claim{State: ClaimFresh}
+		f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 		f.tool.fail = errors.New("the provider refused the write")
 		f.claims.failErr = errors.New("the update failed")
 		_, err := f.invoke(t, `{"idempotency_key":"k-1"}`)
@@ -503,7 +512,7 @@ func TestBookkeepingFailuresNeverChangeWhatTheCallerIsTold(t *testing.T) {
 		f, approvals := approvedRetryFixture(t)
 		approvals.redeemErr = fmt.Errorf("not yours: %w", apperrors.ErrApprovalTokenInvalid)
 		f.claims.releaseErr = errors.New("the delete failed")
-		f.claims.verdict = Claim{State: ClaimFresh}
+		f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 		_, err := f.invoke(t, `{"idempotency_key":"k-1","approval_id":"`+ids.NewV7().String()+`"}`)
 		if !errors.Is(err, apperrors.ErrApprovalTokenInvalid) {
 			t.Fatalf("err = %v, want the redemption's own refusal", err)
@@ -627,7 +636,7 @@ func TestTheRetryOfAnApprovedCallReplaysInsteadOfRedeemingTwice(t *testing.T) {
 	approval := ids.NewV7()
 	call := `{"idempotency_key":"k-1","approval_id":"` + approval.String() + `"}`
 
-	f.claims.verdict = Claim{State: ClaimFresh}
+	f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 	first, err := f.invoke(t, call)
 	if err != nil {
 		t.Fatalf("the approved call: %v", err)
@@ -659,7 +668,7 @@ func TestTheRetryOfAnApprovedCallReplaysInsteadOfRedeemingTwice(t *testing.T) {
 func TestARefusedRedemptionGivesTheKeyBack(t *testing.T) {
 	f, approvals := approvedRetryFixture(t)
 	approvals.redeemErr = fmt.Errorf("that approval is not yours: %w", apperrors.ErrApprovalTokenInvalid)
-	f.claims.verdict = Claim{State: ClaimFresh}
+	f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 
 	_, err := f.invoke(t, `{"idempotency_key":"k-1","approval_id":"`+ids.NewV7().String()+`"}`)
 	if !errors.Is(err, apperrors.ErrApprovalTokenInvalid) {
@@ -696,7 +705,7 @@ func TestAStagedCallHoldsNoKey(t *testing.T) {
 func TestTheRunIsRecordedEvenWhenTheCallerIsGone(t *testing.T) {
 	t.Run("a completed run", func(t *testing.T) {
 		f := newRetryFixture(t)
-		f.claims.verdict = Claim{State: ClaimFresh}
+		f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 		ctx, cancel := context.WithCancel(f.ctx)
 		f.ctx = ctx
 		f.tool.onHandle = cancel // the client hangs up mid-call
@@ -713,7 +722,7 @@ func TestTheRunIsRecordedEvenWhenTheCallerIsGone(t *testing.T) {
 	})
 	t.Run("a failed run", func(t *testing.T) {
 		f := newRetryFixture(t)
-		f.claims.verdict = Claim{State: ClaimFresh}
+		f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 		ctx, cancel := context.WithCancel(f.ctx)
 		f.ctx = ctx
 		f.tool.onHandle = cancel
@@ -808,7 +817,7 @@ func TestAReplayCostsWhatTheCallCostAndNotWhatItCanName(t *testing.T) {
 	f := newRetryFixture(t)
 	same := ids.NewV7()
 	f.tool.records = []ids.UUID{same, same, ids.NewV7()} // one record served twice
-	f.claims.verdict = Claim{State: ClaimFresh}
+	f.claims.verdict = Claim{State: ClaimFresh, Attempt: freshAttempt}
 
 	out, err := f.invoke(t, `{"idempotency_key":"k-1"}`)
 	if err != nil {

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -218,7 +218,7 @@ func (r *Registry) InvokeServing(ctx context.Context, name string, in json.RawMe
 // approval it already spent. Redemption comes second, so a refused redemption
 // gives the key straight back — nothing ran.
 func (r *Registry) runClaimed(ctx context.Context, t mcp.Tool, spec mcp.ToolSpec, res reserved) (json.RawMessage, int, error) {
-	fresh, answered, records, err := r.claimFor(ctx, spec, res)
+	fresh, attempt, answered, records, err := r.claimFor(ctx, spec, res)
 	if !fresh {
 		// A replay hands over the records the ORIGINAL call was charged for, and
 		// claimFor has already re-proven and re-charged them. The COUNT still
@@ -229,10 +229,10 @@ func (r *Registry) runClaimed(ctx context.Context, t mcp.Tool, spec mcp.ToolSpec
 	}
 	redeemed, err := r.redeemPresented(ctx, spec, res)
 	if err != nil {
-		r.releaseUnrunKey(ctx, spec, res)
+		r.releaseUnrunKey(ctx, spec, res, attempt)
 		return nil, 0, err
 	}
-	return r.handle(redeemed, t, spec, res)
+	return r.handle(redeemed, t, spec, res, attempt)
 }
 
 // redeemPresented consumes the approval a retry asserts, and answers the
@@ -261,9 +261,9 @@ func (r *Registry) redeemPresented(ctx context.Context, spec mcp.ToolSpec, res r
 // handle runs an admitted call, seals its answer, and records what a claimed
 // retry key produced — this is the one place that knows both that the tool RAN
 // and what it answered with.
-func (r *Registry) handle(ctx context.Context, t mcp.Tool, spec mcp.ToolSpec, res reserved) (json.RawMessage, int, error) {
+func (r *Registry) handle(ctx context.Context, t mcp.Tool, spec mcp.ToolSpec, res reserved, attempt string) (json.RawMessage, int, error) {
 	sealed, records, err := r.runAndSeal(ctx, t, spec, res.Args)
-	r.settleRun(ctx, spec, res, sealed, records, err)
+	r.settleRun(ctx, spec, res, attempt, sealed, records, err)
 	return sealed, records, err
 }
 

--- a/backend/migrations/core/1788890886_a_settlement_names_the_attempt_that_claimed.down.sql
+++ b/backend/migrations/core/1788890886_a_settlement_names_the_attempt_that_claimed.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE idempotency_key DROP COLUMN attempt_id;

--- a/backend/migrations/core/1788890886_a_settlement_names_the_attempt_that_claimed.up.sql
+++ b/backend/migrations/core/1788890886_a_settlement_names_the_attempt_that_claimed.up.sql
@@ -1,0 +1,25 @@
+-- A settlement names the attempt that took the claim.
+--
+-- The claim row is identified by (principal_id, key, endpoint), and that is the
+-- whole identity a settle or a release matched on. But the row is RE-CLAIMED in
+-- place once it is past the replay window: the digest is overwritten and the
+-- recorded response cleared, for a new attempt, under the same three columns.
+--
+-- So a first attempt still in flight when its claim expired could return and
+-- settle the REPLACEMENT's row — overwriting a result a later replay would then
+-- serve for the wrong call, or deleting a live claim and letting a third
+-- attempt run beside the second.
+--
+-- attempt_id is what a settlement is predicated on. It is stamped fresh on both
+-- the insert and the re-claim, so the two attempts never share one, and a
+-- settlement whose attempt is gone writes nothing.
+-- uuidv7() is volatile, so this ADD COLUMN rewrites the table under an ACCESS
+-- EXCLUSIVE lock rather than taking the metadata-only path a constant default
+-- gets. That is affordable HERE and nowhere by default: idempotency_key holds
+-- only keys inside the replay window, because the retention sweep deletes the
+-- rest, so the rewrite is over a bounded table and not a growing one. The
+-- timeout bounds the wait for the lock, not the hold.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE idempotency_key
+    ADD COLUMN attempt_id uuid NOT NULL DEFAULT uuidv7();

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2799,6 +2799,7 @@ public.graph_interaction_edge.person_id uuid NOT NULL gen=- def=-
 public.graph_interaction_edge.user_id uuid NOT NULL gen=- def=-
 public.graph_interaction_edge_pkey CREATE UNIQUE INDEX graph_interaction_edge_pkey ON public.graph_interaction_edge USING btree (user_id, person_id)
 public.idempotency_key acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
+public.idempotency_key.attempt_id uuid NOT NULL gen=- def=uuidv7()
 public.idempotency_key.created_at timestamp with time zone NOT NULL gen=- def=now()
 public.idempotency_key.endpoint text NOT NULL gen=- def=-
 public.idempotency_key.idempotency_key_pkey PRIMARY KEY (principal_id, key, endpoint)


### PR DESCRIPTION
Closes #649.

## The defect

An idempotency claim row is identified by `(principal_id, key, endpoint)`, and that was the whole identity a settle or a release matched on. But `resolveClaimRow` re-claims the row **in place** once it is past the replay window — digest overwritten, recorded response cleared, `created_at` reset — under those same three columns.

So an attempt still in flight when its own claim expired can return and settle the *replacement's* row. Two harms:

- a stale **settle** overwrites a result a later replay then serves for the wrong call, under a key that looks settled;
- a stale **release** deletes a live claim, and the key is free while the attempt holding it is still running — so a third attempt executes beside the second, which is the one thing the key exists to prevent.

## The fix

The ticket's shape: an epoch on the claim row.

`idempotency_key.attempt_id` is stamped fresh on the insert and again on the re-claim, and is **returned from the row** rather than chosen by the writer and hoped to match — a predicate compared against a value the writer only believes was stored is not a predicate. The caller carries it in a `claimHold`, and `recordClaimOutcome` and `releaseClaim` are both predicated on it. A settlement whose attempt is gone writes nothing.

A hold that names no attempt settles nothing at all rather than falling back to the three columns — that is the replay path, the mismatch path, and the door that degrades past a failed claim. Falling back is the behaviour being removed.

The window is narrow: an attempt has to outlive the replay window, and both transports are bounded far below it. That is why this is a predicate and not a lock — it costs one column in the `WHERE`, and the live attempt still settles normally.

The agent tool surface takes the same widening: `agents.Claim` carries the attempt, and `Settle`/`Fail`/`Release` on the `Idempotency` interface take it, so the tool door cannot settle a claim it no longer holds either.

## The migration

`ADD COLUMN attempt_id uuid NOT NULL DEFAULT uuidv7()`. `uuidv7()` is volatile, so this rewrites the table rather than taking the metadata-only path a constant default gets — affordable **here** and nowhere by default, because the retention sweep keeps `idempotency_key` to the replay window, so the rewrite is over a bounded table. Both halves carry `SET LOCAL lock_timeout = '3s'`; `head_catalog.txt` is regenerated in the same commit.

## Test

`TestASettlementFromAnExpiredAttemptWritesNothing` (compose, real Postgres): claim a key, age the row past the window, let a second attempt re-claim it in place, then have the **first** hold settle and release. Asserts the replacement's claim is neither recorded on nor deleted — and that the live hold still settles, which is what makes this a predicate rather than a lock.

Mutation-checked. Replacing `AND attempt_id = $4` with a tautology fails the test in `recordClaimOutcome` and in `releaseClaim` independently, each on its own assertion.

## Checks

`make check-backend` green; `make craft-static` 0/0/0; `go test -count=1 ./gates` green; compose, migrations and agents integration suites green.