### PR TITLE
fix(weekly): a meeting belongs to whoever hosted it, not whoever filed it

### DIFF
--- a/backend/internal/compose/weekly/meetingattribution_test.go
+++ b/backend/internal/compose/weekly/meetingattribution_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+// "This meeting is that rep's" is spelled once.
+//
+// Two panels ask it — the headline count and the lead funnel — and they sit on
+// one page. Spelled separately they drift, and a meeting credited to different
+// people by two panels is the page contradicting itself about the same week,
+// which is the defect the shared predicate was extracted to end.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Held by: this test, named in meetingIsTheirsSQL's own doc comment.
+func TestTheMeetingAttributionHasOneSpelling(t *testing.T) {
+	t.Parallel()
+	// The shape a second, hand-written spelling takes: the host column tested
+	// against the recorder column in one predicate.
+	handWritten := regexp.MustCompile(`host_user_id[\s\S]{0,120}captured_by`)
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package: %v", err)
+	}
+	var scanned int
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		scanned++
+		if name == "weeklycounts.go" {
+			// The one permitted spelling, in the helper itself.
+			continue
+		}
+		if hit := handWritten.FindString(string(body)); hit != "" {
+			t.Errorf("%s writes the meeting attribution by hand (%q) — call "+
+				"meetingIsTheirsSQL so both panels credit one meeting to one person",
+				name, strings.Join(strings.Fields(hit), " "))
+		}
+	}
+	// A census that reads nothing reports PASS with nothing to notice.
+	if scanned < 8 {
+		t.Fatalf("scanned %d files of this package, below its size — the walk lost its source", scanned)
+	}
+}

--- a/backend/internal/compose/weekly/weekly_integration_test.go
+++ b/backend/internal/compose/weekly/weekly_integration_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/weekly/narrative"
 	"github.com/margince/margince/backend/internal/modules/deals"
@@ -415,5 +417,94 @@ func TestTheWriterRefusesProseTheColumnCannotHold(t *testing.T) {
 	}
 	if err := e.engine.Narrate(e.repCtx, review.ID, atCeiling+"ü", weekClock); err == nil {
 		t.Error("the writer accepted prose past the column's ceiling")
+	}
+}
+
+// A meeting is the HOST's, whoever filed it.
+//
+// Read by captured_by alone, a meeting a colleague minuted or a calendar
+// connector imported counted for whoever recorded it rather than the rep who
+// sat in it — so the same meeting moved between reps' weeks depending on how it
+// reached the CRM, and a rep whose calendar syncs automatically showed none.
+func TestTheWeekCountsMeetingsByHostRatherThanByWhoFiledThem(t *testing.T) {
+	e := setupWeekly(t)
+	owner := integration.OwnerConn(t)
+	inWeek := weekClock.AddDate(0, 0, -3)
+
+	// Hosted by Rep1, filed by somebody else: the connector-import shape.
+	integration.SeedIDRow(t, owner, `
+		INSERT INTO activity (id, kind, subject, occurred_at, meeting_status,
+		                      host_user_id, source, captured_by)
+		VALUES ($1, 'meeting', 'Imported', $2, 'held', $3, 'manual', 'human:someone-else')`,
+		inWeek, e.Rep1)
+	// Hosted by a colleague. Without it the fixture reads 1 either way, and the
+	// assertion could not tell host attribution from capturer attribution.
+	integration.SeedIDRow(t, owner, `
+		INSERT INTO activity (id, kind, subject, occurred_at, meeting_status,
+		                      host_user_id, source, captured_by)
+		VALUES ($1, 'meeting', 'Not mine', $2, 'held', $3, 'manual', 'human:someone-else')`,
+		inWeek, e.Rep2)
+
+	review, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if review.Counts.MeetingsHeld != 1 {
+		t.Errorf("counted %d meetings held for a rep who hosted one of the two, want 1",
+			review.Counts.MeetingsHeld)
+	}
+}
+
+// A task raised after the week closed is not what the meeting produced.
+//
+// "Left a next step" joins a task to a meeting through a shared record, and the
+// join had a lower bound only — so a task created weeks later on the same
+// account credited a meeting that had nothing to do with it, and a review of a
+// closed week changed its answer every time somebody added a task.
+func TestAMeetingsNextStepMustBeRaisedInsideTheWeek(t *testing.T) {
+	e := setupWeekly(t)
+	owner := integration.OwnerConn(t)
+	inWeek := weekClock.AddDate(0, 0, -3)
+
+	meeting := integration.SeedIDRow(t, owner, `
+		INSERT INTO activity (id, kind, subject, occurred_at, meeting_status,
+		                      host_user_id, source, captured_by)
+		VALUES ($1, 'meeting', 'The meeting', $2, 'held', $3, 'manual', 'human:x')`,
+		inWeek, e.Rep1)
+	// A meeting is with a PERSON — the schema refuses a company link, and says
+	// the company sees it through them — so the shared record the join runs
+	// over is the attendee.
+	person := integration.SeedIDRow(t, owner,
+		`INSERT INTO person (id, full_name, source, captured_by)
+		 VALUES ($1, 'The attendee', 'manual', 'human:x')`)
+	linkToPerson(t, owner, meeting, person)
+
+	// Raised AFTER the week closed, on the same account. Real work, and not
+	// this meeting's outcome.
+	late := integration.SeedIDRow(t, owner, `
+		INSERT INTO activity (id, kind, subject, occurred_at, created_at,
+		                      assignee_id, source, captured_by)
+		VALUES ($1, 'task', 'Weeks later', $2, $2, $3, 'manual', 'human:x')`,
+		weekClock.AddDate(0, 0, 14), e.Rep1)
+	linkToPerson(t, owner, late, person)
+
+	review, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if review.Counts.MeetingsWithNextStep != 0 {
+		t.Errorf("a task raised after the week closed credited the meeting with a next step (%d)",
+			review.Counts.MeetingsWithNextStep)
+	}
+}
+
+// linkToPerson files one activity under a person, which is how a meeting and
+// the task that follows it are related — there is no meeting_id on a task.
+func linkToPerson(t *testing.T, owner *pgx.Conn, activity, person ids.UUID) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(), `
+		INSERT INTO activity_link (activity_id, entity_type, person_id)
+		VALUES ($1, 'person', $2)`, activity, person); err != nil {
+		t.Fatalf("linking the activity to its person: %v", err)
 	}
 }

--- a/backend/internal/compose/weekly/weekly_integration_test.go
+++ b/backend/internal/compose/weekly/weekly_integration_test.go
@@ -435,15 +435,15 @@ func TestTheWeekCountsMeetingsByHostRatherThanByWhoFiledThem(t *testing.T) {
 	integration.SeedIDRow(t, owner, `
 		INSERT INTO activity (id, kind, subject, occurred_at, meeting_status,
 		                      host_user_id, source, captured_by)
-		VALUES ($1, 'meeting', 'Imported', $2, 'held', $3, 'manual', 'human:someone-else')`,
-		inWeek, e.Rep1)
+		VALUES ($1, 'meeting', 'Imported', $2, 'held', $3, 'manual', 'human:' || $4::text)`,
+		inWeek, e.Rep1, e.Rep3)
 	// Hosted by a colleague. Without it the fixture reads 1 either way, and the
 	// assertion could not tell host attribution from capturer attribution.
 	integration.SeedIDRow(t, owner, `
 		INSERT INTO activity (id, kind, subject, occurred_at, meeting_status,
 		                      host_user_id, source, captured_by)
-		VALUES ($1, 'meeting', 'Not mine', $2, 'held', $3, 'manual', 'human:someone-else')`,
-		inWeek, e.Rep2)
+		VALUES ($1, 'meeting', 'Not mine', $2, 'held', $3, 'manual', 'human:' || $4::text)`,
+		inWeek, e.Rep2, e.Rep3)
 
 	review, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
 	if err != nil {
@@ -452,6 +452,18 @@ func TestTheWeekCountsMeetingsByHostRatherThanByWhoFiledThem(t *testing.T) {
 	if review.Counts.MeetingsHeld != 1 {
 		t.Errorf("counted %d meetings held for a rep who hosted one of the two, want 1",
 			review.Counts.MeetingsHeld)
+	}
+	// The other side of the same question, in the same test: the person who
+	// FILED both meetings hosted neither, and must be credited with none. A
+	// broken NULL-guard in the fallback would show up here and nowhere else.
+	filer := e.As(e.Rep3, []ids.UUID{e.Team1}, integration.AdminPerms)
+	theirs, _, err := e.engine.AssembleFor(filer, weekClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if theirs.Counts.MeetingsHeld != 0 {
+		t.Errorf("the rep who only recorded the meetings was credited with %d of them",
+			theirs.Counts.MeetingsHeld)
 	}
 }
 

--- a/backend/internal/compose/weekly/weeklycounts.go
+++ b/backend/internal/compose/weekly/weeklycounts.go
@@ -187,11 +187,20 @@ func countWeekLeads(
 // twice across two reps' weeks.
 //
 // "Left a next step" is a task raised AFTER the meeting against a record the
-// meeting was also filed under — through the shared record rather than a direct
-// pointer, because there is no meeting_id on a task. Bounded at BOTH ends: a
-// task created months later on the same account is not something the meeting
-// produced, and one created after the week closed belongs to the week it was
-// created in.
+// meeting was also filed under. Through the SHARED RECORD rather than
+// activity.source_activity_id, which does exist: only some writers populate it
+// — the transcript accept path names the meeting it read, a task typed by hand
+// names nothing — so joining on it would report a rep who writes their own
+// follow-ups as having produced none.
+//
+// Bounded at BOTH ends. A task created months later on the same account is not
+// something the meeting produced, and one created after the week closed belongs
+// to the week it was created in — a frozen review that changed its answer every
+// time somebody added a task would not be frozen.
+//
+// The heuristic is what the data supports, and it is a heuristic: a task raised
+// the Monday after a Friday meeting is plausibly its outcome and is not counted
+// here. Tightening that needs source_activity_id on every writer first.
 func countWeekMeetings(
 	ctx context.Context, tx pgx.Tx, userID ids.UUID, start, end time.Time,
 ) (held, withNextStep int, err error) {

--- a/backend/internal/compose/weekly/weeklycounts.go
+++ b/backend/internal/compose/weekly/weeklycounts.go
@@ -172,13 +172,26 @@ func countWeekLeads(
 // A booking cancelled or no-showed is not a conversation the week can be
 // credited with, so only `held` counts.
 //
-// Attributed by captured_by, because a meeting has no owner: the
-// activity_task_fields CHECK reserves assignee_id for tasks, so filtering
-// meetings by it would match nothing and report every rep as having held none.
+// Attributed by HOST, falling back to the capturer only where no host is
+// recorded.
+//
+// assignee_id is reserved for tasks by the activity_task_fields CHECK, so it
+// cannot answer here — but host_user_id can, and it names the person whose
+// meeting it was rather than the person or connector that filed it. Read by
+// capturer alone, a meeting a colleague minuted or a calendar connector
+// imported counted for whoever recorded it and not for the rep who sat in it,
+// so the same meeting moved between reps depending on how it reached the CRM.
+//
+// The fallback is bounded to rows with NO host: a meeting that names one is
+// that person's, and letting the capturer also claim it would count one meeting
+// twice across two reps' weeks.
 //
 // "Left a next step" is a task raised AFTER the meeting against a record the
 // meeting was also filed under — through the shared record rather than a direct
-// pointer, because there is no meeting_id on a task.
+// pointer, because there is no meeting_id on a task. Bounded at BOTH ends: a
+// task created months later on the same account is not something the meeting
+// produced, and one created after the week closed belongs to the week it was
+// created in.
 func countWeekMeetings(
 	ctx context.Context, tx pgx.Tx, userID ids.UUID, start, end time.Time,
 ) (held, withNextStep int, err error) {
@@ -186,12 +199,15 @@ func countWeekMeetings(
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	startPos, endPos := arg(start), arg(end)
 	capturedPos := arg("human:" + userID.String())
+	hostPos := arg(userID)
 	scope, err := auth.ActivityContentClause(ctx, "m", arg)
 	if err != nil {
 		return 0, 0, err
 	}
 	const heldByRep = `m.kind = 'meeting' AND m.archived_at IS NULL
-		      AND m.meeting_status = 'held' AND m.captured_by = $%[3]d
+		      AND m.meeting_status = 'held'
+		      AND (m.host_user_id = $%[5]d
+		           OR (m.host_user_id IS NULL AND m.captured_by = $%[3]d))
 		      AND m.occurred_at >= $%[1]d AND m.occurred_at < $%[2]d
 		      AND (%[4]s)`
 	err = tx.QueryRow(ctx, fmt.Sprintf(`
@@ -209,8 +225,9 @@ func countWeekMeetings(
 		          JOIN activity task ON task.id = tl.activity_id
 		         WHERE ml.activity_id = m.id AND task.kind = 'task'
 		           AND task.archived_at IS NULL
-		           AND task.created_at >= m.occurred_at))`,
-		startPos, endPos, capturedPos, scope), args...).
+		           AND task.created_at >= m.occurred_at
+		           AND task.created_at < $%[2]d))`,
+		startPos, endPos, capturedPos, scope, hostPos), args...).
 		Scan(&held, &withNextStep)
 	if err != nil {
 		return 0, 0, fmt.Errorf("weekly: counting the week's meetings: %w", err)

--- a/backend/internal/compose/weekly/weeklycounts.go
+++ b/backend/internal/compose/weekly/weeklycounts.go
@@ -201,6 +201,25 @@ func countWeekLeads(
 // The heuristic is what the data supports, and it is a heuristic: a task raised
 // the Monday after a Friday meeting is plausibly its outcome and is not counted
 // here. Tightening that needs source_activity_id on every writer first.
+// meetingIsTheirsSQL is the one spelling of "this meeting is that rep's":
+// hosted by them, or — where no host was recorded — filed by them.
+//
+// TWO readers ask it, the headline count here and the funnel in
+// weeklyscorecard.go, and they must not disagree: a meeting credited to
+// different people by the two panels is one page contradicting itself about the
+// same week. The caller supplies its own placeholders because the two queries
+// number their arguments differently.
+//
+// The fallback is bounded to rows with NO host on purpose. A meeting naming one
+// is that person's, and letting its recorder also claim it would count one
+// meeting twice across two reps.
+//
+// Held by: TestTheMeetingAttributionHasOneSpelling (meetingattribution_test.go)
+func meetingIsTheirsSQL(hostPos, capturedPos string) string {
+	return fmt.Sprintf("(m.host_user_id = %s OR (m.host_user_id IS NULL AND m.captured_by = %s))",
+		hostPos, capturedPos)
+}
+
 func countWeekMeetings(
 	ctx context.Context, tx pgx.Tx, userID ids.UUID, start, end time.Time,
 ) (held, withNextStep int, err error) {
@@ -213,10 +232,9 @@ func countWeekMeetings(
 	if err != nil {
 		return 0, 0, err
 	}
-	const heldByRep = `m.kind = 'meeting' AND m.archived_at IS NULL
+	heldByRep := `m.kind = 'meeting' AND m.archived_at IS NULL
 		      AND m.meeting_status = 'held'
-		      AND (m.host_user_id = $%[5]d
-		           OR (m.host_user_id IS NULL AND m.captured_by = $%[3]d))
+		      AND ` + meetingIsTheirsSQL("$%[5]d", "$%[3]d") + `
 		      AND m.occurred_at >= $%[1]d AND m.occurred_at < $%[2]d
 		      AND (%[4]s)`
 	err = tx.QueryRow(ctx, fmt.Sprintf(`

--- a/backend/internal/compose/weekly/weeklyscorecard.go
+++ b/backend/internal/compose/weekly/weeklyscorecard.go
@@ -249,13 +249,8 @@ func scoreLeads(
 		  SELECT h.status, h.partial_pre_history
 		    FROM activity_meeting_history h
 		    JOIN activity m ON m.id = h.activity_id
-		   -- By HOST, falling back to the recorder only where no host is
-		   -- named, exactly as countWeekMeetings attributes the tally beside
-		   -- it. Two spellings of one question let this panel and the
-		   -- headline count credit the same meeting to different people.
 		   WHERE m.kind = 'meeting'
-		     AND (m.host_user_id = $%[3]d
-		          OR (m.host_user_id IS NULL AND m.captured_by = $%[6]d))
+		     AND `+meetingIsTheirsSQL("$%[3]d", "$%[6]d")+`
 		     AND m.archived_at IS NULL
 		     AND h.effective_at >= $%[1]d AND h.effective_at < $%[2]d
 		     AND (%[7]s))

--- a/backend/internal/compose/weekly/weeklyscorecard.go
+++ b/backend/internal/compose/weekly/weeklyscorecard.go
@@ -199,10 +199,11 @@ func scoreLeads(
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	startPos, endPos, userPos := arg(start), arg(end), arg(userID)
-	// A meeting has no owner and captured_by is a principal STRING, not a
-	// user id — the same attribution countWeekMeetings uses, and the reason
-	// this is not simply userID: comparing the text column to a uuid is a
-	// type error, and comparing it to the bare uuid text would never match.
+	// The RECORDER, used only where a meeting names no host — the same
+	// fallback countWeekMeetings applies. captured_by is a principal STRING
+	// rather than a user id, which is why this is not simply userID: comparing
+	// the text column to a uuid is a type error, and comparing it to the bare
+	// uuid text would never match.
 	capturedPos := arg("human:" + userID.String())
 	scope, err := auth.ScopeClauseFor(ctx, "lead", "l", arg)
 	if err != nil {
@@ -248,7 +249,13 @@ func scoreLeads(
 		  SELECT h.status, h.partial_pre_history
 		    FROM activity_meeting_history h
 		    JOIN activity m ON m.id = h.activity_id
-		   WHERE m.kind = 'meeting' AND m.captured_by = $%[6]d
+		   -- By HOST, falling back to the recorder only where no host is
+		   -- named, exactly as countWeekMeetings attributes the tally beside
+		   -- it. Two spellings of one question let this panel and the
+		   -- headline count credit the same meeting to different people.
+		   WHERE m.kind = 'meeting'
+		     AND (m.host_user_id = $%[3]d
+		          OR (m.host_user_id IS NULL AND m.captured_by = $%[6]d))
 		     AND m.archived_at IS NULL
 		     AND h.effective_at >= $%[1]d AND h.effective_at < $%[2]d
 		     AND (%[7]s))

--- a/backend/internal/compose/weeklyplancapacity_integration_test.go
+++ b/backend/internal/compose/weeklyplancapacity_integration_test.go
@@ -5,7 +5,7 @@
 
 package compose
 
-// What next week already holds, over real migrated Postgres.
+// What the planned week already holds, over real migrated Postgres.
 //
 // The window is the whole subject. A capacity line that counted this week, or a
 // fixed 168 hours, or a meeting somebody has already held would each be a
@@ -14,6 +14,7 @@ package compose
 // knows the installation's reporting zone.
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -99,5 +100,51 @@ func TestCapacityPricesTheWeekItIsGiven(t *testing.T) {
 	if coming.Meetings != 1 {
 		t.Errorf("asked about the week of the 15th, counted %d meetings, want its one",
 			coming.Meetings)
+	}
+}
+
+// A meeting somebody else filed is still this rep's time.
+//
+// Attribution used to read captured_by alone, so a meeting a colleague booked
+// on the rep's behalf — or a calendar connector imported — was absent from the
+// capacity they plan against. The emptier that line looks, the more a rep
+// commits to, so the error runs in the direction that hurts.
+//
+// host_user_id names whose meeting it is; captured_by names who filed it. The
+// fallback to the capturer is bounded to rows carrying NO host, so a meeting
+// naming one cannot also be claimed by whoever recorded it and counted twice.
+func TestCapacityCountsAMeetingHostedByTheRepWhoeverFiledIt(t *testing.T) {
+	e := integration.Setup(t)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	owner := integration.OwnerConn(t)
+	nextWeek := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+
+	// Filed by the admin, hosted by Rep1 — the connector-import shape.
+	if _, err := owner.Exec(context.Background(), `
+		INSERT INTO activity (id, kind, subject, occurred_at, meeting_status,
+		                      host_user_id, source, captured_by)
+		VALUES ($1, 'meeting', 'Imported from the calendar', $2, 'booked', $3,
+		        'manual', 'human:somebody-else')`,
+		ids.NewV7(), time.Date(2026, 6, 16, 9, 0, 0, 0, time.UTC), e.Rep1); err != nil {
+		t.Fatalf("seeding the hosted meeting: %v", err)
+	}
+	// Hosted by somebody else, filed by the admin: not this rep's time, and the
+	// fixture would pass at 1 either way without it.
+	if _, err := owner.Exec(context.Background(), `
+		INSERT INTO activity (id, kind, subject, occurred_at, meeting_status,
+		                      host_user_id, source, captured_by)
+		VALUES ($1, 'meeting', 'A colleague''s meeting', $2, 'booked', $3,
+		        'manual', 'human:somebody-else')`,
+		ids.NewV7(), time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC), e.Rep2); err != nil {
+		t.Fatalf("seeding the colleague's meeting: %v", err)
+	}
+
+	seam := weeklyPlanCapacity{pool: e.Pool}
+	got, err := seam.ForWeek(rep, e.Rep1, nextWeek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Meetings != 1 {
+		t.Errorf("counted %d meetings for the rep who hosts one of the two, want 1", got.Meetings)
 	}
 }

--- a/backend/internal/compose/weeklyplanseam.go
+++ b/backend/internal/compose/weeklyplanseam.go
@@ -99,7 +99,14 @@ func (c weeklyPlanCapacity) ForWeek(
 			  (SELECT count(*) FROM activity m
 			    WHERE m.kind = 'meeting' AND m.archived_at IS NULL
 			      AND m.meeting_status = 'booked'
-			      AND m.captured_by = $3
+			      -- By HOST, falling back to the capturer only where no host is
+			      -- recorded. A meeting a colleague booked or a calendar
+			      -- connector imported is still this rep's time, and reading
+			      -- the capturer alone left it out of the capacity they plan
+			      -- against — the emptier the calendar looks, the more they
+			      -- commit to.
+			      AND (m.host_user_id = $4
+			           OR (m.host_user_id IS NULL AND m.captured_by = $3))
 			      AND m.occurred_at >= $1 AND m.occurred_at < $2),
 			  (SELECT count(*) FROM activity t
 			    WHERE t.kind = 'task' AND t.archived_at IS NULL


### PR DESCRIPTION
Meetings were attributed by `captured_by`, so a meeting a colleague minuted or a calendar connector imported counted for whoever recorded it rather than the rep who sat in it. The same meeting moved between reps' weeks depending on how it reached the CRM, and a rep whose calendar syncs automatically showed none of their own.

`host_user_id` names whose meeting it is and has done all along — the column, its CHECK and its index are in the baseline. The old comment said a meeting has no owner, which is true of `assignee_id` and not of this.

The same read sat in the plan's **capacity seam**, and there it ran in the direction that hurts: the emptier that line looks, the more a rep commits to.

And "left a next step" joined a task to a meeting with a lower bound only, so a task raised weeks later on the same account credited a meeting that had nothing to do with it — and a closed week changed its answer every time somebody added a task.

## From the review

**Codex found the sibling I missed.** `weeklyscorecard.go` still matched `captured_by` alone, so the meeting funnel and the headline count could credit the same meeting to two different people on one page — the defect this change set out to end, left standing in the panel beside it. That is the "fix the invariant, not the call site" rule, and I had broken it.

Fixing it put the same clause in two queries, and the craft gate caught the length. Both are answered by extraction: `meetingIsTheirsSQL` is now the one spelling, held by a test because the uniqueness gate refuses a claim asserted only in a comment.

Two stale comments corrected. The counts said "there is no meeting_id on a task" — `activity.source_activity_id` exists. The honest reason for joining on the shared record instead is that only *some* writers populate it, so joining on it would report a rep who writes their own follow-ups as having produced none. The comment says that now, and names the heuristic as a heuristic.

**Two gaps filed rather than hidden**, both meaning this fix is complete only for the connector path:
- [#5077](https://github.com/margince/margince/issues/5077) — a meeting typed by hand records no host, so it still falls to the recorder.
- [#5078](https://github.com/margince/margince/issues/5078) — an imported meeting carries no `meeting_status` at all, so it reaches neither count. My capacity fixture hand-set `booked`, which masked it; the issue says a test seeded through the real capture writer would have caught it.

## Verification

- `make check-backend` green; `compose/weekly` and `compose` lanes green.
- Both guards mutation-checked. The host test asserts **both** sides in one place — the host credited with one, the filer with none — and files the meetings under a real seat rather than a literal string, so breaking the NULL guard credits the recorder with two. The earlier fixture could not have told.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Meetings are now credited to the person who hosted them, not the person who recorded them, so a meeting imported by a calendar connector or minuted by a colleague counts for the rep who sat in it. Also fixes the "next step" count to only include tasks created within the same week as the meeting, so a closed week no longer changes its answer when a later task is added.

- Both weekly counts and the scorecard now use a shared `meetingIsTheirsSQL` predicate that attributes by `host_user_id`, falling back to `captured_by` only when no host is recorded.
- The capacity seam now uses the same attribution.
- The "next step" join is bounded at both ends, so only tasks created after the meeting but before the week ends count.
- Added tests that assert the host is credited and the filer is not, and that a late task does not count as a next step.
- Known gaps: hand-typed meetings record no host, and imported meetings may lack a meeting status, so those still fall to the recorder or are excluded.

<sup>Written for commit c3fdefe845d79b6c1a8bf6da13f3734be4fd7f11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Weekly meeting counts now credit the meeting host, including calendar-imported meetings, instead of relying solely on who recorded the meeting.
  - Meetings without a recorded host continue to use the person who captured them for attribution.
  - Weekly capacity and scorecard results now better reflect meetings a representative is responsible for.
  - Next-step tasks count only when created after the meeting and before the reviewed week ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->