### PR TITLE
fix(brief): the pipeline headline names the window it covers

### DIFF
--- a/frontend/src/format/zone-by-purpose.test.ts
+++ b/frontend/src/format/zone-by-purpose.test.ts
@@ -162,6 +162,10 @@ const pinnedZones: { file: string; why: string }[] = [
     why: "The rule under test is which SIDE of the reader's own day a moment falls on — today's meeting shows a bare time, another day's shows the date too. Deciding that needs a zone whose offset is not zero: in UTC the fixture's instants land on the same calendar day under either rule, so every case would pass whichever branch ran. The zone is injected by mocking viewerZone, which is the module this gate points callers at; naming it is what makes the expectation ('14:30', not '12:30') checkable at all.",
   },
   {
+    file: "screens/brief.readings.test.tsx",
+    why: "The case is that a date-only period reads as the SAME days for every colleague, and proving it needs three named zones at once: the installation's, which the tile must follow, and a viewer's on either side of UTC. A zone taken off the runner would decide whether the bug can appear at all — east of UTC a viewer-zone read prints the right days by luck, so the assertion would pass over code that is wrong for half the world. The installation's zone is supplied through RecordZoneProvider, the seam the product itself reads.",
+  },
+  {
     file: "screens/brief.weekly.test.tsx",
     why: "The case asserts that the weekly's 'written at' renders in the INSTALLATION's zone, so it provides one through RecordZoneProvider and formats its expectation against the same name. The alternative is naming FALLBACK_RECORD_ZONE, which the arm below forbids and rightly: the component reads that same constant, so the assertion would hold however wrong the zone decision was.",
   },

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2885,7 +2885,7 @@ export const de = {
   "brief.readings.pipeline": "Pipeline",
   "brief.readings.pipelineWorkspace": "Pipeline · gesamte Organisation",
   "brief.readings.pipelineBasis":
-    "{weighted} gewichtet · {priced} von {eligible} bewertet",
+    "{period} · {weighted} gewichtet · {priced} von {eligible} bewertet",
   "brief.readings.pipelineUnread": "die Pipeline war nicht lesbar",
   "brief.readings.pipelineReading": "Pipeline wird gelesen",
   "brief.readings.openLane": "Diese öffnen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2975,7 +2975,7 @@ export const en = {
   "brief.readings.pipeline": "Pipeline outlook",
   "brief.readings.pipelineWorkspace": "Pipeline outlook · whole organization",
   "brief.readings.pipelineBasis":
-    "{weighted} weighted · {priced} of {eligible} priced",
+    "{period} · {weighted} weighted · {priced} of {eligible} priced",
   "brief.readings.pipelineUnread": "the pipeline could not be read",
   "brief.readings.pipelineReading": "reading the pipeline",
   "brief.readings.openLane": "Open these",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2853,7 +2853,7 @@ export const vi = {
   "brief.readings.pipeline": "Toàn cảnh pipeline",
   "brief.readings.pipelineWorkspace": "Toàn cảnh pipeline · toàn bộ tổ chức",
   "brief.readings.pipelineBasis":
-    "{weighted} theo trọng số · {priced} trên {eligible} đã định giá",
+    "{period} · {weighted} theo trọng số · {priced} trên {eligible} đã định giá",
   "brief.readings.pipelineUnread": "không đọc được pipeline",
   "brief.readings.pipelineReading": "đang đọc pipeline",
   "brief.readings.openLane": "Mở những mục này",

--- a/frontend/src/screens/brief.readings.test.tsx
+++ b/frontend/src/screens/brief.readings.test.tsx
@@ -2,6 +2,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { RecordZoneProvider } from "../app/recordzone";
 import { formatDateTime } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { LocaleProvider } from "../i18n";
@@ -25,6 +26,23 @@ import { BriefReadingsStrip } from "./brief.readings";
 // pace, because targets were retired from the product — and the interesting
 // cases are what replaced them: a pipeline figure that must never read as a
 // target, and must say whose pipeline it measured.
+
+// drawInZone renders the strip under a named record zone, which is what a
+// date-only wire value must be read in.
+function drawInZone(zone: string, ...args: Parameters<typeof readingsDay>) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <RecordZoneProvider zone={zone}>
+        <LocaleProvider initial="en">
+          <BriefReadingsStrip day={readingsDay(...args)} />
+        </LocaleProvider>
+      </RecordZoneProvider>
+    </QueryClientProvider>,
+  );
+}
 
 function draw(...args: Parameters<typeof readingsDay>) {
   // A QueryClient, because the pipeline reading is a read of its own: it is the
@@ -433,5 +451,62 @@ describe("the leads reading", () => {
 
     expect(leadsCard().textContent).toContain("2");
     expect(screen.getByText(en["brief.readings.leadsBasis"])).toBeTruthy();
+  });
+});
+
+// A period is a CALENDAR window, not an instant, and it reads the same for
+// every colleague.
+//
+// period_start and period_end are date-only wire values. Read in the viewer's
+// own clock west of UTC they parse as UTC midnight and print the day before, so
+// a rep in Los Angeles saw the third quarter labelled "30 Jun – 29 Sept" while
+// a colleague in Berlin saw "1 Jul – 30 Sept" — two people quoting one page and
+// quoting different quarters. The record's zone is the only answer that is the
+// same for both.
+describe("the pipeline period", () => {
+  afterEach(cleanup);
+
+  it("names the same days west of UTC as it does east of it", async () => {
+    const payload = {
+      period_start: "2026-07-01",
+      period_end: "2026-09-30",
+      scope_kind: "owner",
+      open_minor: 42_000_000,
+      weighted_minor: 16_800_000,
+      best_case_minor: 0,
+      evidence_minor: 0,
+      eligible_count: 12,
+      priced_count: 11,
+      confirmed_date_count: 8,
+      fx_missing_count: 0,
+      as_of: "2026-09-03T06:42:00Z",
+      base_currency: "EUR",
+    };
+    stubPipeline(
+      () =>
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    // The VIEWER sits west of UTC while the installation's calendar does not.
+    // Without this the suite's own machine decides whether the bug can appear
+    // at all: east of UTC a viewer-zone read prints the right days by luck, and
+    // the assertion passes over code that is wrong for half the world.
+    const resolved = Intl.DateTimeFormat.prototype.resolvedOptions;
+    vi.spyOn(
+      Intl.DateTimeFormat.prototype,
+      "resolvedOptions",
+    ).mockImplementation(function (this: Intl.DateTimeFormat) {
+      return { ...resolved.call(this), timeZone: "America/Los_Angeles" };
+    });
+
+    drawInZone("Europe/Berlin");
+    expect(await screen.findByText(/1 Jul 2026 – 30 Sept 2026/)).toBeTruthy();
+    cleanup();
+
+    drawInZone("Asia/Tokyo");
+    expect(await screen.findByText(/1 Jul 2026 – 30 Sept 2026/)).toBeTruthy();
   });
 });

--- a/frontend/src/screens/brief.readings.test.tsx
+++ b/frontend/src/screens/brief.readings.test.tsx
@@ -272,6 +272,10 @@ describe("the brief readings strip", () => {
     // reader who cannot see the second cannot judge the first.
     expect(screen.getByText(/168,000/)).toBeTruthy();
     expect(screen.getByText(/11 of 12 priced/)).toBeTruthy();
+    // THE WINDOW the money covers. €420k of open pipeline means nothing without
+    // it: the same page carries a by-currency total of everything open, and a
+    // reader with no period cannot tell why the two disagree.
+    expect(screen.getByText(/1 Jul 2026 – 30 Sept 2026/)).toBeTruthy();
     // Never a target word. The quota table was dropped by founder decision.
     const strip = screen.getByTestId("brief-readings");
     expect(strip.textContent).not.toMatch(/on track|target|attainment|gap/i);

--- a/frontend/src/screens/brief.readings.tsx
+++ b/frontend/src/screens/brief.readings.tsx
@@ -5,6 +5,7 @@ import { navigate } from "../app/router";
 import { StatCard } from "../design-system/atoms";
 import { StatStrip } from "../design-system/statstrip";
 import {
+  formatDateAbbrev,
   formatDateTime,
   formatMoneyCompact,
   formatMoneyOrAbsent,
@@ -403,7 +404,16 @@ function PipelineOutlook() {
       // The weighted figure and the completeness in one line, because they are
       // read together: a weighted number over a partly priced population is a
       // floor, and a reader who cannot see the second cannot judge the first.
+      // The PERIOD first, because the money means nothing without it. The
+      // headline reads a quarter's open pipeline, and a reader who cannot see
+      // which quarter cannot reconcile it against the currency totals beside
+      // it — one is a window, the other is everything open.
       detail={t("brief.readings.pipelineBasis", {
+        period: `${formatDateAbbrev(
+          data.period_start,
+          locale,
+          viewerZone(),
+        )} – ${formatDateAbbrev(data.period_end, locale, viewerZone())}`,
         weighted: formatMoneyOrAbsent(
           data.weighted_minor,
           data.base_currency,

--- a/frontend/src/screens/brief.readings.tsx
+++ b/frontend/src/screens/brief.readings.tsx
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { StatCard } from "../design-system/atoms";
 import { StatStrip } from "../design-system/statstrip";
+import { middayInstant } from "../format/calendarday";
 import {
   formatDateAbbrev,
   formatDateTime,
@@ -338,6 +340,7 @@ function meetingsReading(day: Worklist): {
 function PipelineOutlook() {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   // The reader's OWN pipeline, under the scope the SERVER names for them.
   //
   // `/analytics/context` answers `default_scope`, which is what Analytics starts
@@ -408,12 +411,18 @@ function PipelineOutlook() {
       // headline reads a quarter's open pipeline, and a reader who cannot see
       // which quarter cannot reconcile it against the currency totals beside
       // it — one is a window, the other is everything open.
+      //
+      // The RECORD's zone, and midday rather than midnight. These are date-only
+      // wire values: there is no instant in "2026-07-01" to localize, and read
+      // in the viewer's clock west of UTC they print the day before — a quarter
+      // labelled 30 Jun – 29 Sept. The period is a property of the
+      // installation's calendar, the same for every colleague reading it.
       detail={t("brief.readings.pipelineBasis", {
         period: `${formatDateAbbrev(
-          data.period_start,
+          middayInstant(data.period_start, recordZone),
           locale,
-          viewerZone(),
-        )} – ${formatDateAbbrev(data.period_end, locale, viewerZone())}`,
+          recordZone,
+        )} – ${formatDateAbbrev(middayInstant(data.period_end, recordZone), locale, recordZone)}`,
         weighted: formatMoneyOrAbsent(
           data.weighted_minor,
           data.base_currency,


### PR DESCRIPTION
The tile read **€185k** over a quarter it never mentioned, beside a sidebar showing every open deal by currency. Both numbers were right and they answer different questions, so a reader who could not see the period had no way to tell why they disagreed — the audit reconciled them by reading the code.

The period was already in the payload: `period_start` and `period_end` are required fields of the readings response, carried since the endpoint was written and rendered by nothing. The fixtures in the tile's own test already set them.

The backend needed no change. The fold was already consistent — eligible and priced count the same slice, so "11 of 12 priced" was never the mismatch the audit suspected. The missing period was.

## From the review

**Codex found an off-by-one I had just introduced.** I formatted the period in the *viewer's* zone, but these are date-only wire values — there is no instant in `"2026-07-01"` to localize, so west of UTC they parse as UTC midnight and print the day before. A rep in Los Angeles would have seen the third quarter labelled **30 Jun – 29 Sept** while a colleague in Berlin saw 1 Jul – 30 Sept: two people quoting one page and quoting different quarters. `timezone.ts` warns about exactly this shape, and I had walked into it.

It reads the record's zone now, anchored at midday the way every other date-only value in the tree is.

**The first mutation check passed, which is how I found the test was worthless.** Reinstating the bug left it green — this machine is east of UTC, where the broken code prints the right days by luck. The test now pins a viewer zone on either side of UTC as well as the installation's, so the runner can no longer decide whether the defect is visible. With that in place, reinstating the bug fails it.

Naming three zones needed ratifying in the zone-by-purpose allowlist, which carries the reason.

## Verification

- `make check-fe` (8487 tests) and `make check-backend` green.
- Mutation-checked twice: once proving the test was inert, and again proving the strengthened version catches the off-by-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The pipeline headline now names the quarter it covers, so a reader can tell why the weighted figure differs from the by-currency sidebar's total of everything open. The period was already in the readings payload as `period_start` and `period_end`; it was just never rendered.

- The period is read in the record's zone and anchored at midday, so the date-only wire values label the same days for every colleague regardless of viewer zone.
- Tests pin a viewer zone on both sides of UTC plus the installation's zone, so the runner's own clock can no longer hide an off-by-one.
- `en`, `de`, and `vi` strings gained the `{period}` placeholder; the backend is unchanged.

<sup>Written for commit 76c0ab10f530102fe766e378109649f705ee131a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline outlook details now display the reporting period alongside weighted and priced totals.
  * Date-only periods remain consistent for viewers in different time zones.
  * Period dates are displayed using the record’s configured time zone.

* **Tests**
  * Added coverage for period boundaries and cross-time-zone date consistency.
  * Updated German, English, and Vietnamese text to include the reporting period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->