### PR TITLE
test(compose): the governed-call gates see the surface they describe

### DIFF
--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 48
+	wantFixtureAnnotations = 47
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/agentcommand_test.go
+++ b/backend/internal/compose/agentcommand_test.go
@@ -18,9 +18,14 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
 )
 
 // seamRecord is a record the caller may see, held in OUR system of record —
@@ -211,4 +216,65 @@ func TestAResolvedTargetWithNoRecordTypeIsRefused(t *testing.T) {
 	if rec.Code != http.StatusForbidden {
 		t.Errorf("an untyped concrete target answered %d, want 403", rec.Code)
 	}
+}
+
+// The TOOL door runs the resolver's Guards too, and this is where that is
+// proven in isolation.
+//
+// TestAnArchiveOfAnExternallyHeldRecordStagesNothing above makes the claim for
+// the REST door; TestBothDoorsRefuseOneRecordNeitherCallerCanSee makes it for
+// both at once, but through a row hidden by ROW SCOPE — and that refusal is not
+// Guards' alone. Guards and Subject answer from one memoized read of the row
+// (archiveResolver.target), so a row the caller cannot read fails Subject too,
+// and the test passes whether or not Guards ran at all.
+//
+// An externally-held record is the case that separates them: the read SUCCEEDS
+// and Subject is happy to describe the row, so a refusal can only have come
+// from Guards. Driven through the registry rather than through StageSubject, so
+// what is proven is the door — a tool door that resolved a subject and never
+// asked the guard would stage here and refuses nothing.
+func TestTheToolDoorRefusesAnExternallyHeldRecordItCanRead(t *testing.T) {
+	staging := &capturingApprovals{}
+	// The tier floor is what makes this a test of the STAGING guard: Guards is
+	// asked on the path to staging, so an auto-execute archive would run the
+	// write without ever consulting it. archive_record on a person is the same
+	// (verb, record type) the both-doors gate floors, for the same reason.
+	reg := agents.NewRegistry(staging, auth.NewGate(fullSeat{}),
+		agents.WithTierFloor(func(tool, recordType string) (mcp.RiskTier, bool) {
+			if tool == "archive_record" && recordType == string(recordTypePerson) {
+				return mcp.TierConfirmationRequired, true
+			}
+			return mcp.TierAutoExecute, false
+		}))
+	agents.RegisterCoreTools(reg, mirroredRecord{}, nil, nil, nil, nil, nil)
+
+	_, err := reg.Invoke(anArchivingAgent(), "archive_record",
+		json.RawMessage(`{"record_type":"person","id":"`+ids.NewV7().String()+`"}`))
+
+	var staged *workflow.StagedApprovalError
+	if errors.As(err, &staged) {
+		t.Errorf("the tool door staged approval %s against a record whose authority lives elsewhere — "+
+			"nobody could ever release it, because the decidability probe and the version pin both read "+
+			"tables this record has no row in", staged.ApprovalID)
+	}
+	if staging.last.Tool != "" {
+		t.Errorf("an approval was staged for %q against a record held in another system of record", staging.last.Tool)
+	}
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Errorf("the tool door answered %v, want the external-system-of-record refusal — Subject reads "+
+			"this row happily, so any other answer means Guards was never asked", err)
+	}
+}
+
+// anArchivingAgent is an agent principal holding the scope an archive consumes.
+// Without one the registry refuses on the missing principal, which is a refusal
+// about the CONTEXT rather than about the record — and the assertion above,
+// asking only that Guards' own answer came back, would have been satisfied by a
+// door that never reached the resolver at all.
+func anArchivingAgent() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:archive", OnBehalfOf: ids.NewV7(),
+		Scopes: principal.NewScopeSet(principal.ScopeRead, principal.ScopeWrite),
+	})
 }

--- a/backend/internal/compose/agentcommandoperand_test.go
+++ b/backend/internal/compose/agentcommandoperand_test.go
@@ -12,13 +12,15 @@ package compose
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
+	"github.com/getkin/kin-openapi/openapi3"
+	chi "github.com/go-chi/chi/v5"
 
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/platform/httperr"
@@ -310,49 +312,50 @@ func syntheticOperandRequest(route string, id ids.UUID) *http.Request {
 // same table declared: the record type, and the routed id rather than one of
 // the route's OTHER path parameters.
 //
-// Derived from agentPolicies rather than a hand-listed set of eight op names:
-// TestEachOperandCommandStagesTheRoutedRecord above hand-picks its eight and
-// would not notice a NINTH such operation the contract grows.
+// THE FAMILY IS DERIVED FROM THE ROUTE'S SHAPE, and that is the whole of the
+// filter. A route that names a record with {id} and carries more path after it
+// resolves its target from the path, which is what makes a synthetic request
+// enough to invoke its decoder. Nothing else narrows the set.
 //
-// The whole-record patch shape (route ends exactly at /{id}) is excluded
-// because a synthetic request cannot exercise it: those decoders read a BODY,
-// and a body is per-operation where a path parameter is not. Their equivalent
-// proof is TestAPatchStagesItsRecordAndID and its siblings above.
-// operandBodies carries a minimal contract body for the routes in this family
-// whose operand is not in the path at all: setProjectStakeholder names its
-// person in the BODY and setProjectCompany names its company there, and both
-// decoders refuse a request that names none (agentcommandoperand.go). Every
-// other route here is decodable from the path alone, which is what lets the
-// walk be synthetic.
+// It used to narrow on the tier as well — confirmation_required only, which is
+// what the name said. Measured, that reached 2 of the 15 update_record routes in
+// this shape and left 13 auto-execute ones unwalked, including both routes the
+// walk carried request bodies for: fixtures nothing read, which is how a census
+// tells you it has stopped seeing its own subject. Tier is the wrong axis
+// besides. A mis-wired decoder is worse under auto_execute than under
+// confirmation, because no human is between the wiring and the write.
 //
-// gatekit:fixture the minimal contract body each body-carrying route in this family declares — expected input, not a waived cost
-var operandBodies = map[string]string{
-	"setProjectStakeholder": `{"person_id":"019ff000-0000-7000-8000-000000000031","role":"champion"}`,
-	"setProjectCompany":     `{"organization_id":"019ff000-0000-7000-8000-000000000032","role":"partner"}`,
-}
-
-func TestEveryConfirmFirstOperandRouteDecodesIntoTheRightCommand(t *testing.T) {
-	checked := 0
-	for route, pol := range agentPolicies {
-		if pol.Access != accessTool || pol.Tool != "update_record" || pol.Tier != tierConfirmationRequired {
-			continue
-		}
-		if strings.HasSuffix(route, "/{id}") {
-			continue
-		}
-		checked++
-
+// The whole-record patch shape (route ends exactly at /{id}) stays out, and for
+// a reason about the request rather than about the route: those decoders read a
+// BODY whose shape is per-operation, where a path parameter is not, so a
+// synthetic request cannot exercise them. Their equivalent proof is
+// TestAPatchStagesItsRecordAndID and its siblings above, and
+// TestEveryWholeRecordPatchRunsItsGuardsBeforeTheAutoExecuteHalf below reaches
+// every one of them through the split.
+func TestEveryOperandRouteDecodesIntoTheCommandItsPolicyNames(t *testing.T) {
+	declared := operationsDeclaringARequestBody(t)
+	family := operandShapedRoutes()
+	assertTheFamilyIsTheContractsOwn(t, family)
+	for route, pol := range family {
 		decode, described := restCommands[pol.Op]
 		if !described {
 			// The completeness gate reports this route by name; here it would
 			// only be a nil decoder to dereference.
 			continue
 		}
-
+		body, written := contractBodies[pol.Op]
+		if declaresBody := declared[pol.Op]; declaresBody != written {
+			if declaresBody {
+				t.Errorf("%s (%s) declares a requestBody in crm.yaml and carries none in contractBodies, so "+
+					"the decode below proves only that commandBody short-circuits an empty payload", route, pol.Op)
+			} else {
+				t.Errorf("%s (%s) declares no requestBody in crm.yaml and carries one in contractBodies, so "+
+					"the walk decodes a shape the route cannot produce", route, pol.Op)
+			}
+			continue
+		}
 		id := ids.NewV7()
-		req := syntheticOperandRequest(route, id)
-		body := []byte(operandBodies[pol.Op])
-		call, err := decode(pol, restCommandDeps{records: seamRecord{}}, req, body)
+		call, err := decode(pol, operandWalkDeps(), syntheticOperandRequest(route, id), []byte(body))
 		if err != nil {
 			t.Errorf("%s (%s): decoding a well-formed request answered %v", route, pol.Op, err)
 			continue
@@ -362,21 +365,196 @@ func TestEveryConfirmFirstOperandRouteDecodesIntoTheRightCommand(t *testing.T) {
 			t.Errorf("%s (%s): naming the subject answered %v", route, pol.Op, err)
 			continue
 		}
-		if info.TargetType != string(pol.RecordType) {
+		if pol.RecordType != "" && info.TargetType != string(pol.RecordType) {
 			t.Errorf("%s (%s) stages target type %q, want %q — the policy table's own declared record type",
 				route, pol.Op, info.TargetType, pol.RecordType)
+		}
+		// A creation binds to a row that does not exist yet, so the routed {id}
+		// names its PARENT — the deal a createOffer hangs an offer off, the room
+		// a thread opens in. Staging that id would bind a human's yes to the
+		// parent record, which is the wrong row to judge and the wrong row to
+		// version-pin, so the expectation inverts rather than lapsing: these
+		// must stage NO id at all. Read off the tool, not off a list of the
+		// three that do it today.
+		if pol.Tool == "create_record" {
+			if info.TargetID != ids.Nil {
+				t.Errorf("%s (%s) stages target id %s, want none — the routed {id} names the PARENT this "+
+					"creation hangs off, and an approval bound to it would ask a human about the wrong row",
+					route, pol.Op, info.TargetID)
+			}
+			continue
+		}
+		// A merge dissolves the record the route names INTO the one its body
+		// does, so the survivor is what a human is asked about and what the
+		// approval must bind to — the routed id belongs to the record that will
+		// not exist. Asserted positively against the body's own target_id
+		// rather than skipped: a decoder that staged the routed id here would
+		// stage the loser, and "not the routed id" alone would pass on any
+		// wrong answer that happened to differ from it.
+		if pol.Tool == "merge_records" {
+			survivor := bodyTargetID(t, route, pol.Op, body)
+			if info.TargetID != survivor {
+				t.Errorf("%s (%s) stages target id %s, want the survivor its body names (%s) — a merge's "+
+					"approval binds to the record that remains, not the one being folded away",
+					route, pol.Op, info.TargetID, survivor)
+			}
+			continue
+		}
+		// A route whose policy declares no record type stages no target either:
+		// the approval decisions are the only ones, and what they stage instead
+		// is TestADecisionStagesNoTargetAndSaysWhichWayItGoes' subject.
+		if pol.RecordType == "" {
+			continue
 		}
 		if info.TargetID != id {
 			t.Errorf("%s (%s) stages target id %s, want %s — restCommands binds this operationId to the "+
 				"WRONG decoder, or the decoder read the wrong path parameter as {id}", route, pol.Op, info.TargetID, id)
 		}
 	}
-	// No literal count: how many such routes exist is the contract's business,
-	// and the completeness gate is what notices one arriving. What this walk
-	// owes is that it ran at all — a filter that selected nothing would report
-	// every decoder correctly wired without invoking one.
-	if checked == 0 {
-		t.Fatal("no confirm-first update_record route carries more than the routed {id} — this walk invoked " +
-			"no decoder, and would pass against every mis-wiring it exists to catch")
+}
+
+// operandShapedRoutes are the agent-reachable mutating routes whose target is
+// named by a routed {id} the path carries MORE after.
+//
+// That shape is the derivation, and it is a fact about the route rather than a
+// judgement about the operation: everything such a route needs to resolve a
+// target is in the path, which is exactly what lets syntheticOperandRequest
+// stand in for a real one. A route ending at /{id} is excluded because its
+// decoder reads a per-operation body instead.
+func operandShapedRoutes() map[string]agentPolicy {
+	family := map[string]agentPolicy{}
+	for route, pol := range agentPolicies {
+		method, template, _ := strings.Cut(route, " ")
+		if pol.Access != accessTool || !mutatingMethod(method) {
+			continue
+		}
+		const routedID = "/{id}"
+		if at := strings.Index(template, routedID); at >= 0 && at+len(routedID) < len(template) {
+			family[route] = pol
+		}
 	}
+	return family
+}
+
+// operandWalkDeps answers for each field of restCommandDeps.
+//
+// Populated across the struct rather than only where the walk's first routes
+// happened to reach: a resolver handed a nil dep panics on the nil interface
+// instead of reporting a wiring defect, and which deps a decoder reaches is
+// what this walk must not have to know in advance. A route the contract adds
+// tomorrow gets a working set with nobody remembering to widen this.
+func operandWalkDeps() restCommandDeps {
+	return restCommandDeps{
+		records:  seamRecord{},
+		channels: channelKinds{},
+		imports:  bothDoorsImports{},
+		tags:     bothDoorsTags{},
+		stages:   operandWalkStages{},
+	}
+}
+
+// operandWalkStages answers a stage's semantic for advanceDeal, which is
+// operand-shaped and reads one to write its summary. "open" is the routine
+// step: the walk is about which row a call binds to, and a close or a reopen
+// would put the summary's own wording under test here instead.
+type operandWalkStages struct{}
+
+func (operandWalkStages) StageSemantic(context.Context, ids.UUID) (string, ids.UUID, error) {
+	return "open", ids.Nil, nil
+}
+
+// bodyTargetID reads the survivor a merge's fixture body names.
+//
+// Read out of the fixture the decoder was handed, rather than restated as a
+// constant beside the assertion: the body sent and the id expected back come
+// from one value, so a fixture edited for some other reason moves both.
+func bodyTargetID(t *testing.T, route, op, body string) ids.UUID {
+	t.Helper()
+	var named struct {
+		TargetID ids.UUID `json:"target_id"`
+	}
+	if err := json.Unmarshal([]byte(body), &named); err != nil {
+		t.Fatalf("%s (%s): reading target_id out of its own fixture body: %v", route, op, err)
+	}
+	if named.TargetID == ids.Nil {
+		t.Fatalf("%s (%s): its fixture body names no target_id, so the assertion below would compare "+
+			"against the zero uuid and pass for a decoder that staged nothing", route, op)
+	}
+	return named.TargetID
+}
+
+// assertTheFamilyIsTheContractsOwn holds the walk's corpus to a second,
+// independent reading of the same question — and fails in BOTH directions.
+//
+// A count guard ("did this walk check anything") is not enough, and measuring
+// it is what put this here: reinstating the tier prefilter that used to narrow
+// this walk drops it from 37 routes to 2, and every assertion below still
+// passes. Under-recognition is the one way a gate must not break, because it
+// reads a smaller surface, reports success, and leaves no failing assertion to
+// notice. A literal 37 would fail the wrong way instead — red on the next route
+// the contract grows, with a message about arithmetic.
+//
+// So the expectation is derived somewhere else: crm.yaml, which is what
+// agentPolicies is generated FROM. The generated table and the contract it came
+// from are two readings of one fact, so a filter that quietly narrows the walk
+// disagrees with the contract and is reported by operationId. A route the
+// contract adds appears on both sides at once and says nothing.
+func assertTheFamilyIsTheContractsOwn(t *testing.T, family map[string]agentPolicy) {
+	t.Helper()
+	walked := map[string]bool{}
+	for _, pol := range family {
+		walked[pol.Op] = true
+	}
+	declared := operandShapedOperationsInTheContract(t)
+	for op := range declared {
+		if !walked[op] {
+			t.Errorf("%s is an operand-shaped tool-accessible mutating operation in crm.yaml and this walk "+
+				"does not reach it — its decoder is never invoked, so every mis-wiring of it passes here", op)
+		}
+	}
+	for op := range walked {
+		if !declared[op] {
+			t.Errorf("%s is walked here and crm.yaml declares no operand-shaped tool-accessible mutating "+
+				"operation by that name — the generated table and the contract disagree", op)
+		}
+	}
+}
+
+// operandShapedOperationsInTheContract reads the family straight out of
+// crm.yaml: a mutating operation carrying an `x-mcp-tool` tier (which is what
+// puts an operation on the tool surface at all) on a path that names a record
+// with {id} and carries more after it.
+func operandShapedOperationsInTheContract(t *testing.T) map[string]bool {
+	t.Helper()
+	const routedID = "/{id}"
+	shaped := map[string]bool{}
+	for path, item := range loadContract(t).Paths.Map() {
+		at := strings.Index(path, routedID)
+		if at < 0 || at+len(routedID) >= len(path) {
+			continue
+		}
+		for method, op := range item.Operations() {
+			if _, onTheToolSurface := op.Extensions["x-mcp-tool"]; !onTheToolSurface || !mutatingMethod(method) {
+				continue
+			}
+			shaped[op.OperationID] = true
+		}
+	}
+	if len(shaped) == 0 {
+		t.Fatal("crm.yaml declares no operand-shaped tool-accessible mutating operation — the comparison " +
+			"above would then demand nothing of the walk")
+	}
+	return shaped
+}
+
+// loadContract reads crm.yaml as an OpenAPI document, for the gates in this
+// package that derive an expectation from the contract rather than from the
+// table generated out of it.
+func loadContract(t *testing.T) *openapi3.T {
+	t.Helper()
+	doc, err := openapi3.NewLoader().LoadFromFile("../../api/crm.yaml")
+	if err != nil {
+		t.Fatalf("loading the contract: %v", err)
+	}
+	return doc
 }

--- a/backend/internal/compose/agentcommandsingle_test.go
+++ b/backend/internal/compose/agentcommandsingle_test.go
@@ -44,13 +44,21 @@ var singlePurposeTools = []string{
 // contractBodies is each route's own minimal request body, as crm.yaml declares
 // it — every required member present and nothing else.
 //
-// They are real bodies rather than nil because the walk below asserts that a
+// They are real bodies rather than nil because the walks below assert that a
 // decoder ACCEPTS the shape its route produces, and commandBody short-circuits
 // an empty body before it decodes anything at all: passing nil would exercise
 // that short-circuit for every route and prove nothing about the structs
 // underneath it. Which routes need an entry is read off the contract rather than
 // stated here — a route that declares a requestBody must have one, and one that
 // declares none must not.
+//
+// ONE map for both walks that decode a synthetic request — the single-purpose
+// walk here and the operand walk in agentcommandoperand_test.go. They ask the
+// same question of the same operations ("what is the minimal body this route
+// declares"), and the two families overlap: advanceDeal and the merges are
+// operand-shaped as well as single-purpose. Two maps answered it twice, and the
+// second held two entries for routes its own walk filtered out — dead fixtures
+// nothing read, which is what a duplicated fixture set decays into.
 //
 // gatekit:fixture the request body crm.yaml declares for each route — expected input the walk decodes, not a waived cost
 var contractBodies = map[string]string{
@@ -85,6 +93,24 @@ var contractBodies = map[string]string{
 	"rejectApproval":        `{"reason":"not this quarter"}`,
 	"approveApprovalBundle": `{"reason":"all six corrections check out"}`,
 	"rejectApprovalBundle":  `{"reason":"the run misread the thread"}`,
+
+	// The operand family's own bodies, on the same rule: every required member
+	// crm.yaml declares, and nothing else.
+	"setProjectStakeholder":          `{"person_id":"019ff000-0000-7000-8000-000000000031","role":"champion"}`,
+	"setProjectCompany":              `{"organization_id":"019ff000-0000-7000-8000-000000000032","role":"partner"}`,
+	"applyTag":                       `{"entity_type":"person","entity_id":"019ff000-0000-7000-8000-000000000033"}`,
+	"removeTag":                      `{"entity_type":"person","entity_id":"019ff000-0000-7000-8000-000000000034"}`,
+	"mergeTags":                      `{"into_tag_id":"019ff000-0000-7000-8000-000000000035"}`,
+	"demoteLead":                     `{"reason":"the account went quiet"}`,
+	"createOffer":                    `{"currency":"EUR","source":"manual"}`,
+	"addOfferLineItem":               `{"quantity":2}`,
+	"updateOfferLineItem":            `{"quantity":3}`,
+	"openDealRoomThread":             `{"body":"can we revisit the delivery date?"}`,
+	"replyDealRoomThread":            `{"body":"yes — moving it a week."}`,
+	"createOrganizationFact":         `{"category":"company","field":"headcount","value":"240"}`,
+	"updateOrganizationFact":         `{"value":"260"}`,
+	"updateOrganizationProfileField": `{"value":"Acme GmbH"}`,
+	"updateCustomFieldOptions":       `{"options":["bronze","silver","gold"]}`,
 }
 
 // What a registration does not say: that the decoder bound to a route can

--- a/backend/internal/compose/agentcommandstagedrow_integration_test.go
+++ b/backend/internal/compose/agentcommandstagedrow_integration_test.go
@@ -121,8 +121,21 @@ func TestBothDoorsStageOneRowForOneOperation(t *testing.T) {
 }
 
 // A record the agent's own row scope hides is refused by BOTH doors, and
-// neither stages anything: the guards each door runs are the same guards,
-// reached through the same resolver.
+// neither stages anything.
+//
+// What this holds is the DOOR-TO-DOOR agreement over a real hidden row: one
+// credential, one answer, through the real provider and the real store's
+// row-scope clause. What it does not hold on its own is that Guards ran.
+// Guards and Subject answer from one memoized read (archiveResolver.target),
+// so a row the caller cannot read fails Subject too, and this test would pass
+// against a door that resolved a subject and never asked the guard.
+//
+// Guards' own contribution — the external-system-of-record refusal, on a row
+// the read SUCCEEDS for — is isolated per door instead, where a stub can hold
+// the read open and vary only that one answer:
+// TestAnArchiveOfAnExternallyHeldRecordStagesNothing for the REST door and
+// TestTheToolDoorRefusesAnExternallyHeldRecordItCanRead for the tool door.
+// Together with this test the claim is whole; neither half states it alone.
 func TestBothDoorsRefuseOneRecordNeitherCallerCanSee(t *testing.T) {
 	e := integration.Setup(t)
 	native := NewProvider(e.Pool)

--- a/backend/internal/compose/agentgateauto.go
+++ b/backend/internal/compose/agentgateauto.go
@@ -80,7 +80,7 @@ func runAutoExecuted(w http.ResponseWriter, r *http.Request, next http.Handler, 
 	// asserted one — so nothing charges it here.
 	performed := &effectRecorder{ResponseWriter: w}
 	metered := &servedMeter{ResponseWriter: performed, r: r, reg: outcome.registry, mayRefuse: theEffectAlreadyLanded}
-	if !redeemed && outcome.pol.Tool == toolUpdateRecord && !actionShapedUpdateOps[outcome.pol.Op] {
+	if !redeemed && reachesTheHumanOwnedSplit(outcome.pol) {
 		splitHumanOwnedUpdate(metered, r, next,
 			splitUpdateDeps{staging: outcome.staging, commands: outcome.commands, ownership: outcome.ownership},
 			outcome.pol, outcome.body)
@@ -189,4 +189,17 @@ func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tok
 	}
 	r.Header.Set(ifMatchHeader, strconv.FormatInt(admitted, 10))
 	return true
+}
+
+// reachesTheHumanOwnedSplit reports whether an admitted call is the shape the
+// field split governs: a whole-record update_record patch, whose body can mix
+// fields a human owns with fields an agent may write.
+//
+// Named rather than spelled inline because the gate that walks this path
+// (TestEveryWholeRecordPatchRunsItsGuardsBeforeTheAutoExecuteHalf) needs the
+// same answer, and a walk that restated the condition would go on driving the
+// set it was written against after this one moved — passing over a route that
+// had stopped being covered.
+func reachesTheHumanOwnedSplit(pol agentPolicy) bool {
+	return pol.Tool == toolUpdateRecord && !actionShapedUpdateOps[pol.Op]
 }

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -9,17 +9,24 @@ package compose
 // a client that cannot read its own error.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
 
 // bufferedFor builds a buffered response already holding a status and headers,
@@ -438,4 +445,196 @@ func TestARefusalBeforeAnythingIsWrittenReportsNoWrite(t *testing.T) {
 		t.Error("a refusal that wrote nothing reported a write, which strands the caller's idempotency key " +
 			"on a call they are entitled to retry unchanged")
 	}
+}
+
+// Every route the field split governs settles its refusals BEFORE the
+// auto-execute half runs — not only the one operation this was first proven for.
+//
+// Registering all the whole-record patch routes put patchResolver.Guards on
+// this path: a records.Read plus the external-system-of-record refusal that the
+// split path never ran on its own before. Deliberate, and until now exercised
+// for updateOrganization alone, with the policy written as a literal beside the
+// assertion — so the rest carried the ordering on the strength of sharing a
+// code path, which is the argument that stops being true the moment one of them
+// stops sharing it.
+//
+// The corpus is production's OWN routing condition (reachesTheHumanOwnedSplit,
+// agentgateauto.go) over the generated policy table, and the policies are its
+// rows rather than literals. A route that joins this family is walked here
+// without anybody remembering to add it; one that leaves stops being walked at
+// the same moment it stops being routed. Nothing narrows it further.
+//
+// What each case proves is the ORDERING, which is the whole of #1073: a target
+// this door will not stage against must cost the caller a retry, never a
+// half-applied patch under a 4xx saying the change was refused. The handler
+// failing the test if it runs at all is that assertion — everything the door
+// can refuse on is a function of the policy, the path and the staged sub-patch,
+// all of which exist before dispatch.
+//
+// Every route lands on ONE of two positive assertions, and that is what keeps
+// the walk from reading a shrinking corpus as success: a served record type
+// must be refused before dispatch, and an unserved one — where Guards has no
+// seam row and so no refusal to make — must reach the handler. Silence is not
+// available to either.
+func TestEveryWholeRecordPatchRunsItsGuardsBeforeTheAutoExecuteHalf(t *testing.T) {
+	family := splitGovernedRoutes()
+	served := 0
+	for route, pol := range family {
+		// patchResolver.Guards refuses on the SEAM's answer about the row —
+		// unreadable, or held in another system of record — so a record type
+		// the seam does not serve has no such answer and no refusal to make.
+		//
+		// The exclusion is datasource's own list of served types, which is
+		// production data rather than a set written down here: a type that
+		// joins the seam joins this assertion in the same commit, with nobody
+		// to remember it. That is what stops this walk from quietly shrinking
+		// — the one failure mode a census does not report.
+		if !servedByTheRecordSeam(pol.RecordType) {
+			continue
+		}
+		// And a route that sends no patchable field has no human-owned one
+		// either, so the ownership probe finds no conflict and the call
+		// dispatches without ever reaching the staging arm Guards sits on.
+		// Read off the contract, the same place the body itself comes from.
+		conflict, body := patchBodyFromTheContract(t, pol.Op)
+		if body == nil {
+			continue
+		}
+		served++
+		t.Run(pol.Op, func(t *testing.T) {
+			staging := &capturingApprovals{}
+			rec := httptest.NewRecorder()
+			next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Errorf("%s: the handler ran for a record whose authority lives elsewhere — the "+
+					"agent-owned half was written for a call this door then refused", route)
+			})
+
+			admitAgentCall(rec, splitRequestFor(route, body), next, admissionOutcome{
+				staging: staging, ownership: mixedHumanOwned{conflict: conflict},
+				commands: restCommandDeps{records: mirroredRecord{}}, pol: pol, body: body,
+				registry: agents.NewRegistry(nil, auth.NewGate(fullSeat{})),
+			})
+
+			if staging.last.Tool != "" {
+				t.Errorf("%s: an approval was staged against a record whose authority lives elsewhere — "+
+					"nobody could ever release it", route)
+			}
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Errorf("%s: an externally-held target answered %d, want %d (unsupported_by_sor)",
+					route, rec.Code, http.StatusUnprocessableEntity)
+			}
+		})
+	}
+	if served == 0 {
+		t.Fatal("no route the field split governs both targets a seam-served record type and patches a " +
+			"field — this walk drove nothing, and would pass against a guard that had stopped running " +
+			"on the path entirely")
+	}
+}
+
+// splitGovernedRoutes are the agent-reachable routes the field split governs,
+// asked of production's own condition rather than restated here.
+func splitGovernedRoutes() map[string]agentPolicy {
+	family := map[string]agentPolicy{}
+	for route, pol := range agentPolicies {
+		if pol.Access == accessTool && reachesTheHumanOwnedSplit(pol) {
+			family[route] = pol
+		}
+	}
+	return family
+}
+
+// splitRequestFor is the request the router would hand the gate for one route
+// of this family, carrying the body the contract declares.
+//
+// Built from the route TEMPLATE, so every path parameter is bound — not just
+// the routed {id}. Several of these operations name a second operand in the
+// path (the fact key, the profile field, the stakeholder), and a request that
+// left one unbound would be refused for the missing segment rather than by the
+// guard under test: a 500 that reads exactly like the refusal being asserted.
+func splitRequestFor(route string, body []byte) *http.Request {
+	req := syntheticOperandRequest(route, ids.NewV7())
+	if body == nil {
+		return req
+	}
+	withBody := req.Clone(req.Context())
+	withBody.Body = io.NopCloser(bytes.NewReader(body))
+	withBody.ContentLength = int64(len(body))
+	return withBody
+}
+
+// patchBodyFromTheContract builds one operation's minimal patch body out of
+// crm.yaml, and names which of its fields the ownership probe will call
+// human-owned.
+//
+// TWO fields where the schema has them, because the RESIDUE path is reached
+// only by a mixed patch: one field conflicts and is staged, the rest
+// auto-execute. A schema declaring one takes allHumanOwned's terminal branch
+// instead, which refuses the same way and for the same reason — this walk is
+// about the ordering both branches share, and neither may dispatch first.
+//
+// Read from the contract rather than written here because the split reasons
+// about field NAMES: a name this schema does not carry would exercise the walk
+// against a patch the route cannot receive, and the operation whose real fields
+// stopped matching would be the one case that quietly went on passing.
+func patchBodyFromTheContract(t *testing.T, op string) (conflict string, body []byte) {
+	t.Helper()
+	for _, item := range loadContract(t).Paths.Map() {
+		for _, candidate := range item.Operations() {
+			if candidate.OperationID != op || candidate.RequestBody == nil {
+				continue
+			}
+			schema := candidate.RequestBody.Value.Content.Get("application/json").Schema.Value
+			names := slices.Sorted(maps.Keys(schema.Properties))
+			if len(names) == 0 {
+				t.Fatalf("%s declares a request body with no patchable field, so the ownership probe "+
+					"below has nothing to name and this walk sends an empty patch", op)
+			}
+			fields := map[string]any{}
+			for _, name := range names[:min(2, len(names))] {
+				fields[name] = placeholderFor(schema.Properties[name].Value)
+			}
+			encoded, err := json.Marshal(fields)
+			if err != nil {
+				t.Fatalf("%s: encoding its own fields: %v", op, err)
+			}
+			return names[0], encoded
+		}
+	}
+	// No request body: the route sends no fields, so there is nothing for the
+	// ownership probe to be asked about and nothing to split. The refusal under
+	// test is Guards' own, which reads the ROW rather than the fields, so it is
+	// owed here exactly as it is for a route that patches columns.
+	return "", nil
+}
+
+// placeholderFor is a value of the type the contract declares for a field.
+//
+// The values are never read — every case here is decided before the patch
+// reaches a writer — but they are typed anyway, because an untyped placeholder
+// makes the body a shape the route does not accept, and the first case that DID
+// read one would be proven against a request no caller can send.
+//
+//craft:ignore naked-any a JSON value of whichever type the schema declares — the return is fed straight to json.Marshal, and any narrower type would be one of these cases spelled as a union
+func placeholderFor(schema *openapi3.Schema) any {
+	switch {
+	case len(schema.Enum) > 0:
+		return schema.Enum[0]
+	case schema.Type.Is("integer"), schema.Type.Is("number"):
+		return 1
+	case schema.Type.Is("boolean"):
+		return true
+	case schema.Type.Is("array"):
+		return []any{}
+	case schema.Type.Is("object"):
+		return map[string]any{}
+	default:
+		return "placeholder"
+	}
+}
+
+// servedByTheRecordSeam answers from datasource's own list, the same source
+// agents.servedByTheRecordSeam reads — not a copy of the types it names today.
+func servedByTheRecordSeam(rt agentRecordType) bool {
+	return slices.Contains(datasource.EntityTypes(), datasource.EntityType(rt))
 }


### PR DESCRIPTION
Closes #1072 — three of the four gaps it filed. The fourth is already closed, with evidence below.

## 1. The wiring walk checked 2 of 37 routes

`TestEveryConfirmFirstOperandRouteDecodesIntoTheRightCommand` is the one gate that proves a decoder bound to an operationId is the **right** one: it decodes a synthetic request for the route the policy table names and compares the staged target against what that table declared. The presence gate cannot do this — a swapped decoder still stages something, usually something that looks right.

Its `Tier != tierConfirmationRequired` filter reached **2** routes and dropped **13**, and the two routes it carried request bodies for (`setProjectStakeholder`, `setProjectCompany`) were both in the dropped set. Fixtures nothing read — a census telling you it has stopped seeing its subject.

Tier was the wrong axis regardless. A mis-wired decoder is *worse* under `auto_execute`, because no human sits between the wiring and the write.

The family is now the route's **shape** — a routed `{id}` with more path after it, which is exactly what makes a synthetic request sufficient — and it covers 37 routes. The expectation splits three ways, each a positive assertion rather than a skip:

| shape | staged target | derived from |
|---|---|---|
| patch / action | the declared record type, at the routed id | `pol.RecordType` |
| creation | **no id** — the routed `{id}` names the parent | `pol.Tool == "create_record"` |
| merge | the survivor the body names | `pol.Tool == "merge_records"` |

`operandBodies` is gone: it and `contractBodies` were two answers to "what is the minimal body this route declares", and the second had decayed into dead entries. One map now, and the walk makes the same crm.yaml agreement check the single-purpose walk does — a route that declares a body must have one, and one that declares none must not.

## 2. …and it can no longer fail short

The important measurement. With the walk widened, reinstating the old prefilter drops it from 37 routes to 2 **and every assertion still passes**. Under-recognition is the one way a gate must not break: it reads a smaller surface, reports PASS, and leaves no failing assertion to notice. A literal `37` fails the other way — red on the next route the contract grows, with a message about arithmetic.

So the corpus is held against **crm.yaml**, the contract `agentPolicies` is generated from: an independent reading of the same fact, compared in both directions. Reinstating the prefilter now names 31 operations the walk stopped reaching.

## 3. The split's guards were proven for one operation

Registering the whole-record patch routes put `patchResolver.Guards` on the residue path — a `records.Read` plus the external-SoR refusal the split never ran on its own before. One test drove it, with `agentPolicy{Op: "updateOrganization", …}` written as a literal beside the assertion; the rest carried the ordering on the strength of sharing a code path.

Thirteen routes are now driven, and the corpus is **production's own routing condition**. I extracted `reachesTheHumanOwnedSplit` from `agentgateauto.go` so the gate asks the same question the gate under test asks, rather than restating it — a walk that restated it would go on driving the old set after production moved.

Each case asserts #1073's ordering: a target this door will not stage against costs the caller a retry, never a half-applied patch under a 4xx saying the change was refused. Two exclusions, both derived from production data rather than listed: a record type `datasource.EntityTypes()` does not serve has no seam row for Guards to refuse on, and a route declaring no patchable field has no human-owned one either.

## 4. A row-scope refusal does not isolate the guard it names

`TestBothDoorsRefuseOneRecordNeitherCallerCanSee` claimed "the guards each door runs are the same guards". `Guards` and `Subject` answer from one memoized read (`archiveResolver.target`), so a row hidden by row scope fails `Subject` too — the test passed whether or not `Guards` ran.

An externally-held record separates them: the read **succeeds** and `Subject` describes the row happily, so a refusal can only be Guards'. The REST door already had that test; the tool door now has its own (`TestTheToolDoorRefusesAnExternallyHeldRecordItCanRead`), driven through the registry with the tier floor that makes it reach staging at all. The both-doors comment now says what it holds and points at the two halves that hold the rest.

## Gap 2 was already closed

`assertEveryServedOperationIsComparedOrRatified` is the fitness function the ticket asks for. A tool that gains a record type without its `OpenAPIOp` gaining the operationId does not drop out silently: it fails unless ratified in `notExpressibleByItsVerb` with a reason, and the verb's scope is read from the published `InputSchema` enum unioned with `Registry.Performs` — the system-derived source the ticket names. No change.

## Mutation checks

Each against the defect it names, on a `cp` backup:

| mutation | before | after |
|---|---|---|
| `addOfferLineItem` bound to `applyTag`'s decoder (the ticket's own example) | presence gate green | fails, names the wrong record type |
| `createOffer` stages the routed deal id | not asserted | fails |
| the tier prefilter reinstated | **passed** | fails, 31 routes named |
| the residue path dispatches before it refuses | 1 test | 10 fail |
| `boundCommand.Guards` short-circuited | both-doors test green | both isolating tests fail |

## Checks

`make check-backend` green; `make craft-static` 0/0/0; `go test -count=1 ./gates` green; the compose integration lane green. One `//craft:ignore naked-any` with a reason on `placeholderFor`, whose return is fed straight to `json.Marshal`. `wantFixtureAnnotations` lowered 48 → 47 with `operandBodies`.