### PR TITLE
fix(capture): a Telegram 409 says which of its two causes it met

### DIFF
--- a/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_fixture_integration_test.go
@@ -146,6 +146,14 @@ func (f *fakeTelegramAPI) DeleteWebhook(context.Context, string) error {
 	return nil
 }
 
+// WebhookRegistered: these bots arrive with none, which is the ordinary case.
+// Recorded like every other call, so a suite asserting the provider sequence
+// sees the ask rather than only its consequence.
+func (f *fakeTelegramAPI) WebhookRegistered(context.Context, string) (bool, error) {
+	f.record("getWebhookInfo")
+	return false, nil
+}
+
 // GetUpdates answers the offset contract: everything still held at or above
 // offset, with the batch's highest id, and the acknowledgement of everything
 // below applied first.

--- a/backend/internal/compose/telegrampoll.go
+++ b/backend/internal/compose/telegrampoll.go
@@ -368,11 +368,19 @@ func (w *telegramPollWorker) answerPollFailure(wsCtx context.Context, target cap
 
 // answerRivalConsumer handles Telegram's 409 — something else holds this bot's
 // updates. There are two causes and they need different answers, so this
-// establishes WHICH rather than inferring it: clear the one cause this
-// installation can clear (a registered webhook — pending updates deliberately
-// KEPT, they are the customer's messages), then ask again with NO long-poll
-// interval, so the second answer is a fact about a bot that provably carries no
-// webhook.
+// establishes WHICH rather than inferring it: ASK whether a webhook is
+// registered, clear the one cause this installation can clear (pending updates
+// deliberately KEPT, they are the customer's messages), then ask again with NO
+// long-poll interval, so the second answer is a fact about a bot that provably
+// carries no webhook.
+//
+// The ASK is what makes the report true. deleteWebhook is idempotent and
+// answers ok whether or not anything was there, so a clear followed by a poll
+// that succeeds used to be reported as "cleared a webhook that was blocking
+// this bot" even when no webhook had ever existed and a transient rival had
+// simply stopped. That sends an operator looking for a registration that is not
+// there while the actual rival goes unnamed — and the two causes have opposite
+// remedies, so guessing between them is worse than saying which is unknown.
 //
 // The re-ask uses the SAME offset, so it acknowledges nothing: whatever it comes
 // back with is still held by Telegram and belongs to the next poll. That is what
@@ -383,15 +391,36 @@ func (w *telegramPollWorker) answerPollFailure(wsCtx context.Context, target cap
 // bot on its second attempt meeting a genuinely registered webhook would be parked
 // under a cause that is not true, and recovered only by hand.
 func (w *telegramPollWorker) answerRivalConsumer(wsCtx context.Context, target capture.ChannelPollTarget, token string, err error) error {
+	// Asked BEFORE the clear, because afterwards there is nothing left to ask:
+	// the answer would be "none" whichever cause was true.
+	registered, infoErr := w.api.WebhookRegistered(wsCtx, token)
+	if infoErr != nil {
+		// Not fatal, and not guessed at either. Without this answer the two
+		// causes cannot be told apart, so the report below says so rather than
+		// picking one.
+		w.log.WarnContext(wsCtx, "telegram_poll: could not establish whether a webhook is registered; the cause of the refusal will be reported as unknown",
+			"connection", target.ID.String(), "error", infoErr.Error())
+	}
 	if delErr := w.api.DeleteWebhook(wsCtx, token); delErr != nil {
 		return fmt.Errorf("telegram_poll: connection %s is refused by Telegram and its webhook could not be cleared: %w",
 			target.ID, errors.Join(err, delErr))
 	}
 	_, _, reasked := w.api.GetUpdates(wsCtx, token, target.PollOffset, 0, telegram.AllowedUpdates())
 	if !errors.Is(reasked, telegram.ErrWebhookActive) {
-		// The registration WAS the cause and it is gone. This job's long poll is
-		// over either way, so the failure is returned for River's ladder rather
-		// than the re-ask's answer being consumed here.
+		// The bot polls again. This job's long poll is over either way, so the
+		// failure is returned for River's ladder rather than the re-ask's answer
+		// being consumed here — but WHY it polls again is now known rather than
+		// assumed, and the two readings send an operator to different places.
+		if infoErr == nil && !registered {
+			w.log.WarnContext(wsCtx, "telegram_poll: another consumer was holding this bot's updates and has stopped; no webhook was registered; retrying",
+				"connection", target.ID.String())
+			return fmt.Errorf("telegram_poll: connection %s was refused by a rival consumer that has since stopped: %w", target.ID, err)
+		}
+		if infoErr != nil {
+			w.log.WarnContext(wsCtx, "telegram_poll: polling recovered after clearing any webhook, but whether one was registered could not be established; retrying",
+				"connection", target.ID.String())
+			return fmt.Errorf("telegram_poll: connection %s recovered after a clear, cause unestablished: %w", target.ID, err)
+		}
 		w.log.WarnContext(wsCtx, "telegram_poll: cleared a webhook that was blocking this bot's polling; retrying",
 			"connection", target.ID.String())
 		return fmt.Errorf("telegram_poll: connection %s had a webhook registered, now cleared: %w", target.ID, err)

--- a/backend/internal/compose/telegrampoll_test.go
+++ b/backend/internal/compose/telegrampoll_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -142,19 +144,78 @@ func TestTheTelegramPollJobTimeoutExceedsItsLongPoll(t *testing.T) {
 	}
 }
 
+// The report names the cause it established, and the two causes have opposite
+// remedies.
+//
+// deleteWebhook is idempotent and answers ok whether or not anything was there,
+// so a clear followed by a poll that succeeds cannot tell "the webhook was the
+// cause" from "a rival let go" — and the old report always said the former. It
+// sent an operator looking for a registration that was not there while the
+// actual rival went unnamed.
+func TestAConflictReportsWhichCauseItEstablished(t *testing.T) {
+	for _, c := range []struct {
+		name       string
+		registered bool
+		want       string
+		wantNot    string
+	}{
+		{
+			name:       "a webhook was registered and cleared",
+			registered: true,
+			want:       "had a webhook registered, now cleared",
+		},
+		{
+			name:       "no webhook: another consumer had the bot and let go",
+			registered: false,
+			want:       "refused by a rival consumer that has since stopped",
+			wantNot:    "had a webhook registered",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			api := &clearRecordingAPI{webhookRegistered: c.registered}
+			w := newTelegramPollWorker(nil, nil, api, nil, quietTestLogger())
+
+			err := w.answerPollFailure(context.Background(), capture.ChannelPollTarget{ID: ids.NewV7()},
+				"1:x", fmt.Errorf("telegram: getUpdates: %w", telegram.ErrWebhookActive))
+			if err == nil {
+				t.Fatal("the conflict was swallowed")
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("got %v, want it to say %q", err, c.want)
+			}
+			if c.wantNot != "" && strings.Contains(err.Error(), c.wantNot) {
+				t.Errorf("got %v, which claims %q — that registration does not exist, and looking for it is not the remedy", err, c.wantNot)
+			}
+		})
+	}
+}
+
 // clearRecordingAPI is the provider boundary for the failure arms: it records
 // every webhook clear and answers a bare re-ask, because these cases are about
 // what the poller DOES with a refusal, not about a batch.
 type clearRecordingAPI struct {
 	telegram.API
 	cleared []string
+	// asked records every call in order, so a test can assert the webhook was
+	// ASKED ABOUT before it was cleared. Afterwards there is nothing left to
+	// ask: getWebhookInfo would answer "none" whichever cause was true, so the
+	// order is the property rather than the calls being present.
+	asked []string
+	// webhookRegistered is what WebhookRegistered answers.
+	webhookRegistered bool
 	// reaskTimeouts is the interval each getUpdates was asked to hold for. The
 	// re-ask after a clear must name ZERO: a second long poll would spend the job's
 	// remaining budget learning what an immediate ask answers.
 	reaskTimeouts []int
 }
 
+func (a *clearRecordingAPI) WebhookRegistered(context.Context, string) (bool, error) {
+	a.asked = append(a.asked, "getWebhookInfo")
+	return a.webhookRegistered, nil
+}
+
 func (a *clearRecordingAPI) DeleteWebhook(_ context.Context, token string) error {
+	a.asked = append(a.asked, "deleteWebhook")
 	a.cleared = append(a.cleared, token)
 	return nil
 }
@@ -185,6 +246,13 @@ func TestAConflictClearsTheWebhookThenRe_asksToEstablishTheCause(t *testing.T) {
 	}
 	if len(api.reaskTimeouts) != 1 || api.reaskTimeouts[0] != 0 {
 		t.Fatalf("the re-ask asked Telegram to hold for %v, want a single ask of 0 — a second long poll would spend the job's whole budget on it", api.reaskTimeouts)
+	}
+	// ASKED FIRST. After the clear there is nothing left to establish: the
+	// answer would be "no webhook" whichever cause was true, so a poller that
+	// asked afterwards could only report a guess.
+	want := []string{"getWebhookInfo", "deleteWebhook"}
+	if !slices.Equal(api.asked, want) {
+		t.Fatalf("provider calls %v, want %v — the registration has to be established before it is cleared", api.asked, want)
 	}
 }
 

--- a/backend/internal/compose/telegrampollfixture_integration_test.go
+++ b/backend/internal/compose/telegrampollfixture_integration_test.go
@@ -65,6 +65,12 @@ type telegramPollFakeAPI struct {
 	// state rather than counting calls is what lets one fixture serve both the
 	// repairable conflict and the one that survives a clear.
 	webhookRegistered bool
+	// rivalHolds models the OTHER 409 cause, the one no clear repairs: another
+	// consumer holding this bot's updates. It refuses that many polls and then
+	// stops, which is what a transient rival does — and it is the case that
+	// looked identical to a cleared webhook, because deleteWebhook answers ok
+	// whether or not anything was there.
+	rivalHolds int
 	// onGetUpdates runs inside getUpdates, after the batch is chosen and outside
 	// the mutex, so a test can make something else commit WHILE a poll is in
 	// flight — the 25s window a lifecycle change actually lands in.
@@ -73,6 +79,14 @@ type telegramPollFakeAPI struct {
 
 func (f *telegramPollFakeAPI) GetMe(context.Context, string) (telegram.Bot, error) {
 	return f.bot, nil
+}
+
+// WebhookRegistered answers the same field DeleteWebhook clears, so a fixture
+// cannot claim a webhook was cleared that this fake never had.
+func (f *telegramPollFakeAPI) WebhookRegistered(context.Context, string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.webhookRegistered, nil
 }
 
 func (f *telegramPollFakeAPI) DeleteWebhook(context.Context, string) error {
@@ -89,6 +103,13 @@ func (f *telegramPollFakeAPI) GetUpdates(_ context.Context, _ string, offset int
 	failWith := f.failWith
 	if failWith == nil && f.webhookRegistered {
 		failWith = fmt.Errorf("telegram: getUpdates: Conflict: can't use getUpdates method while webhook is active: %w",
+			telegram.ErrWebhookActive)
+	}
+	if failWith == nil && f.rivalHolds > 0 {
+		f.rivalHolds--
+		// Telegram answers the SAME sentinel for both causes — which is the
+		// whole reason the poller has to establish which one it met.
+		failWith = fmt.Errorf("telegram: getUpdates: Conflict: terminated by other getUpdates request: %w",
 			telegram.ErrWebhookActive)
 	}
 	hook := f.onGetUpdates

--- a/backend/internal/compose/telegrampollhealth_integration_test.go
+++ b/backend/internal/compose/telegrampollhealth_integration_test.go
@@ -157,6 +157,54 @@ func TestAConflictAWebhookClearRepairsLeavesTheConnectionLive(t *testing.T) {
 	}
 }
 
+// A rival that stops is reported as a rival, not as a cleared webhook.
+//
+// deleteWebhook is idempotent and answers ok whether or not anything was there,
+// so a clear followed by a poll that succeeds used to be read as "the webhook
+// was the cause" — even when no webhook had ever been registered and another
+// consumer had simply let go. The log then sent an operator looking for a
+// registration that does not exist while the actual rival went unnamed, and the
+// two causes have opposite remedies.
+//
+// The bot here carries NO webhook and meets a rival that holds one poll.
+func TestAConflictWithNoWebhookIsReportedAsARivalRatherThanAClear(t *testing.T) {
+	e := integration.Setup(t)
+	integration.ApplyRiverSchema(t)
+	vault := keyvault.NewMemory()
+
+	api := &telegramPollFakeAPI{
+		bot:  telegram.Bot{ID: 92000014, Username: "rival_consumer_bot"},
+		held: []json.RawMessage{telegramPrivateUpdate(7201, 781201, 112, "after the rival let go")},
+	}
+	conn := connectTestTelegramBot(t, e, vault, api, 92000014, "rival_consumer_bot")
+	// One refusal, and no webhook anywhere: the rival has the bot and then
+	// stops, which is exactly the pair the old report could not tell apart.
+	api.rivalHolds = 1
+	api.webhookRegistered = false
+
+	err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn)
+	if err == nil {
+		t.Fatal("the conflict was swallowed — a poll that collected nothing must not report success")
+	}
+	// WHICH cause it names is asserted at the unit level, where the raw error
+	// is the return value: this job's failure reaches the caller sanitised, so
+	// a report assertion here would be checking the redaction rather than the
+	// diagnosis. What this proves is the half that needs a database — that a
+	// rival letting go leaves a live connection that goes on to collect.
+
+	// The connection stays live: a rival is not a reason to retire a bot that
+	// is now pollable, and the retry proves it is.
+	if status := telegramConnectionStatus(t, e, conn); status != "connected" {
+		t.Fatalf("status = %q, want connected", status)
+	}
+	if err := runOnePoll(t, newTestPollWorker(e, vault, api, ambientPollInserter(t, e)), e.WS, conn); err != nil {
+		t.Fatalf("the poll after the rival let go: %v", err)
+	}
+	if n := rawCaptureCount(t, e, conn, 7201); n != 1 {
+		t.Errorf("%d raw rows after the retry, want 1", n)
+	}
+}
+
 // telegramConnectionStatus reads the connection's status through the same
 // transaction seam the poller writes it through.
 func telegramConnectionStatus(t *testing.T, e *integration.Env, conn capture.ChannelConnection) string {

--- a/backend/internal/modules/capture/channelconnfixture_test.go
+++ b/backend/internal/modules/capture/channelconnfixture_test.go
@@ -45,6 +45,9 @@ type fakeTelegram struct {
 	// deleteWebhookErr, when non-nil, is what DeleteWebhook answers — the one
 	// provider refusal that can stop a connect after getMe has already succeeded.
 	deleteWebhookErr error
+	// webhookRegistered is what WebhookRegistered answers. False by default,
+	// which is the ordinary case: a bot arrives at connect with no webhook.
+	webhookRegistered bool
 	// deleteWebhookHook runs once, before the next DeleteWebhook takes the lock, so
 	// a test can drive a second concurrent lifecycle operation while this one is
 	// mid-flight at the provider. It fires outside the mutex because what it drives
@@ -119,6 +122,15 @@ func (f *fakeTelegram) GetUpdates(context.Context, string, int64, int, []string)
 	// The connect suite is about the binding lifecycle, never about ingress; a
 	// test that polls here is asking the wrong fixture and must be told so.
 	panic("fakeTelegram: the channel-connect suite must not poll for updates")
+}
+
+// WebhookRegistered: this fixture's bots arrive with no webhook, which is the
+// ordinary case a connect meets. A test that needs the other answer sets
+// webhookRegistered.
+func (f *fakeTelegram) WebhookRegistered(context.Context, string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.webhookRegistered, nil
 }
 
 func (f *fakeTelegram) DeleteWebhook(_ context.Context, token string) error {

--- a/backend/internal/modules/capture/telegram/api.go
+++ b/backend/internal/modules/capture/telegram/api.go
@@ -59,6 +59,17 @@ type API interface {
 	// Telegram refuses getUpdates while a webhook exists, so clearing whatever a
 	// bot arrives carrying is what makes it pollable at all.
 	DeleteWebhook(ctx context.Context, token string) error
+	// WebhookRegistered reports whether this bot currently has a webhook, which
+	// is the one question deleteWebhook cannot answer: it is idempotent and
+	// returns ok whether or not anything was there.
+	//
+	// Named for the question rather than for getWebhookInfo, because that is
+	// what the caller needs. Telegram refuses getUpdates for two different
+	// reasons — a registered webhook, or another consumer holding the same bot
+	// — and without this the two are indistinguishable after the fact: a clear
+	// followed by a successful poll reads as "the webhook was the cause" even
+	// when there was never a webhook and a rival simply went away.
+	WebhookRegistered(ctx context.Context, token string) (bool, error)
 	// GetUpdates long-polls for the next batch after offset, returning each
 	// update's raw JSON — the subject and normalize passes both read raw bytes
 	// — and the highest update_id in the batch (0 when the batch is empty).
@@ -132,15 +143,6 @@ func (a *httpAPI) GetMe(ctx context.Context, token string) (Bot, error) {
 		return Bot{}, fmt.Errorf("getMe answered without a bot id: %w", ErrRequestRejected)
 	}
 	return Bot{ID: out.ID, Username: out.Username}, nil
-}
-
-// DeleteWebhook clears any webhook registered against the bot.
-//
-// drop_pending_updates is deliberately NOT sent: its default is false, and those
-// pending updates are the customer's messages — the first poll after a connect is
-// meant to collect them.
-func (a *httpAPI) DeleteWebhook(ctx context.Context, token string) error {
-	return a.call(ctx, token, "deleteWebhook", nil, nil)
 }
 
 // longPollSlack is the headroom a long poll gets on top of the interval it asks

--- a/backend/internal/modules/capture/telegram/webhook.go
+++ b/backend/internal/modules/capture/telegram/webhook.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package telegram
+
+// The two webhook calls, together because they answer one question between
+// them: whether this bot has a registration, and clearing it if it does.
+//
+// They are a pair rather than two utilities. deleteWebhook is idempotent and
+// answers ok whether or not anything was there, so it cannot report what it
+// repaired — and Telegram refuses getUpdates for two different reasons, a
+// registered webhook or another consumer holding the same bot, with the SAME
+// error. A caller that clears and then polls successfully has learned nothing
+// about which it met unless it asked first.
+
+import "context"
+
+// DeleteWebhook clears any webhook registered against the bot.
+//
+// drop_pending_updates is deliberately NOT sent: its default is false, and those
+// pending updates are the customer's messages — the first poll after a connect is
+// meant to collect them.
+func (a *httpAPI) DeleteWebhook(ctx context.Context, token string) error {
+	return a.call(ctx, token, "deleteWebhook", nil, nil)
+}
+
+// WebhookRegistered asks getWebhookInfo whether this bot has one.
+//
+// The URL is the registration: Telegram answers getWebhookInfo for every bot,
+// and reports an EMPTY url for one that has no webhook rather than refusing.
+// So an empty url is a definite "none", not a missing answer.
+func (a *httpAPI) WebhookRegistered(ctx context.Context, token string) (bool, error) {
+	var out struct {
+		URL string `json:"url"`
+	}
+	if err := a.call(ctx, token, "getWebhookInfo", nil, &out); err != nil {
+		return false, err
+	}
+	return out.URL != "", nil
+}


### PR DESCRIPTION
Closes #2061.

## The wrong report

Telegram refuses `getUpdates` for **two** reasons and answers the same error for both: a registered webhook, or another consumer holding the same bot. The poller cleared the one cause it can clear and re-asked to establish which it was.

But `deleteWebhook` is **idempotent** — it answers `ok: true` whether or not anything was there. So a clear followed by a poll that succeeds says nothing about what repaired it, and the code read it as the webhook every time:

```
cleared a webhook that was blocking this bot's polling
```

When no webhook had ever been registered and a transient rival simply let go, that sends an operator looking for a registration that does not exist while the actual rival goes unnamed. The two causes have **opposite remedies** — one is a configuration this installation can fix, the other is a second process somebody has to find — so guessing between them is worse than saying which is unknown.

## Asked before the clear

`getWebhookInfo` answers it, and the order is the property: afterwards there is nothing left to establish, because the answer would be "none" whichever cause was true. The port names the question rather than the endpoint:

```go
// WebhookRegistered reports whether this bot currently has a webhook, which
// is the one question deleteWebhook cannot answer …
WebhookRegistered(ctx context.Context, token string) (bool, error)
```

Three reports now instead of one:

| what was established | reported as |
|---|---|
| a webhook was registered | `had a webhook registered, now cleared` |
| no webhook, and the poll now works | `refused by a rival consumer that has since stopped` |
| the ask itself failed | `recovered after a clear, cause unestablished` |

The third matters as much as the others: a failed `getWebhookInfo` leaves the two causes indistinguishable, and the honest answer is to say so rather than fall back on one of them.

## Tests

- `TestAConflictReportsWhichCauseItEstablished` — both readings, and the no-webhook case asserts the report does **not** claim a cleared registration. Against the old behaviour: `which claims "had a webhook registered" — that registration does not exist, and looking for it is not the remedy`.
- `TestAConflictClearsTheWebhookThenRe_asksToEstablishTheCause` gains a call-order assertion, `[getWebhookInfo, deleteWebhook]`, since asking afterwards could only report a guess.
- `TestAConflictWithNoWebhookIsReportedAsARivalRatherThanAClear` — the end-to-end half: a rival that lets go leaves a live connection that goes on to collect. The fake gained `rivalHolds` to model it.

**The split is deliberate.** A poll job's failure reaches its caller sanitised (`the job failed for a reason it could not classify; the diagnosis is in the process log`), so an integration assertion on the message would be checking the redaction rather than the diagnosis. The report is asserted where the raw error is the return value; the recovery is asserted where a database is needed.

## Scope

Part 1 of the issue — *"the connection stays `connected` while ingesting nothing"* — is **already fixed** on main: a 409 that survives the clear parks the connection as `ChannelPollStoppedByRivalConsumer`, and `TestAConflictThatSurvivesTheWebhookClearParksTheConnection` holds it. Only the reporting was still wrong.

`api.go` crossed the 500-line cap with the new method, so the two webhook calls moved to `webhook.go` — together, because they answer one question between them and neither is usable without the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC