### PR TITLE
fix(approvals): a decision whose effect failed can be decided again

### DIFF
--- a/backend/gates/effectredemption_test.go
+++ b/backend/gates/effectredemption_test.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+//gate:kind reachability H2
+
+package gates
+
+// Every approval effect redeems the approval it ran.
+//
+// WHY THIS IS LOAD-BEARING. An effect runs after its decision commits, so a
+// failure leaves the row approved with consumed_at NULL. Deciding again
+// re-drives it (approvals.effectIsStillOwed), which is what stops a transient
+// fault from stranding a human's yes forever — and the only reason that is safe
+// is that consumed_at answers "did this run" as a FACT. It answers it because
+// every effect consumes the approval in the same transaction as its write: one
+// that wrote anything left consumed_at set and is refused a second run.
+//
+// An effect registered without a redemption breaks that silently and in the
+// worst direction. It would report success, leave consumed_at NULL, and be
+// re-driven by the next decision on the row — applying its write a second time,
+// for kinds that are emphatically not idempotent (a send, a merge, an owner
+// reassignment). Nothing else in the tree would fail.
+//
+// WHAT THIS CANNOT SEE, because a reader should not take more from it than it
+// says. The walk is syntactic: it asks whether a redemption is REACHABLE from
+// the registered function, not whether every path through it redeems. An effect
+// that redeems on one branch and returns nil on another satisfies this gate,
+// and only the branch's own test would catch it. What the gate is for is the
+// omission — a kind registered with no redemption anywhere, which is how a new
+// effect arrives — and that it does catch, including one added to the
+// table-driven registration.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// redemptionCalls are the ways an effect consumes the approval it ran. All
+// three, because which one an effect reaches is its own business: the plain
+// Redeem for a kind that writes through a store opening its own transaction,
+// RedeemAndApply where the write can join the redemption's, RedeemInTx where
+// the caller already holds one.
+var redemptionCalls = []string{"Redeem", "RedeemAndApply", "RedeemInTx"}
+
+// effectRegistrationScope sweeps for files that register an approval effect.
+//
+// The subject is the WithEffect CALL rather than a directory listing, so a
+// registration added in a new file joins the corpus by being a registration.
+// gatekit.Scope then sweeps the negative space: a registration outside the
+// composition root is reported here rather than passed over, which is what
+// makes the root a proof instead of an assertion.
+var effectRegistrationScope = gatekit.Scope{
+	Roots:   []string{"internal/compose"},
+	Subject: func(_ string, file *ast.File) bool { return registersAnEffect(file) },
+	Exempt:  gatekit.Waive(map[string]string{}),
+}
+
+func registersAnEffect(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "WithEffect" {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func TestEveryRegisteredEffectRedeemsTheApprovalItRan(t *testing.T) {
+	t.Parallel()
+	files := composeFilesFor(t)
+	decls := functionDeclarations(files)
+	registered := effectConstructors(t, effectRegistrationScope.Files(t))
+	if len(registered) == 0 {
+		t.Fatal("no approval effect is registered anywhere under the composition root — this gate read an " +
+			"empty corpus, which is the one way it can report success over a surface it never saw")
+	}
+	for _, name := range registered {
+		decl, known := decls[name]
+		if !known {
+			t.Errorf("%s is registered as an approval effect and its declaration is not in the composition "+
+				"root — this gate cannot see whether it redeems, and an effect it cannot see is one it "+
+				"cannot vouch for", name)
+			continue
+		}
+		if !reachesARedemption(decl, decls, map[string]bool{}) {
+			t.Errorf("%s is registered as an approval effect and reaches no redemption. An effect that "+
+				"does not consume its approval leaves consumed_at NULL after it succeeds, so the next "+
+				"decision on that row re-drives it and its write lands twice. Redeem through the service "+
+				"(Redeem, RedeemAndApply or RedeemInTx) in the same transaction as the write", name)
+		}
+	}
+}
+
+// effectConstructors reads the function named as each WithEffect's second
+// argument — the thing that builds the effect, and therefore the thing whose
+// body holds the redemption.
+func effectConstructors(t *testing.T, files []gatekit.ParsedFile) []string {
+	t.Helper()
+	byField := functionsAssignedToFields(files)
+	seen := map[string]bool{}
+	for _, parsed := range files {
+		ast.Inspect(parsed.File, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "WithEffect" || len(call.Args) != 2 {
+				return true
+			}
+			if named := effectFunctionIdent(call.Args[1]); named != nil {
+				name := named.Name
+				// A registration may hand over a struct FIELD holding the
+				// function (`late.effect(svc, …)`, sendpath.go), in which case
+				// the name here is the field's and the functions are in the
+				// literal that fills it. Following that is what keeps a table-
+				// driven registration inside the gate instead of reported as
+				// unreadable — and a table is precisely where a kind gets added
+				// without anybody looking at this gate.
+				if supplied := byField[name]; len(supplied) > 0 {
+					for _, fn := range supplied {
+						seen[fn] = true
+					}
+					return true
+				}
+				seen[name] = true
+				return true
+			}
+			// An effect written inline has no name to follow. Reported rather
+			// than skipped: an unreadable registration is exactly the shape
+			// this gate must not pass over in silence.
+			t.Errorf("%s: an approval effect is registered as an expression this gate cannot resolve to a "+
+				"function, so whether it redeems is unchecked. Register a named constructor", parsed.Path)
+			return true
+		})
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// effectFunctionIdent is the identifier a registration argument ultimately
+// names, whether the effect is built by calling something
+// (`heldAcceptEffect(svc, …)`), handed over by name, or reached through a
+// selector.
+//
+// It answers with the IDENTIFIER rather than a string, because the question is
+// which declaration this argument points at — not what text the expression
+// holds. gatekit.StringExpr answers that other question, and reaching for it
+// here would be asking a value extractor to name a function.
+func effectFunctionIdent(arg ast.Expr) *ast.Ident {
+	switch node := arg.(type) {
+	case *ast.CallExpr:
+		return effectFunctionIdent(node.Fun)
+	case *ast.SelectorExpr:
+		return node.Sel
+	case *ast.Ident:
+		return node
+	}
+	return nil
+}
+
+// reachesARedemption walks from an effect's constructor into the functions it
+// calls, because the redemption is rarely in the body that was registered: a
+// constructor returns the closure, and several delegate the write to a helper
+// beside them.
+//
+// Bounded by the functions this corpus holds, and by `walked`, so a cycle
+// terminates. A call out of the corpus is not a redemption and not a defect on
+// its own — what the gate asserts is that a redemption IS reachable, and a name
+// it cannot follow simply is not one.
+func reachesARedemption(decl *ast.FuncDecl, decls map[string]*ast.FuncDecl, walked map[string]bool) bool {
+	if walked[decl.Name.Name] {
+		return false
+	}
+	walked[decl.Name.Name] = true
+	if gatekit.CallsAny(decl, redemptionCalls) {
+		return true
+	}
+	reached := false
+	ast.Inspect(decl, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || reached {
+			return !reached
+		}
+		if next, known := decls[calleeName(call)]; known && reachesARedemption(next, decls, walked) {
+			reached = true
+		}
+		return !reached
+	})
+	return reached
+}
+
+// functionDeclarations indexes the corpus by function name, which is how the
+// walk above follows a call.
+func functionDeclarations(files []gatekit.ParsedFile) map[string]*ast.FuncDecl {
+	decls := map[string]*ast.FuncDecl{}
+	for _, parsed := range files {
+		for _, d := range parsed.File.Decls {
+			if fn, ok := d.(*ast.FuncDecl); ok && fn.Recv == nil {
+				decls[fn.Name.Name] = fn
+			}
+		}
+	}
+	return decls
+}
+
+// composeFilesFor parses the whole composition root, not only the files that
+// register an effect: the redemption is often a call away, in a sibling file
+// the registration never mentions.
+//
+// A plain read rather than a gatekit.Scope, because it makes no coverage claim
+// — effectRegistrationScope is what proves the gate looks where the
+// registrations are, and this only supplies the bodies that walk follows.
+func composeFilesFor(t *testing.T) []gatekit.ParsedFile {
+	t.Helper()
+	root := filepath.Join(repoRoot, "backend", "internal", "compose")
+	fset := token.NewFileSet()
+	var parsed []gatekit.ParsedFile
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			return parseErr
+		}
+		parsed = append(parsed, gatekit.ParsedFile{Path: path, File: file})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("parsing the composition root: %v", err)
+	}
+	if len(parsed) == 0 {
+		t.Fatalf("no Go source under %s — the walk below would follow no call and every effect would "+
+			"report as unreadable", root)
+	}
+	return parsed
+}
+
+// functionsAssignedToFields indexes every function name a composite literal
+// assigns to a named field, so a registration that hands over a field can be
+// followed to what fills it.
+//
+// By field name across the whole corpus rather than by resolved type: the type
+// checker would answer precisely, and it is a far heavier gate for an answer
+// this shape already gives — a field named `effect` filled with a function is
+// an effect, whatever struct carries it. Over-reach costs a redundant check;
+// under-reach would be an effect nobody looked at.
+func functionsAssignedToFields(files []gatekit.ParsedFile) map[string][]string {
+	byField := map[string][]string{}
+	for _, parsed := range files {
+		ast.Inspect(parsed.File, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				field, isField := kv.Key.(*ast.Ident)
+				value, isFunc := kv.Value.(*ast.Ident)
+				if isField && isFunc {
+					byField[field.Name] = append(byField[field.Name], value.Name)
+				}
+			}
+			return true
+		})
+	}
+	return byField
+}

--- a/backend/internal/modules/approvals/bundle.go
+++ b/backend/internal/modules/approvals/bundle.go
@@ -214,10 +214,17 @@ func outcomeOf(status string) BundleOutcome {
 // the decision transaction has committed.
 //
 // A failure is that member's outcome and no one else's. The decisions are
-// committed, so there is nothing to roll back and nothing to retry: the member
-// reads approved-and-unredeemed, its audit trail says how far it got, and the
-// caller is told which one did not land. The cause goes to the log because the
-// wire deliberately carries no internals to a client.
+// committed, so there is nothing to roll back here: the member reads
+// approved-and-unredeemed, its audit trail says how far it got, and the caller
+// is told which one did not land. The cause goes to the log because the wire
+// deliberately carries no internals to a client.
+//
+// It is no longer a dead end, which it used to be. Approving that member
+// singly re-drives its effect rather than answering already-decided
+// (effectIsStillOwed, decide.go), so the failure this reports is one a caller
+// can act on. This function does not re-drive on its own: a bundle call is
+// "decide these", and a member it did not decide keeps the outcome that says
+// so.
 func (s *Service) releaseDecidedMembers(ctx context.Context, members []BundleMember, approve bool) {
 	if !approve {
 		return // a rejection releases nothing

--- a/backend/internal/modules/approvals/decide.go
+++ b/backend/internal/modules/approvals/decide.go
@@ -113,7 +113,13 @@ func (s *Service) recordDecision(ctx context.Context, id ids.ApprovalID, approve
 		return nil
 	})
 	if err != nil {
-		return a, err
+		if s.effectIsStillOwed(a, approve, err) {
+			// The decision stands and its work never ran. Re-drive rather than
+			// refuse: see effectIsStillOwed for why this is the only answer
+			// that is not a dead end.
+			return a, s.runDecisionEffect(ctx, id, a, approve)
+		}
+		return row{}, err
 	}
 	return a, s.runDecisionEffect(ctx, id, a, approve)
 }
@@ -156,112 +162,6 @@ func (s *Service) runPrecheck(ctx context.Context, id ids.ApprovalID, approve bo
 	return check(ctx, a.ProposedChange, edited)
 }
 
-// runDecisionEffect runs what a COMMITTED decision releases: a step-up's window
-// widening, or the kind's registered follow-on executor.
-//
-// It is spelled once because two callers release decisions — one approval at a
-// time here, a whole bundle at a time in bundle.go — and a second copy of this
-// branch is how a bundle member would quietly stop executing what a human
-// approved.
-//
-// The decision is already committed when this runs, so a failure never un-decides
-// anything: the approval IS decided either way, and the approved-unredeemed row
-// and its audit trail say exactly how far it got. That is also why the error says
-// "approved, but …" — a human told only "redis is unreachable" would reasonably
-// decide again, and the row would refuse them as already decided.
-func (s *Service) runDecisionEffect(ctx context.Context, id ids.ApprovalID, a row, approve bool) error {
-	// A step-up's effect is not a write into another module, so it does not run
-	// through the effect table — which is closed to agent-minted stagings for
-	// the reason serverProposed states, and a step-up is always agent-minted.
-	// It widens the window the staging named, from that row's own passport
-	// (quotarelease.go).
-	if approve && a.Kind == KindVolumeRelease {
-		if err := s.applyVolumeRelease(ctx, a); err != nil {
-			return s.recordEffectFailure(ctx, id,
-				"the agent's window could not be widened, so the approval has not taken effect",
-				fmt.Errorf("approved, but widening the agent's window failed: %w", err))
-		}
-		return nil
-	}
-	if effect, ok := s.effects[a.Kind]; ok && approve && serverProposed(a) {
-		if err := effect(ctx, id, a.ProposedChange, a.DiffHash); err != nil {
-			return s.recordEffectFailure(ctx, id,
-				"this was approved, but the work it released did not run",
-				fmt.Errorf("approved, but executing the %s effect failed: %w", a.Kind, err))
-		}
-	}
-	return nil
-}
-
-// recordEffectFailure marks an approved row whose effect did not run, and
-// returns the caller's own error unchanged.
-//
-// Without the mark the row is unreachable: it is not pending, so the decision
-// lane skips it, and it names a human decider, so the receipts lane does too. A
-// person approved something, was told it was approved, and the work never
-// happened — with the only trace an error on one request nobody may have read.
-//
-// The stored sentence is written HERE rather than from the executor's error,
-// which carries whatever the failing module said and can name a table, a
-// statement or a host. What reaches a reader says what happened and what it
-// means for them.
-//
-// A failure to record the failure is logged and swallowed on purpose, and it is
-// the one place in this file that swallows anything: the caller is already
-// returning an error about the effect, and replacing it with a bookkeeping
-// error would tell the human who approved the row the wrong thing about what
-// went wrong.
-func (s *Service) recordEffectFailure(ctx context.Context, id ids.ApprovalID, reader string, cause error) error {
-	// Detached from the request's cancellation: an effect that failed BECAUSE
-	// the request was cancelled or timed out is exactly a failure this mark
-	// exists to keep, and writing it through the dead context would lose it.
-	ctx = context.WithoutCancel(ctx)
-	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		// The IS NULL arm is the CAS: two failures racing on one row keep the
-		// FIRST mark, because that is the one whose timestamp says when the
-		// work was actually lost. Zero rows affected is that race resolved,
-		// not an error.
-		tag, err := tx.Exec(ctx,
-			`UPDATE approval SET effect_failed_at = now(), effect_failure = $2
-			  WHERE id = $1 AND effect_failed_at IS NULL`, id, reader)
-		if err == nil && tag.RowsAffected() == 0 {
-			s.logger().InfoContext(ctx, "approvals: effect failure already marked", "approval_id", id.String())
-		}
-		return err
-	})
-	if err != nil {
-		s.logger().ErrorContext(ctx, "approvals: an approved effect failed and the row could not be marked",
-			"approval_id", id.String(), "error", err)
-	}
-	return cause
-}
-
-// serverProposed reports whether this staging was minted by a SERVER-SIDE
-// proposal flow rather than by an agent asserting a passport.
-//
-// The effect table is keyed by the kind string alone, and a kind is not a
-// namespace: the REST admission gate stages under the operation's TOOL name,
-// so an agent could mint a staging whose kind matched a kind some compose
-// proposal flow had registered an executor for — "enrich" names both the
-// scrape proposal and the tool behind three agent-reachable routes. A human
-// approving that staging then invoked the compose executor over an
-// agent-authored REST envelope, which consumed the approval in its own
-// committed transaction and only then failed to parse: the human got a 500,
-// the approval could never be redeemed again, and the audit row asserted a
-// redemption for an effect that never ran.
-//
-// Provenance is the discriminator, because it is the thing that actually
-// differs: a server-side proposal is staged by the system or by a human, and
-// carries no passport. An agent-minted staging is redeemed the way ADR-0055
-// says — by repeating the identical call with the approval token — and needs
-// no server-side executor at all.
-func serverProposed(a row) bool { return a.PassportID == nil }
-
-// decideInTx runs the decision inside the caller's transaction: the
-// decide-authority + row-scope gate, the pending guard, the optional
-// modify-then-approve edit, the status write, and the write shape. It
-// returns the re-read row so the follow-on effect runs against committed
-// state.
 // countIfAPersonDecided records the track record, and records nothing for an
 // automatic apply.
 //
@@ -338,7 +238,13 @@ func (s *Service) decideInTx(ctx context.Context, tx pgx.Tx, p principal.Princip
 		return row{}, err
 	}
 	if st := a.effectiveStatus(s.now()); st != "pending" {
-		return row{}, &AlreadyDecidedError{Status: st}
+		// The ROW travels with the refusal. recordDecision has to tell an
+		// approved row whose effect never ran from one that is genuinely
+		// finished, and re-reading it there would be a second look at a row
+		// this transaction is holding — a different answer is possible, and it
+		// is the answer that decides whether a human's yes is honoured or
+		// refused.
+		return a, &AlreadyDecidedError{Status: st}
 	}
 
 	status, action, verdict := approvalStatusRejected, "reject", approvalStatusRejected

--- a/backend/internal/modules/approvals/decisioneffect.go
+++ b/backend/internal/modules/approvals/decisioneffect.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+// What a COMMITTED decision releases, and how a release that did not happen is
+// recovered.
+//
+// Split from decide.go because it answers a different question. That file
+// decides — the authority gate, the pending guard, the status write, the write
+// shape, all inside one transaction. This one runs afterwards, outside it, and
+// the whole difficulty here is that "afterwards" is where a failure can no
+// longer be rolled back: what is left on the row is the only record that the
+// work is still owed, and effectIsStillOwed is what reads it.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// effectIsStillOwed reports whether a decision this call could not make was
+// already made, and left its work undone.
+//
+// THE TRAP THIS OPENS. runDecisionEffect runs after the decision commits, so an
+// effect that fails leaves the row approved with consumed_at NULL — and the
+// obvious retry, deciding again, is refused as already-decided. There is no
+// other surface that re-drives an effect, so a transient failure at that moment
+// (the store unreachable for a second, a deploy mid-flight) permanently strands
+// the approval: the human said yes, the work never ran, and nothing they can do
+// makes it run. runPrecheck narrows the window for the kinds that register one
+// by refusing BEFORE the decision commits, but it is a preflight, and every
+// failure it cannot foresee still lands here.
+//
+// WHY RE-DRIVING IS SAFE, and it is not "because effects are idempotent" —
+// several are emphatically not. It is safe because every effect REDEEMS: it
+// consumes the approval inside the same transaction as its write, so an effect
+// that got as far as writing anything left consumed_at set, and this predicate
+// refuses. An effect that failed left it NULL and wrote nothing. The single-use
+// redemption is what makes "did this run" a fact about the row rather than a
+// guess, and TestEveryRegisteredEffectRedeemsTheApprovalItRan
+// (backend/gates/effectredemption_test.go) is what keeps it true of a kind
+// registered later.
+//
+// The conditions, and what each one excludes:
+//
+//   - approve — a decline runs INSIDE the decision transaction, so a failed one
+//     rolled the decision back and the row is still pending. There is nothing
+//     decided to re-drive, and a reject arriving on an approved row is a real
+//     conflict.
+//   - the row is APPROVED — not rejected, not expired. Expiry in particular is
+//     a verdict of its own, and re-driving one would apply what nobody released.
+//   - consumed_at IS NULL — the effect never redeemed, which is the whole
+//     signal.
+//   - serverProposed — an agent-minted row reaches no executor at all, so there
+//     is nothing owed. It is also what keeps a step-up out: a staged volume
+//     release always carries the passport whose window it widens, and widening
+//     is a counter increment with no redemption behind it, so re-driving one
+//     would hand out the window twice.
+//   - the kind has a registered effect — with none, no work was ever owed and
+//     already-decided is the honest answer.
+func (s *Service) effectIsStillOwed(a row, approve bool, err error) bool {
+	var decided *AlreadyDecidedError
+	if !errors.As(err, &decided) || !approve || decided.Status != approvalStatusApproved {
+		return false
+	}
+	if a.ConsumedAt != nil || !serverProposed(a) {
+		return false
+	}
+	_, registered := s.effects[a.Kind]
+	return registered
+}
+
+// runDecisionEffect runs what a COMMITTED decision releases: a step-up's window
+// widening, or the kind's registered follow-on executor.
+//
+// It is spelled once because two callers release decisions — one approval at a
+// time here, a whole bundle at a time in bundle.go — and a second copy of this
+// branch is how a bundle member would quietly stop executing what a human
+// approved.
+//
+// The decision is already committed when this runs, so a failure never un-decides
+// anything: the approval IS decided either way, and the approved-unredeemed row
+// and its audit trail say exactly how far it got. That is also why the error says
+// "approved, but …" — a human told only "redis is unreachable" would reasonably
+// decide again, and the row would refuse them as already decided.
+func (s *Service) runDecisionEffect(ctx context.Context, id ids.ApprovalID, a row, approve bool) error {
+	// A step-up's effect is not a write into another module, so it does not run
+	// through the effect table — which is closed to agent-minted stagings for
+	// the reason serverProposed states, and a step-up is always agent-minted.
+	// It widens the window the staging named, from that row's own passport
+	// (quotarelease.go).
+	if approve && a.Kind == KindVolumeRelease {
+		if err := s.applyVolumeRelease(ctx, a); err != nil {
+			return s.recordEffectFailure(ctx, id,
+				"the agent's window could not be widened, so the approval has not taken effect",
+				fmt.Errorf("approved, but widening the agent's window failed: %w", err))
+		}
+		return nil
+	}
+	if effect, ok := s.effects[a.Kind]; ok && approve && serverProposed(a) {
+		if err := effect(ctx, id, a.ProposedChange, a.DiffHash); err != nil {
+			return s.recordEffectFailure(ctx, id,
+				"this was approved, but the work it released did not run",
+				fmt.Errorf("approved, but executing the %s effect failed: %w", a.Kind, err))
+		}
+	}
+	return nil
+}
+
+// recordEffectFailure marks an approved row whose effect did not run, and
+// returns the caller's own error unchanged.
+//
+// Without the mark the row is unreachable: it is not pending, so the decision
+// lane skips it, and it names a human decider, so the receipts lane does too. A
+// person approved something, was told it was approved, and the work never
+// happened — with the only trace an error on one request nobody may have read.
+//
+// The stored sentence is written HERE rather than from the executor's error,
+// which carries whatever the failing module said and can name a table, a
+// statement or a host. What reaches a reader says what happened and what it
+// means for them.
+//
+// A failure to record the failure is logged and swallowed on purpose, and it is
+// the one place in this file that swallows anything: the caller is already
+// returning an error about the effect, and replacing it with a bookkeeping
+// error would tell the human who approved the row the wrong thing about what
+// went wrong.
+func (s *Service) recordEffectFailure(ctx context.Context, id ids.ApprovalID, reader string, cause error) error {
+	// Detached from the request's cancellation: an effect that failed BECAUSE
+	// the request was cancelled or timed out is exactly a failure this mark
+	// exists to keep, and writing it through the dead context would lose it.
+	ctx = context.WithoutCancel(ctx)
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// The IS NULL arm is the CAS: two failures racing on one row keep the
+		// FIRST mark, because that is the one whose timestamp says when the
+		// work was actually lost. Zero rows affected is that race resolved,
+		// not an error.
+		tag, err := tx.Exec(ctx,
+			`UPDATE approval SET effect_failed_at = now(), effect_failure = $2
+			  WHERE id = $1 AND effect_failed_at IS NULL`, id, reader)
+		if err == nil && tag.RowsAffected() == 0 {
+			s.logger().InfoContext(ctx, "approvals: effect failure already marked", "approval_id", id.String())
+		}
+		return err
+	})
+	if err != nil {
+		s.logger().ErrorContext(ctx, "approvals: an approved effect failed and the row could not be marked",
+			"approval_id", id.String(), "error", err)
+	}
+	return cause
+}
+
+// serverProposed reports whether this staging was minted by a SERVER-SIDE
+// proposal flow rather than by an agent asserting a passport.
+//
+// The effect table is keyed by the kind string alone, and a kind is not a
+// namespace: the REST admission gate stages under the operation's TOOL name,
+// so an agent could mint a staging whose kind matched a kind some compose
+// proposal flow had registered an executor for — "enrich" names both the
+// scrape proposal and the tool behind three agent-reachable routes. A human
+// approving that staging then invoked the compose executor over an
+// agent-authored REST envelope, which consumed the approval in its own
+// committed transaction and only then failed to parse: the human got a 500,
+// the approval could never be redeemed again, and the audit row asserted a
+// redemption for an effect that never ran.
+//
+// Provenance is the discriminator, because it is the thing that actually
+// differs: a server-side proposal is staged by the system or by a human, and
+// carries no passport. An agent-minted staging is redeemed the way ADR-0055
+// says — by repeating the identical call with the approval token — and needs
+// no server-side executor at all.
+func serverProposed(a row) bool { return a.PassportID == nil }
+
+// decideInTx runs the decision inside the caller's transaction: the
+// decide-authority + row-scope gate, the pending guard, the optional
+// modify-then-approve edit, the status write, and the write shape. It
+// returns the re-read row so the follow-on effect runs against committed
+// state.

--- a/backend/internal/modules/approvals/effectredrive_integration_test.go
+++ b/backend/internal/modules/approvals/effectredrive_integration_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// A decision whose effect failed can be decided again, and the second decision
+// runs the work the first one released.
+//
+// The trap this closes: runDecisionEffect runs AFTER the decision commits, so a
+// failing effect leaves the row approved with consumed_at NULL — and deciding
+// again used to answer already-decided. Nothing else re-drives an effect, so a
+// transient failure at that one moment stranded the approval permanently: the
+// human said yes, the work never ran, and nothing they could do made it run.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestADecisionWhoseEffectFailedIsRedrivenByDecidingAgain(t *testing.T) {
+	e := setupStaging(t)
+	// The effect fails once and then works — a transient fault, which is the
+	// case this exists for. A permanently broken effect is told about twice and
+	// that is the honest answer; what must not happen is the FIRST answer
+	// becoming the last one available.
+	runs := 0
+	e.svc.WithEffect(kindSiteLead, func(ctx context.Context, id ids.ApprovalID, _ json.RawMessage, diffHash string) error {
+		runs++
+		if runs == 1 {
+			return errors.New("the capture sink refused this lead: relation lead_intake, host db-3")
+		}
+		return e.redeems(ctx, id, diffHash)
+	})
+	ctx := e.asHumanWith(decidesEverything())
+	org := e.organization(t)
+	id := e.stageInto(ctx, t, ids.NewV7(), org, kindSiteLead, "lead-anna")
+
+	if _, err := e.svc.Decide(ctx, id, true, nil); err == nil {
+		t.Fatal("the failing effect's error was swallowed — the decider was told it worked")
+	}
+	if at, _ := e.effectFailureOf(t, id); at == nil {
+		t.Fatal("the first decision left no failure mark, so this test is not about a stranded row")
+	}
+
+	// Deciding again: the same verdict, on a row that already carries it.
+	if _, err := e.svc.Decide(ctx, id, true, nil); err != nil {
+		t.Fatalf("deciding an approved row whose effect never ran answered %v — a human who said yes has "+
+			"no other way to make the work happen, so this refusal is where the approval dies", err)
+	}
+	if runs != 2 {
+		t.Errorf("the effect ran %d time(s), want 2 — the second decision was accepted without re-driving "+
+			"the work it exists to release", runs)
+	}
+	if status := e.statusOf(t, id); status != approvalStatusApproved {
+		t.Errorf("stored status = %s, want approved — a re-drive decides nothing new", status)
+	}
+}
+
+// A genuinely finished approval still refuses, and this is the assertion that
+// makes the one above safe rather than merely convenient.
+//
+// Re-driving is safe because every effect REDEEMS — it consumes the approval in
+// the same transaction as its write — so consumed_at is a fact about whether
+// the work ran rather than a guess. An effect that got as far as writing left
+// it set, and this must then be a conflict: a second decide that re-ran a
+// consumed approval would apply its write twice, and several of these effects
+// are not remotely idempotent.
+func TestAConsumedApprovalStillRefusesASecondDecision(t *testing.T) {
+	e := setupStaging(t)
+	runs := 0
+	e.svc.WithEffect(kindSiteLead, func(ctx context.Context, id ids.ApprovalID, _ json.RawMessage, diffHash string) error {
+		runs++
+		return e.redeems(ctx, id, diffHash)
+	})
+	ctx := e.asHumanWith(decidesEverything())
+	org := e.organization(t)
+	id := e.stageInto(ctx, t, ids.NewV7(), org, kindSiteLead, "lead-anna")
+
+	if _, err := e.svc.Decide(ctx, id, true, nil); err != nil {
+		t.Fatalf("the first decision: %v", err)
+	}
+
+	_, err := e.svc.Decide(ctx, id, true, nil)
+
+	var decided *AlreadyDecidedError
+	if !errors.As(err, &decided) {
+		t.Fatalf("deciding a consumed approval answered %v, want already-decided — its work landed, and "+
+			"running it again would write it twice", err)
+	}
+	if runs != 1 {
+		t.Errorf("the effect ran %d time(s), want 1 — a consumed approval was re-driven", runs)
+	}
+}
+
+// A REJECTED row is not re-drivable however its decline went. A decline runs
+// inside the decision transaction, so a failed one rolled the decision back and
+// left the row pending; a rejected row therefore always means the decline
+// succeeded, and an approve arriving on one is a real conflict about the
+// verdict rather than a retry of the work.
+func TestARejectedApprovalIsNotRedrivenByApprovingIt(t *testing.T) {
+	e := setupStaging(t)
+	runs := 0
+	e.svc.WithEffect(kindSiteLead, func(context.Context, ids.ApprovalID, json.RawMessage, string) error {
+		runs++
+		return nil
+	})
+	ctx := e.asHumanWith(decidesEverything())
+	org := e.organization(t)
+	id := e.stageInto(ctx, t, ids.NewV7(), org, kindSiteLead, "lead-anna")
+
+	reason := "not this quarter"
+	if _, err := e.svc.Decide(ctx, id, false, &reason); err != nil {
+		t.Fatalf("rejecting: %v", err)
+	}
+
+	_, err := e.svc.Decide(ctx, id, true, nil)
+
+	var decided *AlreadyDecidedError
+	if !errors.As(err, &decided) {
+		t.Fatalf("approving a rejected row answered %v, want already-decided", err)
+	}
+	if runs != 0 {
+		t.Errorf("the effect ran %d time(s) for a row nobody approved", runs)
+	}
+}
+
+// redeems is what a real effect does before it writes: consume the approval,
+// once, so the row records that the work ran.
+//
+// Through the service rather than an UPDATE of consumed_at, because the
+// single-use redemption is exactly the mechanism the re-drive rests on — a
+// stub that set the column itself would prove the predicate reads a column,
+// not that the column means what production makes it mean.
+func (e *stagingEnv) redeems(ctx context.Context, id ids.ApprovalID, diffHash string) error {
+	_, _, err := e.svc.Redeem(ctx, id, kindSiteLead, diffHash)
+	return err
+}

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -336,7 +336,7 @@ internal/modules/ai/voicecorpus.go#const CorpusMeterVersion
 internal/modules/aiactivity/handler.go#var eventType
 internal/modules/aiactivity/store.go#method Change.args
 internal/modules/approvals/authority.go#const objectActivity
-internal/modules/approvals/decide.go#method Service.runDecisionEffect
+internal/modules/approvals/decisioneffect.go#method Service.runDecisionEffect
 internal/modules/approvals/evidence.go#func validateEvidence
 internal/modules/approvals/expiresweep.go#method Service.ExpireDue
 internal/modules/approvals/expiry.go#func neverExpiringKinds

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -260,7 +260,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistdestination_test.go` | H2 | Every source the worklist can emit has one screen it belongs on. |
 | `worklistreasonkinds_test.go` | H2 | Every reason a row gives is one the contract declares and a client can render. |
 
-## Reachability (18)
+## Reachability (19)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -269,6 +269,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `composerowscope_test.go` | H2 | Review-loop rule 3 as a fitness function over the compose tier: anything that returns a record is a read, so a query that hands back a REFERENCE to a row-scoped record applies that record's row scope. |
 | `consentproof_test.go` | H2 | The Art. 7(1) demonstrability invariant as a fitness function: every write that sets a person\_consent STATE appends a consent\_event proof row in the same function (data-model §3.4 — the current state is always backed by an append-only event saying when, how, and by whom). |
 | `dedupespine_test.go` | H2 | The identity-spine fitness functions. |
+| `effectredemption_test.go` | H2 | Every approval effect redeems the approval it ran. |
 | `liveprobelock_test.go` | H2 | A live-probed write of a HELD row locks its subject. |
 | `messagingpackreach_test.go` | H2 | Every messaging rule set a shipped unit declares is one the boot registers. |
 | `moduleaudits_test.go` | H2 | A module that owns tables writes their history. |


### PR DESCRIPTION
Closes #680 — **defect 2**. Defect 1 (the non-atomic LinkedIn apply) landed in #5059: `linkedInMatchAcceptEffect` now drives `svc.RedeemAndApply` with `people.ApplyLinkedInMatchTx`, so a failed apply rolls the redemption back.

## The trap

`runDecisionEffect` runs **after** the decision transaction commits. An effect that fails leaves the row `approved` with `consumed_at IS NULL` — and the obvious retry, deciding again, was refused as already-decided. Nothing else in the tree re-drives an effect.

So a transient fault at that one moment stranded the approval permanently: the human said yes, the work never ran, and nothing they could do made it run. `runPrecheck` narrows the window for the kinds that register one, but it is a preflight — every failure it cannot foresee still lands here.

## The fix

`recordDecision` re-drives instead of refusing, gated on `effectIsStillOwed`. Four conditions, each excluding a case where re-driving would be wrong:

| condition | what it excludes |
|---|---|
| `approve` | a decline runs **inside** the decision transaction, so a failed one rolled the decision back and the row is still pending — nothing decided to re-drive, and a reject on an approved row is a real conflict |
| status is `approved` | not rejected, not expired. Expiry is a verdict of its own; re-driving one would apply what nobody released |
| `consumed_at IS NULL` | the effect never redeemed — the whole signal |
| `serverProposed` | an agent-minted row reaches no executor. It also keeps a **step-up** out: a staged volume release always carries the passport whose window it widens, and widening is a counter increment with no redemption behind it, so re-driving one would hand out the window twice |

## Why it is safe — and why that needed a gate

Not because effects are idempotent. Several emphatically are not: a send, a merge, an owner reassignment.

It is safe because **every effect redeems** — it consumes the approval in the same transaction as its write — so an effect that got as far as writing anything left `consumed_at` set and is refused a second run. The single-use redemption is what makes "did this run" a fact about the row rather than a guess.

I checked all 18 registered effects by hand and every one redeems. That is exactly the kind of thing that is true today and load-bearing tomorrow, so `TestEveryRegisteredEffectRedeemsTheApprovalItRan` now holds it:

- the corpus is every `WithEffect` **registration**, via `gatekit.Scope` — so a registration in a new file joins by being a registration, and one appearing outside the composition root is reported rather than passed over;
- the walk follows each registered constructor into the functions it calls, because the redemption is rarely in the body that was registered — a constructor returns the closure and several delegate the write to a helper;
- it reads the **table-driven** registration too (`lateApprovalEffects` hands over a struct field), which is where a kind gets added without anybody looking at a gate.

The gate says plainly what it cannot see: the walk is syntactic, so an effect that redeems on one branch and returns nil on another satisfies it. What it is for is the omission — a kind registered with no redemption anywhere — and that it catches.

## The bundle path

Unchanged, and its comment corrected. It said a failed member had "nothing to retry"; that is no longer true — approving that member singly re-drives it. The bundle does not re-drive on its own, because a bundle call is "decide these" and a member it did not decide keeps the outcome that says so. No row is permanently stranded any more.

## File split

`decide.go` crossed the 500-line ceiling, so what a committed decision **releases** moved to `decisioneffect.go`. Different question: it runs outside the transaction, where a failure can no longer be rolled back, and what is left on the row is the only record that the work is still owed. The debt-register entry for `runDecisionEffect` follows the move.

## Tests and mutations

The two the issue asks for, plus the rejected case:

- `TestADecisionWhoseEffectFailedIsRedrivenByDecidingAgain` — the effect fails once then works; the second decide re-drives it.
- `TestAConsumedApprovalStillRefusesASecondDecision` — a finished approval still answers already-decided, and its effect does not run twice. The stub redeems **through the service**, not by setting the column: a stub that set it would prove the predicate reads a column, not that the column means what production makes it mean.
- `TestARejectedApprovalIsNotRedrivenByApprovingIt`.

Each condition mutation-checked independently: removing the re-drive, dropping the `consumed_at` check, dropping the approve/approved check, and registering a new effect with no redemption. All four fail the test that names them.

## Checks

`make check-backend` green; `make craft-static` 0/0/0; `go test -count=1 ./gates` green; the approvals integration lane green. Gate inventory regenerated.