### PR TITLE
fix(weekly): the deal block counts the week that closed, not today

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -41322,6 +41322,20 @@ components:
             deal however many times it was edited — a rep who corrected a typo three times did not
             upgrade three times.
         forecast_down: { type: integer, minimum: 0 }
+        unreconstructible:
+          type: integer
+          minimum: 0
+          description: |
+            Deals left OUT of the four population counts above because their state at the week's
+            closing instant could not be rebuilt: the audit images describing their week sit
+            behind an erasure, and the append-only spine means reading them would put back
+            exactly what a scrub certified destroyed.
+
+            Nonzero means `open` and the three coverage counts are a floor rather than a total,
+            and a reader must be told so. Zero is the ordinary answer. ABSENT means the week was
+            scored before this reconstruction existed, which is a third fact again: those counts
+            are the current-state figures they always were, and nothing can retroactively make
+            them week-end facts.
 
     WeeklyReview:
       type: object

--- a/backend/gates/scrubbedentitytypes_test.go
+++ b/backend/gates/scrubbedentitytypes_test.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Which RECORD TYPES a scrub verb is ever written against.
+//
+// scrubverbs_test.go asks the neighbouring question — which verbs certify a
+// scrub — and derives its corpus from privacy's writers so a new one cannot
+// arrive unjudged. This asks what those verbs are written ABOUT, because a
+// reader outside privacy has to decide whether the boundary is live for the
+// records it reads.
+//
+// The weekly review is such a reader. Its deal block reconstructs a deal's state
+// as of the week's closing instant by reverse-applying audit images, and it
+// stops at a scrub tombstone: the spine is append-only, so the images a scrub
+// certified gone are still physically there, and folding one back would put
+// erased data onto a rep's scorecard. Today no writer in the tree tombstones a
+// `deal`, so that boundary excludes nothing and the reader's shortfall count is
+// always zero.
+//
+// THAT IS THE FACT THIS GATE PINS, and the reason it is a gate rather than a
+// comment. "No deal is ever scrubbed" is true today and invisible if it stops
+// being true: deal erasure would land, the weekly's boundary would quietly start
+// firing, and nobody would have decided that a rep's frozen week may now report
+// a shortfall. The census fails on that day and asks for the decision.
+//
+// It fails in the useful direction. A record type ADDED to the scrub set breaks
+// this; one removed does not, because a shrinking set cannot surprise a reader
+// that already handles the boundary.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// scrubTombstoneWriters are the call sites that stamp a scrub tombstone.
+//
+// Named rather than pattern-matched on the verb, because the verb travels as a
+// constant (actionErase) at some sites and a literal at others, and matching the
+// FUNCTION is what makes both visible. A new writer that calls neither is the
+// gap this cannot see; scrubverbs_test.go covers the verb side of that.
+var scrubTombstoneWriters = map[string]bool{
+	// Carries the verb itself; every call is a scrub.
+	"tombstoneCollateralScrubs": true,
+	// Generic audit doors, which are scrub sites only when the verb they are
+	// handed is one.
+	"AuditWithEvidence": true,
+	"Audit":             true,
+	"AuditEvent":        true,
+}
+
+// scrubbedEntityTypes is what the tree tombstones today, and the list a reader
+// of the erasure boundary may rely on.
+//
+// `deal` is deliberately ABSENT and that absence is load-bearing — see the file
+// comment. Adding it here is a product decision about frozen weekly reviews, not
+// a test fix.
+var scrubbedEntityTypes = map[string]bool{
+	"person":                true,
+	"lead":                  true,
+	"activity":              true,
+	"attachment":            true,
+	"deal_room_participant": true,
+	"scheduled_send":        true,
+	"voice_learning_signal": true,
+	"ai_call":               true,
+	"ai_call_payload":       true,
+}
+
+func TestEveryScrubbedRecordTypeIsOneAReaderOfTheBoundaryExpects(t *testing.T) {
+	t.Parallel()
+	found, opaque := scrubbedTypesInPrivacy(t)
+	for _, site := range opaque {
+		t.Errorf("%s stamps a scrub tombstone whose record type is not a literal, so "+
+			"this census cannot read it and would pass without ever seeing it.\n"+
+			"Spell the entity type at the call site, or extend scrubbedTypesInPrivacy "+
+			"to resolve it.", site)
+	}
+	if len(found) == 0 {
+		t.Fatal("no scrub tombstone writer found in the privacy module — this census " +
+			"reads a smaller tree than it thinks, which is the one way it must not fail")
+	}
+
+	var unexpected []string
+	for entity := range found {
+		if !scrubbedEntityTypes[entity] {
+			unexpected = append(unexpected, entity)
+		}
+	}
+	sort.Strings(unexpected)
+	for _, entity := range unexpected {
+		t.Errorf("privacy writes a scrub tombstone against %q, which this census does "+
+			"not list.\n\nEvery reader that reverse-applies audit images for %[1]q now "+
+			"stops at that tombstone. Decide what each should do, then add %[1]q here.\n"+
+			"The weekly review's deal block is one such reader "+
+			"(compose/weekly/weeklyweekend.go): a %[1]q scrub makes a rep's frozen week "+
+			"report a shortfall it never reported before.", entity)
+	}
+}
+
+// scrubbedTypesInPrivacy reads the entity-type argument of every scrub
+// tombstone writer in the privacy module.
+//
+// The entity type is the writer's third argument at the storekit sites and its
+// third at tombstoneCollateralScrubs. A non-literal argument is skipped and
+// reported by the emptiness check above rather than guessed at.
+func scrubbedTypesInPrivacy(t *testing.T) (map[string]bool, []string) {
+	t.Helper()
+	found := map[string]bool{}
+	var opaque []string
+	dir := filepath.Join(moduleRoot(t), "internal", "modules", "privacy")
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading the privacy module: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", name, parseErr)
+		}
+		var insideCollateralWriter bool
+		ast.Inspect(file, func(n ast.Node) bool {
+			if fn, ok := n.(*ast.FuncDecl); ok {
+				insideCollateralWriter = fn.Name.Name == "tombstoneCollateralScrubs"
+				return true
+			}
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isScrubTombstoneCall(call) {
+				return true
+			}
+			// A tombstone site whose entity type is not a literal cannot be read
+			// here, and skipping it silently is the way this census fails short:
+			// it would report PASS having never seen the argument. Such a site is
+			// reported instead, so the choice is explicit — spell the type at the
+			// call, or teach this walk to follow it.
+			// The forwarding call INSIDE tombstoneCollateralScrubs passes its own
+			// parameter, which is opaque here by construction; its callers name
+			// the type and those are the sites this census reads. Reporting the
+			// definition would be a permanent false positive.
+			if !insideCollateralWriter && !hasLiteralEntityArgument(call) {
+				opaque = append(opaque, fset.Position(call.Pos()).String())
+			}
+			for _, arg := range call.Args {
+				lit, ok := arg.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				value, unquoteErr := strconv.Unquote(lit.Value)
+				// Recorded whether or not the census expects it. Filtering to the
+				// known set here would make an unexpected type impossible to find,
+				// which is a census reporting PASS by reading a smaller tree than
+				// its subject.
+				if unquoteErr == nil && looksLikeAnEntityType(value) {
+					found[value] = true
+				}
+			}
+			return true
+		})
+	}
+	return found, opaque
+}
+
+// hasLiteralEntityArgument reports whether this tombstone call names its record
+// type as a string literal — the only shape this walk can read.
+func hasLiteralEntityArgument(call *ast.CallExpr) bool {
+	for _, arg := range call.Args {
+		lit, ok := arg.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			continue
+		}
+		if value, err := strconv.Unquote(lit.Value); err == nil && looksLikeAnEntityType(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// scrubVerbConstants are privacy's own names for the three verbs that certify a
+// scrub. scrubverbs_test.go holds the list itself against the module's writers;
+// this names the identifiers so a call passing one is recognised.
+var scrubVerbConstants = map[string]bool{
+	"actionErase": true, "actionAnonymize": true, "actionRestrict": true,
+}
+
+// looksLikeAnEntityType separates a record type from the other string literals
+// a tombstone writer carries — the verb itself, and the reason and cause the
+// evidence map holds.
+//
+// Shape rather than an allowlist: a lowercase snake_case word IS how every
+// entity type in this tree is spelled, and matching the shape means a type
+// nobody anticipated still lands in the census. The verbs are excluded by name
+// because they share that shape.
+func looksLikeAnEntityType(value string) bool {
+	if value == "" || value == "erase" || value == "anonymize" || value == "restrict" {
+		return false
+	}
+	for _, r := range value {
+		if (r < 'a' || r > 'z') && r != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+// isScrubTombstoneCall reports whether this call stamps a scrub tombstone.
+//
+// Two shapes, and the second is why this is not simply "a call carrying a scrub
+// verb". tombstoneCollateralScrubs holds the verb INSIDE itself — every call to
+// it is a scrub by construction, and its arguments name only the record type —
+// so a check that demanded a verb argument would skip precisely the writer that
+// stamps five of the tree's record types.
+func isScrubTombstoneCall(call *ast.CallExpr) bool {
+	name := calleeName(call)
+	if !scrubTombstoneWriters[name] {
+		return false
+	}
+	if name == "tombstoneCollateralScrubs" {
+		return true
+	}
+	for _, arg := range call.Args {
+		switch a := arg.(type) {
+		case *ast.Ident:
+			// The three scrub verb constants BY NAME. A prefix match on "action"
+			// would also admit actionArchive, which certifies no scrub — and a
+			// retention policy's own archive row would then be read as one.
+			if scrubVerbConstants[a.Name] {
+				return true
+			}
+		case *ast.BasicLit:
+			if a.Kind != token.STRING {
+				continue
+			}
+			value, err := strconv.Unquote(a.Value)
+			if err == nil && (value == "erase" || value == "anonymize" || value == "restrict") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/weekly/weeklydealscore.go
+++ b/backend/internal/compose/weekly/weeklydealscore.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+// The deal block's one statement.
+//
+// Beside the reconstruction it depends on rather than beside the Go that binds
+// its arguments: the CTE this composes with — week_end, from weeklyweekend.go —
+// is what makes the population counts describe the week rather than today, and
+// the two read as one piece of reasoning.
+
+// dealScoreSQL is the deal block's one statement.
+//
+// One statement rather than ten, because ten counts read at ten moments
+// describe ten slightly different weeks. Lifted out of the function so the
+// arithmetic beside it stays readable at a glance; the format verbs are bound
+// at the single call site below.
+const dealScoreSQL = `
+		WITH mine AS (
+		  SELECT d.id, d.stage_id, d.pipeline_id, d.expected_close_date,
+		         d.close_date_provisional, d.archived_at, d.status
+		    FROM deal d
+		   WHERE d.owner_id = $%[3]d AND (%[8]s)
+		     -- Existing at the cutoff is a precondition of being IN the week. The
+		     -- rewind below says what a deal LOOKED like then; it cannot say
+		     -- whether it was there, so a deal minted after the week closed would
+		     -- otherwise be folded into a count of that week's pipeline at its
+		     -- birth values.
+		     AND d.created_at < $%[2]d),
+		%[10]s,
+		-- The population counts read the WEEK-END row, never the current one. A
+		-- deal closed on Tuesday was open when the week ended, and belongs in the
+		-- denominator of the week being judged.
+		open_deals AS (
+		  SELECT * FROM week_end
+		   WHERE status = 'open' AND NOT was_archived AND NOT unreconstructible),
+		-- Stage moves inside the window, with both ends' positions resolved.
+		-- A move whose two stages sit in different pipelines resolves to NULL
+		-- on one side and is counted as neither direction.
+		moves AS (
+		  SELECT h.deal_id, h.changed_at, h.from_stage_id,
+		         fs."position" AS from_pos, ts."position" AS to_pos
+		    FROM deal_stage_history h
+		    JOIN mine ON mine.id = h.deal_id
+		    LEFT JOIN stage fs ON fs.id = h.from_stage_id
+		         AND fs.pipeline_id = mine.pipeline_id
+		    LEFT JOIN stage ts ON ts.id = h.to_stage_id
+		         AND ts.pipeline_id = mine.pipeline_id
+		   WHERE h.changed_at >= $%[1]d AND h.changed_at < $%[2]d
+		     AND h.to_stage_id IS DISTINCT FROM h.from_stage_id),
+		-- How long the deal sat in the stage it LEFT: this move's moment less
+		-- the previous move into that stage. A deal whose prior move is outside
+		-- the window still resolves, because the lookup is not windowed.
+		dwell AS (
+		  SELECT m.deal_id,
+		         EXTRACT(epoch FROM m.changed_at - (
+		           SELECT max(p.changed_at) FROM deal_stage_history p
+		            WHERE p.deal_id = m.deal_id AND p.changed_at < m.changed_at
+		         )) / 86400 AS days
+		    FROM moves m
+		   WHERE m.from_stage_id IS NOT NULL),
+		-- Category moves, one row per deal: a rep who corrected a typo three
+		-- times did not downgrade three times. The direction is the deal's
+		-- FIRST and LAST category inside the window, compared once.
+		--
+		-- No erasure boundary here, unlike the rewind above, and the difference is
+		-- what the two read. The rewind folds an image back onto a record a reader
+		-- sees; this compares one enum against itself and keeps neither value. A
+		-- forecast category is a four-valued CHECK — omitted, pipeline, best_case,
+		-- commit — carrying nothing a scrub certifies gone, so stopping at a
+		-- tombstone would withhold a direction while disclosing nothing.
+		cat AS (
+		  SELECT a.entity_id,
+		         (array_agg(a.before->>'forecast_category'
+		           ORDER BY a.occurred_at, a.id))[1] AS first_cat,
+		         (array_agg(a.after->>'forecast_category'
+		           ORDER BY a.occurred_at DESC, a.id DESC))[1] AS last_cat
+		    FROM audit_log a
+		    JOIN mine ON mine.id = a.entity_id
+		   WHERE a.entity_type = 'deal'
+		     AND a.occurred_at >= $%[1]d AND a.occurred_at < $%[2]d
+		     AND a.before->>'forecast_category' IS DISTINCT FROM a.after->>'forecast_category'
+		   GROUP BY a.entity_id)
+		SELECT
+		  EXISTS (SELECT 1 FROM open_deals) OR EXISTS (SELECT 1 FROM moves)
+		    -- A week whose every deal is behind an erasure still HAS a deal block.
+		    -- Without this the block vanishes, which reads as 'this rep had no
+		    -- deals' — the one thing that is certainly false. It is present,
+		    -- its counts are zero, and the shortfall beside them says why.
+		    OR EXISTS (SELECT 1 FROM week_end WHERE unreconstructible),
+		  (SELECT count(*) FROM moves WHERE from_pos IS NOT NULL AND to_pos > from_pos),
+		  (SELECT count(*) FROM moves WHERE from_pos IS NOT NULL AND to_pos < from_pos),
+		  (SELECT round(percentile_cont(0.5) WITHIN GROUP (ORDER BY days))::int
+		     FROM dwell WHERE days IS NOT NULL),
+		  (SELECT count(*) FROM open_deals o
+		    WHERE EXISTS (
+		      SELECT 1 FROM activity_link tl
+		        JOIN activity task ON task.id = tl.activity_id
+		       WHERE tl.deal_id = o.id AND task.kind = 'task'
+		         AND task.archived_at IS NULL
+		         -- The task as the week CLOSED, not as it stands now. A task
+		         -- ticked off on Monday was still the deal's open next step on
+		         -- Sunday, and reading is_done today erases it from the week that
+		         -- earned it. Created-after is excluded for the mirror reason: a
+		         -- task written on Monday was not Sunday's next step.
+		         AND task.created_at < $%[2]d
+		         -- Done BEFORE the cutoff means it was not the deal's open next
+		         -- step then. done_at travels with is_done and is CLEARED when a
+		         -- task is reopened, so a task finished in-week and reopened after
+		         -- carries no stamp: is_done is false and the task counts, which
+		         -- is right — it was open at the cutoff either way only if it was
+		         -- not finished before it, and a cleared stamp cannot say it was.
+		         -- The residual gap is a task finished in-week, reopened after, and
+		         -- finished again: the second stamp is post-cutoff, so it counts.
+		         AND NOT (task.is_done AND task.done_at IS NOT NULL
+		                  AND task.done_at < $%[2]d))),
+		  (SELECT count(*) FROM open_deals),
+		  (SELECT count(*) FROM open_deals o
+		    WHERE (SELECT count(DISTINCT pl.person_id)
+		             FROM activity_link dl
+		             JOIN activity act ON act.id = dl.activity_id
+		             JOIN activity_link pl ON pl.activity_id = dl.activity_id
+		            WHERE dl.deal_id = o.id AND pl.person_id IS NOT NULL
+		              AND act.archived_at IS NULL
+		              -- BOUNDED AT BOTH ENDS. The lower bound is the 30-day
+		              -- coverage window; the upper is the cutoff, without which
+		              -- two contacts who first spoke to the deal on Monday would
+		              -- make the closed week read multi-threaded when it was not.
+		              AND act.occurred_at >= $%[4]d
+		              AND act.occurred_at < $%[2]d) >= $%[5]d),
+		  (SELECT count(*) FROM open_deals o
+		    WHERE o.expected_close_date IS NOT NULL
+		      AND NOT o.close_date_provisional
+		      AND o.expected_close_date >= (timezone($%[9]d, $%[2]d))::date),
+		  (SELECT count(*) FROM cat WHERE %[6]s > %[7]s),
+		  (SELECT count(*) FROM cat WHERE %[6]s < %[7]s),
+		  (SELECT count(*) FROM week_end WHERE unreconstructible)`

--- a/backend/internal/compose/weekly/weeklyhandlers.go
+++ b/backend/internal/compose/weekly/weeklyhandlers.go
@@ -168,6 +168,7 @@ func scorecardToWire(card Scorecard) *crmcontracts.WeeklyReviewScorecard {
 			WithNextStep:      d.WithNextStep, Open: d.Open,
 			MultiThreaded: d.MultiThreaded, CloseDateSound: d.CloseDateSound,
 			ForecastUp: d.ForecastUp, ForecastDown: d.ForecastDown,
+			Unreconstructible: d.Unreconstructible,
 		}
 	}
 	return out

--- a/backend/internal/compose/weekly/weeklyscorecard.go
+++ b/backend/internal/compose/weekly/weeklyscorecard.go
@@ -26,6 +26,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/modules/privacy"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -87,6 +88,20 @@ type DealBlock struct {
 	// Category moves, each deal counted ONCE however many times it was edited.
 	ForecastUp   int
 	ForecastDown int
+
+	// Deals whose state at the closing instant could not be reconstructed,
+	// because the audit images describing their week sit behind an erasure.
+	//
+	// Reported rather than absorbed. These deals are absent from every population
+	// count above, so a reader who is not told would take a smaller Open than the
+	// rep really had for the whole truth. Nonzero means the counts beside it are a
+	// floor, and the panel says so.
+	//
+	// A POINTER, because nil is a third fact and not a zero. A scorecard frozen
+	// before this reconstruction existed cannot say what it failed to rebuild —
+	// its counts are the current-state figures they always were — and folding
+	// that to 0 would claim those old weeks were fully reconstructed.
+	Unreconstructible *int
 }
 
 // multiThreadWindow is how far back a deal's second contact may be and still
@@ -333,87 +348,6 @@ func forecastRank(column string) string {
 		WHEN 'pipeline' THEN 1 WHEN 'omitted' THEN 0 ELSE -1 END`
 }
 
-// dealScoreSQL is the deal block's one statement.
-//
-// One statement rather than ten, because ten counts read at ten moments
-// describe ten slightly different weeks. Lifted out of the function so the
-// arithmetic beside it stays readable at a glance; the format verbs are bound
-// at the single call site below.
-const dealScoreSQL = `
-		WITH mine AS (
-		  SELECT d.id, d.stage_id, d.pipeline_id, d.expected_close_date,
-		         d.close_date_provisional, d.archived_at, d.status
-		    FROM deal d
-		   WHERE d.owner_id = $%[3]d AND (%[8]s)),
-		open_deals AS (SELECT * FROM mine WHERE status = 'open' AND archived_at IS NULL),
-		-- Stage moves inside the window, with both ends' positions resolved.
-		-- A move whose two stages sit in different pipelines resolves to NULL
-		-- on one side and is counted as neither direction.
-		moves AS (
-		  SELECT h.deal_id, h.changed_at, h.from_stage_id,
-		         fs."position" AS from_pos, ts."position" AS to_pos
-		    FROM deal_stage_history h
-		    JOIN mine ON mine.id = h.deal_id
-		    LEFT JOIN stage fs ON fs.id = h.from_stage_id
-		         AND fs.pipeline_id = mine.pipeline_id
-		    LEFT JOIN stage ts ON ts.id = h.to_stage_id
-		         AND ts.pipeline_id = mine.pipeline_id
-		   WHERE h.changed_at >= $%[1]d AND h.changed_at < $%[2]d
-		     AND h.to_stage_id IS DISTINCT FROM h.from_stage_id),
-		-- How long the deal sat in the stage it LEFT: this move's moment less
-		-- the previous move into that stage. A deal whose prior move is outside
-		-- the window still resolves, because the lookup is not windowed.
-		dwell AS (
-		  SELECT m.deal_id,
-		         EXTRACT(epoch FROM m.changed_at - (
-		           SELECT max(p.changed_at) FROM deal_stage_history p
-		            WHERE p.deal_id = m.deal_id AND p.changed_at < m.changed_at
-		         )) / 86400 AS days
-		    FROM moves m
-		   WHERE m.from_stage_id IS NOT NULL),
-		-- Category moves, one row per deal: a rep who corrected a typo three
-		-- times did not downgrade three times. The direction is the deal's
-		-- FIRST and LAST category inside the window, compared once.
-		cat AS (
-		  SELECT a.entity_id,
-		         (array_agg(a.before->>'forecast_category'
-		           ORDER BY a.occurred_at, a.id))[1] AS first_cat,
-		         (array_agg(a.after->>'forecast_category'
-		           ORDER BY a.occurred_at DESC, a.id DESC))[1] AS last_cat
-		    FROM audit_log a
-		    JOIN mine ON mine.id = a.entity_id
-		   WHERE a.entity_type = 'deal'
-		     AND a.occurred_at >= $%[1]d AND a.occurred_at < $%[2]d
-		     AND a.before->>'forecast_category' IS DISTINCT FROM a.after->>'forecast_category'
-		   GROUP BY a.entity_id)
-		SELECT
-		  EXISTS (SELECT 1 FROM open_deals) OR EXISTS (SELECT 1 FROM moves),
-		  (SELECT count(*) FROM moves WHERE from_pos IS NOT NULL AND to_pos > from_pos),
-		  (SELECT count(*) FROM moves WHERE from_pos IS NOT NULL AND to_pos < from_pos),
-		  (SELECT round(percentile_cont(0.5) WITHIN GROUP (ORDER BY days))::int
-		     FROM dwell WHERE days IS NOT NULL),
-		  (SELECT count(*) FROM open_deals o
-		    WHERE EXISTS (
-		      SELECT 1 FROM activity_link tl
-		        JOIN activity task ON task.id = tl.activity_id
-		       WHERE tl.deal_id = o.id AND task.kind = 'task'
-		         AND task.archived_at IS NULL AND NOT task.is_done)),
-		  (SELECT count(*) FROM open_deals),
-		  (SELECT count(*) FROM open_deals o
-		    WHERE (SELECT count(DISTINCT pl.person_id)
-		             FROM activity_link dl
-		             JOIN activity act ON act.id = dl.activity_id
-		             JOIN activity_link pl ON pl.activity_id = dl.activity_id
-		            WHERE dl.deal_id = o.id AND pl.person_id IS NOT NULL
-		              AND act.archived_at IS NULL
-		              AND act.occurred_at >= $%[4]d) >= $%[5]d),
-		  (SELECT count(*) FROM open_deals o
-		    WHERE o.expected_close_date IS NOT NULL
-		      AND NOT o.close_date_provisional
-		      AND o.expected_close_date >= (timezone($%[9]d, $%[2]d))::date),
-		  (SELECT count(*) FROM cat WHERE %[6]s > %[7]s),
-		  (SELECT count(*) FROM cat WHERE %[6]s < %[7]s)`
-
 // scoreDeals reads the pipeline block, or reports it absent.
 //
 // ABSENT means the rep had no open deal AND no stage change in the window —
@@ -441,6 +375,10 @@ func scoreDeals(
 	sincePos := arg(end.Add(-multiThreadWindow))
 	stakeholdersPos := arg(minStakeholders)
 	zonePos := arg(zone)
+	// The erasure boundary's vocabulary, bound once and read by the rewind.
+	// privacy owns the list; a literal here would be a second copy of the one
+	// rule where almost-the-same resurrects what was certified destroyed.
+	verbsPos := arg(privacy.ScrubVerbs())
 	scope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
 	if err != nil {
 		return nil, err
@@ -456,10 +394,13 @@ func scoreDeals(
 	var median *int
 	err = tx.QueryRow(ctx, fmt.Sprintf(dealScoreSQL,
 		startPos, endPos, userPos, sincePos, stakeholdersPos,
-		forecastRank("last_cat"), forecastRank("first_cat"), scope, zonePos), args...).
+		forecastRank("last_cat"), forecastRank("first_cat"), scope, zonePos,
+		weekEndDealsSQL(fmt.Sprintf("$%d", endPos), fmt.Sprintf("$%d", verbsPos))),
+		args...).
 		Scan(&present, &block.Advances, &block.Regressions, &median,
 			&block.WithNextStep, &block.Open, &block.MultiThreaded,
-			&block.CloseDateSound, &block.ForecastUp, &block.ForecastDown)
+			&block.CloseDateSound, &block.ForecastUp, &block.ForecastDown,
+			&block.Unreconstructible)
 	if err != nil {
 		return nil, fmt.Errorf("weekly: scoring the week's deals: %w", err)
 	}

--- a/backend/internal/compose/weekly/weeklyscorecardsql.go
+++ b/backend/internal/compose/weekly/weeklyscorecardsql.go
@@ -63,6 +63,10 @@ func insertScorecard(ctx context.Context, tx pgx.Tx, reviewID ids.UUID, card Sco
 		add("deal_close_date_sound", d.CloseDateSound)
 		add("deal_forecast_up", d.ForecastUp)
 		add("deal_forecast_down", d.ForecastDown)
+		// Zero is a real answer here and means every deal reconstructed. NULL is
+		// reserved for scorecards frozen before the reconstruction existed, so a
+		// block measured now always writes a number.
+		add("deal_unreconstructible", d.Unreconstructible)
 	}
 
 	_, err := tx.Exec(ctx, fmt.Sprintf(
@@ -86,7 +90,7 @@ func readScorecard(ctx context.Context, tx pgx.Tx, reviewID ids.UUID) (*Scorecar
 	// Every nullable column scans through a pointer, because a block's absence
 	// is exactly what NULL means here.
 	var la, ld, lp, lat, lb, mb, mh, mn, mp *int
-	var da, dr, dns, do, dmt, dcd, dfu, dfd *int
+	var da, dr, dns, do, dmt, dcd, dfu, dfd, dun *int
 	err := tx.QueryRow(ctx, `
 		SELECT has_lead_block, lead_advanced, lead_disqualified, lead_promoted,
 		       lead_answered_in_target, lead_breached, meetings_booked,
@@ -94,10 +98,11 @@ func readScorecard(ctx context.Context, tx pgx.Tx, reviewID ids.UUID) (*Scorecar
 		       has_deal_block, deal_advances, deal_regressions,
 		       deal_median_days_in_stage, deal_with_next_step, deal_open,
 		       deal_multi_threaded, deal_close_date_sound,
-		       deal_forecast_up, deal_forecast_down
+		       deal_forecast_up, deal_forecast_down, deal_unreconstructible
 		  FROM weekly_review_scorecard WHERE weekly_review_id = $1`, reviewID).
 		Scan(&hasLead, &la, &ld, &lp, &lat, &lb, &mb, &mh, &mn, &mp,
-			&hasDeal, &da, &dr, &d.MedianDaysInStage, &dns, &do, &dmt, &dcd, &dfu, &dfd)
+			&hasDeal, &da, &dr, &d.MedianDaysInStage, &dns, &do, &dmt, &dcd, &dfu, &dfd,
+			&dun)
 	if errors.Is(err, pgx.ErrNoRows) {
 		//nolint:nilnil // a review written before scorecards existed HAS none; the panel draws nothing rather than the read failing.
 		return nil, nil
@@ -118,6 +123,11 @@ func readScorecard(ctx context.Context, tx pgx.Tx, reviewID ids.UUID) (*Scorecar
 		d.WithNextStep, d.Open = deref(dns), deref(do)
 		d.MultiThreaded, d.CloseDateSound = deref(dmt), deref(dcd)
 		d.ForecastUp, d.ForecastDown = deref(dfu), deref(dfd)
+		// NOT deref'd, unlike every column above it. NULL here means the week was
+		// scored before the reconstruction existed, and folding that to zero would
+		// claim those old weeks were rebuilt completely when they were never
+		// rebuilt at all.
+		d.Unreconstructible = dun
 		card.Deal = &d
 	}
 	return &card, nil

--- a/backend/internal/compose/weekly/weeklyweekend.go
+++ b/backend/internal/compose/weekly/weeklyweekend.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+// The deal as it stood when the week closed, not as it stands today.
+//
+// Four of the deal block's counts describe a POPULATION rather than an event:
+// how many deals were open, how many carried a next step, how many were
+// multi-threaded, how many had a sound close date. The others count things that
+// happened inside the window and are bounded by it, so they answer the same way
+// whenever they are asked. These four read the deal row, and the deal row is
+// current.
+//
+// That is invisible when the review runs the moment the week closes and wrong
+// every other time. The dispatcher retries all week for a rep whose review
+// landed un-narrated, so a review written on Thursday counted Thursday's
+// pipeline as Sunday's — and the review is write-once, so the wrong number is
+// the permanent record of that week.
+//
+// The fix is to walk the audit spine backwards from the closing instant and
+// undo every change made since, which the spine can answer for status, the
+// close date and its provisional flag.
+//
+// OWNERSHIP IS NOT REWOUND, and that is a stated limit rather than an oversight.
+// The rep's deals are selected by CURRENT owner_id, so a deal reassigned after
+// the week closed lands on the new owner's week and leaves the old owner's. The
+// image is there to read — deallinks.go sets owner_id through the patch — but
+// the selection feeds four counts (open_deals, moves, dwell, cat), and each
+// needs its own answer to whose week a reassigned deal's event belongs in.
+// Those are product questions, and guessing them would put somebody else's work
+// on a rep's scorecard, which is the defect this file exists to fix. Issue 5086
+// carries it. Archival is the exception in shape: the
+// archive verb writes no field images (dealarchive.go audits the lifecycle, not
+// the column), so the VERB is the signal and the reverse-apply reads actions
+// rather than images for that one field.
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/modules/privacy"
+)
+
+// weekEndDealsSQL reconstructs each of the rep's deals as of the closing
+// instant.
+//
+// One pass over the spine per deal rather than a snapshot table: the audit rows
+// already exist and already carry the images, and a projection written beside
+// them would be a second answer to a question the spine can answer, drifting the
+// first time somebody wrote one and not the other.
+//
+// THE ERASURE BOUNDARY IS THE POINT, not a detail. The spine is append-only, so
+// a scrub cannot rewrite the images captured before it — the images of an erased
+// deal are still sitting there, and a reverse-apply that read them would put
+// what was certified destroyed back onto a rep's weekly review. privacy's own
+// boundary is what decides which rows are readable, taken through
+// UnscrubbedImageSQL rather than respelled here: that helper's comment says
+// plainly that almost-the-same is how the boundary comes to mean two moments,
+// and this is a fifth reader of it, not a second copy.
+//
+// A deal whose reconstruction would cross its own tombstone is not quietly
+// reported at its current values and not quietly dropped. It is counted as
+// unreconstructible, and a block carrying any such deal says so rather than
+// publishing a number it cannot stand behind.
+//
+// NO WRITER TOMBSTONES A DEAL TODAY, so this excludes nothing in practice: the
+// scrub verbs are written against person, lead, activity, attachment,
+// deal_room_participant, scheduled_send and the AI records. It is here because
+// it must be here BEFORE deal erasure lands rather than after — a boundary added
+// afterwards has already served the images it was meant to withhold. The day the
+// set widens, gates/scrubbedentitytypes_test.go fails and asks what a frozen
+// week should report.
+//
+// The verbs are the field-image ones. `update` and `restore` carry the column
+// patches (the two the update door may write, per auditverb), `advance_stage`
+// carries the deal's stage patch and can move status with it, and `archive`
+// carries the lifecycle. Every other verb's payload is
+// evidence ABOUT an operation rather than an image of the row, and reverse-
+// applying one would fabricate a change that never happened — the same closed
+// set privacy's field history projects, for the same reason.
+func weekEndDealsSQL(endPos, verbsPos string) string {
+	// Each fragment already closes its own CTE with a comma; the pieces are
+	// concatenated, not punctuated.
+	return fmt.Sprintf(rewindSQL+foldSQL+weekEndRowSQL,
+		endPos, privacy.UnscrubbedImageSQL("a", verbsPos))
+}
+
+// rewindSQL reads every post-cutoff change to one of the rep's deals, with the
+// erasure boundary applied per row, and names the deals it may not rebuild.
+const rewindSQL = `
+		-- Every post-cutoff change to one of the rep's deals, with the erasure
+		-- boundary applied per row.
+		rewind AS (
+		  SELECT a.entity_id, a.action, a.before, a.occurred_at, a.id,
+		         %[2]s AS readable
+		    FROM audit_log a
+		    JOIN mine ON mine.id = a.entity_id
+		   WHERE a.entity_type = 'deal'
+		     AND a.occurred_at >= %[1]s
+		     AND a.action IN ('update', 'advance_stage', 'archive', 'restore')),
+		-- A deal is unreconstructible when ANY post-cutoff row of it is behind a
+		-- scrub. Asked over the whole rewind rather than one row: a readable
+		-- change followed by an erased one still means the spine cannot be
+		-- trusted to describe this deal's week.
+		scrubbed AS (
+		  SELECT DISTINCT entity_id FROM rewind WHERE NOT readable),`
+
+// foldSQL rewinds each column by its own oldest post-cutoff change and reads
+// the archival lifecycle from the verb.
+const foldSQL = `
+		-- EACH COLUMN IS REWOUND BY ITS OWN OLDEST CHANGE, not by one shared row.
+		-- A patch carries only the columns it moved, so the first post-cutoff
+		-- edit is authoritative for what IT touched and silent about the rest.
+		-- Reading a single row and falling back to current values everywhere else
+		-- would undo the first edit and keep the second, producing a row that
+		-- existed at no instant: last week's status beside this week's close date.
+		first_image AS (
+		  SELECT r.entity_id, col.name AS column_name,
+		         (array_agg(r.before -> col.name
+		           ORDER BY r.occurred_at, r.id))[1] AS value
+		    FROM rewind r
+		    CROSS JOIN LATERAL (VALUES
+		      ('expected_close_date'), ('close_date_provisional'), ('status')
+		    ) AS col(name)
+		   WHERE r.before ? col.name
+		   GROUP BY r.entity_id, col.name),
+		-- One row per deal, pivoted. jsonb has no max(), and none is wanted: each
+		-- (deal, column) group holds exactly one value already, so the aggregate
+		-- is only collapsing three rows into three columns.
+		rewound AS (
+		  SELECT entity_id,
+		         (array_agg(value) FILTER (WHERE column_name = 'expected_close_date'))[1]
+		           AS expected_close_date,
+		         (array_agg(value) FILTER (WHERE column_name = 'close_date_provisional'))[1]
+		           AS close_date_provisional,
+		         (array_agg(value) FILTER (WHERE column_name = 'status'))[1] AS status
+		    FROM first_image GROUP BY entity_id),
+		-- Archival is read from the VERB, because the archive writer records the
+		-- lifecycle and passes no field images (dealarchive.go audits with nil
+		-- images either side). A post-cutoff 'archive' therefore means the deal
+		-- was live when the week closed.
+		--
+		-- ONLY 'archive'. There is no un-archive writer for a deal — dealarchive.go
+		-- has ArchiveDeal and no counterpart — so 'archive' is the only lifecycle
+		-- verb a deal ever carries, and a second one says the same thing as the
+		-- first. 'restore' is NOT the opposite of it: auditverb calls that verb
+		-- "an ordinary update in every respect except what the trail calls it",
+		-- written by the reversal path over any field. Reading it as an un-archive
+		-- would mark a deal archived because somebody undid a name correction.
+		-- The deal was live at the cutoff only if it was archived after it AND
+		-- carries no archive row from BEFORE it. Both halves are needed:
+		-- retention's archiveDeal writes archived_at unconditionally, so a deal
+		-- already archived can take a SECOND archive row later, and reading the
+		-- post-cutoff verb alone would report that deal as live through a week it
+		-- spent archived. The current archived_at cannot answer this — it holds
+		-- the LATEST stamp, which is the post-cutoff one.
+		lifecycle AS (
+		  SELECT DISTINCT r.entity_id
+		    FROM rewind r
+		   WHERE r.action = 'archive'
+		     AND NOT EXISTS (
+		       SELECT 1 FROM audit_log prior
+		        WHERE prior.entity_type = 'deal' AND prior.entity_id = r.entity_id
+		          AND prior.action = 'archive' AND prior.occurred_at < %[1]s)),`
+
+// weekEndRowSQL is the deal as it stood when the week closed: a rewound value
+// per column where one moved, the current value where none did.
+const weekEndRowSQL = `
+		week_end AS (
+		  SELECT m.id, m.stage_id, m.pipeline_id,
+		         -- A column with no post-cutoff change never moved, so the current
+		         -- value IS the week-end value. PRESENCE decides that, never the
+		         -- value: a patch clearing a column records JSON null, which says
+		         -- "it was empty" — and COALESCE on the extracted text would read
+		         -- that as "no image" and fall through to today's value, silently
+		         -- giving the week a date it did not have.
+		         CASE WHEN r.expected_close_date IS NOT NULL
+		              THEN (r.expected_close_date #>> '{}')::date
+		              ELSE m.expected_close_date END AS expected_close_date,
+		         CASE WHEN r.close_date_provisional IS NOT NULL
+		              THEN (r.close_date_provisional #>> '{}')::boolean
+		              ELSE m.close_date_provisional END AS close_date_provisional,
+		         CASE WHEN r.status IS NOT NULL
+		              THEN r.status #>> '{}'
+		              ELSE m.status END AS status,
+		         -- Archived after the cutoff means live at it; otherwise the
+		         -- current archival state stands, never having moved.
+		         CASE WHEN l.entity_id IS NOT NULL THEN false
+		              ELSE m.archived_at IS NOT NULL END AS was_archived,
+		         (s.entity_id IS NOT NULL) AS unreconstructible
+		    FROM mine m
+		    LEFT JOIN rewound r ON r.entity_id = m.id
+		    LEFT JOIN lifecycle l ON l.entity_id = m.id
+		    LEFT JOIN scrubbed s ON s.entity_id = m.id)`

--- a/backend/internal/compose/weekly/weeklyweekend_integration_test.go
+++ b/backend/internal/compose/weekly/weeklyweekend_integration_test.go
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package weekly
+
+// The scorecard's population counts, asked of a week that has already moved on.
+//
+// These cases are integration cases for the reason the rest of this suite is:
+// the thing under test is the reverse-apply SQL, and it reads audit images that
+// only exist because the real writers put them there. A test that inserted its
+// own audit rows would prove the query can read rows the test knows how to
+// write, which is not the claim.
+//
+// The fixture never back-dates a write. The writers stamp now(), so every audit
+// row lands after the closing cutoff of the week under review — which is exactly
+// the situation being tested: a review assembled late, describing a week whose
+// deals have changed since.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/shared/kernel/auditverb"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// weekBirth is an instant inside the week weekClock reviews — the Monday-to-
+// Sunday week before that Wednesday. A deal dated here existed when the week
+// closed; every write this suite makes afterwards happens at wall-clock now,
+// which is long after that Sunday, so each one is a post-cutoff change and the
+// reconstruction has to undo it.
+var weekBirth = weekClock.AddDate(0, 0, -9)
+
+// openDealFor mints one deal owned by the rep, through the real writer, and
+// hands back the won stage beside it so a caller can close it the way the
+// product does.
+//
+// The deal's created_at is then moved into the week under review. That is the
+// one thing this fixture back-dates, and it has to: audit_log is immutable by
+// trigger (trg_audit_no_mutate, BEFORE DELETE OR UPDATE), so a test cannot move
+// the EDIT it makes into the past, and the whole
+// situation being tested is a deal that existed during the week and changed
+// after it. Moving the birth backwards is the only end of that pair a test can
+// hold. The audit rows stay where the writers put them, which is exactly the
+// side the reconstruction reads.
+func openDealFor(t *testing.T, e *weekEnv, name string) (ids.DealID, ids.StageID) {
+	t.Helper()
+	pipeline, open, won := integration.DealFixture(t, e.Env)
+	repOwner := ids.From[ids.UserKind](e.Rep1)
+	created, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: name, PipelineID: pipeline, StageID: open,
+		Source: "manual", OwnerID: &repOwner,
+	})
+	if err != nil {
+		t.Fatalf("seeding deal %s: %v", name, err)
+	}
+	id := ids.From[ids.DealKind](ids.UUID(created.Id))
+	bornInTheWeek(t, id)
+	return id, won
+}
+
+// bornInTheWeek dates a seeded deal into the week the review covers.
+func bornInTheWeek(t *testing.T, id ids.DealID) {
+	t.Helper()
+	if _, err := integration.OwnerConn(t).Exec(context.Background(),
+		`UPDATE deal SET created_at = $2 WHERE id = $1`, id, weekBirth); err != nil {
+		t.Fatalf("dating the deal into the week under review: %v", err)
+	}
+}
+
+// winDeal closes a deal the way the product does: an advance to the won stage,
+// which is the writer that moves status and records the audit image the rewind
+// reads. A direct status patch is not a door the product offers.
+func winDeal(t *testing.T, e *weekEnv, id ids.DealID, won ids.StageID) {
+	t.Helper()
+	reason := "verbal"
+	detail := "Rahmenvertrag liegt beim Kunden"
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), id, deals.AdvanceDealInput{
+		ToStageID: won, WonWithoutContractReason: &reason,
+		WonWithoutContractDetail: &detail,
+	}); err != nil {
+		t.Fatalf("winning the deal: %v", err)
+	}
+}
+
+// dealBlockAt assembles the rep's review and hands back its deal block.
+func dealBlockAt(t *testing.T, e *weekEnv) *DealBlock {
+	t.Helper()
+	review, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
+	if err != nil {
+		t.Fatalf("assembling the week: %v", err)
+	}
+	if review.Scorecard == nil || review.Scorecard.Deal == nil {
+		t.Fatal("the rep has an open deal, so the week has a deal block to judge")
+	}
+	return review.Scorecard.Deal
+}
+
+// A DEAL CLOSED AFTER THE WEEK ENDED WAS STILL OPEN WHEN IT ENDED.
+//
+// The defect this holds: the population counts read the deal row, and the deal
+// row is current. The dispatcher retries all week for a rep whose review landed
+// un-narrated, so a review written on Thursday counted Thursday's pipeline as
+// last Sunday's. Permanently: uq_weekly_review_user_week refuses a second review
+// for the week, so the first figures stand as that week's record for good.
+//
+// Reading the count as 1 is the whole claim. With the reconstruction reverted
+// this reads 0: the deal is won TODAY, and today is what the old query asked.
+func TestADealClosedAfterTheWeekEndedStillCountsAsOpenThatWeek(t *testing.T) {
+	e := setupWeekly(t)
+	id, wonStage := openDealFor(t, e, "Weber Rahmenvertrag")
+
+	// Won NOW — after the closing cutoff of the week under review. Through the
+	// real writer, so the audit image the rewind reads is the one production
+	// writes.
+	winDeal(t, e, id, wonStage)
+
+	block := dealBlockAt(t, e)
+	if block.Open != 1 {
+		t.Errorf("open deals at week end = %d, want 1 — the deal was won after the "+
+			"week closed, so the week it belongs to had it open", block.Open)
+	}
+	// Present and zero, never absent: a week measured now always answers the
+	// question, and absent is reserved for weeks scored before it was asked.
+	if block.Unreconstructible == nil {
+		t.Fatal("a week scored now must say what it could not rebuild, even when that is none")
+	}
+	if got := *block.Unreconstructible; got != 0 {
+		t.Errorf("unreconstructible = %d, want 0 — nothing here is behind an erasure", got)
+	}
+}
+
+// A DEAL ARCHIVED AFTER THE WEEK ENDED WAS STILL IN IT.
+//
+// Archival is the one field the rewind reads by VERB rather than by image: the
+// archive writer audits the lifecycle and passes nil images either side, so
+// there is no before-value to fold. Undoing an 'archive' means the deal was
+// live at the cutoff, and this is what proves the verb path works — the image
+// path cannot answer this case at all.
+func TestADealArchivedAfterTheWeekEndedStillCountsInIt(t *testing.T) {
+	e := setupWeekly(t)
+	id, _ := openDealFor(t, e, "Kessler Wartung")
+
+	if _, err := e.Deals.ArchiveDeal(e.Admin(), id, nil); err != nil {
+		t.Fatalf("archiving the deal: %v", err)
+	}
+
+	block := dealBlockAt(t, e)
+	if block.Open != 1 {
+		t.Errorf("open deals at week end = %d, want 1 — the deal was archived after "+
+			"the week closed, and the archive verb is what says it was live before",
+			block.Open)
+	}
+}
+
+// A DEAL CREATED AFTER THE WEEK ENDED WAS NOT IN IT.
+//
+// The mirror of the two above, and the case a reverse-apply gets wrong by
+// omission: rewinding tells you what a deal LOOKED like, never whether it
+// existed. A deal minted this morning has no audit row before the cutoff and
+// must not appear in a count of last week's pipeline.
+//
+// It is asserted through the block's absence rather than through Open == 0,
+// because a rep whose only deal postdates the week has nothing to judge at all.
+func TestADealCreatedAfterTheWeekEndedIsNotCountedInIt(t *testing.T) {
+	e := setupWeekly(t)
+	// Seeded WITHOUT the back-dating every other case here applies: this deal is
+	// born at wall-clock now, which is after the reviewed week closed. That is
+	// the whole premise, so it cannot share the helper.
+	pipeline, open, _ := integration.DealFixture(t, e.Env)
+	repOwner := ids.From[ids.UserKind](e.Rep1)
+	if _, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "Neumann Erstauftrag", PipelineID: pipeline, StageID: open,
+		Source: "manual", OwnerID: &repOwner,
+	}); err != nil {
+		t.Fatalf("seeding the deal: %v", err)
+	}
+
+	review, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
+	if err != nil {
+		t.Fatalf("assembling the week: %v", err)
+	}
+	if review.Scorecard == nil {
+		t.Fatal("a review carries a scorecard even when its blocks are absent")
+	}
+	if d := review.Scorecard.Deal; d != nil && d.Open != 0 {
+		t.Errorf("open deals at week end = %d, want 0 — the deal did not exist when "+
+			"the week closed", d.Open)
+	}
+}
+
+// AN ERASED DEAL IS COUNTED AS UNRECONSTRUCTIBLE, NEVER QUIETLY AT TODAY'S
+// VALUES.
+//
+// The spine is append-only, so a scrub cannot rewrite the images captured
+// before it — they are still sitting in audit_log. A rewind that read them
+// would put back onto a rep's weekly review exactly what the scrub certified
+// destroyed. So the boundary excludes the deal from every population count and
+// tallies it separately, which is what tells a reader the counts are a floor.
+func TestADealBehindAnErasureIsReportedRatherThanCountedAtTodaysValues(t *testing.T) {
+	e := setupWeekly(t)
+	owner := integration.OwnerConn(t)
+	ctx := context.Background()
+	id, wonStage := openDealFor(t, e, "Vogel Ablösung")
+
+	// An ordinary post-cutoff edit FIRST, so the deal has a rewind row at all;
+	// then the scrub over the top of it. A deal with no post-cutoff change never
+	// reaches the boundary, so seeding only the tombstone would pass whether or
+	// not the boundary works.
+	winDeal(t, e, id, wonStage)
+	// The tombstone is written directly because NO WRITER IN THE TREE PRODUCES
+	// ONE FOR A DEAL. privacy tombstones person, lead, activity, attachment,
+	// deal_room_participant, scheduled_send and the AI records — never a deal —
+	// so this row cannot be seeded through production, and the boundary excludes
+	// nothing today.
+	//
+	// The boundary is still the right code to hold: it fails closed the day deal
+	// erasure lands, and that day is what
+	// TestEveryScrubbedRecordTypeIsOneAReaderOfTheBoundaryExpects exists to
+	// announce. This case proves the query honours a tombstone when one exists;
+	// the gate proves nobody adds one without deciding what a frozen week should
+	// then report. Neither claims on its own that the path is live.
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id)
+		VALUES ('system', 'system:retention', 'erase', 'deal', $1)`, id); err != nil {
+		t.Fatalf("writing the erasure tombstone: %v", err)
+	}
+
+	block := dealBlockAt(t, e)
+	if block.Unreconstructible == nil {
+		t.Fatal("a week scored now must say what it could not rebuild")
+	}
+	if got := *block.Unreconstructible; got != 1 {
+		t.Errorf("unreconstructible = %d, want 1 — the deal's week sits behind an "+
+			"erasure and cannot be rebuilt from images the scrub certified gone", got)
+	}
+	if block.Open != 0 {
+		t.Errorf("open deals at week end = %d, want 0 — an unreconstructible deal is "+
+			"left out of the counts and reported, never folded in at today's values",
+			block.Open)
+	}
+}
+
+// TWO POST-CUTOFF EDITS TO DIFFERENT COLUMNS, AND BOTH MUST BE UNDONE.
+//
+// A patch carries only the columns it moved, so the oldest post-cutoff change
+// is the right source for the columns IT touched and says nothing about the
+// rest. A reconstruction that reads one row and falls back to the current value
+// for everything else undoes the first edit and keeps the second — a row that
+// existed at no instant, mixing last week's status with this week's close date.
+func TestEachColumnIsRewoundByItsOwnOldestChange(t *testing.T) {
+	e := setupWeekly(t)
+	id, wonStage := openDealFor(t, e, "Hartmann Ausbau")
+
+	// First edit: the close date moves. Second: the deal is won. Different
+	// columns, in that order, both after the week closed.
+	future := time.Date(2027, 3, 31, 0, 0, 0, 0, time.UTC)
+	if _, err := e.Deals.UpdateDeal(e.Admin(), id, deals.UpdateDealInput{
+		ExpectedClose: &future,
+	}); err != nil {
+		t.Fatalf("moving the close date: %v", err)
+	}
+	winDeal(t, e, id, wonStage)
+
+	block := dealBlockAt(t, e)
+	// Won AFTER the week, so it was open during it — this holds the status
+	// column, whose own oldest change is the SECOND edit.
+	if block.Open != 1 {
+		t.Errorf("open deals at week end = %d, want 1 — the win came after the week "+
+			"closed, and the edit before it must not hide that", block.Open)
+	}
+	// And the close date, whose own oldest change is the FIRST edit. Asserted
+	// beside the status because one column proves only its own path: a rewind
+	// that read one shared row could get either right while mixing the other in.
+	//
+	// The deal was seeded with no close date, so it was NOT sound at week end.
+	// The post-cutoff edit gave it a firm future one; reading today's row would
+	// count it as sound and report a deal in better shape than the week left it.
+	if block.CloseDateSound != 0 {
+		t.Errorf("deals with a sound close date at week end = %d, want 0 — the date "+
+			"was set after the week closed, so that week had none", block.CloseDateSound)
+	}
+}
+
+// UNDOING AN EDIT IS NOT UNARCHIVING A DEAL.
+//
+// The archival rewind reads the VERB rather than an image, and 'restore' looks
+// like the opposite of 'archive' until you read what writes it: auditverb calls
+// a restore "an ordinary update in every respect except what the trail calls
+// it", written by the reversal path over any field at all. There is no
+// un-archive writer for a deal — dealarchive.go has ArchiveDeal and no
+// counterpart — so reading 'restore' as one would drop a never-archived deal
+// out of the week because somebody undid a name correction on it.
+func TestUndoingAnEditDoesNotReadAsUnarchivingTheDeal(t *testing.T) {
+	e := setupWeekly(t)
+	id, _ := openDealFor(t, e, "Brandt Servicevertrag")
+
+	// A post-cutoff edit recorded the way the reversal path records one: the
+	// same update door, carrying the restore verb. The deal is never archived.
+	renamed := "Brandt Servicevertrag (korrigiert)"
+	if _, err := e.Deals.UpdateDeal(e.Admin(), id, deals.UpdateDealInput{
+		Name:  &renamed,
+		Trail: auditverb.Trail{Verb: auditverb.Restore},
+	}); err != nil {
+		t.Fatalf("undoing the edit: %v", err)
+	}
+
+	block := dealBlockAt(t, e)
+	if block.Open != 1 {
+		t.Errorf("open deals at week end = %d, want 1 — the deal was never archived, "+
+			"and a restore-verb row is an ordinary edit rather than an un-archive",
+			block.Open)
+	}
+}
+
+// A DEAL ARCHIVED BEFORE THE WEEK AND AGAIN AFTER IT WAS ARCHIVED ALL WEEK.
+//
+// The archival rewind reads the post-cutoff 'archive' verb as "it was live
+// before". That holds only while a deal cannot be archived twice — and it can:
+// retention's archiveDeal writes archived_at unconditionally, so a deal a human
+// already archived takes a second row when a sweep reaches it. Reading the later
+// verb alone would report the deal open through a week it spent archived, and
+// the current archived_at cannot correct that because it holds the LATER stamp.
+func TestADealArchivedBeforeAndAgainAfterTheWeekIsNotReportedOpen(t *testing.T) {
+	e := setupWeekly(t)
+	owner := integration.OwnerConn(t)
+	ctx := context.Background()
+	id, _ := openDealFor(t, e, "Seidel Altvertrag")
+
+	// Archived BEFORE the cutoff: the row is dated into the reviewed week, the
+	// way the deal's own birth is, because a test cannot back-date an audit row.
+	if _, err := e.Deals.ArchiveDeal(e.Admin(), id, nil); err != nil {
+		t.Fatalf("archiving the deal: %v", err)
+	}
+	if _, err := owner.Exec(ctx, `
+		UPDATE audit_log SET occurred_at = $2
+		 WHERE entity_type = 'deal' AND entity_id = $1 AND action = 'archive'`,
+		id, weekBirth.AddDate(0, 0, 1)); err != nil {
+		// audit_log refuses UPDATE by trigger, so the pre-cutoff row is written
+		// directly instead — the same shape ArchiveDeal writes, at an instant the
+		// writer cannot be asked for.
+		if _, insErr := owner.Exec(ctx, `
+			INSERT INTO audit_log (actor_type, actor_id, action, entity_type,
+			                       entity_id, occurred_at)
+			VALUES ('human', 'human:fixture', 'archive', 'deal', $1, $2)`,
+			id, weekBirth.AddDate(0, 0, 1)); insErr != nil {
+			t.Fatalf("seeding the pre-cutoff archive: %v", insErr)
+		}
+	}
+	// And archived again after the week, which is the row the rewind sees first.
+	if _, err := owner.Exec(ctx,
+		`INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id)
+		 VALUES ('system', 'system:retention', 'archive', 'deal', $1)`, id); err != nil {
+		t.Fatalf("seeding the retention archive: %v", err)
+	}
+
+	review, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
+	if err != nil {
+		t.Fatalf("assembling the week: %v", err)
+	}
+	if review.Scorecard == nil {
+		t.Fatal("a review carries a scorecard even when its blocks are absent")
+	}
+	if d := review.Scorecard.Deal; d != nil && d.Open != 0 {
+		t.Errorf("open deals at week end = %d, want 0 — the deal was already archived "+
+			"when the week closed, and a later archive does not make it live", d.Open)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -36166,6 +36166,18 @@ type WeeklyScorecardDealBlock struct {
 	Open        int `json:"open"`
 	Regressions int `json:"regressions"`
 
+	// Unreconstructible Deals left OUT of the four population counts above because their state at the week's
+	// closing instant could not be rebuilt: the audit images describing their week sit
+	// behind an erasure, and the append-only spine means reading them would put back
+	// exactly what a scrub certified destroyed.
+	//
+	// Nonzero means `open` and the three coverage counts are a floor rather than a total,
+	// and a reader must be told so. Zero is the ordinary answer. ABSENT means the week was
+	// scored before this reconstruction existed, which is a third fact again: those counts
+	// are the current-state figures they always were, and nothing can retroactively make
+	// them week-end facts.
+	Unreconstructible *int `json:"unreconstructible,omitempty"`
+
 	// WithNextStep Open deals carrying an open task. A count beside `open`, never a rate.
 	WithNextStep int `json:"with_next_step"`
 }

--- a/backend/migrations/core/1788899276_a_week_says_what_it_could_not_reconstruct.down.sql
+++ b/backend/migrations/core/1788899276_a_week_says_what_it_could_not_reconstruct.down.sql
@@ -1,0 +1,7 @@
+-- Bounded, because ALTER TABLE takes an ACCESS EXCLUSIVE lock and a weekly
+-- scorecard is written by a job that runs while people are reading. Waiting
+-- unbounded behind one long reader would queue every writer behind this.
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE weekly_review_scorecard
+    DROP COLUMN deal_unreconstructible;

--- a/backend/migrations/core/1788899276_a_week_says_what_it_could_not_reconstruct.up.sql
+++ b/backend/migrations/core/1788899276_a_week_says_what_it_could_not_reconstruct.up.sql
@@ -1,0 +1,28 @@
+-- The deals whose week could not be reconstructed.
+--
+-- The deal block's population counts (open, with a next step, multi-threaded,
+-- close date sound) describe the pipeline as the week CLOSED, rebuilt by
+-- walking the audit spine backwards from the closing instant. A deal whose
+-- post-cutoff changes sit behind an erasure cannot be walked: the spine is
+-- append-only, so the images are still there, and reading them would put back
+-- onto a rep's review exactly what a scrub certified destroyed.
+--
+-- Such a deal is left out of every count above and TALLIED HERE, because a
+-- reader who is not told takes a smaller open count for the whole truth. Zero
+-- is the ordinary answer and means the counts beside it are complete.
+--
+-- Left OUT of weekly_review_scorecard_deal_block_shape deliberately, for the
+-- reason deal_median_days_in_stage is: that CHECK binds columns which are
+-- present exactly when the block is, and this one is NULL on every scorecard
+-- frozen before the reconstruction existed. Adding it there would refuse rows
+-- already written and shipped. NULL therefore means "this week was scored
+-- before the question was asked", which a reader must not read as zero — those
+-- reviews' population counts are the current-state figures they always were,
+-- and nothing here can retroactively make them week-end facts.
+-- Bounded, because ALTER TABLE takes an ACCESS EXCLUSIVE lock and a weekly
+-- scorecard is written by a job that runs while people are reading. Waiting
+-- unbounded behind one long reader would queue every writer behind this.
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE weekly_review_scorecard
+    ADD COLUMN deal_unreconstructible integer;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -6259,6 +6259,7 @@ public.weekly_review_scorecard.deal_median_days_in_stage integer gen=- def=-
 public.weekly_review_scorecard.deal_multi_threaded integer gen=- def=-
 public.weekly_review_scorecard.deal_open integer gen=- def=-
 public.weekly_review_scorecard.deal_regressions integer gen=- def=-
+public.weekly_review_scorecard.deal_unreconstructible integer gen=- def=-
 public.weekly_review_scorecard.deal_with_next_step integer gen=- def=-
 public.weekly_review_scorecard.has_deal_block boolean NOT NULL gen=- def=-
 public.weekly_review_scorecard.has_lead_block boolean NOT NULL gen=- def=-

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -122,7 +122,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (133)
+## Census (134)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -238,6 +238,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebookdelegation_test.go` | H3 | AGENTS.md is the rulebook — at the root, and in any directory that needs one of its own. |
 | `safetydefects_test.go` | H2 | Every declared stage-automation safety defect can actually stop a rule. |
 | `satellite_lifecycle_test.go` | H2 | Person-satellite lifecycle reach as a fitness function. |
+| `scrubbedentitytypes_test.go` | H2 | Which RECORD TYPES a scrub verb is ever written against. |
 | `scrubverbs_test.go` | H2 | Every verb the privacy module writes is judged a scrub or ratified as not one. |
 | `seatfanout_test.go` | H2 | A nightly agent acts FOR A PERSON, and the identity of one night's work has to say which person. |
 | `sendcontext_test.go` | H2 | Every send says WHY it is being sent. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -30973,6 +30973,19 @@ export interface components {
              */
             forecast_up: number;
             forecast_down: number;
+            /**
+             * @description Deals left OUT of the four population counts above because their state at the week's
+             *     closing instant could not be rebuilt: the audit images describing their week sit
+             *     behind an erasure, and the append-only spine means reading them would put back
+             *     exactly what a scrub certified destroyed.
+             *
+             *     Nonzero means `open` and the three coverage counts are a floor rather than a total,
+             *     and a reader must be told so. Zero is the ordinary answer. ABSENT means the week was
+             *     scored before this reconstruction existed, which is a third fact again: those counts
+             *     are the current-state figures they always were, and nothing can retroactively make
+             *     them week-end facts.
+             */
+            unreconstructible?: number;
         };
         /**
          * @description One rep's week, as it was measured when the week closed. Every count is as-of `as_of`,

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2612,6 +2612,9 @@ export const de = {
   "brief.weekly.scorecard.closeDateSound": "Festes Abschlussdatum hinterlegt",
   "brief.weekly.scorecard.forecastMoves": "Forecast hochgestuft",
   "brief.weekly.scorecard.forecastMovesBasis": "{down} herabgestuft",
+  "brief.weekly.scorecard.unreconstructible": "Nicht rekonstruierbare Deals",
+  "brief.weekly.scorecard.unreconstructibleBasis":
+    "Ihre Woche liegt hinter einer Löschung, die Zahlen oben sind daher ein Mindestwert",
   // Die kommende Woche. Der eingefrorene Rückblick sagt, was war; dies ist der
   // einzige Teil dieser Seite, den noch jemand ändern kann.
   "plan.title": "Ihre Woche planen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2704,6 +2704,9 @@ export const en = {
   "brief.weekly.scorecard.closeDateSound": "Firm close date recorded",
   "brief.weekly.scorecard.forecastMoves": "Forecast upgrades",
   "brief.weekly.scorecard.forecastMovesBasis": "{down} downgraded",
+  "brief.weekly.scorecard.unreconstructible": "Deals we could not rebuild",
+  "brief.weekly.scorecard.unreconstructibleBasis":
+    "Their week sits behind an erasure, so the counts above are a floor",
   // The week ahead. The frozen review says what happened; this is the only part
   // of that page anybody can still change.
   "plan.title": "Plan your week",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2585,6 +2585,9 @@ export const vi = {
   "brief.weekly.scorecard.closeDateSound": "Đã ghi ngày chốt cố định",
   "brief.weekly.scorecard.forecastMoves": "Nâng dự báo",
   "brief.weekly.scorecard.forecastMovesBasis": "{down} hạ dự báo",
+  "brief.weekly.scorecard.unreconstructible": "Giao dịch không dựng lại được",
+  "brief.weekly.scorecard.unreconstructibleBasis":
+    "Tuần của chúng nằm sau một lần xóa, nên các số trên là mức tối thiểu",
   // Tuần tới. Bản tổng kết đã đóng băng nói điều đã xảy ra; đây là phần duy nhất
   // của trang đó mà vẫn còn ai đó thay đổi được.
   "plan.title": "Lập kế hoạch tuần của bạn",

--- a/frontend/src/screens/brief.weekly.scorecard.test.tsx
+++ b/frontend/src/screens/brief.weekly.scorecard.test.tsx
@@ -132,4 +132,37 @@ describe("the weekly scorecard", () => {
       screen.getByText(en["brief.weekly.scorecard.partialHistory"]),
     ).toBeTruthy();
   });
+
+  // Three states, not two. Zero and absent both draw nothing, but they are
+  // different facts: zero means the week was rebuilt completely, absent means
+  // it was scored before the rebuild existed. Only a real shortfall is drawn,
+  // and drawing it is what stops a reader taking a floor for a total.
+  it("reports deals it could not rebuild, and only when there are some", () => {
+    render(
+      <ScorecardPanel
+        scorecard={{ deal: { ...dealBlock, unreconstructible: 0 } }}
+      />,
+    );
+    expect(
+      screen.queryByText(en["brief.weekly.scorecard.unreconstructible"]),
+    ).toBeNull();
+
+    cleanup();
+    // A week scored before the reconstruction existed sends no field at all.
+    // It must read like the zero case rather than throwing or drawing "0".
+    render(<ScorecardPanel scorecard={{ deal: dealBlock }} />);
+    expect(
+      screen.queryByText(en["brief.weekly.scorecard.unreconstructible"]),
+    ).toBeNull();
+
+    cleanup();
+    render(
+      <ScorecardPanel
+        scorecard={{ deal: { ...dealBlock, unreconstructible: 2 } }}
+      />,
+    );
+    expect(
+      screen.getByText(en["brief.weekly.scorecard.unreconstructible"]),
+    ).toBeTruthy();
+  });
 });

--- a/frontend/src/screens/brief.weekly.scorecard.tsx
+++ b/frontend/src/screens/brief.weekly.scorecard.tsx
@@ -148,6 +148,19 @@ function DealBlockStrip({
           down: n(block.forecast_down),
         })}
       />
+      {/* Drawn only when non-zero, the same rule the partial-history card
+          follows: a caveat the reader needs, never a reassurance nobody asked
+          for. Absent (rather than zero) means the week was scored before the
+          reconstruction existed, and that draws nothing either — there is no
+          shortfall to report, because the question was never asked of it. */}
+      {block.unreconstructible != null && block.unreconstructible > 0 && (
+        <StatCard
+          label={t("brief.weekly.scorecard.unreconstructible")}
+          value={n(block.unreconstructible)}
+          numeric
+          detail={t("brief.weekly.scorecard.unreconstructibleBasis")}
+        />
+      )}
     </StatStrip>
   );
 }


### PR DESCRIPTION
## What was wrong

Four of the weekly scorecard's deal counts — **open**, **with a next step**, **multi-threaded**, **close date sound** — describe a *population* rather than an event, and they read the deal table as it stands right now. The review is written once (`uq_weekly_review_user_week`), so whatever they read becomes that week's permanent record.

That is invisible when the review runs the moment the week closes, and wrong every other time. The dispatcher retries all week for a rep whose review landed un-narrated (`repsWithoutAReviewFor`), so a review written on Thursday recorded Thursday's pipeline as last Sunday's. A deal won on Tuesday simply vanished from the week it was open in.

## What it does now

The counts read a deal reconstructed as of the closing instant, by walking the audit spine backwards from it (`weeklyweekend.go`).

**Each column is rewound by its own oldest post-cutoff change.** A patch carries only the columns it moved, so one shared row would undo the first edit and keep the second — a row that existed at no instant, mixing last week's status with this week's close date.

**Presence of an image decides the fallback, never its value.** A patch clearing a column records JSON `null`, which says "it was empty". Reading that as "no image" would silently give the week a date it did not have.

**Archival is read from the verb**, because the archive writer records the lifecycle and passes no field images. Only `archive` — a `restore` is an ordinary update the reversal path writes, so reading it as an un-archive would drop a never-archived deal out of the week because somebody undid a name correction. And since retention's `archiveDeal` writes unconditionally, a deal already archived can take a second archive row later, so a prior row is checked too.

## The erasure boundary

The reconstruction stops at privacy's boundary, taken through `UnscrubbedImageSQL` rather than respelled. The spine is append-only, so the images a scrub certified gone are still physically there, and folding one back would put erased data onto a rep's scorecard. Such a deal is left out of every count and **tallied separately**: the scorecard reports what it could not rebuild rather than publishing a number it cannot stand behind.

**No writer tombstones a `deal` today**, so that boundary excludes nothing yet. It is here because it has to exist *before* deal erasure lands rather than after — a boundary added afterwards has already served the images it was meant to withhold. `gates/scrubbedentitytypes_test.go` fails the day the scrub set widens and asks what a frozen week should then report.

## Known limit

**Ownership is not rewound.** A deal reassigned after the week closed still lands on the new owner's week and leaves the old owner's. The image is there to read, but the selection feeds four counts and each needs its own answer to whose week a reassigned deal's event belongs in. Those are product questions, and guessing them would put somebody else's work on a rep's scorecard — the same class of defect this fixes. Filed as #5086, and stated in the code rather than left silent.

## Also tightened

- A task's next-step count reads whether it was done **before the cutoff**, not whether it is done now.
- The multi-threaded window is bounded at both ends, so two contacts who first spoke on Monday cannot make the closed week read multi-threaded.

## Wire

Additive optional field. Existing clients are unaffected. Absent is a third state from zero: the week was scored before the reconstruction existed, so its counts are the current-state figures they always were — nothing can retroactively make them week-end facts.

## Tests

Seven integration cases through real writers, each mutation-checked (revert the guard, confirm the test fails, restore):

- a deal won after the week still counts as open in it
- a deal archived after the week still counts in it
- a deal archived before **and** again after is not reported open
- a deal created after the week is not counted in it
- each column is rewound by its own oldest change (this one found a real defect: the close date was inheriting today's value)
- undoing an edit does not read as unarchiving
- a deal behind an erasure is reported, never folded in at today's values

Frontend covers all three states of the new field. The census gate was itself checked both ways — that it sees a deal scrub, and that it reports a call site whose entity type it cannot read rather than passing blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the weekly scorecard's four deal population counts — open, with a next step, multi-threaded, close date sound — so they describe the pipeline as it stood when the week closed instead of as it stands today. The review is write-once, and the dispatcher can write it days after the week ends, so the old counts permanently recorded Thursday's pipeline as last Sunday's.

**Reconstruction**
- Walks the audit spine backwards from the closing instant, rewinding each column by its own oldest post-cutoff change.
- Reads archival from the `archive` verb because the writer records no field images; a prior archive row is also checked since retention can archive a deal twice.
- A task counts as the week's next step only if it was not done before the cutoff, and the multi-threaded window is bounded at both ends.

**Erasure boundary**
- Stops the rewind at privacy's erasure boundary, taken through `UnscrubbedImageSQL`; deals behind it are left out of every count and tallied in a new `unreconstructible` field instead.
- The field is optional on the wire: absent means the week was scored before this reconstruction existed, which is a different fact from zero.
- No writer tombstones a deal today, so the boundary excludes nothing yet; a census gate fails the day the scrub set widens.
- Ownership is not rewound — a deal reassigned after the week still lands on the new owner's week (issue #5086).

<sup>Written for commit b3d2b7554988f29d72640040f87ff2e8e4ac8436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Weekly scorecards now identify deals whose historical state could not be reconstructed.
  - Scorecard counts indicate when reported figures are minimums because some historical data is unavailable.
  - Historical deal statuses are evaluated at the week’s closing time, improving accuracy for deals later edited, archived, or won.
- **Localization**
  - Added messaging for this information in English, German, and Vietnamese.
- **Documentation**
  - Updated the gate inventory to reflect expanded coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->