### PR TITLE
test(compose): the growth-fit probe proves the other reader's row survives

### DIFF
--- a/backend/internal/compose/integration/growthfit_e2e_integration_test.go
+++ b/backend/internal/compose/integration/growthfit_e2e_integration_test.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"context"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -135,7 +136,7 @@ func TestTheGrowthFitCacheRowIsKeyedToTheReaderWhoAskedForIt(t *testing.T) {
 	// band this company could not produce, and leave the acting reader with
 	// nothing of their own. The row is live: it would be served on sight.
 	acting := readerByEmail(t, e, bootstrappedAdminEmail)
-	giveTheCachedRowToAnotherReader(t, e, orgID, acting)
+	other := giveTheCachedRowToAnotherReader(t, e, orgID, acting)
 
 	var second growthFitResponse
 	if status := e.Call(t, "GET", "/v1/organizations/"+orgID+"/growth-fit", nil, nil, &second); status != http.StatusOK {
@@ -145,14 +146,48 @@ func TestTheGrowthFitCacheRowIsKeyedToTheReaderWhoAskedForIt(t *testing.T) {
 		t.Fatal("the read served another reader's cached assessment — the cache is keyed on write and not on read")
 	}
 
-	// And it wrote its own row rather than overwriting theirs, which is the
-	// same guarantee seen from the write side.
-	var mine ids.UUID
-	if err := e.Owner.QueryRow(context.Background(),
-		`SELECT user_id FROM org_growth_fit WHERE organization_id = $1 AND user_id = $2`,
-		orgID, acting).Scan(&mine); err != nil {
-		t.Fatalf("the acting reader's own row is missing after their read: %v", err)
+	// And it wrote its own row rather than overwriting theirs — BOTH halves,
+	// because either alone is satisfied by the defect. A write keyed on the
+	// organization and not the reader replaces the other reader's row and still
+	// leaves the acting reader with one of their own, so "mine exists" passes
+	// for exactly the keying this test exists to refuse. What separates them is
+	// that theirs is still there.
+	readers := cachedGrowthFitReaders(t, e, orgID)
+	if !slices.Contains(readers, acting) {
+		t.Errorf("the acting reader has no row of their own after their read; the cache holds %v", readers)
 	}
+	if !slices.Contains(readers, other) {
+		t.Errorf("the other reader's cached row is gone after somebody else read the same company — the "+
+			"cache write is keyed on the organization rather than on (organization, reader), so one "+
+			"reader's assessment evicts another's; the cache holds %v", readers)
+	}
+}
+
+// cachedGrowthFitReaders returns the readers holding a cached assessment of
+// this company. Read as a SET rather than probed one id at a time: what the
+// assertions above are about is which rows survived a write, and a per-id
+// existence check reports the first missing one without saying what is there
+// instead.
+func cachedGrowthFitReaders(t *testing.T, e *apptest.AppEnv, orgID string) []ids.UUID {
+	t.Helper()
+	rows, err := e.Owner.Query(context.Background(),
+		`SELECT user_id FROM org_growth_fit WHERE organization_id = $1 ORDER BY user_id`, orgID)
+	if err != nil {
+		t.Fatalf("reading the cached growth-fit rows: %v", err)
+	}
+	defer rows.Close()
+	var readers []ids.UUID
+	for rows.Next() {
+		var reader ids.UUID
+		if scanErr := rows.Scan(&reader); scanErr != nil {
+			t.Fatalf("scanning a cached growth-fit row: %v", scanErr)
+		}
+		readers = append(readers, reader)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the cached growth-fit rows: %v", err)
+	}
+	return readers
 }
 
 func namesMissingInput(missing []string, want string) bool {
@@ -236,7 +271,11 @@ func readerByEmail(t *testing.T, e *apptest.AppEnv, email string) ids.UUID {
 // with keying — and the test would pass over an unkeyed read. This row carries
 // the fingerprint the next read will compute, so it is live: an unkeyed read
 // finds it, accepts it, and serves it.
-func giveTheCachedRowToAnotherReader(t *testing.T, e *apptest.AppEnv, orgID string, acting ids.UUID) {
+// giveTheCachedRowToAnotherReader returns the reader it handed the row to, so
+// the caller can assert that reader's row is still there afterwards. Without
+// the id there is nothing to look for, and "the acting reader has a row" is
+// satisfied by a write that replaced the other one.
+func giveTheCachedRowToAnotherReader(t *testing.T, e *apptest.AppEnv, orgID string, acting ids.UUID) ids.UUID {
 	t.Helper()
 	other := ids.NewV7()
 	if _, err := e.Owner.Exec(context.Background(),
@@ -255,4 +294,5 @@ func giveTheCachedRowToAnotherReader(t *testing.T, e *apptest.AppEnv, orgID stri
 	if tag.RowsAffected() != 1 {
 		t.Fatalf("moved %d cache rows, want exactly the one the first read wrote", tag.RowsAffected())
 	}
+	return other
 }

--- a/backend/internal/compose/orgdossier/readercachekeying_test.go
+++ b/backend/internal/compose/orgdossier/readercachekeying_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package orgdossier
+
+// A reader cache is keyed on the READER as well as the company.
+//
+// These caches hold one reader's assembled view of a company — assembled from
+// what that reader may see, so two readers of the same company hold legitimately
+// different rows. A statement keyed on the organization alone breaks that two
+// ways at once and neither is loud: a read serves somebody else's assessment,
+// and a write evicts it.
+//
+// The end-to-end proof that it behaves this way exists for growth-fit
+// (TestTheGrowthFitCacheRowIsKeyedToTheReaderWhoAskedForIt, compose/integration).
+// It costs a booted app and a real read, which is why there is one of it and not
+// one per cache — and why the dossier cache, the same type with the same shape,
+// had no proof at all. This is the cheap half that covers every cache: the
+// statements themselves, read off the values the package actually uses.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// readerCacheStatements collects the readerCache values this package declares,
+// by variable name, with the two statements each one holds.
+//
+// From the SOURCE rather than from a list written here: a third cache added
+// beside these two is judged without anybody remembering this test, which is
+// the case that matters — the dossier cache went unproven precisely because the
+// growth-fit one had a test and nothing asked about its sibling.
+func readerCacheStatements(t *testing.T) map[string]map[string]string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), "cache.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing cache.go: %v", err)
+	}
+	caches := map[string]map[string]string{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.ValueSpec)
+		if !ok || len(spec.Names) != 1 || len(spec.Values) != 1 {
+			return true
+		}
+		lit, ok := spec.Values[0].(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		if named, ok := lit.Type.(*ast.Ident); !ok || named.Name != "readerCache" {
+			return true
+		}
+		statements := map[string]string{}
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			field, isField := kv.Key.(*ast.Ident)
+			// The string, not the source text. A raw literal's own text carries
+			// its backticks, so every substring check below would be asking
+			// about a string Postgres never receives — the difference is
+			// invisible until an escape or a quote style changes and the census
+			// quietly stops matching.
+			sql, isLiteral := gatekit.StringExpr(kv.Value, nil, gatekit.FoldStrict)
+			if isField && isLiteral {
+				statements[field.Name] = sql
+			}
+		}
+		caches[spec.Names[0].Name] = statements
+		return true
+	})
+	return caches
+}
+
+func TestEveryReaderCacheIsKeyedOnTheReaderAndNotTheCompanyAlone(t *testing.T) {
+	caches := readerCacheStatements(t)
+	if len(caches) == 0 {
+		t.Fatal("cache.go declares no readerCache value — this test read an empty corpus, and would " +
+			"report every cache correctly keyed without looking at one")
+	}
+	for name, statements := range caches {
+		for _, field := range []string{"selectOne", "upsertOne"} {
+			if _, present := statements[field]; !present {
+				t.Errorf("%s declares no %s, so half of its keying is unstated and unchecked", name, field)
+			}
+		}
+		// The READ, or one reader is served another's assessment of a company
+		// they see differently.
+		if !strings.Contains(statements["selectOne"], "user_id = $1") {
+			t.Errorf("%s.selectOne does not bind user_id, so it serves whichever reader's row it finds "+
+				"first — an assessment assembled from what somebody else could see", name)
+		}
+		// The WRITE, and this is the half the end-to-end test could not see
+		// until #665: a conflict target without user_id makes one row per
+		// company, so a second reader's read evicts the first's.
+		if !strings.Contains(statements["upsertOne"], "ON CONFLICT (user_id, organization_id)") {
+			t.Errorf("%s.upsertOne does not resolve conflicts on (user_id, organization_id), so the cache "+
+				"holds one row per company rather than one per reader and each read evicts the last "+
+				"reader's row", name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #665.

## The gap

`TestTheGrowthFitCacheRowIsKeyedToTheReaderWhoAskedForIt` proved two things: the acting reader is not served another reader's cached assessment, and the acting reader ends up with a row of their own.

Neither says the write left the **other** reader's row alone. A cache keyed on the organization and not the reader replaces that row and satisfies both assertions — and the comment above them claimed exactly the guarantee they did not make ("it wrote its own row rather than overwriting theirs").

`giveTheCachedRowToAnotherReader` now returns the reader it handed the row to, and the test asserts both rows are present afterwards. Read as a **set** rather than probed one id at a time: what is under test is which rows survived a write, and a per-id existence check reports the first missing one without saying what is there instead.

## The mutation, and why it is not the one the issue suggested

The issue proposes dropping `user_id` from the conflict target. That needs a unique index on `organization_id` alone, which does not exist — so the statement fails outright rather than misbehaving, and proves nothing.

Deleting the company's other rows before the insert produces the same state honestly: one row per organization. Under it the new assertion fails and **the two pre-existing ones still pass** — visible in the run, where only the `other`-reader error fires. That is the gap the issue reported, demonstrated rather than asserted.

## The sibling cache had no proof at all

`org_dossier` is the same `readerCache` with the same shape, and nothing anywhere asserted its keying. It went unproven for the ordinary reason: growth-fit had a test, and nothing asked about the other one.

A second end-to-end test would cost another booted app and another real read for the same claim. Instead the cheap half now covers every cache — `TestEveryReaderCacheIsKeyedOnTheReaderAndNotTheCompanyAlone` reads the two statements off the `readerCache` values the package declares, derived from the source so a third cache is judged without anybody remembering this test.

Both halves, because they fail differently and neither implies the other:

| half | what goes wrong without it |
|---|---|
| `selectOne` binds `user_id` | one reader is served another's assessment of a company they see differently |
| `upsertOne` conflicts on `(user_id, organization_id)` | the cache holds one row per company, and each read evicts the last reader's |

Each mutation-checked against each cache: dropping the dossier's conflict target and unbinding growth-fit's select each fail, naming the cache and the half.

The statements are read through `gatekit.StringExpr` rather than off the literal's source text — a raw literal carries its own backticks, so substring checks against the text ask about a string Postgres never receives, and the difference stays invisible until a quote style changes and the census silently stops matching.

## Checks

`make check-backend` green; `make craft-static` 0/0/0; `go test -count=1 ./gates` green; the compose/integration lane green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded integration coverage for cached organization data shared between readers.
  - Added validation that each reader retains its own cached data after cache handoff scenarios.
  - Added checks confirming cache entries remain isolated by reader and organization, reducing the risk of cross-reader data exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->