### PR TITLE
feat(deals): the list sorts by the name and status columns it draws

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -21437,10 +21437,14 @@ components:
         `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
         cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
         accepted multi-field spelling; any other comma-separated multi-field spec returns
-        `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-        enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-        columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-        an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+        `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+        resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+        index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+        they can order by: a header that cannot be clicked is a dead control. Some columns are not
+        yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+        its pipeline or a partner by its organization's name, needs a sort the server cannot express
+        yet — and a resource's own list documents which. An out-of-vocabulary field returns
+        `422 code: sort_field_not_allowed`.
     IncludeArchived:
       name: include_archived
       in: query

--- a/backend/internal/compose/integration/customfields_vocab_integration_test.go
+++ b/backend/internal/compose/integration/customfields_vocab_integration_test.go
@@ -269,11 +269,21 @@ func assertFullNameAndDefaultSort(t *testing.T, f cfvFixture) {
 }
 
 // TestCustomFieldVocab_CoreVocabulary: each list's core sortable
-// vocabulary is exactly its data-model §13.5 DM-VOCAB table — every
-// spec-listed field sorts in both directions (full_name ordering proves
-// the ORDER BY), the documented default spelling stays accepted, and a
-// real column the tables do not list — or a multi-field spec — is
-// refused.
+// vocabulary covers the DM-VOCAB set it was drawn from — every field in
+// it sorts in both directions (full_name ordering proves the ORDER BY),
+// the documented default spelling stays accepted, and a real column the
+// list does not publish — or a multi-field spec — is refused.
+//
+// COVERS rather than EQUALS, and the difference is a ruling rather than
+// drift. The vocabulary is now the columns a list publishes: a header a
+// reader can see is one they can order by, so a list that draws a column
+// the DM-VOCAB set omits accepts it anyway. `deal.name` is the first —
+// it sorted in poc-1, the spec table dropped it, and the deals list drew
+// it as an unsortable header until the rule put it back.
+//
+// So the refusal below has to be a column the list does NOT draw.
+// Otherwise this test pins the old rule and the new one cannot land
+// without it looking like a regression.
 func TestCustomFieldVocab_CoreVocabulary(t *testing.T) {
 	f := setupCFV(t)
 	// The deal list shares f's Env (Setup rebuilds the schema, so one
@@ -285,12 +295,20 @@ func TestCustomFieldVocab_CoreVocabulary(t *testing.T) {
 	assertSpecFieldsSortable(t, resources)
 	assertFullNameAndDefaultSort(t, f)
 
-	// A real column DM-VOCAB-3 does not list stays outside the vocabulary:
-	// deal name sorted in poc-1, and the spec table dropped it.
-	dealName := "name"
+	// A real column of `deal` the deals list does not draw stays outside the
+	// vocabulary. Chosen for that reason: refusing a name no table has would
+	// pass against a vocabulary that had become "any column", which is the way
+	// widening one goes wrong.
+	notDrawn := "captured_by"
 	var sortErr *storekit.SortError
-	if err := resources["deals (DM-VOCAB-3)"].list(dealName); !errors.As(err, &sortErr) || sortErr.Code != storekit.CodeSortFieldNotAllowed {
-		t.Fatalf("deals sort=name err = %v, want SortError %s", err, storekit.CodeSortFieldNotAllowed)
+	if err := resources["deals (DM-VOCAB-3)"].list(notDrawn); !errors.As(err, &sortErr) || sortErr.Code != storekit.CodeSortFieldNotAllowed {
+		t.Fatalf("deals sort=%s err = %v, want SortError %s", notDrawn, err, storekit.CodeSortFieldNotAllowed)
+	}
+
+	// And the column the ruling put back does sort, so this test cannot go on
+	// passing if the widening is reverted somewhere else.
+	if err := resources["deals (DM-VOCAB-3)"].list("name"); err != nil {
+		t.Fatalf("deals sort=name: %v — a column the list draws must be one it orders by", err)
 	}
 
 	multi := "-created_at,full_name"

--- a/backend/internal/compose/integration/dealsortvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/dealsortvocabulary_integration_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A column the deals list SHOWS is a column the deals list SORTS BY.
+//
+// The list draws seven columns and its sort vocabulary reached three of them,
+// so four headers were dead controls a reader had to learn to ignore — and the
+// frontend said so in a comment beside each one rather than being able to fix
+// it, because the vocabulary was pinned to a spec set written before the
+// columns were. Lars ruled on 2026-08-21 that the rule is the columns, for
+// every list in the product.
+//
+// Two of the four are reachable today and are held here. The other two are
+// JOINED columns — a stage orders by its position in its pipeline, a partner by
+// the organization's name — and the list machinery renders one quoted
+// identifier of the row's own table, so they need the sort model to take an
+// expression first. That is why this file pins two rather than four, and it is
+// stated so a reader does not read the gap as an oversight.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// TestTheDealsListSortsByTheNameColumnItDraws: alphabetical, which a list of
+// deals had no way to offer at all.
+func TestTheDealsListSortsByTheNameColumnItDraws(t *testing.T) {
+	f := setupDealCFV(t)
+	// Seeded out of order, so a pass cannot come from insertion order — which
+	// is what the default `-created_at` sort would give.
+	carla := f.seedScoredDeal(t, "Carla renewal", nil)
+	alma := f.seedScoredDeal(t, "Alma expansion", nil)
+	brig := f.seedScoredDeal(t, "Brig retainer", nil)
+
+	ascending := "name"
+	got, _ := f.listDealIDs(t, deals.ListDealsInput{Sort: &ascending})
+	assertIDOrder(t, got, []ids.UUID{alma, brig, carla}, "name ascending")
+
+	descending := "-name"
+	got, _ = f.listDealIDs(t, deals.ListDealsInput{Sort: &descending})
+	assertIDOrder(t, got, []ids.UUID{carla, brig, alma}, "name descending")
+}
+
+// TestTheDealsListSortsByTheStatusColumnItDraws: by the stored value, so the
+// three groups sit together.
+//
+// Alphabetical rather than by lifecycle — lost, open, won — because status is a
+// text column and the machinery orders by the column. Asserted as the order it
+// actually produces rather than the order a reader might expect, because a test
+// that wanted the lifecycle order would be asking for a second copy of the
+// vocabulary on the sorting side.
+func TestTheDealsListSortsByTheStatusColumnItDraws(t *testing.T) {
+	e := Setup(t)
+	pipeline, openStage, wonStage := DealFixture(t, e)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, dealCFVPerms)
+
+	openDeal := e.SeedDeal(t, "Still open", pipeline, openStage, &e.Rep1)
+	wonDeal := e.SeedDeal(t, "Closed won", pipeline, openStage, &e.Rep1)
+	// Through the real transition: a status written by hand would order
+	// correctly over a column no writer ever puts that value in.
+	if _, err := e.Deals.AdvanceDeal(ctx, ids.From[ids.DealKind](wonDeal), wonInput(wonStage)); err != nil {
+		t.Fatalf("winning the deal: %v", err)
+	}
+
+	listed := func(spec string) []ids.UUID {
+		t.Helper()
+		rows, _, err := e.Deals.ListDeals(ctx, deals.ListDealsInput{Sort: &spec})
+		if err != nil {
+			t.Fatalf("ListDeals(sort=%s): %v", spec, err)
+		}
+		out := make([]ids.UUID, len(rows))
+		for i, d := range rows {
+			out[i] = ids.UUID(d.Id)
+		}
+		return out
+	}
+
+	// "open" < "won"
+	assertIDOrder(t, listed("status"), []ids.UUID{openDeal, wonDeal}, "status ascending")
+	assertIDOrder(t, listed("-status"), []ids.UUID{wonDeal, openDeal}, "status descending")
+}
+
+// The refusal still refuses. Widening a vocabulary is the shape most likely to
+// widen it too far — a sort that reached any column at all would let a caller
+// order by a column the list does not publish, and the refusal is what keeps
+// the vocabulary a vocabulary.
+func TestTheDealsListStillRefusesAFieldItDoesNotPublish(t *testing.T) {
+	f := setupDealCFV(t)
+	f.seedScoredDeal(t, "Only deal", nil)
+
+	// A real column of `deal`, deliberately: refusing a nonsense name proves
+	// nothing about a vocabulary that might simply be "any column".
+	notPublished := "captured_by"
+	if _, _, err := f.store.ListDeals(f.ctx, deals.ListDealsInput{Sort: &notPublished}); err == nil {
+		t.Fatal("the list sorted by a column it does not publish — the vocabulary has stopped being one, and a caller can now order by anything the table holds")
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -37581,10 +37581,14 @@ type ListActivitiesParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// IncludeArchived Include soft-deleted (archived) rows. Default false.
@@ -38424,10 +38428,14 @@ type ListCustomFieldsParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// Object Target core object (CUSTOM-FIELDS-PARAM-2).
@@ -38612,10 +38620,14 @@ type ListDealRoomsParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// IncludeArchived Include soft-deleted (archived) rows. Default false.
@@ -38728,10 +38740,14 @@ type ListDealsParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// IncludeArchived Include soft-deleted (archived) rows. Default false.
@@ -39272,10 +39288,14 @@ type ListLeadsParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// IncludeArchived Include soft-deleted (archived) rows. Default false.
@@ -39567,10 +39587,14 @@ type ListOfferTemplatesParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// IncludeArchived Include soft-deleted (archived) rows. Default false.
@@ -39766,10 +39790,14 @@ type ListOrganizationsParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// IncludeArchived Include soft-deleted (archived) rows. Default false.
@@ -40446,10 +40474,14 @@ type ListPartnersParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort        *Sort                          `form:"sort,omitempty" json:"sort,omitempty"`
 	PartnerRole *ListPartnersParamsPartnerRole `form:"partner_role,omitempty" json:"partner_role,omitempty"`
 	CertStatus  *ListPartnersParamsCertStatus  `form:"cert_status,omitempty" json:"cert_status,omitempty"`
@@ -40480,10 +40512,14 @@ type ListPeopleParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// IncludeArchived Include soft-deleted (archived) rows. Default false.
@@ -40853,10 +40889,14 @@ type ListProductsParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// IncludeArchived Include soft-deleted (archived) rows. Default false.
@@ -40915,10 +40955,14 @@ type ListProjectsParams struct {
 	// `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
 	// cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
 	// accepted multi-field spelling; any other comma-separated multi-field spec returns
-	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-	// enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-	// columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-	// an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+	// `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+	// resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+	// index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+	// they can order by: a header that cannot be clicked is a dead control. Some columns are not
+	// yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+	// its pipeline or a partner by its organization's name, needs a sort the server cannot express
+	// yet — and a resource's own list documents which. An out-of-vocabulary field returns
+	// `422 code: sort_field_not_allowed`.
 	Sort *Sort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// IncludeArchived Include soft-deleted (archived) rows. Default false.

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -105,20 +105,38 @@ type ListDealsInput struct {
 	CustomFilters map[string]string
 }
 
-// dealNameColumn is the deal's display-name column, the quick-find
-// match expression. Deliberately NOT in the sortable vocabulary: the
-// data-model §13.5 DM-VOCAB-3 set does not list it.
+// dealNameColumn is the deal's display-name column and the quick-find
+// match expression.
 const dealNameColumn = "name"
 
-// dealListFields is the deal list's core sortable vocabulary — exactly
-// the data-model §13.5 DM-VOCAB-3 set; active cf_ columns join it per
-// request.
+// dealListFields is the deal list's sortable vocabulary; active cf_ columns
+// join it per request.
+//
+// A COLUMN THE LIST SHOWS IS A COLUMN THE LIST SORTS BY. It used to be exactly
+// the data-model §13.5 DM-VOCAB-3 set, and the deals list draws seven columns
+// of which that set reached three — so four headers were dead controls a reader
+// had to learn to ignore, and the frontend said so in a comment beside each one
+// rather than being able to fix it. Lars ruled on 2026-08-21 that the rule is
+// the columns, for every list in the product; where that and the older set
+// disagree, this follows the rule.
+//
+// `name` and `status` are the two the ruling reaches today, because they are
+// columns of `deal` and the list machinery orders by a base column. `stage` and
+// the two organization columns are joined — a stage sorts by its POSITION in
+// its pipeline rather than by its name, and a partner sorts by the
+// organization's — and storekit's ORDER BY renders one quoted identifier, so
+// those three need the sort model to take an expression before they can be
+// offered. Named here rather than left as an unexplained gap: the frontend
+// columns cite this vocabulary by name, so a reader who finds two of the four
+// fixed needs to know why the others were not.
 var dealListFields = map[string]string{
 	"created_at":          storekit.KindTimestamp,
 	"updated_at":          storekit.KindTimestamp,
 	"last_activity_at":    storekit.KindTimestamp,
 	"amount_minor":        fieldcatalog.TypeCurrency,
 	"expected_close_date": fieldcatalog.TypeDate,
+	dealNameColumn:        fieldcatalog.TypeText,
+	"status":              fieldcatalog.TypeText,
 }
 
 // wireRowTags renders one deal row's tag chips. A twin of the people module's:

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -33806,10 +33806,14 @@ export interface components {
          *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
          *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
          *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-         *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-         *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-         *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-         *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+         *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+         *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+         *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+         *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+         *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+         *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+         *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+         *     `422 code: sort_field_not_allowed`.
          */
         Sort: string;
         /** @description Include soft-deleted (archived) rows. Default false. */
@@ -34471,10 +34475,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Include soft-deleted (archived) rows. Default false. */
@@ -35968,10 +35976,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Include soft-deleted (archived) rows. Default false. */
@@ -37645,10 +37657,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 partner_role?: "hosting" | "consulting" | "strategic";
@@ -37824,10 +37840,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Include soft-deleted (archived) rows. Default false. */
@@ -38180,10 +38200,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Include soft-deleted (archived) rows. Default false. */
@@ -39555,10 +39579,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Include soft-deleted (archived) rows. Default false. */
@@ -41804,10 +41832,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Include soft-deleted (archived) rows. Default false. */
@@ -47803,10 +47835,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Target core object (CUSTOM-FIELDS-PARAM-2). */
@@ -50375,10 +50411,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Include soft-deleted (archived) rows. Default false. */
@@ -50561,10 +50601,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Include soft-deleted (archived) rows. Default false. */
@@ -51320,10 +51364,14 @@ export interface operations {
                  *     `created_at`/`id` tie-breaker is always appended so ordering is total and the keyset
                  *     cursor is deterministic. The default sort when omitted is `-created_at,id` — also the only
                  *     accepted multi-field spelling; any other comma-separated multi-field spec returns
-                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the indexed columns
-                 *     enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
-                 *     columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
-                 *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 *     `422 code: sort_unsupported`. **Allowed sort fields per resource** are the columns that
+                 *     resource's list publishes, plus the workspace's active `cf_` columns (custom columns carry no
+                 *     index in V1 — a `cf_` sort runs as a tenant-scoped scan). A column a reader can see is one
+                 *     they can order by: a header that cannot be clicked is a dead control. Some columns are not
+                 *     yet offered even so — one that orders by a JOINED value, such as a stage by its position in
+                 *     its pipeline or a partner by its organization's name, needs a sort the server cannot express
+                 *     yet — and a resource's own list documents which. An out-of-vocabulary field returns
+                 *     `422 code: sort_field_not_allowed`.
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Include soft-deleted (archived) rows. Default false. */

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -1465,6 +1465,9 @@ function dealColumns(
       key: "name",
       header: t("people.name"),
       cell: (deal) => deal.name,
+      // Alphabetical, which a list of deals had no way to offer until the
+      // API's sort vocabulary took the columns this list draws.
+      sort: "name",
       fixed: true,
     },
     tagsColumn<Deal>(t),
@@ -1475,7 +1478,8 @@ function dealColumns(
       // apart from a deal nobody has linked.
       //
       // No `sort`, for the reason the partner column below carries none: the
-      // API's sortable vocabulary does not include it, and a header that
+      // company is a JOINED column and the list machinery orders by one column
+      // of the row's own table, so the API cannot offer it yet. A header that
       // looked sortable and refused would be worse than one that never
       // offered.
       key: "company",
@@ -1488,9 +1492,10 @@ function dealColumns(
       // per-row is worse in a list than an empty cell — a column that comes
       // and goes cannot be scanned down.
       //
-      // It carries no `sort`, because the API's sortable vocabulary is a fixed
-      // five-field set that does not include it. That limitation is not this
-      // column's to fix (see the sorting issue), and a header that looked
+      // It carries no `sort` because the partner is a JOINED column: ordering
+      // by it means ordering by the organization's name, and the list
+      // machinery renders one quoted identifier of the row's own table. That
+      // limitation is not this column's to fix, and a header that looked
       // sortable and refused would be worse than one that never offered.
       key: "partner",
       header: t("deal.partnerOrg"),
@@ -1552,6 +1557,12 @@ function dealColumns(
       cell: (deal) => (
         <Badge tone={dealStatusTone(deal.status)}>{deal.status}</Badge>
       ),
+      // By the stored value, so the three groups sit together. Alphabetical
+      // rather than by lifecycle — `lost` before `open` before `won` — because
+      // `deal.status` is a text column and the machinery orders by the column
+      // rather than by a vocabulary this side would have to keep a second copy
+      // of.
+      sort: "status",
     },
   ];
 }


### PR DESCRIPTION
Part of #2090 — two of the four dead headers on the deals list, and the boundary named for the other two.

## The rule, and what it overrides

The deals list draws seven columns and its sort vocabulary reached **three**. The frontend already knew: each unsortable column carried a comment explaining that *"the API's sortable vocabulary is a fixed five-field set that does not include it"*, one of them pointing at this issue. It could not fix it from that side.

The vocabulary was pinned to a spec set written before the columns were, and the comment said so — which is exactly why nobody had appended to it. #2090 records the ruling that supersedes it:

> **Any column shown in a list must be sortable by that column.** … If a column is worth showing, it is worth ordering by, and a header that cannot be clicked is a dead control the user has to learn to ignore.

The rulebook settles the precedence: a current request outranks an older document, and *"do not refuse or narrow ordinary product evolution because an older document disagrees."*

## Two of four, and why not four

| column | sortable now | why |
|---|---|---|
| `name` | ✅ | a column of `deal` |
| `status` | ✅ | a column of `deal` |
| `stage` | ✗ | orders by the stage's **position in its pipeline**, not its name |
| `partner` / `company` | ✗ | orders by the **organization's** name |

`storekit`'s `OrderBy` renders one quoted identifier of the row's own table:

```go
return " ORDER BY " + quoteColumnIdentifier(s.name) + " " + dir + " NULLS LAST, …"
```

So the three joined columns need the sort model to take an **expression** before they can be offered at all. That is platform work across every list, not a deals change, and it is the real remaining cost of the ruling — worth knowing before someone estimates the rest of #2090 from the two easy ones.

The boundary is written where each column is declared, on **both** sides of the wire. The two headers that stay dead no longer quote a five-field set that no longer exists; they say what actually blocks them.

## Both sides, one change

The frontend columns cite this vocabulary by name, so splitting would leave one half describing the other wrongly. The two headers gain their `sort`, and the contract's `Sort` description now states the rule instead of pointing at a spec chapter — which is also what `TestEveryTouchedFileExplainsWhatItCites` asked for the moment I touched that sentence, and it is right: a reader cannot open that chapter from this tree.

## Tests

`dealsortvocabulary_integration_test.go`, three cases:

- **name**, ascending and descending, seeded out of order so a pass cannot come from insertion order — which is what the default `-created_at` would give.
- **status**, through `AdvanceDeal` into a won stage rather than a hand-set column, so the ordering is over a value a writer actually produces.
- **the refusal still refuses**, over `captured_by` — a REAL column of `deal` the list does not publish. Widening a vocabulary is the change most likely to widen it into "any column", and refusing a nonsense name would prove nothing about that.

Removing the two entries fails the first two and leaves the third passing, which is the split it should have.

`make check-backend` and `make check-fe` green.

*(Unrelated, seen while running: `worklist.today.test.tsx > submits once however fast the reader presses` failed once under the full parallel suite with `expected 2 to be 1`, then passed 4/4 in isolation. That is the known double-submit race — a `waitFor` on a count cannot turn a 2 back into a 1, so the second submit has already happened by the time it is asserted. Not this change; flagged because it reds unrelated PRs.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC