### PR TITLE
fix(brief): the morning's readings stay on the morning

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2891,7 +2891,7 @@ export const de = {
     "{period} · {weighted} gewichtet · {priced} von {eligible} bewertet",
   "brief.readings.pipelineUnread": "die Pipeline war nicht lesbar",
   "brief.readings.pipelineReading": "Pipeline wird gelesen",
-  "brief.readings.openLane": "Diese öffnen",
+  "brief.readings.openLaneNamed": "{reading} öffnen",
   "brief.readings.meetings": "Termine heute",
   "brief.readings.meetingsBasis": "im heutigen Kalender",
   "brief.readings.needsPrep_one": "1 unvorbereitet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2981,7 +2981,7 @@ export const en = {
     "{period} · {weighted} weighted · {priced} of {eligible} priced",
   "brief.readings.pipelineUnread": "the pipeline could not be read",
   "brief.readings.pipelineReading": "reading the pipeline",
-  "brief.readings.openLane": "Open these",
+  "brief.readings.openLaneNamed": "Open {reading}",
   "brief.readings.meetings": "Meetings ahead",
   "brief.readings.meetingsBasis": "on today's calendar",
   "brief.readings.needsPrep_one": "1 needs prep",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2859,7 +2859,7 @@ export const vi = {
     "{period} · {weighted} theo trọng số · {priced} trên {eligible} đã định giá",
   "brief.readings.pipelineUnread": "không đọc được pipeline",
   "brief.readings.pipelineReading": "đang đọc pipeline",
-  "brief.readings.openLane": "Mở những mục này",
+  "brief.readings.openLaneNamed": "Mở {reading}",
   "brief.readings.meetings": "Cuộc họp hôm nay",
   "brief.readings.meetingsBasis": "trong lịch hôm nay",
   "brief.readings.needsPrep_one": "1 chưa chuẩn bị",

--- a/frontend/src/screens/brief.dials.test.tsx
+++ b/frontend/src/screens/brief.dials.test.tsx
@@ -30,8 +30,17 @@ beforeEach(() => {
 // next are all drawn from it, and a hand-built copy here would drift from theirs
 // one edited field at a time.
 function worklist(scopeOptions: Worklist["scope_options"]) {
-  const day = readingsDay({}, [waitingRow()]);
-  return { ...day, scope_options: scopeOptions };
+  // The row is marked CHANGED and a source is marked UNAVAILABLE, so all three
+  // morning elements above the work column actually draw. The default fixture
+  // leaves both empty, and both of those elements return null on an empty one —
+  // so a weekly case built on it would assert their absence over elements that
+  // were never going to appear, and would keep passing if the guard broke.
+  const day = readingsDay({}, [{ ...waitingRow(), changed_since_brief: true }]);
+  return {
+    ...day,
+    scope_options: scopeOptions,
+    sources_unavailable: [{ source: "calendar", reason: "not_connected" }],
+  };
 }
 
 /** Stub every read the Brief fans out to, for a reader with the given scopes. */
@@ -156,6 +165,41 @@ describe("the Brief's dials", () => {
     // load rather than one that was never there. `page-zones-aside` is the
     // class that reserves the column.
     expect(document.querySelector(".page-zones-aside")).toBeNull();
+  });
+
+  // THE READINGS AND THE NOTICES ABOVE THEM BELONG TO THE MORNING TOO.
+  //
+  // The same defect as the rail, one layer up and missed when the rail was
+  // fixed: the coverage callout, the changed-overnight notice and the readings
+  // strip are drawn ABOVE the view branch, so they render whatever the dial
+  // says. All three read the worklist — today's queue — and the worklist is
+  // fetched unconditionally, so under the weekly a rep saw today's urgent count
+  // and today's overnight changes stacked on top of a week that had closed.
+  it("leaves the morning's readings and notices off the weekly", async () => {
+    globalThis.location.hash = "#/brief?view=weekly";
+    stubBrief(["mine"]);
+    render(<BriefScreen />);
+
+    await screen.findByRole("group", { name: en["brief.view.label"] });
+    await waitFor(() =>
+      expect(document.querySelector("#brief-weekly")).not.toBeNull(),
+    );
+    expect(screen.queryByTestId("brief-readings")).toBeNull();
+    expect(document.querySelector(".brief-coverage")).toBeNull();
+    expect(document.body.textContent).not.toContain(en["brief.changed.lead"]);
+  });
+
+  // The positive control for the case above, and it is the assertion that gives
+  // it any force. All three elements are absent on a weekly for two possible
+  // reasons — the guard, or a fixture that never made them appear — and only
+  // seeing them on the morning tells those apart.
+  it("keeps the readings and notices on the morning", async () => {
+    stubBrief(["mine"]);
+    render(<BriefScreen />);
+
+    await screen.findByTestId("brief-readings");
+    expect(document.querySelector(".brief-coverage")).not.toBeNull();
+    expect(document.body.textContent).toContain(en["brief.changed.lead"]);
   });
 
   // And it is still there on the morning, or the assertion above passes over a

--- a/frontend/src/screens/brief.readings.test.tsx
+++ b/frontend/src/screens/brief.readings.test.tsx
@@ -509,4 +509,30 @@ describe("the pipeline period", () => {
     drawInZone("Asia/Tokyo");
     expect(await screen.findByText(/1 Jul 2026 – 30 Sept 2026/)).toBeTruthy();
   });
+  // FOUR DOORS, FOUR NAMES.
+  //
+  // Every open button on this strip used to be called "Open these". Sighted, the
+  // card above each one says which "these" — a screen reader tabbing the strip
+  // hears the same four words four times and cannot tell the lanes apart, so the
+  // one control on each reading is the one thing that does not identify it.
+  //
+  // Asserted as a SET rather than card by card: the defect is duplication, and a
+  // per-card check passes on four buttons that share a name as happily as on
+  // four that do not.
+  it("gives every reading's door its own accessible name", async () => {
+    drawInZone("Europe/Berlin");
+
+    await screen.findByText(en["brief.readings.urgent"]);
+    const names = screen
+      .getAllByRole("button")
+      .map((button) => button.getAttribute("aria-label") ?? button.textContent)
+      .filter((name): name is string => Boolean(name?.startsWith("Open ")));
+
+    // The strip draws four readings and each one has a door, so the filter must
+    // find exactly four. Asserting only that the matches are distinct would
+    // pass on a strip where two doors lost the prefix and fell out of the set
+    // entirely — the filter would then be hiding the very buttons at issue.
+    expect(names).toHaveLength(4);
+    expect(new Set(names).size).toBe(names.length);
+  });
 });

--- a/frontend/src/screens/brief.readings.tsx
+++ b/frontend/src/screens/brief.readings.tsx
@@ -103,7 +103,9 @@ export function BriefReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
           // zero already reads as "none"; a line under it repeating that says
           // the same thing twice and drops the one fact it could add.
           detail={t("brief.readings.urgentBasis")}
-          openLabel={t("brief.readings.openLane")}
+          openLabel={t("brief.readings.openLaneNamed", {
+            reading: t("brief.readings.urgent"),
+          })}
           onOpen={() => openLane("all")}
         />
         <MeetingsStat
@@ -127,7 +129,9 @@ export function BriefReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
           value={formatNumber(readings.review, locale)}
           tone={readings.review > 0 ? "warn" : undefined}
           detail={t("brief.readings.decisionsBasis")}
-          openLabel={t("brief.readings.openLane")}
+          openLabel={t("brief.readings.openLaneNamed", {
+            reading: t("brief.readings.decisions"),
+          })}
           onOpen={() => openLane("decisions")}
         />
       </StatStrip>
@@ -164,7 +168,9 @@ function MeetingsStat({
       value={formatNumber(meetings, locale)}
       tone={unready !== null && unready > 0 ? "warn" : undefined}
       detail={meetingsDetail(meetings, unready, locale, t, plural)}
-      openLabel={t("brief.readings.openLane")}
+      openLabel={t("brief.readings.openLaneNamed", {
+        reading: t("brief.readings.meetings"),
+      })}
       onOpen={onOpen}
     />
   );
@@ -227,7 +233,9 @@ function LeadsStat({
               value: formatDateTime(soonest, locale, viewerZone()),
             })
       }
-      openLabel={t("brief.readings.openLane")}
+      openLabel={t("brief.readings.openLaneNamed", {
+        reading: t("brief.readings.leads"),
+      })}
       onOpen={onOpen}
     />
   );

--- a/frontend/src/screens/brief.tsx
+++ b/frontend/src/screens/brief.tsx
@@ -281,23 +281,34 @@ export function BriefScreen() {
           onChange={(next) => setParams(paramsFor(next))}
         />
       </div>
-      {/* Before the readings, because a strip of numbers a reader cannot trust
-          is worse than one they can qualify — and in the MAIN column rather
-          than the rail, though the rail is where the Brief plan drew it. This
-          is a callout that appears only when a source was withheld, failed or
-          stopped short, so it is a fact about the whole page rather than
-          context beside it, and it qualifies the strip directly under it. In
-          the rail it would be a warning about the queue, filed away from the
-          queue. */}
-      {worklistQuery.data && <BriefCoverage day={worklistQuery.data} />}
-      {/* And what has happened since the night looked, under the coverage line
-          and above the readings: both are facts about the page as a whole
-          rather than about any one row, and a reader takes them before the
-          figures they qualify. */}
-      {worklistQuery.data && <ChangedSinceBrief day={worklistQuery.data} />}
-      {/* The strip reads the SAME worklist answer the queue below it reads, so
-          the five figures cannot disagree with the rows they summarise. */}
-      {worklistQuery.data && <BriefReadingsStrip day={worklistQuery.data} />}
+      {/* ALL THREE BELONG TO THE MORNING, and are drawn inside it rather than
+          above the branch. Each reads the worklist — today's queue — and the
+          worklist is fetched whatever the dial says, so drawn unconditionally
+          they put today's urgent count and today's overnight changes on top of
+          a week that had closed. The rail below carries the same rule and the
+          same reason; these were missed when it was fixed, because nothing
+          asserted them either. */}
+      {address.view !== "weekly" && worklistQuery.data && (
+        <>
+          {/* Before the readings, because a strip of numbers a reader cannot trust
+            is worse than one they can qualify — and in the MAIN column rather
+            than the rail, though the rail is where the Brief plan drew it. This
+            is a callout that appears only when a source was withheld, failed or
+            stopped short, so it is a fact about the whole page rather than
+            context beside it, and it qualifies the strip directly under it. In
+            the rail it would be a warning about the queue, filed away from the
+            queue. */}
+          <BriefCoverage day={worklistQuery.data} />
+          {/* And what has happened since the night looked, under the coverage line
+            and above the readings: both are facts about the page as a whole
+            rather than about any one row, and a reader takes them before the
+            figures they qualify. */}
+          <ChangedSinceBrief day={worklistQuery.data} />
+          {/* The strip reads the SAME worklist answer the queue below it reads, so
+            the five figures cannot disagree with the rows they summarise. */}
+          <BriefReadingsStrip day={worklistQuery.data} />
+        </>
+      )}
       {/* Screen-level so it survives the deck re-rendering under it. */}
       {decidedNote}
       <PageZones


### PR DESCRIPTION
## What was wrong

Three elements on Brief sat **above** the view branch and drew whatever the dial said:

- the coverage callout (`BriefCoverage`)
- the changed-overnight notice (`ChangedSinceBrief`)
- the readings strip (`BriefReadingsStrip`)

All three read the worklist — today's queue — and the worklist is fetched whatever the view. So a rep who switched to the weekly saw today's urgent count and today's overnight changes stacked on top of a week that had already closed.

The rail below them carries the same rule and already had the fix, with a comment in `brief.tsx` explaining exactly this bug class. These three were missed when it landed, because nothing asserted them either.

## Accessible names

Four buttons on the readings strip were all called **"Open these"**. Sighted, the card above each one says which "these" — Urgent moves, Decisions waiting, Meetings ahead, Lead response. A screen reader tabbing the strip hears the same four words four times, so the one control on each reading is the one thing that does not identify it.

Each door now names its own reading (`Open {reading}`), in en/de/vi. The old key had no remaining callers and is removed.

## About the tests

The weekly case is built on a fixture where all three elements **actually draw**. The default fixture leaves `sources_unavailable` empty and sets no `changed_since_brief` flag, and both of those elements return `null` on such a payload — so a test built on it would assert their absence over elements that were never going to appear, and would keep passing if the guard broke. Codex caught that; the fixture now marks a row changed and a source unavailable.

Its positive control asserts all three **on the morning**, which is what distinguishes a working guard from an empty fixture.

The a11y test asserts the door count is exactly four as well as distinct — asserting only distinctness would pass on a strip where two doors lost the prefix and fell out of the filtered set entirely.

Both guards mutation-checked: revert the change, confirm the test fails, restore.

## Left as they are

Two Brief doors are filed as #5090 rather than fixed here. The feed's "N more" counts `waitingRows` (which excludes approvals) and the overnight notice counts `changed_since_brief` rows; both link to a bare `#/worklist` that shows everything. Making either exact needs a filter value the server's vocabulary does not have — a contract change with generated types on both sides, not a link fix. Guessing a near-enough lane would replace a wrong number with a wrong number that looks right.

`worklist.copy.ts SOURCE_QUEUE` is deliberately **not** touched: those three rows name a queue because no record exists to open, and the file argues the case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Brief screen so the coverage callout, changed-overnight notice, and readings strip render only on the morning view; the weekly view previously stacked today's figures on top of a closed week. Also names each readings-strip button after its own reading instead of labeling all four "Open these".

**Bug Fixes**
- The three elements read today's worklist, which is fetched regardless of view, so they now live inside the morning branch rather than above it.
- The rail below already carried this rule; these three were missed because no test asserted them.
- The weekly test now uses a fixture where all three elements actually draw, so it fails if the guard breaks; a positive control asserts they appear on the morning.

**Accessibility**
- Each of the four doors now reads "Open {reading}" (e.g., "Open Urgent moves") in en, de, and vi, and the old shared key is removed.

Known limitation, filed as #5090: the feed's "N more" and the overnight notice both link to the unfiltered worklist; making them exact needs a new server-side filter value rather than a link change.

<sup>Written for commit 81565265a6e8f80692c1d5dd3b7ad295be8ee26e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reading buttons now have distinct, descriptive labels, making each reading lane easier to identify with assistive technologies.

* **Bug Fixes**
  * Brief coverage, changed-overnight notices, and reading summaries no longer appear in the weekly view.
  * Updated translations support named reading labels in English, German, and Vietnamese.

* **Tests**
  * Added coverage confirming correct visibility by view and unique accessible names for reading buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->