### PR TITLE
fix(brief): a count and its door read one filter

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -11242,8 +11242,24 @@ paths:
             licence to read a colleague's inbox.
         - name: filter
           in: query
-          schema: { type: string, enum: [all, customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system] }
-          description: 'Narrow the queue to one kind of work. Omitted means everything, which is the default view.'
+          schema: { type: string, enum: [all, customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system, except_decisions, changed_since_brief] }
+          description: |
+            Narrow the queue. Omitted means everything, which is the default view.
+
+            Most values name ONE kind of work. Two do not, and exist because a surface
+            counted a population this vocabulary could not then ask for — a count whose
+            link lands on a different population is a number that lies about where it goes.
+
+            `except_decisions` is everything a decisions-drawing surface has NOT already
+            answered. It is the complement of `decisions`, not a kind of work, and no
+            single category spells it.
+
+            `changed_since_brief` is the rows whose material moment falls after the
+            overnight run's data cutoff — the same test that stamps each row's
+            `changed_since_brief` flag — and, like the value above, not the decisions a
+            brief already draws as cards. With no run to compare against it answers empty
+            rather than everything: absent is not false, and a reader asking what changed
+            since a night that never happened is owed nothing, not the whole queue.
         - name: limit
           in: query
           schema: { type: integer, minimum: 1, maximum: 100, default: 25 }
@@ -42616,7 +42632,7 @@ components:
             The scopes this reader may ask for, narrowest first — derived from their own
             row scope. A client draws a control only when there is more than one, so a
             rep who can only see their own work is never offered a switch that would 403.
-        filter: { type: string, enum: [all, customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system], description: 'The narrowing this read applied.' }
+        filter: { type: string, enum: [all, customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system, except_decisions, changed_since_brief], description: 'The narrowing this read applied. The same vocabulary the query parameter takes.' }
         summary: { $ref: '#/components/schemas/WorklistSummary' }
         queue:
           type: array

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -11251,15 +11251,19 @@ paths:
             link lands on a different population is a number that lies about where it goes.
 
             `except_decisions` is everything a decisions-drawing surface has NOT already
-            answered. It is the complement of `decisions`, not a kind of work, and no
-            single category spells it.
+            answered: every row whose SOURCE is not `approval`. Not a kind of work, and
+            deliberately not the complement of the `decisions` CATEGORY, which is a wider
+            set — an introduction request classifies as a decision and is not an approval,
+            so a category reading would drop a row the counting surface kept. A folded
+            group's source is `batch` and it is kept, like any other row that is not
+            itself an approval.
 
             `changed_since_brief` is the rows whose material moment falls after the
             overnight run's data cutoff — the same test that stamps each row's
-            `changed_since_brief` flag — and, like the value above, not the decisions a
-            brief already draws as cards. With no run to compare against it answers empty
-            rather than everything: absent is not false, and a reader asking what changed
-            since a night that never happened is owed nothing, not the whole queue.
+            `changed_since_brief` flag — and, like the value above, not the rows a brief
+            already draws as cards. With no run to compare against it answers empty rather
+            than everything: absent is not false, and a reader asking what changed since a
+            night that never happened is owed nothing, not the whole queue.
         - name: limit
           in: query
           schema: { type: integer, minimum: 1, maximum: 100, default: 25 }

--- a/backend/gates/briefdeckexclusion_test.go
+++ b/backend/gates/briefdeckexclusion_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// A Brief count and the door beneath it must exclude the SAME rows.
+//
+// Brief draws its decisions as cards in a deck, and the feed below counts only
+// what the deck has not answered. The link under that count opens the worklist
+// narrowed to `except_decisions`, which the server evaluates. So one exclusion
+// is spelled twice — `brief.sentence.ts` decides the count, `page.go` decides
+// the door — and the two disagreeing is the exact defect the filter was added to
+// remove, reappearing where nobody looks for it.
+//
+// This is not hypothetical. The obvious server-side reading was category
+// `decisions`, which is a WIDER set than the client's source test: an
+// introduction request classifies as a decision and is not an approval, so the
+// door dropped a row the count had included. That version passed every unit test
+// on both sides, because each side is self-consistent.
+//
+// Both directions, like the minor-units mirror: a source added to one side and
+// not the other fails.
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+const (
+	briefDeckClient = "../frontend/src/screens/brief.sentence.ts"
+	briefDeckServer = "internal/compose/attention/page.go"
+)
+
+// The client's constant: `const DECK_ANSWERS = "approval";`
+var clientDeckAnswers = regexp.MustCompile(
+	`DECK_ANSWERS\s*=\s*"([a-z_]+)"`)
+
+// The server's: `const deckAnswers = crmcontracts.WorklistItemSource("approval")`
+var serverDeckAnswers = regexp.MustCompile(
+	`deckAnswers\s*=\s*crmcontracts\.WorklistItemSource\("([a-z_]+)"\)`)
+
+// TestTheDeckExclusionIsSpelledTheSameOnBothSides holds the pair.
+func TestTheDeckExclusionIsSpelledTheSameOnBothSides(t *testing.T) {
+	t.Parallel()
+
+	client := onlyMatch(t, briefDeckClient, clientDeckAnswers,
+		"DECK_ANSWERS in brief.sentence.ts")
+	server := onlyMatch(t, briefDeckServer, serverDeckAnswers,
+		"deckAnswers in page.go")
+
+	if client != server {
+		t.Fatalf("the count excludes source %q and the door excludes %q — a rep "+
+			"told \"N more\" would land on a list holding a different number",
+			client, server)
+	}
+}
+
+// onlyMatch reads exactly one capture out of a file.
+//
+// Exactly one, because both halves of a failure are silent otherwise: no match
+// means the constant was renamed and this gate has stopped reading its subject,
+// and two matches mean one side grew a second spelling that this comparison
+// would then pick between arbitrarily.
+func onlyMatch(t *testing.T, path string, pattern *regexp.Regexp, what string) string {
+	t.Helper()
+
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	found := pattern.FindAllStringSubmatch(string(source), -1)
+	if len(found) != 1 {
+		t.Fatalf("found %d spellings of %s in %s, wanted exactly one: this gate "+
+			"reads that constant, so none means it has stopped watching its "+
+			"subject and two means the subject has forked",
+			len(found), what, path)
+	}
+	return found[0][1]
+}

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -333,6 +333,18 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 			occurred = member.occurredAt
 		}
 	}
+	// Whether the night had seen this group, from the members it stands for.
+	//
+	// NOT from `occurred` above, which is the OLDEST member's moment: a group
+	// whose third failure arrived this morning would be judged by its first and
+	// reported as old news. A group is new when any member is, because that is
+	// what a reader means by a group appearing in the overnight notice.
+	//
+	// Carried explicitly because the fold MINTS a row: the members were stamped
+	// before the fold ran, and a synthetic row inherits none of their fields
+	// unless it is told to. Left out, an incident group reached the changed
+	// strip with an absent flag and was silently dropped from it.
+	row.ChangedSinceBrief = groupChangedSinceBrief(members)
 	return ranked{
 		item:       row,
 		foldedFrom: from,
@@ -347,6 +359,35 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 		// picking one member's owner and reporting it as the group's.
 		ownerRef: ownerOfTheGroup(members),
 	}
+}
+
+// groupChangedSinceBrief says whether the night had seen a folded group.
+//
+// TRUE IF ANY MEMBER IS NEW. A group stands for its members, and one arriving
+// after the run makes the group something the reader has not read — judging it
+// by the oldest member would report a fresh failure as old news.
+//
+// Absent when NO member carries the flag, which keeps the three states the wire
+// distinguishes: a run that saw everything answers false, and a morning with no
+// run at all answers nothing. A group of unflagged members has no answer to
+// give, and false would claim a night that never happened had seen them.
+func groupChangedSinceBrief(members []ranked) *bool {
+	answer := false
+	answered := false
+	for _, member := range members {
+		if member.item.ChangedSinceBrief == nil {
+			continue
+		}
+		answered = true
+		if *member.item.ChangedSinceBrief {
+			answer = true
+			break
+		}
+	}
+	if !answered {
+		return nil
+	}
+	return &answer
 }
 
 // ownerOfTheGroup is the one answer a folded row may give.

--- a/backend/internal/compose/attention/linkedfilter_test.go
+++ b/backend/internal/compose/attention/linkedfilter_test.go
@@ -183,6 +183,138 @@ func TestChangedSinceBriefDropsDecisionsTheDeckAlreadyDrew(t *testing.T) {
 	}
 }
 
+// TestAnIntroductionRequestIsNotOneOfTheDecksCards holds the two sides on one
+// spelling of the exclusion.
+//
+// The client drops `source === "approval"`; the obvious server reading is
+// category `decisions`, and that is a WIDER set — an introduction request
+// classifies as a decision and is not an approval. Reading the category dropped
+// from the door a row the count had included, which is the original defect
+// reappearing where nobody looks for it. Both versions pass every unit test on
+// their own side, because each side is self-consistent.
+func TestAnIntroductionRequestIsNotOneOfTheDecksCards(t *testing.T) {
+	t.Parallel()
+
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		Introductions: lane(
+			item("intro", "introduction_request", withDue(rankInstant.Add(time.Hour))),
+		),
+		NeedsYou: []crmcontracts.AttentionItem{
+			item("decision", "approval", withKind("send_email")),
+		},
+	}
+	rows := classifyDay(day, rankInstant, dayMoney{})
+
+	// The premise: both rows land in the same category, so a category test
+	// cannot tell them apart and this test would prove nothing without it.
+	for _, row := range rows {
+		if row.item.Category != categoryDecisions {
+			t.Fatalf("row %q classifies as %q — the fixture no longer models two "+
+				"rows one category cannot separate", row.item.Id, row.item.Category)
+		}
+	}
+
+	kept := keepFiltered(rows, filterExceptDecisions)
+	if ids := rankedIDs(kept); len(ids) != 1 || ids[0] != "intro" {
+		t.Fatalf("kept %v, wanted the introduction alone: the deck draws "+
+			"approvals as cards and an introduction is not one", ids)
+	}
+}
+
+// TestAFoldedGroupReachesTheChangedPageThroughWorklist is the wiring half.
+//
+// groupChangedSinceBrief can be right while batches.go never calls it, and the
+// unit test below cannot tell: the fold MINTS a row, so a missing assignment
+// looks exactly like a group the night had seen. Reverting the assignment left
+// the whole package green until this test existed.
+//
+// Three failures of ONE rule, which is what batchFloor takes to fold, all after
+// the night's cutoff. The group must arrive on a page asking for what changed.
+func TestAFoldedGroupReachesTheChangedPageThroughWorklist(t *testing.T) {
+	t.Parallel()
+
+	cutoff := readInstant.Add(-6 * time.Hour)
+	fired := cutoff.Add(time.Hour)
+	rule := ids.New[ids.AutomationKind]()
+	runs := make([]TroubledAutomationRun, 0, batchFloor)
+	for at := range batchFloor {
+		runs = append(runs, TroubledAutomationRun{
+			ID: ids.NewV7(), AutomationID: rule, Name: "Route new leads",
+			Outcome: "failed", Reason: "the assignee seat is gone",
+			// Spread, so the group's own sort moment is the OLDEST — the value
+			// a freshness rule reading `occurred` would wrongly judge it by.
+			OccurredAt: fired.Add(time.Duration(at) * time.Minute),
+		})
+	}
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
+		stubBriefing{ran: true, asOf: cutoff},
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		&stubAutomations{rows: runs},
+		nil, nil, fixedClock)
+
+	// The premise: unfiltered, these three really did fold into one row. Without
+	// it the assertion below would pass over three unfolded rows and prove
+	// nothing about a minted one.
+	whole, err := svc.Worklist(pageReader(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("unfiltered worklist: %v", err)
+	}
+	if len(whole.Queue) != 1 || whole.Queue[0].Batch == nil {
+		t.Fatalf("the unfiltered page holds %d rows and the first carries batch "+
+			"%v — the fixture no longer folds, so this test would not be about a "+
+			"minted row", len(whole.Queue), whole.Queue[0].Batch)
+	}
+
+	narrowed, err := svc.Worklist(
+		pageReader(), "", string(filterChangedSinceBrief), ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("narrowed worklist: %v", err)
+	}
+	if len(narrowed.Queue) != 1 {
+		t.Fatalf("the changed page holds %d rows, wanted the incident group: a "+
+			"minted row inherits no flag, so the group was dropped from a notice "+
+			"its members belonged in", len(narrowed.Queue))
+	}
+}
+
+// TestAFoldedGroupCarriesItsMembersFreshness holds the minted row's flag.
+//
+// A fold MINTS a WorklistItem, so it inherits nothing its members carried unless
+// it is told to. The freshness stamping now runs before the fold — it has to,
+// because the filter reads it — so a group reached the changed strip with an
+// absent flag and was silently dropped from a notice its members belonged in.
+//
+// Any member, not the oldest: the batch takes its sort moment from the oldest
+// member, and judging freshness by that would report a failure that arrived this
+// morning as old news.
+func TestAFoldedGroupCarriesItsMembersFreshness(t *testing.T) {
+	t.Parallel()
+
+	old, fresh := false, true
+	members := []ranked{
+		{item: crmcontracts.WorklistItem{ChangedSinceBrief: &old}},
+		{item: crmcontracts.WorklistItem{ChangedSinceBrief: &fresh}},
+	}
+
+	if answer := groupChangedSinceBrief(members); answer == nil || !*answer {
+		t.Fatalf("a group holding one fresh member answered %v, wanted true — the "+
+			"reader has not read it", answer)
+	}
+	if answer := groupChangedSinceBrief(members[:1]); answer == nil || *answer {
+		t.Fatalf("a group whose every member is old answered %v, wanted false",
+			answer)
+	}
+	// Absent stays absent: a night that never ran leaves every member unflagged,
+	// and false would claim it had seen them.
+	unflagged := []ranked{{item: crmcontracts.WorklistItem{}}}
+	if answer := groupChangedSinceBrief(unflagged); answer != nil {
+		t.Fatalf("a group of unflagged members answered %v, wanted no answer",
+			*answer)
+	}
+}
+
 // TestANamedCategoryStillFiltersByEquality is the control.
 //
 // keepFiltered took over from a function that only ever compared categories, so
@@ -213,18 +345,58 @@ func TestANamedCategoryStillFiltersByEquality(t *testing.T) {
 	}
 }
 
-// TestOnlyADecisionsFilterOpensTheFoldedDeck holds which narrowings unfold.
+// TestEveryFoldableCategoryOpensItsOwnGroup derives the unfold set from the
+// fold itself.
+//
+// foldableCategories is a second spelling of batchKeyOf's own branches, and a
+// category that learns to fold without arriving there gets a Review verb that
+// returns the group the reader pressed it on. That is not hypothetical: the
+// frontend's reviewFilter used to send every group to `decisions`, so pressing
+// Review on a broken automation filtered its own failures out of view, and this
+// change reintroduced the same defect for `system` by keying the unfold on
+// `decisions` alone.
+//
+// The census drives real rows through batchKeyOf rather than reading the map
+// back to itself, so it fails in the direction that matters: a category that
+// folds and is missing here.
+func TestEveryFoldableCategoryOpensItsOwnGroup(t *testing.T) {
+	t.Parallel()
+
+	routine := levelRoutine
+	dupe := ranked{item: crmcontracts.WorklistItem{
+		Category: categoryDecisions, Level: routine, Source: "dedupe_candidate",
+	}}
+	cause := "one-broken-rule"
+	incident := ranked{item: crmcontracts.WorklistItem{
+		Category: categorySystem, Source: "automation_run", CauseRef: &cause,
+	}}
+
+	for _, row := range []ranked{dupe, incident} {
+		if _, folds := batchKeyOf(row); !folds {
+			t.Fatalf("a %q row did not fold — the fixture no longer models the "+
+				"case this census is about", row.item.Category)
+		}
+		if !opensTheDeck(string(row.item.Category)) {
+			t.Fatalf("category %q folds but a filter naming it does not open the "+
+				"group: pressing Review on one of these rows returns the group "+
+				"the reader pressed it on", row.item.Category)
+		}
+	}
+}
+
+// TestOnlyAFoldableCategoryOpensTheFoldedDeck holds which narrowings unfold.
 //
 // foldAndRepin draws a pile of alike routine decisions as one row and is skipped
 // for a reader who asked to see inside it. The two link-only values are not that
 // request: answering "what changed overnight" with a hundred rows the unfiltered
 // page draws as one makes the door hold more than the count that sent the
 // reader, which is the same disagreement in the other direction.
-func TestOnlyADecisionsFilterOpensTheFoldedDeck(t *testing.T) {
+func TestOnlyAFoldableCategoryOpensTheFoldedDeck(t *testing.T) {
 	t.Parallel()
 
 	folded := map[string]bool{
 		string(categoryDecisions):              true,
+		string(categorySystem):                 true,
 		string(filterExceptDecisions):          false,
 		string(filterChangedSinceBrief):        false,
 		string(crmcontracts.WorklistFilterAll): false,

--- a/backend/internal/compose/attention/linkedfilter_test.go
+++ b/backend/internal/compose/attention/linkedfilter_test.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The two filter values a count links to.
+//
+// Both exist for one reason: a Brief surface counted a population this
+// vocabulary could not then ask for, so its "N more" link opened a queue holding
+// a different N. The rules below are what make the count and the door one
+// answer, and each test states the wrong number it stops.
+
+import (
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// TestTheChangedFilterReachesThePageThroughWorklist is the wiring test, and it
+// is the one that matters most.
+//
+// keepFiltered can be right while the endpoint is wrong, because the flag it
+// reads used to be stamped AFTER the narrowing ran — over the cut page, where a
+// filter could never see it. Every existing test of that stamping calls
+// markChangedSinceBrief directly, so moving the call left the whole package
+// green: the unit tests above passed against a Worklist that answered the entire
+// queue to `filter=changed_since_brief`.
+//
+// This drives the real entry point. Two bounces either side of the night's data
+// cutoff, ASYMMETRIC in nothing but their moment, so the boundary is what
+// decides the answer and not a count.
+func TestTheChangedFilterReachesThePageThroughWorklist(t *testing.T) {
+	t.Parallel()
+
+	cutoff := readInstant.Add(-6 * time.Hour)
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
+		stubBriefing{ran: true, asOf: cutoff},
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		&stubBounces{rows: []BouncedSend{
+			{ID: ids.NewV7(), Subject: "after the night", BouncedAt: cutoff.Add(time.Hour)},
+			{ID: ids.NewV7(), Subject: "before the night", BouncedAt: cutoff.Add(-time.Hour)},
+		}},
+		nil, nil, nil, fixedClock)
+
+	// The control first: unfiltered, the page holds both. Without it a filter
+	// that answered nothing at all would pass the assertion below.
+	whole, err := svc.Worklist(pageReader(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("unfiltered worklist: %v", err)
+	}
+	if len(whole.Queue) != 2 {
+		t.Fatalf("the unfiltered page holds %d rows, wanted both bounces — the "+
+			"fixture, not the filter, is what this test would otherwise prove",
+			len(whole.Queue))
+	}
+
+	narrowed, err := svc.Worklist(
+		pageReader(), "", string(filterChangedSinceBrief), ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("narrowed worklist: %v", err)
+	}
+	if len(narrowed.Queue) != 1 {
+		t.Fatalf("the narrowed page holds %d rows, wanted only the send that "+
+			"bounced after the night read", len(narrowed.Queue))
+	}
+	if title := narrowed.Queue[0].Title; title == nil || *title != "after the night" {
+		t.Fatalf("the page kept %v, wanted the row the night did not see", title)
+	}
+	// The echo, so a client can tell which narrowing it got back.
+	if narrowed.Filter == nil || *narrowed.Filter != crmcontracts.WorklistFilter(filterChangedSinceBrief) {
+		t.Fatalf("the page reported filter %v, wanted the one it was asked for",
+			narrowed.Filter)
+	}
+}
+
+// TestExceptDecisionsKeepsEveryKindButDecisions holds the feed footer's cut.
+//
+// The footer counts `waitingRows`, which drops the approvals the Decisions deck
+// above already draws. Sent to a bare queue, a rep told "11 more" landed on a
+// list of 14 — the three decisions they had just been shown as cards.
+func TestExceptDecisionsKeepsEveryKindButDecisions(t *testing.T) {
+	t.Parallel()
+
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{
+			item("decision", "approval", withKind("send_email")),
+		},
+		AtRisk:  lane(item("deal", "deal_at_risk")),
+		Planned: []crmcontracts.AttentionItem{item("task", "task")},
+	}
+
+	kept := keepFiltered(
+		classifyDay(day, rankInstant, dayMoney{}), filterExceptDecisions)
+
+	if ids := rankedIDs(kept); len(ids) != 2 {
+		t.Fatalf("kept %v, wanted the deal and the task and not the decision", ids)
+	}
+	for _, row := range kept {
+		if row.item.Category == categoryDecisions {
+			t.Fatalf("kept a %q row: the complement of decisions holds none",
+				row.item.Category)
+		}
+	}
+}
+
+// TestChangedSinceBriefKeepsOnlyWhatTheNightMissed holds the notice's cut.
+//
+// The overnight notice names rows the run did not see and used to link to the
+// whole queue, so "3 things changed" opened a page of forty with no way to tell
+// which three.
+func TestChangedSinceBriefKeepsOnlyWhatTheNightMissed(t *testing.T) {
+	t.Parallel()
+
+	cutoff := rankInstant.Add(-time.Hour)
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		AtRisk: lane(
+			item("fresh", "deal_at_risk", withOccurred(cutoff.Add(time.Minute))),
+			item("seen", "deal_at_risk", withOccurred(cutoff.Add(-time.Minute))),
+		),
+	}
+
+	rows := markChangedSinceBrief(classifyDay(day, rankInstant, dayMoney{}), cutoff)
+	kept := keepFiltered(rows, filterChangedSinceBrief)
+
+	if ids := rankedIDs(kept); len(ids) != 1 || ids[0] != "fresh" {
+		t.Fatalf("kept %v, wanted only the row that moved after the cutoff", ids)
+	}
+}
+
+// TestChangedSinceBriefKeepsNothingWithoutARun is the absent-is-not-false case.
+//
+// A zero cutoff leaves every flag unset, and an unset flag is "there was no
+// night" rather than "the night saw this". Treating absent as a match would
+// answer the whole queue to a reader asking what changed — reporting a morning
+// with no overnight run as one where everything is new.
+func TestChangedSinceBriefKeepsNothingWithoutARun(t *testing.T) {
+	t.Parallel()
+
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("r1", "deal_at_risk", withOccurred(rankInstant))),
+	}
+
+	rows := markChangedSinceBrief(
+		classifyDay(day, rankInstant, dayMoney{}), time.Time{})
+	if kept := keepFiltered(rows, filterChangedSinceBrief); len(kept) != 0 {
+		t.Fatalf("kept %v with no run to compare against, wanted nothing",
+			rankedIDs(kept))
+	}
+}
+
+// TestChangedSinceBriefDropsDecisionsTheDeckAlreadyDrew keeps the two cuts
+// agreeing with each other.
+//
+// The strip counting this population counts it over the same rows the feed is
+// answerable for, so a decision it deliberately did not name must not appear
+// behind its link either. Without this the door held one more row than the
+// number that sent the reader — the original defect, one layer down.
+func TestChangedSinceBriefDropsDecisionsTheDeckAlreadyDrew(t *testing.T) {
+	t.Parallel()
+
+	cutoff := rankInstant.Add(-time.Hour)
+	fresh := cutoff.Add(time.Minute)
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{
+			item("decision", "approval", withKind("send_email"), withOccurred(fresh)),
+		},
+		AtRisk: lane(item("deal", "deal_at_risk", withOccurred(fresh))),
+	}
+
+	rows := markChangedSinceBrief(classifyDay(day, rankInstant, dayMoney{}), cutoff)
+	kept := keepFiltered(rows, filterChangedSinceBrief)
+
+	if ids := rankedIDs(kept); len(ids) != 1 || ids[0] != "deal" {
+		t.Fatalf("kept %v, wanted the deal alone — the decision is already a card",
+			ids)
+	}
+}
+
+// TestANamedCategoryStillFiltersByEquality is the control.
+//
+// keepFiltered took over from a function that only ever compared categories, so
+// the seven ordinary lanes must still answer exactly what they did. A refusal
+// test needs an admit case, and this is it: without it the three above would
+// pass against a filter that kept nothing at all.
+func TestANamedCategoryStillFiltersByEquality(t *testing.T) {
+	t.Parallel()
+
+	day := crmcontracts.Attention{
+		AsOf:     rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{item("d1", "approval", withKind("send_email"))},
+		AtRisk:   lane(item("r1", "deal_at_risk")),
+	}
+	rows := classifyDay(day, rankInstant, dayMoney{})
+
+	for _, want := range []struct {
+		filter crmcontracts.WorklistFilter
+		id     string
+	}{
+		{"deals_at_risk", "r1"},
+		{crmcontracts.WorklistFilter(categoryDecisions), "d1"},
+	} {
+		kept := keepFiltered(rows, want.filter)
+		if ids := rankedIDs(kept); len(ids) != 1 || ids[0] != want.id {
+			t.Fatalf("filter %q kept %v, wanted just %q", want.filter, ids, want.id)
+		}
+	}
+}
+
+// TestOnlyADecisionsFilterOpensTheFoldedDeck holds which narrowings unfold.
+//
+// foldAndRepin draws a pile of alike routine decisions as one row and is skipped
+// for a reader who asked to see inside it. The two link-only values are not that
+// request: answering "what changed overnight" with a hundred rows the unfiltered
+// page draws as one makes the door hold more than the count that sent the
+// reader, which is the same disagreement in the other direction.
+func TestOnlyADecisionsFilterOpensTheFoldedDeck(t *testing.T) {
+	t.Parallel()
+
+	folded := map[string]bool{
+		string(categoryDecisions):              true,
+		string(filterExceptDecisions):          false,
+		string(filterChangedSinceBrief):        false,
+		string(crmcontracts.WorklistFilterAll): false,
+		"deals_at_risk":                        false,
+		"":                                     false,
+	}
+	for filter, want := range folded {
+		if got := opensTheDeck(filter); got != want {
+			t.Fatalf("opensTheDeck(%q) = %v, wanted %v", filter, got, want)
+		}
+	}
+}
+
+func rankedIDs(rows []ranked) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.item.Id)
+	}
+	return out
+}

--- a/backend/internal/compose/attention/linkedfilter_test.go
+++ b/backend/internal/compose/attention/linkedfilter_test.go
@@ -234,17 +234,23 @@ func TestAnIntroductionRequestIsNotOneOfTheDecksCards(t *testing.T) {
 func TestAFoldedGroupReachesTheChangedPageThroughWorklist(t *testing.T) {
 	t.Parallel()
 
+	// MIXED freshness, and every variant this test must reject depends on it.
+	// The last firing is after the night; the earlier ones are before it, so the
+	// group's own sort moment — its OLDEST member — is stale. All-fresh members
+	// would pass against "oldest member decides", against "any member decides",
+	// and against filtering before folding, all three.
 	cutoff := readInstant.Add(-6 * time.Hour)
-	fired := cutoff.Add(time.Hour)
 	rule := ids.New[ids.AutomationKind]()
 	runs := make([]TroubledAutomationRun, 0, batchFloor)
 	for at := range batchFloor {
+		fired := cutoff.Add(-time.Hour)
+		if at == batchFloor-1 {
+			fired = cutoff.Add(time.Hour)
+		}
 		runs = append(runs, TroubledAutomationRun{
 			ID: ids.NewV7(), AutomationID: rule, Name: "Route new leads",
 			Outcome: "failed", Reason: "the assignee seat is gone",
-			// Spread, so the group's own sort moment is the OLDEST — the value
-			// a freshness rule reading `occurred` would wrongly judge it by.
-			OccurredAt: fired.Add(time.Duration(at) * time.Minute),
+			OccurredAt: fired,
 		})
 	}
 	svc := NewService(
@@ -272,10 +278,46 @@ func TestAFoldedGroupReachesTheChangedPageThroughWorklist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("narrowed worklist: %v", err)
 	}
+	// ONE row, and which one matters. Filtering before folding would answer the
+	// single fresh MEMBER — a row with no batch — and judging the group by its
+	// oldest member would answer nothing at all.
 	if len(narrowed.Queue) != 1 {
 		t.Fatalf("the changed page holds %d rows, wanted the incident group: a "+
 			"minted row inherits no flag, so the group was dropped from a notice "+
 			"its members belonged in", len(narrowed.Queue))
+	}
+	if narrowed.Queue[0].Batch == nil {
+		t.Fatalf("the changed page answered row %q, which carries no batch: the "+
+			"narrowing ran before the fold, so it kept the member and never saw "+
+			"the group that replaced it", narrowed.Queue[0].Id)
+	}
+}
+
+// TestAGroupOfApprovalsIsNotItselfAnApproval holds the batch's own source.
+//
+// "Contains an approval" and "IS an approval" are different predicates, and the
+// client runs the second: it tests `item.source !== "approval"`, and a folded
+// group's source is `batch`, so the browser keeps it. A server walking the
+// group's members to find an approval inside would drop it — the same
+// count-and-door disagreement the filter exists to remove, moved one level down
+// into the fold.
+func TestAGroupOfApprovalsIsNotItselfAnApproval(t *testing.T) {
+	t.Parallel()
+
+	group := ranked{
+		item: crmcontracts.WorklistItem{
+			Id: "group", Source: "batch", Category: categoryDecisions,
+		},
+		foldedFrom: []crmcontracts.WorklistItemSource{"approval", "approval"},
+	}
+	loose := ranked{item: crmcontracts.WorklistItem{
+		Id: "loose", Source: "approval", Category: categoryDecisions,
+	}}
+
+	kept := keepFiltered([]ranked{group, loose}, filterExceptDecisions)
+	if ids := rankedIDs(kept); len(ids) != 1 || ids[0] != "group" {
+		t.Fatalf("kept %v, wanted the group and not the loose approval: the deck "+
+			"draws approvals, and a group of them is a different row", ids)
 	}
 }
 
@@ -356,31 +398,71 @@ func TestANamedCategoryStillFiltersByEquality(t *testing.T) {
 // change reintroduced the same defect for `system` by keying the unfold on
 // `decisions` alone.
 //
-// The census drives real rows through batchKeyOf rather than reading the map
-// back to itself, so it fails in the direction that matters: a category that
-// folds and is missing here.
+// The census PROBES batchKeyOf rather than reading foldableCategories back to
+// itself, and it probes every category with every shape the fold admits — so a
+// category that learns to fold tomorrow is visible here whether or not anybody
+// remembered this test. Under-recognition is the one direction a census must not
+// fail in: it reads a smaller subject, reports PASS, and leaves no assertion to
+// notice.
+//
+// The SET's completeness against the contract enum is held elsewhere, by
+// gates/contractvocabulary_test.go, which reads any map keyed on generated enum
+// constants. This holds the other half: that the set matches the fold.
 func TestEveryFoldableCategoryOpensItsOwnGroup(t *testing.T) {
 	t.Parallel()
 
-	routine := levelRoutine
-	dupe := ranked{item: crmcontracts.WorklistItem{
-		Category: categoryDecisions, Level: routine, Source: "dedupe_candidate",
-	}}
+	// Every shape the fold admits, from batchKeyOf's own branches: a duplicate
+	// pair, the two routine decision kinds, and a system incident with a cause.
+	// Each is tried under EVERY category, so the probe cannot miss a category
+	// that starts folding by reusing one of these shapes.
+	held, capture := kindHeldDraft, "capture_counterparty"
 	cause := "one-broken-rule"
-	incident := ranked{item: crmcontracts.WorklistItem{
-		Category: categorySystem, Source: "automation_run", CauseRef: &cause,
-	}}
+	shapes := []crmcontracts.WorklistItem{
+		{Level: levelRoutine, Source: "dedupe_candidate"},
+		{Level: levelRoutine, Source: "approval", Kind: &held},
+		{Level: levelRoutine, Source: "approval", Kind: &capture},
+		{Source: "automation_run", CauseRef: &cause},
+	}
 
-	for _, row := range []ranked{dupe, incident} {
-		if _, folds := batchKeyOf(row); !folds {
-			t.Fatalf("a %q row did not fold — the fixture no longer models the "+
-				"case this census is about", row.item.Category)
+	folds := map[crmcontracts.WorklistItemCategory]bool{}
+	for category := range everyCategory() {
+		for _, shape := range shapes {
+			row := ranked{item: shape}
+			row.item.Category = category
+			if _, ok := batchKeyOf(row); ok {
+				folds[category] = true
+			}
 		}
-		if !opensTheDeck(string(row.item.Category)) {
-			t.Fatalf("category %q folds but a filter naming it does not open the "+
-				"group: pressing Review on one of these rows returns the group "+
-				"the reader pressed it on", row.item.Category)
+	}
+
+	// The premise: the probe found SOMETHING. A shape vocabulary gone stale
+	// would report no foldable category and pass every check below.
+	if len(folds) == 0 {
+		t.Fatal("no category folded any probe shape — the shapes no longer model " +
+			"what batchKeyOf admits, so this census is reading nothing")
+	}
+	for category := range everyCategory() {
+		if folds[category] != opensTheDeck(string(category)) {
+			t.Fatalf("category %q folds=%v but a filter naming it opens=%v: a "+
+				"foldable category whose filter does not unfold returns the group "+
+				"the reader pressed Review on, and the reverse skips a fold the "+
+				"unfiltered page applies",
+				category, folds[category], opensTheDeck(string(category)))
 		}
+	}
+}
+
+// everyCategory is the contract's own vocabulary, which the classifiers assign
+// and gates/contractvocabulary_test.go holds complete.
+func everyCategory() map[crmcontracts.WorklistItemCategory]bool {
+	return map[crmcontracts.WorklistItemCategory]bool{
+		crmcontracts.WorklistItemCategoryCustomerWaiting: true,
+		crmcontracts.WorklistItemCategoryDealsAtRisk:     true,
+		crmcontracts.WorklistItemCategoryDecisions:       true,
+		crmcontracts.WorklistItemCategoryLeads:           true,
+		crmcontracts.WorklistItemCategoryMeetings:        true,
+		crmcontracts.WorklistItemCategorySystem:          true,
+		crmcontracts.WorklistItemCategoryTasks:           true,
 	}
 }
 

--- a/backend/internal/compose/attention/page.go
+++ b/backend/internal/compose/attention/page.go
@@ -48,12 +48,67 @@ func sortByRank(rows []ranked) {
 	sort.SliceStable(rows, func(i, j int) bool { return less(rows[i], rows[j]) })
 }
 
-func keepCategory(rows []ranked, want crmcontracts.WorklistItemCategory) []ranked {
+// The two filter values that are not a category.
+//
+// Both were added because a Brief surface counted a population this vocabulary
+// could not then ask for, so its "N more" link went to a bare queue showing a
+// different N. A count and its door now read the same rule.
+const (
+	// filterExceptDecisions is the complement of `decisions`: what a surface
+	// drawing its own decisions deck has not already answered.
+	filterExceptDecisions = crmcontracts.WorklistFilter("except_decisions")
+	// filterChangedSinceBrief is the rows the overnight run did not see.
+	filterChangedSinceBrief = crmcontracts.WorklistFilter("changed_since_brief")
+)
+
+// opensTheDeck says whether a filter is a request to see inside the folded
+// group of routine decisions.
+//
+// Only a narrowing that lands ON decisions is. Answering "show me decisions"
+// with the group a reader was trying to open is a door back to itself, which is
+// the rule foldAndRepin states; answering "show me what changed overnight" with
+// a hundred alike rows the unfiltered page draws as one is the same door
+// misbehaving the other way.
+func opensTheDeck(filter string) bool {
+	return filter == string(categoryDecisions)
+}
+
+// keepFiltered narrows the candidates to what one filter value asks for.
+//
+// Most values name a category and are a plain equality. Two are not, and they
+// are here rather than in the caller because a filter that lives in two places
+// is a filter that answers two things: the surface counting a population and the
+// door narrowing to it must read ONE rule, which is the whole reason these two
+// values exist.
+//
+// `changedSinceBrief` decides this one, and it may be absent. A row carries no
+// flag when there was no run to compare against or when the row has no material
+// moment to date, and absent is refused rather than kept: "the night saw this"
+// and "there was no night" are different facts, and answering the whole queue to
+// a reader who asked what changed would report a quiet morning as a busy one.
+func keepFiltered(rows []ranked, want crmcontracts.WorklistFilter) []ranked {
 	kept := make([]ranked, 0, len(rows))
 	for _, row := range rows {
-		if row.item.Category == want {
+		if keepsRow(row, want) {
 			kept = append(kept, row)
 		}
 	}
 	return kept
+}
+
+func keepsRow(row ranked, want crmcontracts.WorklistFilter) bool {
+	switch want {
+	case filterExceptDecisions:
+		return row.item.Category != categoryDecisions
+	case filterChangedSinceBrief:
+		// Decisions excluded, and not as a convenience: the strip that counts
+		// this population counts it over the rows a decisions-drawing surface is
+		// answerable for, so that a row already on screen as a card is not also
+		// named as news. A filter admitting decisions would open a longer queue
+		// than the number that sent the reader — the defect, one layer down.
+		return row.item.Category != categoryDecisions &&
+			row.item.ChangedSinceBrief != nil && *row.item.ChangedSinceBrief
+	default:
+		return string(row.item.Category) == string(want)
+	}
 }

--- a/backend/internal/compose/attention/page.go
+++ b/backend/internal/compose/attention/page.go
@@ -79,11 +79,20 @@ func opensTheDeck(filter string) bool {
 }
 
 // The categories batchKeyOf can fold, and therefore the ones a reader can ask
-// to see inside. Derived from that function's own branches; the census beside
-// it fails if a category learns to fold without arriving here.
+// to see inside.
+//
+// A DELIBERATE SELECTION over the category enum, not a set that fell short of
+// it: the other five carry no fold, so a filter naming one has no group to open
+// and unfolding for it would skip a fold the unfiltered page applies.
+//
+// Spelled with the generated constants so the closed-vocabulary gate can read
+// it. Written with this package's own short aliases the set was INVISIBLE to
+// that gate — it recognises a vocabulary by its keys being contract constants —
+// which is the quiet half of this kind of drift: the map is checked by nothing
+// and reports no shortfall because nobody is counting.
 var foldableCategories = map[crmcontracts.WorklistItemCategory]bool{
-	categoryDecisions: true,
-	categorySystem:    true,
+	crmcontracts.WorklistItemCategoryDecisions: true,
+	crmcontracts.WorklistItemCategorySystem:    true,
 }
 
 // keepFiltered narrows the candidates to what one filter value asks for.
@@ -129,26 +138,22 @@ func keepsRow(row ranked, want crmcontracts.WorklistFilter) bool {
 // alreadyACard says whether a decisions-drawing surface has already answered a
 // row, so the complement above must leave it out.
 //
-// BY SOURCE, matching the client rule exactly. The browser's spelling is
-// `item.source !== "approval"` (frontend/src/screens/brief.sentence.ts), and the
-// obvious server-side reading — category `decisions` — is a WIDER set: an
-// introduction request classifies there and is not an approval, so a category
-// test dropped from the door a row the count had included. A count and a door
-// that exclude differently is the defect this filter exists to remove, so the
-// two sides spell one rule.
+// ONE test on the row's OWN source, matching the client exactly. The browser's
+// spelling is `item.source !== "approval"` (frontend/src/screens/brief.sentence.ts),
+// and the two obvious server-side readings are both wider:
 //
-// A folded group stands for its members and inherits their exclusion; a batch of
-// duplicate questions is drawn as a card exactly as its members would be.
+//   - Category `decisions` includes an introduction request, which is not an
+//     approval, so a category test dropped from the door a row the count kept.
+//   - Walking a folded group's members drops a batch of approvals, whose own
+//     source is `batch` — so the client keeps it and a members-walking server
+//     would not. "Contains an approval" and "is an approval" are different
+//     predicates, and only the second is the rule both sides run.
+//
+// A batch is therefore its own row here, which is also the honest reading: the
+// deck draws approvals, and a group of them is a different row than the ones it
+// stands for.
 func alreadyACard(row ranked) bool {
-	if row.item.Source == deckAnswers {
-		return true
-	}
-	for _, folded := range row.foldedFrom {
-		if folded == deckAnswers {
-			return true
-		}
-	}
-	return false
+	return row.item.Source == deckAnswers
 }
 
 // deckAnswers is the source a brief's decisions deck draws as cards.

--- a/backend/internal/compose/attention/page.go
+++ b/backend/internal/compose/attention/page.go
@@ -61,16 +61,29 @@ const (
 	filterChangedSinceBrief = crmcontracts.WorklistFilter("changed_since_brief")
 )
 
-// opensTheDeck says whether a filter is a request to see inside the folded
-// group of routine decisions.
+// opensTheDeck says whether a filter is a request to see inside a folded group.
 //
-// Only a narrowing that lands ON decisions is. Answering "show me decisions"
-// with the group a reader was trying to open is a door back to itself, which is
-// the rule foldAndRepin states; answering "show me what changed overnight" with
-// a hundred alike rows the unfiltered page draws as one is the same door
-// misbehaving the other way.
+// A narrowing onto a FOLDABLE CATEGORY is. Answering "show me decisions" with
+// the group a reader was trying to open is a door back to itself, which is the
+// rule foldAndRepin states — and `system` folds too, so the Review verb on a
+// broken automation lands here for exactly the same reason. That verb already
+// had this bug once: it used to send every group to `decisions`, which filtered
+// a system group's own failures out of view.
+//
+// The two link-only values are NOT that request, which is why this is a set
+// rather than `narrowed`. Answering "what changed overnight" with a hundred
+// alike rows the unfiltered page draws as one makes the door hold more than the
+// count that sent the reader — the same disagreement in the other direction.
 func opensTheDeck(filter string) bool {
-	return filter == string(categoryDecisions)
+	return foldableCategories[crmcontracts.WorklistItemCategory(filter)]
+}
+
+// The categories batchKeyOf can fold, and therefore the ones a reader can ask
+// to see inside. Derived from that function's own branches; the census beside
+// it fails if a category learns to fold without arriving here.
+var foldableCategories = map[crmcontracts.WorklistItemCategory]bool{
+	categoryDecisions: true,
+	categorySystem:    true,
 }
 
 // keepFiltered narrows the candidates to what one filter value asks for.
@@ -99,16 +112,48 @@ func keepFiltered(rows []ranked, want crmcontracts.WorklistFilter) []ranked {
 func keepsRow(row ranked, want crmcontracts.WorklistFilter) bool {
 	switch want {
 	case filterExceptDecisions:
-		return row.item.Category != categoryDecisions
+		return !alreadyACard(row)
 	case filterChangedSinceBrief:
-		// Decisions excluded, and not as a convenience: the strip that counts
-		// this population counts it over the rows a decisions-drawing surface is
-		// answerable for, so that a row already on screen as a card is not also
-		// named as news. A filter admitting decisions would open a longer queue
+		// The deck's own rows excluded, and not as a convenience: the strip that
+		// counts this population counts it over the rows a decisions-drawing
+		// surface is answerable for, so a row already on screen as a card is not
+		// also named as news. A filter admitting them would open a longer queue
 		// than the number that sent the reader — the defect, one layer down.
-		return row.item.Category != categoryDecisions &&
+		return !alreadyACard(row) &&
 			row.item.ChangedSinceBrief != nil && *row.item.ChangedSinceBrief
 	default:
 		return string(row.item.Category) == string(want)
 	}
 }
+
+// alreadyACard says whether a decisions-drawing surface has already answered a
+// row, so the complement above must leave it out.
+//
+// BY SOURCE, matching the client rule exactly. The browser's spelling is
+// `item.source !== "approval"` (frontend/src/screens/brief.sentence.ts), and the
+// obvious server-side reading — category `decisions` — is a WIDER set: an
+// introduction request classifies there and is not an approval, so a category
+// test dropped from the door a row the count had included. A count and a door
+// that exclude differently is the defect this filter exists to remove, so the
+// two sides spell one rule.
+//
+// A folded group stands for its members and inherits their exclusion; a batch of
+// duplicate questions is drawn as a card exactly as its members would be.
+func alreadyACard(row ranked) bool {
+	if row.item.Source == deckAnswers {
+		return true
+	}
+	for _, folded := range row.foldedFrom {
+		if folded == deckAnswers {
+			return true
+		}
+	}
+	return false
+}
+
+// deckAnswers is the source a brief's decisions deck draws as cards.
+//
+// The client names the same constant beside its own filter, and the gate below
+// holds the pair: two spellings of one exclusion drift the first time either
+// side learns a new source.
+const deckAnswers = crmcontracts.WorklistItemSource("approval")

--- a/backend/internal/compose/attention/readings_test.go
+++ b/backend/internal/compose/attention/readings_test.go
@@ -65,7 +65,7 @@ func TestAFilterDoesNotEmptyTheOtherReadings(t *testing.T) {
 
 	// What a page filtered to decisions would carry, against the snapshot the
 	// readings are actually taken over.
-	narrowed := keepCategory(considered, categoryDecisions)
+	narrowed := keepFiltered(considered, crmcontracts.WorklistFilter(categoryDecisions))
 	overNarrowed := readingsOf(narrowed, nil, nil)
 	overConsidered := readingsOf(considered, nil, nil)
 

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -297,11 +297,29 @@ func (s *Service) worklistFrom(
 	// "tasks, not shown", and a filtered-out source that hit its bound took its
 	// more_available signal out with it.
 	considered := rows
+	// Which of these the night had not seen, stamped over EVERY candidate rather
+	// than the cut page, because `changed_since_brief` is one of the narrowings
+	// below and a filter cannot read a flag set after it runs.
+	//
+	// One pass serving both the filter and the drawing is what stops the door and
+	// the count disagreeing — the defect these two filter values exist to fix. It
+	// costs one comparison per row against an instant this call already holds.
+	rows = markChangedSinceBrief(rows, s.briefCutoff)
 	narrowed := filter != "" && filter != string(crmcontracts.WorklistFilterAll)
 	if narrowed {
-		rows = keepCategory(rows, crmcontracts.WorklistItemCategory(filter))
+		rows = keepFiltered(rows, crmcontracts.WorklistFilter(filter))
 	}
-	if !narrowed {
+	// The routine-decision fold, skipped for a narrowing that IS opening the
+	// group — foldAndRepin's own rule, and the reason it is conditional at all.
+	//
+	// `opensTheDeck` rather than `narrowed`, because the two new filter values are
+	// narrowings that are not that request. A reader asking what changed overnight
+	// asked about freshness and can be owed decisions; answering with a hundred
+	// alike rows the unfiltered page draws as one would make the door show more
+	// than the count that sent them — the same disagreement in the other
+	// direction. `except_decisions` keeps no decision to fold, so the call is a
+	// no-op there and costs only the walk.
+	if !opensTheDeck(filter) {
 		rows = s.foldAndRepin(rows, len(day.NeedsYou) >= batchScanDepth)
 	}
 	// Cut to the page BEFORE explaining and counting. Ranking the whole set and
@@ -352,9 +370,10 @@ func (s *Service) worklistFrom(
 	// cut from the ranking above; a frozen walk's sequence is a previous run of
 	// that same comparator, and running it again here would return the reader's
 	// own rows in today's order rather than the one they were shown.
-	// Which of these the night had not seen, against the run's own data cutoff.
-	// Over the CUT page, because it is drawn and never ranked.
-	shown = markChangedSinceBrief(shown, s.briefCutoff)
+	// Already stamped, above the narrowing: `shown` is a slice of those same rows,
+	// so it carries the flags the `changed_since_brief` filter read. Stamping
+	// again here would be a second answer to one question, and the page's copy
+	// would be the one a reader sees while the filter used the other.
 	ordered := renderInOrder(stampAsOf(shown, day.AsOf), readerOf(ctx))
 	bands := bandsOf(ordered)
 	out := crmcontracts.Worklist{

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -305,22 +305,27 @@ func (s *Service) worklistFrom(
 	// the count disagreeing — the defect these two filter values exist to fix. It
 	// costs one comparison per row against an instant this call already holds.
 	rows = markChangedSinceBrief(rows, s.briefCutoff)
-	narrowed := filter != "" && filter != string(crmcontracts.WorklistFilterAll)
-	if narrowed {
-		rows = keepFiltered(rows, crmcontracts.WorklistFilter(filter))
-	}
-	// The routine-decision fold, skipped for a narrowing that IS opening the
-	// group — foldAndRepin's own rule, and the reason it is conditional at all.
+	// The fold, skipped for a narrowing that IS opening the group — foldAndRepin's
+	// own rule, and the reason it is conditional at all.
 	//
-	// `opensTheDeck` rather than `narrowed`, because the two new filter values are
+	// `opensTheDeck` rather than `narrowed`, because the two link-only values are
 	// narrowings that are not that request. A reader asking what changed overnight
 	// asked about freshness and can be owed decisions; answering with a hundred
 	// alike rows the unfiltered page draws as one would make the door show more
 	// than the count that sent them — the same disagreement in the other
-	// direction. `except_decisions` keeps no decision to fold, so the call is a
-	// no-op there and costs only the walk.
+	// direction.
+	//
+	// BEFORE the narrowing, so the filter judges the rows this page will actually
+	// draw. A fold MINTS a row, so filtering first left the members to be tested
+	// and the group they became untested: an incident group whose members were all
+	// stale reached a page asking only for what changed, because the three rows the
+	// filter had approved were replaced afterwards by one it never saw.
 	if !opensTheDeck(filter) {
 		rows = s.foldAndRepin(rows, len(day.NeedsYou) >= batchScanDepth)
+	}
+	narrowed := filter != "" && filter != string(crmcontracts.WorklistFilterAll)
+	if narrowed {
+		rows = keepFiltered(rows, crmcontracts.WorklistFilter(filter))
 	}
 	// Cut to the page BEFORE explaining and counting. Ranking the whole set and
 	// then slicing left the last returned row comparing itself against a row the

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -260,7 +260,7 @@ func TestAFilteredQueueCarriesOnlyThatKindOfWork(t *testing.T) {
 		AtRisk:   lane(item("r1", "deal_at_risk")),
 	}
 
-	kept := keepCategory(classifyDay(day, rankInstant, dayMoney{}), "deals_at_risk")
+	kept := keepFiltered(classifyDay(day, rankInstant, dayMoney{}), "deals_at_risk")
 
 	if len(kept) != 1 || kept[0].item.Id != "r1" {
 		t.Fatalf("filtering for deals kept %d rows, wanted just the deal", len(kept))

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14073,14 +14073,16 @@ func (e WeeklyReviewOutlookPeriodKind) Valid() bool {
 
 // Defines values for WorklistFilter.
 const (
-	WorklistFilterAll             WorklistFilter = "all"
-	WorklistFilterCustomerWaiting WorklistFilter = "customer_waiting"
-	WorklistFilterDealsAtRisk     WorklistFilter = "deals_at_risk"
-	WorklistFilterDecisions       WorklistFilter = "decisions"
-	WorklistFilterLeads           WorklistFilter = "leads"
-	WorklistFilterMeetings        WorklistFilter = "meetings"
-	WorklistFilterSystem          WorklistFilter = "system"
-	WorklistFilterTasks           WorklistFilter = "tasks"
+	WorklistFilterAll               WorklistFilter = "all"
+	WorklistFilterChangedSinceBrief WorklistFilter = "changed_since_brief"
+	WorklistFilterCustomerWaiting   WorklistFilter = "customer_waiting"
+	WorklistFilterDealsAtRisk       WorklistFilter = "deals_at_risk"
+	WorklistFilterDecisions         WorklistFilter = "decisions"
+	WorklistFilterExceptDecisions   WorklistFilter = "except_decisions"
+	WorklistFilterLeads             WorklistFilter = "leads"
+	WorklistFilterMeetings          WorklistFilter = "meetings"
+	WorklistFilterSystem            WorklistFilter = "system"
+	WorklistFilterTasks             WorklistFilter = "tasks"
 )
 
 // Valid indicates whether the value is a known member of the WorklistFilter enum.
@@ -14088,11 +14090,15 @@ func (e WorklistFilter) Valid() bool {
 	switch e {
 	case WorklistFilterAll:
 		return true
+	case WorklistFilterChangedSinceBrief:
+		return true
 	case WorklistFilterCustomerWaiting:
 		return true
 	case WorklistFilterDealsAtRisk:
 		return true
 	case WorklistFilterDecisions:
+		return true
+	case WorklistFilterExceptDecisions:
 		return true
 	case WorklistFilterLeads:
 		return true
@@ -16770,14 +16776,16 @@ func (e GetWorklistParamsScope) Valid() bool {
 
 // Defines values for GetWorklistParamsFilter.
 const (
-	All             GetWorklistParamsFilter = "all"
-	CustomerWaiting GetWorklistParamsFilter = "customer_waiting"
-	DealsAtRisk     GetWorklistParamsFilter = "deals_at_risk"
-	Decisions       GetWorklistParamsFilter = "decisions"
-	Leads           GetWorklistParamsFilter = "leads"
-	Meetings        GetWorklistParamsFilter = "meetings"
-	System          GetWorklistParamsFilter = "system"
-	Tasks           GetWorklistParamsFilter = "tasks"
+	All               GetWorklistParamsFilter = "all"
+	ChangedSinceBrief GetWorklistParamsFilter = "changed_since_brief"
+	CustomerWaiting   GetWorklistParamsFilter = "customer_waiting"
+	DealsAtRisk       GetWorklistParamsFilter = "deals_at_risk"
+	Decisions         GetWorklistParamsFilter = "decisions"
+	ExceptDecisions   GetWorklistParamsFilter = "except_decisions"
+	Leads             GetWorklistParamsFilter = "leads"
+	Meetings          GetWorklistParamsFilter = "meetings"
+	System            GetWorklistParamsFilter = "system"
+	Tasks             GetWorklistParamsFilter = "tasks"
 )
 
 // Valid indicates whether the value is a known member of the GetWorklistParamsFilter enum.
@@ -16785,11 +16793,15 @@ func (e GetWorklistParamsFilter) Valid() bool {
 	switch e {
 	case All:
 		return true
+	case ChangedSinceBrief:
+		return true
 	case CustomerWaiting:
 		return true
 	case DealsAtRisk:
 		return true
 	case Decisions:
+		return true
+	case ExceptDecisions:
 		return true
 	case Leads:
 		return true
@@ -36268,7 +36280,7 @@ type Worklist struct {
 	// not drawing.
 	Counts []WorklistCount `json:"counts"`
 
-	// Filter The narrowing this read applied.
+	// Filter The narrowing this read applied. The same vocabulary the query parameter takes.
 	Filter *WorklistFilter `json:"filter,omitempty"`
 
 	// NextCursor Send this back as `cursor` to continue past the last row of this page. See that
@@ -36368,7 +36380,7 @@ type Worklist struct {
 	Walk *WorklistWalk `json:"walk,omitempty"`
 }
 
-// WorklistFilter The narrowing this read applied.
+// WorklistFilter The narrowing this read applied. The same vocabulary the query parameter takes.
 type WorklistFilter string
 
 // WorklistScope Whose work this read answered for.
@@ -42309,7 +42321,22 @@ type GetWorklistParams struct {
 	// licence to read a colleague's inbox.
 	Scope *GetWorklistParamsScope `form:"scope,omitempty" json:"scope,omitempty"`
 
-	// Filter Narrow the queue to one kind of work. Omitted means everything, which is the default view.
+	// Filter Narrow the queue. Omitted means everything, which is the default view.
+	//
+	// Most values name ONE kind of work. Two do not, and exist because a surface
+	// counted a population this vocabulary could not then ask for — a count whose
+	// link lands on a different population is a number that lies about where it goes.
+	//
+	// `except_decisions` is everything a decisions-drawing surface has NOT already
+	// answered. It is the complement of `decisions`, not a kind of work, and no
+	// single category spells it.
+	//
+	// `changed_since_brief` is the rows whose material moment falls after the
+	// overnight run's data cutoff — the same test that stamps each row's
+	// `changed_since_brief` flag — and, like the value above, not the decisions a
+	// brief already draws as cards. With no run to compare against it answers empty
+	// rather than everything: absent is not false, and a reader asking what changed
+	// since a night that never happened is owed nothing, not the whole queue.
 	Filter *GetWorklistParamsFilter `form:"filter,omitempty" json:"filter,omitempty"`
 
 	// Limit How many ranked items to return.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -42328,15 +42328,19 @@ type GetWorklistParams struct {
 	// link lands on a different population is a number that lies about where it goes.
 	//
 	// `except_decisions` is everything a decisions-drawing surface has NOT already
-	// answered. It is the complement of `decisions`, not a kind of work, and no
-	// single category spells it.
+	// answered: every row whose SOURCE is not `approval`. Not a kind of work, and
+	// deliberately not the complement of the `decisions` CATEGORY, which is a wider
+	// set — an introduction request classifies as a decision and is not an approval,
+	// so a category reading would drop a row the counting surface kept. A folded
+	// group's source is `batch` and it is kept, like any other row that is not
+	// itself an approval.
 	//
 	// `changed_since_brief` is the rows whose material moment falls after the
 	// overnight run's data cutoff — the same test that stamps each row's
-	// `changed_since_brief` flag — and, like the value above, not the decisions a
-	// brief already draws as cards. With no run to compare against it answers empty
-	// rather than everything: absent is not false, and a reader asking what changed
-	// since a night that never happened is owed nothing, not the whole queue.
+	// `changed_since_brief` flag — and, like the value above, not the rows a brief
+	// already draws as cards. With no run to compare against it answers empty rather
+	// than everything: absent is not false, and a reader asking what changed since a
+	// night that never happened is owed nothing, not the whole queue.
 	Filter *GetWorklistParamsFilter `form:"filter,omitempty" json:"filter,omitempty"`
 
 	// Limit How many ranked items to return.

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (102)
+## Parity (103)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -34,6 +34,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `basevaluespelling_test.go` | H2 | One deal's base-currency value is spelled twice, in two packages that cannot import each other, and this is what stops the two from drifting. |
 | `benchrecordswitch_test.go` | H2 | Both bench harnesses ask the SAME variable whether to publish a record, and both answer only to the same value. |
 | `bookinginvite_test.go` | H2 | What booking a meeting CLAIMS and what it DOES, held against each other. |
+| `briefdeckexclusion_test.go` | H3 | A Brief count and the door beneath it must exclude the SAME rows. |
 | `captureledgerstatuses_test.go` | H2 | The disposition ledger's status vocabulary has ONE definition, and it is the column's own constraint. |
 | `coachingroles_test.go` | H2 | The seats that may coach are seats that exist. |
 | `coderabbitpathrules_test.go` | H3 | What .coderabbit.yaml tells the reviewer about backend Go, held against what is true. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -45878,15 +45878,19 @@ export interface operations {
                  *     link lands on a different population is a number that lies about where it goes.
                  *
                  *     `except_decisions` is everything a decisions-drawing surface has NOT already
-                 *     answered. It is the complement of `decisions`, not a kind of work, and no
-                 *     single category spells it.
+                 *     answered: every row whose SOURCE is not `approval`. Not a kind of work, and
+                 *     deliberately not the complement of the `decisions` CATEGORY, which is a wider
+                 *     set — an introduction request classifies as a decision and is not an approval,
+                 *     so a category reading would drop a row the counting surface kept. A folded
+                 *     group's source is `batch` and it is kept, like any other row that is not
+                 *     itself an approval.
                  *
                  *     `changed_since_brief` is the rows whose material moment falls after the
                  *     overnight run's data cutoff — the same test that stamps each row's
-                 *     `changed_since_brief` flag — and, like the value above, not the decisions a
-                 *     brief already draws as cards. With no run to compare against it answers empty
-                 *     rather than everything: absent is not false, and a reader asking what changed
-                 *     since a night that never happened is owed nothing, not the whole queue.
+                 *     `changed_since_brief` flag — and, like the value above, not the rows a brief
+                 *     already draws as cards. With no run to compare against it answers empty rather
+                 *     than everything: absent is not false, and a reader asking what changed since a
+                 *     night that never happened is owed nothing, not the whole queue.
                  */
                 filter?: "all" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system" | "except_decisions" | "changed_since_brief";
                 /** @description How many ranked items to return. */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -32128,10 +32128,10 @@ export interface components {
              */
             scope_options: ("mine" | "unassigned" | "team" | "all")[];
             /**
-             * @description The narrowing this read applied.
+             * @description The narrowing this read applied. The same vocabulary the query parameter takes.
              * @enum {string}
              */
-            filter?: "all" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system";
+            filter?: "all" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system" | "except_decisions" | "changed_since_brief";
             summary: components["schemas"]["WorklistSummary"];
             /** @description Everything actionable, best-first. The order is the product of this endpoint. */
             queue: components["schemas"]["WorklistItem"][];
@@ -45870,8 +45870,25 @@ export interface operations {
                  *     licence to read a colleague's inbox.
                  */
                 scope?: "mine" | "unassigned" | "team" | "all";
-                /** @description Narrow the queue to one kind of work. Omitted means everything, which is the default view. */
-                filter?: "all" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system";
+                /**
+                 * @description Narrow the queue. Omitted means everything, which is the default view.
+                 *
+                 *     Most values name ONE kind of work. Two do not, and exist because a surface
+                 *     counted a population this vocabulary could not then ask for — a count whose
+                 *     link lands on a different population is a number that lies about where it goes.
+                 *
+                 *     `except_decisions` is everything a decisions-drawing surface has NOT already
+                 *     answered. It is the complement of `decisions`, not a kind of work, and no
+                 *     single category spells it.
+                 *
+                 *     `changed_since_brief` is the rows whose material moment falls after the
+                 *     overnight run's data cutoff — the same test that stamps each row's
+                 *     `changed_since_brief` flag — and, like the value above, not the decisions a
+                 *     brief already draws as cards. With no run to compare against it answers empty
+                 *     rather than everything: absent is not false, and a reader asking what changed
+                 *     since a night that never happened is owed nothing, not the whole queue.
+                 */
+                filter?: "all" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system" | "except_decisions" | "changed_since_brief";
                 /** @description How many ranked items to return. */
                 limit?: number;
                 /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8805,6 +8805,11 @@ export const de = {
   "worklist.filter.tasks": "Aufgaben",
   "worklist.filter.decisions": "Entscheidungen",
   "worklist.filter.system": "System",
+  "worklist.filter.linked.except_decisions":
+    "Alles außer den Entscheidungen, nach denen Ihr Briefing bereits gefragt hat.",
+  "worklist.filter.linked.changed_since_brief":
+    "Nur das, was sich seit dem Lauf der letzten Nacht geändert hat.",
+  "worklist.filter.linked.clear": "Ganze Liste anzeigen",
   "worklist.category.customer_waiting": "Kunde wartet",
   "worklist.category.leads": "Lead",
   "worklist.signal.closing_soon": "Schließt bald",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8940,6 +8940,11 @@ export const en = {
   "worklist.filter.tasks": "Tasks",
   "worklist.filter.decisions": "Decisions",
   "worklist.filter.system": "System",
+  "worklist.filter.linked.except_decisions":
+    "Showing everything except the decisions your brief already asked you about.",
+  "worklist.filter.linked.changed_since_brief":
+    "Showing only what changed since last night's run.",
+  "worklist.filter.linked.clear": "Show the whole queue",
   "worklist.category.customer_waiting": "Customer waiting",
   "worklist.category.leads": "Lead",
   "worklist.signal.closing_soon": "Closing soon",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8698,6 +8698,11 @@ export const vi = {
   "worklist.filter.tasks": "Công việc",
   "worklist.filter.decisions": "Quyết định",
   "worklist.filter.system": "Hệ thống",
+  "worklist.filter.linked.except_decisions":
+    "Hiển thị mọi thứ trừ các quyết định mà bản tóm tắt của bạn đã hỏi.",
+  "worklist.filter.linked.changed_since_brief":
+    "Chỉ hiển thị những gì đã thay đổi kể từ lần chạy đêm qua.",
+  "worklist.filter.linked.clear": "Hiển thị toàn bộ danh sách",
   "worklist.category.customer_waiting": "Khách đang chờ",
   "worklist.category.leads": "Khách tiềm năng",
   "worklist.signal.closing_soon": "Sắp chốt",

--- a/frontend/src/screens/brief.changed.test.tsx
+++ b/frontend/src/screens/brief.changed.test.tsx
@@ -148,13 +148,19 @@ describe("what changed since the brief", () => {
 
   // The only way out of the strip. Without it a reader is told three things
   // moved and given nowhere to go and see them.
-  it("offers the way to the rows it named", () => {
+  //
+  // It carries the SAME narrowing this strip counted. A bare `#/worklist` named
+  // three rows and opened a queue of forty, so the count and its door shared
+  // nothing at all — which is the whole reason the server grew this filter.
+  it("opens the rows it named, and not the whole queue", () => {
     draw([
       item({ id: "a", title: "Aster replied", changed_since_brief: true }),
     ]);
 
     const link = screen.getByText(en["brief.changed.open"]);
-    expect(link.getAttribute("href")).toBe("#/worklist");
+    expect(link.getAttribute("href")).toBe(
+      "#/worklist?filter=changed_since_brief",
+    );
   });
 
   // A payload with no queue at all draws nothing rather than throwing: a page

--- a/frontend/src/screens/brief.changed.tsx
+++ b/frontend/src/screens/brief.changed.tsx
@@ -6,6 +6,7 @@ import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { waitingRows } from "./brief.sentence";
 import { itemTitle } from "./worklist.copy";
+import { worklistLaneHref } from "./worklist.header";
 import type { Worklist } from "./worklist.queries";
 
 // What has happened since the night looked.
@@ -66,7 +67,12 @@ export function ChangedSinceBrief({ day }: Readonly<{ day: Worklist }>) {
             count: formatNumber(rest, locale),
           })}`
         : ""}{" "}
-      <a className="entity-link" href="#/worklist">
+      {/* The SAME cut this strip counted. A bare `#/worklist` named three rows
+          and opened a queue of forty with no way to tell which three, so the
+          count and its door shared nothing at all. The server applies the same
+          freshness test that stamped the flags read above, which is why this is
+          one rule rather than a browser-side narrowing that could disagree. */}
+      <a className="entity-link" href={worklistLaneHref("changed_since_brief")}>
         {t("brief.changed.open")}
       </a>
     </Callout>

--- a/frontend/src/screens/brief.feed.test.tsx
+++ b/frontend/src/screens/brief.feed.test.tsx
@@ -186,7 +186,12 @@ describe("the morning feed", () => {
     const link = screen.getByText(
       en["brief.feed.rest"].replace("{count}", "3"),
     );
-    expect(link.getAttribute("href")).toBe("#/worklist");
+    // The door narrows to the same population the count was taken over. The
+    // test below proves the count drops approvals; a bare `#/worklist` would
+    // then open a queue holding them, so a rep told "11 more" landed on 14.
+    expect(link.getAttribute("href")).toBe(
+      "#/worklist?filter=except_decisions",
+    );
   });
 
   // The remainder counts what THIS surface is showing, not what the queue

--- a/frontend/src/screens/brief.feed.tsx
+++ b/frontend/src/screens/brief.feed.tsx
@@ -10,6 +10,7 @@ import { formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { waitingRows } from "./brief.sentence";
+import { worklistLaneHref } from "./worklist.header";
 import type { Worklist, WorklistItem } from "./worklist.queries";
 import { WorklistRow } from "./worklist.row";
 
@@ -66,7 +67,13 @@ export function BriefFeed({
           // The way to the rest. A page showing eight of nineteen rows that did
           // not say where the other eleven are has hidden them.
           day && rest > 0 ? (
-            <a className="entity-link" href="#/worklist">
+            // The SAME cut this footer counted. `rest` comes off waitingRows,
+            // which drops the approvals the Decisions deck above already draws,
+            // so a bare `#/worklist` sent a rep told "11 more" to a list of 14.
+            <a
+              className="entity-link"
+              href={worklistLaneHref("except_decisions")}
+            >
               {t("brief.feed.rest", { count: formatNumber(rest, locale) })}
             </a>
           ) : undefined

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -12,6 +12,7 @@ import type { Locale, useT } from "../i18n";
 import { translatePlural } from "../i18n";
 import { BRIEF_PARAM, COMPOSE_PARAM, THREAD_PARAM } from "./personpage.address";
 import { settingsHref } from "./settingsrouting";
+import { countsUnder } from "./worklist.narrowing";
 import type {
   Worklist,
   WorklistComparison,
@@ -828,10 +829,9 @@ export function completenessText(
   // candidates and call a growing list incomplete for ever.
   loaded?: number,
 ): string | null {
-  const counted =
-    filter === "all"
-      ? day.counts
-      : day.counts.filter((count) => count.category === filter);
+  // Null is a narrowing these figures cannot describe. See countsUnder.
+  const counted = countsUnder(day, filter);
+  if (counted === null) return null;
   const shown =
     loaded ?? counted.reduce((total, count) => total + count.shown, 0);
   const considered = counted.reduce(

--- a/frontend/src/screens/worklist.counts.test.tsx
+++ b/frontend/src/screens/worklist.counts.test.tsx
@@ -262,41 +262,30 @@ describe("what the page says about what it is not showing", () => {
     expect(unfiltered).toContain("5/35");
   });
 
-  // A narrowing that spans several categories still reports what it hid.
+  // The two link-only narrowings say NOTHING, and for one reason each.
   //
-  // `except_decisions` matches no single `count.category`, so the per-category
-  // lookup found nothing, summed zero considered, and returned null — a
-  // truncated page reporting itself complete. Reading the complement is the
-  // honest answer, because these figures CAN express it.
-  it("reports completeness for a narrowing that spans categories", () => {
+  // `changed_since_brief` cuts across every category on a per-row freshness the
+  // counts do not carry. `except_decisions` excludes by SOURCE — the approvals a
+  // brief draws as cards — and these figures are keyed by category, so the
+  // near-miss complement of the `decisions` category would undercount: it drops
+  // an introduction request, which is a decision and is not an approval, that
+  // the server keeps.
+  //
+  // Silence is the honest answer. The danger is silence arrived at by accident,
+  // which is what the per-category lookup produced before — it found nothing,
+  // summed zero considered, and reported a truncated page as complete.
+  it("says nothing where the counts cannot describe the narrowing", () => {
     const page = day([
-      { category: "tasks", considered: 30, shown: 5, more_available: false },
+      { category: "tasks", considered: 30, shown: 5, more_available: true },
       { category: "decisions", considered: 4, shown: 4, more_available: false },
     ]);
     const t = ((key: string, vars?: Record<string, string>) =>
       `${key}:${vars?.shown}/${vars?.considered}`) as never;
 
-    // Five of the thirty tasks are on screen; the four decisions are not part
-    // of this cut and contribute to neither figure.
-    expect(completenessText(page, "except_decisions", t, "en")).toContain(
-      "5/30",
-    );
-  });
-
-  // And the one these figures genuinely cannot answer says nothing.
-  //
-  // `changed_since_brief` cuts across every category on a per-row freshness the
-  // counts do not carry. Silence is correct; the danger is silence arrived at by
-  // accident, which is what an empty per-category lookup produced — and which
-  // would have started printing a wrong number the moment the arms changed.
-  it("says nothing where the counts cannot describe the narrowing", () => {
-    const page = day([
-      { category: "tasks", considered: 30, shown: 5, more_available: true },
-    ]);
-    const t = ((key: string, vars?: Record<string, string>) =>
-      `${key}:${vars?.shown}/${vars?.considered}`) as never;
-
     expect(completenessText(page, "changed_since_brief", t, "en")).toBeNull();
+    // Not "5/30" either: that is the category complement, which is a DIFFERENT
+    // population from the one the server returns.
+    expect(completenessText(page, "except_decisions", t, "en")).toBeNull();
     // The control: the same day, asked a question the counts DO answer, speaks.
     expect(completenessText(page, "tasks", t, "en")).not.toBeNull();
   });

--- a/frontend/src/screens/worklist.counts.test.tsx
+++ b/frontend/src/screens/worklist.counts.test.tsx
@@ -261,4 +261,43 @@ describe("what the page says about what it is not showing", () => {
     // Unfiltered, the same day genuinely IS hiding the thirty tasks.
     expect(unfiltered).toContain("5/35");
   });
+
+  // A narrowing that spans several categories still reports what it hid.
+  //
+  // `except_decisions` matches no single `count.category`, so the per-category
+  // lookup found nothing, summed zero considered, and returned null — a
+  // truncated page reporting itself complete. Reading the complement is the
+  // honest answer, because these figures CAN express it.
+  it("reports completeness for a narrowing that spans categories", () => {
+    const page = day([
+      { category: "tasks", considered: 30, shown: 5, more_available: false },
+      { category: "decisions", considered: 4, shown: 4, more_available: false },
+    ]);
+    const t = ((key: string, vars?: Record<string, string>) =>
+      `${key}:${vars?.shown}/${vars?.considered}`) as never;
+
+    // Five of the thirty tasks are on screen; the four decisions are not part
+    // of this cut and contribute to neither figure.
+    expect(completenessText(page, "except_decisions", t, "en")).toContain(
+      "5/30",
+    );
+  });
+
+  // And the one these figures genuinely cannot answer says nothing.
+  //
+  // `changed_since_brief` cuts across every category on a per-row freshness the
+  // counts do not carry. Silence is correct; the danger is silence arrived at by
+  // accident, which is what an empty per-category lookup produced — and which
+  // would have started printing a wrong number the moment the arms changed.
+  it("says nothing where the counts cannot describe the narrowing", () => {
+    const page = day([
+      { category: "tasks", considered: 30, shown: 5, more_available: true },
+    ]);
+    const t = ((key: string, vars?: Record<string, string>) =>
+      `${key}:${vars?.shown}/${vars?.considered}`) as never;
+
+    expect(completenessText(page, "changed_since_brief", t, "en")).toBeNull();
+    // The control: the same day, asked a question the counts DO answer, speaks.
+    expect(completenessText(page, "tasks", t, "en")).not.toBeNull();
+  });
 });

--- a/frontend/src/screens/worklist.header.tsx
+++ b/frontend/src/screens/worklist.header.tsx
@@ -10,6 +10,8 @@
 // them are one thing: a lane the strip offers and the address cannot spell, or
 // the reverse, is a link somebody pastes that opens the wrong day.
 
+import { routeHash } from "../app/router";
+import { hashWithParams } from "../app/urlstate";
 import { SegmentedControl } from "../design-system/atoms";
 import { FilterPills } from "../design-system/filterpills";
 import { formatNumber } from "../format/format";
@@ -24,7 +26,12 @@ import type {
 import "./worklist.css";
 
 // The cuts through the queue. `all` first because it is the default view.
-const FILTERS: readonly WorklistFilter[] = [
+//
+// `as const` rather than a widened annotation, and it is load-bearing: each pill
+// reads `worklist.filter.<value>`, so the literal type is what makes a pill
+// without a label a compile error. Annotated as the whole filter vocabulary it
+// would silently admit the link-only values below, which have no pill copy.
+const FILTERS = [
   "all",
   "customer_waiting",
   "leads",
@@ -33,7 +40,27 @@ const FILTERS: readonly WorklistFilter[] = [
   "tasks",
   "decisions",
   "system",
-];
+] as const satisfies readonly WorklistFilter[];
+
+// The narrowings that are reachable by ADDRESS but are not pills.
+//
+// Both are the destination of a count on another screen — Brief's feed footer
+// and its overnight notice — and both exist so that count and its link read one
+// filter. Neither is a lane a reader picks: `except_decisions` is a complement
+// that only means something on a screen already drawing its own decisions, and
+// `changed_since_brief` describes a moment rather than a kind of work. Offered
+// as pills they would be two cuts nobody asked for, so the row stays the seven
+// kinds plus `all` and these arrive by link.
+const LINKED_ONLY = [
+  "except_decisions",
+  "changed_since_brief",
+] as const satisfies readonly WorklistFilter[];
+
+/** A narrowing that only a link can ask for. */
+type LinkedOnlyFilter = (typeof LINKED_ONLY)[number];
+
+/** Every filter this build can be addressed with — the pills and the links. */
+const ADDRESSABLE: readonly WorklistFilter[] = [...FILTERS, ...LINKED_ONLY];
 
 /** The dial's name in the address. One spelling, read and written. */
 export const WORKLIST_FILTER_PARAM = "filter";
@@ -44,12 +71,51 @@ export const WORKLIST_FILTER_PARAM = "filter";
  * An unknown value reads as `all` rather than as an error: the vocabulary grows
  * on the server, and a pasted link naming a lane this build has not learnt
  * should show the day rather than an empty screen or a crash.
+ *
+ * Read against ADDRESSABLE, not the pill row. A link-only narrowing checked
+ * against the pills would fall through to `all` — the door would open the whole
+ * queue while the count that sent the reader named a part of it, which is the
+ * exact defect these two values were added to fix.
  */
 export function worklistFilterFrom(
   params: ReadonlyMap<string, string>,
 ): WorklistFilter {
   const asked = params.get(WORKLIST_FILTER_PARAM);
-  return FILTERS.find((value) => value === asked) ?? "all";
+  return ADDRESSABLE.find((value) => value === asked) ?? "all";
+}
+
+/**
+ * Whether this narrowing arrived by link rather than off the pill row.
+ *
+ * A type guard, so the caption below can spell `worklist.filter.linked.<value>`
+ * and have the compiler check that both link-only values have copy — the same
+ * protection the pill row gets from FILTERS being `as const`.
+ */
+export function isLinkedOnlyFilter(
+  filter: WorklistFilter,
+): filter is LinkedOnlyFilter {
+  return (LINKED_ONLY as readonly WorklistFilter[]).includes(filter);
+}
+
+/**
+ * The address that opens the queue on one narrowing.
+ *
+ * ONE spelling, because the surfaces that link here count a population first and
+ * the count is only true if the door applies the same filter. Two hand-written
+ * `#/worklist?filter=…` strings are two chances to typo a value that then falls
+ * through to `all` — silently, since an unknown filter is deliberately not an
+ * error — and the reader lands on the whole queue under a number describing part
+ * of it. That is the defect this function exists to make unrepeatable.
+ *
+ * Built from the router's own two halves rather than by hand, so an address
+ * written here and one the dial on the screen writes are byte-identical — which
+ * is what lets the reader arrive by link, press a pill, and press Back.
+ */
+export function worklistLaneHref(filter: WorklistFilter): string {
+  return hashWithParams(
+    routeHash({ screen: "worklist" }),
+    new Map([[WORKLIST_FILTER_PARAM, filter]]),
+  );
 }
 
 /**
@@ -159,6 +225,23 @@ export function WorklistHeader({
           onChange={onFilter}
           label={t("worklist.filter.label")}
         />
+        {/* A narrowing that came by LINK names itself, because no pill is
+            pressed to name it. Without this the reader arrives from Brief at a
+            short queue with the whole row unselected and nothing saying why —
+            which reads as a broken page rather than a narrowed one. The way
+            back out is the same control, so the sentence carries it. */}
+        {isLinkedOnlyFilter(filter) && (
+          <p className="t-caption worklist-completeness">
+            {t(`worklist.filter.linked.${filter}` as const)}{" "}
+            <button
+              type="button"
+              className="link-button"
+              onClick={() => onFilter("all")}
+            >
+              {t("worklist.filter.linked.clear")}
+            </button>
+          </p>
+        )}
         {/* What the page is NOT showing. Drawn only when there is a difference
             to report: on a day the queue carries whole, "12 of 12" is noise. */}
         {completeness !== null && (

--- a/frontend/src/screens/worklist.linkedcaption.test.tsx
+++ b/frontend/src/screens/worklist.linkedcaption.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { WorklistHeader } from "./worklist.header";
+import type { Worklist, WorklistFilter } from "./worklist.queries";
+
+// What a page narrowed BY LINK says about itself.
+//
+// The pill row holds the seven kinds of work and `all`. A link-only narrowing
+// presses none of them, so without a sentence the reader arrives from Brief at a
+// short queue with the whole row unselected and nothing saying why — which reads
+// as a broken page rather than a narrowed one. A unit test over the vocabulary
+// cannot see that: it passes whether or not anything is drawn.
+
+afterEach(cleanup);
+
+function day(): Worklist {
+  return {
+    as_of: "2026-09-02T09:00:00Z",
+    scope: "mine",
+    scope_options: ["mine"],
+    queue: [],
+    summary: { urgent: 0, due: 0, in_play: 0, lower_priority: 0, total: 0 },
+    sources_unavailable: [],
+    reach: [],
+    counts: [],
+    readings: {
+      revenue_at_risk_minor: 0,
+      revenue_currency: "EUR",
+      buyer_replies: 0,
+      prospecting: 0,
+      review: 0,
+      more_available: false,
+    },
+  } as unknown as Worklist;
+}
+
+function draw(filter: WorklistFilter, onFilter = () => {}) {
+  return render(
+    <LocaleProvider initial="en">
+      <WorklistHeader
+        day={day()}
+        loaded={0}
+        scope="mine"
+        filter={filter}
+        owner=""
+        onScope={() => {}}
+        onFilter={onFilter}
+        onOwner={() => {}}
+      />
+    </LocaleProvider>,
+  );
+}
+
+describe("a page narrowed by link", () => {
+  it("names the narrowing the reader arrived under", () => {
+    draw("changed_since_brief");
+
+    expect(
+      screen.getByText(en["worklist.filter.linked.changed_since_brief"], {
+        exact: false,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("names the feed's cut too", () => {
+    draw("except_decisions");
+
+    expect(
+      screen.getByText(en["worklist.filter.linked.except_decisions"], {
+        exact: false,
+      }),
+    ).toBeTruthy();
+  });
+
+  // The way back out. A narrowing with no pill pressed leaves the reader no
+  // control that undoes it, so the sentence carries one.
+  it("offers a way back to the whole queue", () => {
+    const onFilter = vi.fn();
+    draw("changed_since_brief", onFilter);
+
+    screen.getByText(en["worklist.filter.linked.clear"]).click();
+
+    expect(onFilter).toHaveBeenCalledWith("all");
+  });
+
+  // The positive control. Without it every assertion above would pass against a
+  // header that drew the caption on EVERY page, including the seven where a
+  // pressed pill already says which cut is on screen.
+  it("says nothing on a page the pill row can name", () => {
+    draw("meetings");
+
+    expect(screen.queryByText(en["worklist.filter.linked.clear"])).toBeNull();
+  });
+});

--- a/frontend/src/screens/worklist.linkedfilter.test.ts
+++ b/frontend/src/screens/worklist.linkedfilter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLinkedOnlyFilter,
+  WORKLIST_FILTER_PARAM,
+  worklistFilterFrom,
+  worklistLaneHref,
+} from "./worklist.header";
+
+// The narrowings a link asks for and a pill cannot.
+//
+// Both exist so that a count on Brief and the door beneath it read ONE filter.
+// The failure they replace was silent in both directions: an unknown filter
+// deliberately falls back to `all`, so a value the address could not spell
+// opened the whole queue under a number describing part of it, with nothing on
+// screen to say the narrowing had been dropped.
+
+describe("the filters that arrive by link", () => {
+  // The one that would have shipped the bug back. worklistFilterFrom used to
+  // read the PILL list; a link-only value checked against that list is not
+  // found, falls through to `all`, and the door opens everything.
+  it("reads a link-only value off the address instead of falling back", () => {
+    for (const filter of ["except_decisions", "changed_since_brief"] as const) {
+      const params = new Map([[WORKLIST_FILTER_PARAM, filter]]);
+      expect(worklistFilterFrom(params)).toBe(filter);
+    }
+  });
+
+  // The behaviour that makes the above a real risk rather than a theoretical
+  // one: an unknown lane is not an error, so a typo cannot be seen.
+  it("still falls back to all for a lane this build does not know", () => {
+    const params = new Map([[WORKLIST_FILTER_PARAM, "not_a_lane"]]);
+    expect(worklistFilterFrom(params)).toBe("all");
+  });
+
+  it("keeps reading the ordinary pill lanes", () => {
+    const params = new Map([[WORKLIST_FILTER_PARAM, "meetings"]]);
+    expect(worklistFilterFrom(params)).toBe("meetings");
+  });
+
+  // The href and the reader are one rule: whatever the builder writes, the
+  // screen must read back. Asserting the string alone would pass against a
+  // builder that spelled a value the reader then discards.
+  it("writes an address its own reader resolves to the same filter", () => {
+    for (const filter of ["except_decisions", "changed_since_brief"] as const) {
+      const href = worklistLaneHref(filter);
+      const query = new URLSearchParams(href.slice(href.indexOf("?") + 1));
+      const params = new Map(query.entries());
+
+      expect(href.startsWith("#/worklist?")).toBe(true);
+      expect(worklistFilterFrom(params)).toBe(filter);
+    }
+  });
+
+  // Only the two link-only values name themselves in the caption, because only
+  // they leave the pill row with nothing pressed. A pill lane doing so would
+  // print a sentence beside the pressed pill that already says it.
+  it("marks the link-only values and no others", () => {
+    expect(isLinkedOnlyFilter("except_decisions")).toBe(true);
+    expect(isLinkedOnlyFilter("changed_since_brief")).toBe(true);
+    for (const pill of ["all", "meetings", "decisions", "system"] as const) {
+      expect(isLinkedOnlyFilter(pill)).toBe(false);
+    }
+  });
+});

--- a/frontend/src/screens/worklist.narrowing.ts
+++ b/frontend/src/screens/worklist.narrowing.ts
@@ -14,12 +14,18 @@ import type { Worklist, WorklistFilter } from "./worklist.queries";
  * The per-category figures a narrowing is measured over, or null where they
  * cannot express it.
  *
- * Here rather than beside `completenessText`, because the answer depends on the
- * vocabulary this file owns. The seven kinds are one category each and `all` is
- * all of them. The two link-only narrowings are neither: `except_decisions` is
- * every category but one, which these figures DO express, and
- * `changed_since_brief` cuts across them per row on a freshness the counts do
- * not carry — so it has no answer here and says so.
+ * The seven kinds are one category each and `all` is all of them. NEITHER
+ * link-only narrowing is a category, and neither can be assembled from these
+ * figures:
+ *
+ *   - `changed_since_brief` cuts across every category on a per-row freshness
+ *     the counts do not carry.
+ *   - `except_decisions` excludes by SOURCE — the rows a brief draws as cards
+ *     are the `approval` ones — and these figures are keyed by category. The
+ *     complement of the `decisions` CATEGORY is a near-miss, not the same set:
+ *     it drops an introduction request the server keeps. `reach` carries the
+ *     per-source figures, but summing it here would be a second copy of the
+ *     source-to-category map the contract says the browser must not hold.
  *
  * Null rather than an empty list, and the difference is the defect: an empty
  * list sums to zero considered, which every reader of these figures reads as a
@@ -36,16 +42,8 @@ export function countsUnder(
   if (filter === "all") {
     return day.counts;
   }
-  if (filter === "except_decisions") {
-    return day.counts.filter((count) => count.category !== "decisions");
-  }
-  if (filter === "changed_since_brief") {
+  if (filter === "except_decisions" || filter === "changed_since_brief") {
     return null;
   }
   return day.counts.filter((count) => count.category === filter);
 }
-
-// The ways a row can be put down, derived from the item rather than spelled
-// again: the contract declares them inline, and a hand-written union would go
-// stale the moment the server gained a fourth — silently, because nothing
-// compares the two.

--- a/frontend/src/screens/worklist.narrowing.ts
+++ b/frontend/src/screens/worklist.narrowing.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Which of the day's per-category figures a given narrowing is measured over.
+//
+// Its own file because it belongs to neither of the two it sits between and both
+// are frozen at their length: `worklist.copy.ts` writes the completeness
+// sentence and `worklist.header.tsx` owns the lane vocabulary, and this is the
+// join — the rule that says a narrowing is not always one category.
+
+import type { Worklist, WorklistFilter } from "./worklist.queries";
+
+/**
+ * The per-category figures a narrowing is measured over, or null where they
+ * cannot express it.
+ *
+ * Here rather than beside `completenessText`, because the answer depends on the
+ * vocabulary this file owns. The seven kinds are one category each and `all` is
+ * all of them. The two link-only narrowings are neither: `except_decisions` is
+ * every category but one, which these figures DO express, and
+ * `changed_since_brief` cuts across them per row on a freshness the counts do
+ * not carry — so it has no answer here and says so.
+ *
+ * Null rather than an empty list, and the difference is the defect: an empty
+ * list sums to zero considered, which every reader of these figures reads as a
+ * complete page. A narrowing that hid fifteen rows reported nothing hidden.
+ *
+ * A caller must therefore say nothing rather than compute over the answer. The
+ * arithmetic would return null too, but by accident — and the accident stops
+ * being harmless the moment a caller grows an arm that prints a zero.
+ */
+export function countsUnder(
+  day: Worklist,
+  filter: WorklistFilter,
+): Worklist["counts"] | null {
+  if (filter === "all") {
+    return day.counts;
+  }
+  if (filter === "except_decisions") {
+    return day.counts.filter((count) => count.category !== "decisions");
+  }
+  if (filter === "changed_since_brief") {
+    return null;
+  }
+  return day.counts.filter((count) => count.category === filter);
+}
+
+// The ways a row can be put down, derived from the item rather than spelled
+// again: the contract declares them inline, and a hand-written union would go
+// stale the moment the server gained a fourth — silently, because nothing
+// compares the two.

--- a/frontend/src/screens/worklist.queries.ts
+++ b/frontend/src/screens/worklist.queries.ts
@@ -29,7 +29,10 @@ export type WorklistScope = Worklist["scope"];
 export const UNASSIGNED: WorklistScope = "unassigned";
 export type WorklistFilter = NonNullable<Worklist["filter"]>;
 export type WorklistCategory = WorklistItem["category"];
-
+// The ways a row can be put down, derived from the item rather than spelled
+// again: the contract declares them inline, and a hand-written union would go
+// stale the moment the server gained a fourth — silently, because nothing
+// compares the two.
 export type WorklistDisposition = NonNullable<
   WorklistItem["dispositions"]
 >[number];

--- a/frontend/src/screens/worklist.queries.ts
+++ b/frontend/src/screens/worklist.queries.ts
@@ -29,10 +29,7 @@ export type WorklistScope = Worklist["scope"];
 export const UNASSIGNED: WorklistScope = "unassigned";
 export type WorklistFilter = NonNullable<Worklist["filter"]>;
 export type WorklistCategory = WorklistItem["category"];
-// The ways a row can be put down, derived from the item rather than spelled
-// again: the contract declares them inline, and a hand-written union would go
-// stale the moment the server gained a fourth — silently, because nothing
-// compares the two.
+
 export type WorklistDisposition = NonNullable<
   WorklistItem["dispositions"]
 >[number];


### PR DESCRIPTION
Two links on Brief named a number and opened a list holding a different one.

- The feed footer counts `waitingRows`, which drops the approvals the Decisions deck above already draws. A rep told "11 more" landed on a list of 14.
- The overnight notice counts rows the night did not see and linked to the same bare `#/worklist`, so "3 things changed" opened a page of forty with no way to tell which three.

Neither count could be asked for: the filter vocabulary named seven kinds of work, and the feed needs the complement of one while the notice needs a moment rather than a kind.

## What changed

Two new server-side filter values:

- **`except_decisions`** — every row whose SOURCE is not `approval`. Deliberately not the complement of the `decisions` category, which is wider: an introduction request classifies as a decision and is not an approval, so a category reading drops a row the counting surface kept.
- **`changed_since_brief`** — rows whose material moment falls after the overnight run's data cutoff, same test that stamps each row's flag. With no run to compare against it answers empty rather than everything.

The freshness stamping moved above the narrowing (it ran over the cut page, so the filter saw nothing set and answered an empty queue), and the fold moved above it too (a fold mints a row, so filtering first tested the members and left the group untested).

Both values are addressable but are not pills — neither is a lane a reader picks — and `worklistFilterFrom` reads them off a wider list than the pill row so a link-only value cannot silently fall through to `all`. A page narrowed by link names its narrowing and offers the way back, because no pressed pill says which cut is on screen.

## Found by review, fixed here

- A folded group inherited no freshness flag and was dropped from a notice its members belonged in. It now answers for its members, true when ANY is fresh — the group's sort moment is its OLDEST member, and judging by that reports a failure that arrived this morning as old news.
- `system` stopped opening its own incident group: the unfold was keyed on `decisions` alone, but `system` folds too and the frontend's Review verb lands there, so pressing Review on a broken automation returned the group the reader pressed it on. That verb had this bug once before, from the other direction.
- The completeness sentence reported a truncated page as complete under a cross-category narrowing.
- A first attempt at the source rule walked a folded group's members, which drops a batch of approvals the client keeps.

## Gates

`make check-backend` and `make check-fe` both green. New parity gate `briefdeckexclusion_test.go` holds the client and server exclusion constants together and fails in either direction.

Every guard is mutation-checked: reverting the stamping move empties the narrowed page, filter-before-fold answers a member instead of the group, oldest-member aggregation drops it, the members-walking variant drops a batch, the category complement reports a wrong completeness, and a category added to or dropped from the fold set each fails exactly one named test.

Closes #5090

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the two Brief links so the number they name and the worklist they open read the same filter; both used to open a bare queue holding a different number of rows.

- Adds two link-only filter values, `except_decisions` and `changed_since_brief`, so each link narrows to the population it counted.
- `except_decisions` excludes by source (`approval`) to match the client's count, not by the wider `decisions` category.
- `changed_since_brief` returns only rows newer than the overnight cutoff, and nothing when no run happened.
- Freshness stamping and the fold now run before the narrowing, so the filters see the flags and judge the rows the page draws.
- Folded groups carry their members' freshness (new when any member is new) instead of being dropped from the notice.
- Fixes the `system` deck so Review on a broken automation opens the members, not the group itself.
- The completeness sentence stays silent for these cross-category narrowings instead of reporting a truncated page as complete.
- Adds a parity gate holding the client and server exclusion constant together.

Closes #5090.

<sup>Written for commit 5bc0241424d9ac683dc53027faa1c8b97b5fd87e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

