### PR TITLE
fix(consent): the transactional purpose key no longer authorizes a send by itself

### DIFF
--- a/backend/internal/modules/consent/authorizedecide.go
+++ b/backend/internal/modules/consent/authorizedecide.go
@@ -188,6 +188,30 @@ func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, personID, purpos
 	}
 	switch verdict.State {
 	case VerdictAllowed:
+		// THE TRANSACTIONAL CLASS DOES NOT CARRY ITSELF ON THE SEND PATH.
+		//
+		// VerdictForPerson allows ClassTransactional unconditionally, because
+		// Art 6(1)(b) really does mean the contract is the basis and the guard
+		// endpoint has to say so about a person who has an invoice coming. But
+		// that answer is about a PERSON, and this function is about a MESSAGE:
+		// we are only here because resolveCategory found nothing supporting
+		// this one — no thread, no live deal, no accepted claim — and
+		// resolutionForClass already said so with legacy_transactional_unevidenced.
+		//
+		// Taking the allow anyway is what let any message calling itself
+		// operational become one, on nothing but the purpose key. The lead arm
+		// closed this hole already (TestALeadTakesNoAuthorityFromATransactionalPurpose);
+		// this is the same hole for persons, and the reason code is the one the
+		// resolution had picked before the legacy gate overrode it.
+		//
+		// The guard endpoint and the legacy gate keep VerdictForPerson's answer
+		// untouched: an invoice with real evidence resolves as supported and
+		// returns from decideResolved's supported arm, never reaching here.
+		if purpose.Class == ClassTransactional {
+			d.Verdict = commsauthz.VerdictReview
+			d.ReasonCode = commsauthz.ReasonLegacyTransactionalUnevidenced
+			break
+		}
 		// A basis this call DERIVED is written down before the send relies on
 		// it (Art. 5(2)). The engine is the only authority now, so it is the
 		// only thing left that can make that record: grantedForRecipient used

--- a/backend/internal/modules/consent/authorizedecide.go
+++ b/backend/internal/modules/consent/authorizedecide.go
@@ -96,6 +96,24 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}
+	// ONLY EVIDENCE THIS CALLER WAS SHOWN TO HOLD travels any further.
+	//
+	// refuseUnreadableEvidence runs inside validate, and validate runs only for
+	// arm 3 of resolution — the thread and live-deal arms answer before it. So
+	// a message allowed by one of those two carries evidence ids nobody has
+	// checked this caller may see, and writing them to the decision row would
+	// hand them to the transmit phase. That phase runs under the system
+	// principal, for which auth.Require returns nil, so an unchecked id there
+	// becomes an authorization the sender could never have obtained: name any
+	// invoice in the installation, get allowed by an open deal at staging, and
+	// have the invoice arm allow it at transmit.
+	//
+	// EvidenceChecked is the resolution's own record of having passed that
+	// check, so what reaches the row is the intersection of "named" and
+	// "readable by the person who named it".
+	if res.EvidenceChecked {
+		d.Evidence = req.Evidence
+	}
 	if res.Supported {
 		// The record bears the category out — and the subject may still have
 		// said stop. The evidence arms never read person_consent, so this is

--- a/backend/internal/modules/consent/authorizeevidencecarry.go
+++ b/backend/internal/modules/consent/authorizeevidencecarry.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Carrying the evidence a message was staged on to the phase that sends it.
+//
+// The transmit phase re-asks the whole question, which is the design: a thread
+// can be archived and a deal can close while a delivery waits in the queue, so
+// the answer must be taken again against the record as it is now. But re-asking
+// needs the same INPUTS. stagedRequestFor rebuilt the question from the claimed
+// category and the thread key alone, so a message supported by a named invoice
+// or contract arrived at transmit with a zero id, found no document, and fell
+// through to whatever the legacy purpose key said.
+//
+// While the transactional class allowed unconditionally that fall-through hid
+// the loss: the invoice went out on the purpose key rather than on the invoice,
+// and the two answers agreed by accident. They no longer do.
+//
+// WHAT IS CARRIED IS THE POINTER, NEVER THE VERDICT. An id is a question to ask
+// again — is this invoice still live, is this person still employed there — and
+// every one of those checks runs at transmit exactly as it ran at staging. The
+// resolution itself is deliberately not carried, for the reason stagedClaims
+// gives: it would let a message ride an answer the record no longer supports.
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// stagedEvidence is the wire shape of communication_decision.evidence.
+//
+// Written with explicit json tags and omitempty so a row carries only the ids
+// that were actually named: an absent key and a zero uuid mean the same thing
+// to the reader, and the sparse form is what makes the column readable to a
+// human looking at a decision row.
+type stagedEvidence struct {
+	ActivityID     *ids.UUID `json:"activity_id,omitempty"`
+	DealID         *ids.UUID `json:"deal_id,omitempty"`
+	InvoiceID      *ids.UUID `json:"invoice_id,omitempty"`
+	ContractID     *ids.UUID `json:"contract_id,omitempty"`
+	ConsentEventID *ids.UUID `json:"consent_event_id,omitempty"`
+	BasisID        *ids.UUID `json:"basis_id,omitempty"`
+}
+
+// evidenceJSON renders the evidence a caller named for storage on the decision
+// row. An empty Evidence renders as {}, which is the column's own default.
+func evidenceJSON(e commsauthz.Evidence) ([]byte, error) {
+	out, err := json.Marshal(stagedEvidence{
+		ActivityID:     nonZeroID(e.ActivityID),
+		DealID:         nonZeroID(e.DealID),
+		InvoiceID:      nonZeroID(e.InvoiceID),
+		ContractID:     nonZeroID(e.ContractID),
+		ConsentEventID: nonZeroID(e.ConsentEventID),
+		BasisID:        nonZeroID(e.BasisID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("consent: render the staged evidence: %w", err)
+	}
+	return out, nil
+}
+
+// evidenceFrom reads back what evidenceJSON wrote.
+//
+// A row whose evidence cannot be parsed yields NO evidence rather than an
+// error. Every id it holds is re-validated at transmit anyway, so the worst an
+// unreadable column can do is send the message down the same path it took
+// before this file existed — a review naming what could not be evidenced.
+// Failing the dispatch instead would turn one malformed row into a stuck
+// delivery.
+func evidenceFrom(raw []byte) commsauthz.Evidence {
+	if len(raw) == 0 {
+		return commsauthz.Evidence{}
+	}
+	var in stagedEvidence
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return commsauthz.Evidence{}
+	}
+	return commsauthz.Evidence{
+		ActivityID:     derefID(in.ActivityID),
+		DealID:         derefID(in.DealID),
+		InvoiceID:      derefID(in.InvoiceID),
+		ContractID:     derefID(in.ContractID),
+		ConsentEventID: derefID(in.ConsentEventID),
+		BasisID:        derefID(in.BasisID),
+	}
+}
+
+func nonZeroID(id ids.UUID) *ids.UUID {
+	if id.IsZero() {
+		return nil
+	}
+	return &id
+}
+
+func derefID(id *ids.UUID) ids.UUID {
+	if id == nil {
+		return ids.UUID{}
+	}
+	return *id
+}

--- a/backend/internal/modules/consent/authorizeevidencecarry_test.go
+++ b/backend/internal/modules/consent/authorizeevidencecarry_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The evidence round-trip, and the three shapes a row can hold that are not a
+// round-trip at all.
+//
+// Unit, not integration: this is a pure encode/decode pair, and the question it
+// answers — does a delivery staged before this code shipped still dispatch — is
+// about what the decoder does with the bytes, not about any join.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// Every id a caller can name survives the trip to the column and back.
+//
+// Asserted field by field rather than with a struct compare, so a field ADDED
+// to Evidence and forgotten in evidenceJSON fails here naming itself, rather
+// than failing as "the structs differ" somewhere a reader has to diff by eye.
+func TestEveryEvidenceIDSurvivesTheRoundTrip(t *testing.T) {
+	in := commsauthz.Evidence{
+		ActivityID:     ids.NewV7(),
+		DealID:         ids.NewV7(),
+		InvoiceID:      ids.NewV7(),
+		ContractID:     ids.NewV7(),
+		ConsentEventID: ids.NewV7(),
+		BasisID:        ids.NewV7(),
+	}
+	raw, err := evidenceJSON(in)
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	got := evidenceFrom(raw)
+
+	for _, c := range []struct {
+		field    string
+		want, is ids.UUID
+	}{
+		{"activity", in.ActivityID, got.ActivityID},
+		{"deal", in.DealID, got.DealID},
+		{"invoice", in.InvoiceID, got.InvoiceID},
+		{"contract", in.ContractID, got.ContractID},
+		{"consent event", in.ConsentEventID, got.ConsentEventID},
+		{"basis", in.BasisID, got.BasisID},
+	} {
+		if c.is != c.want {
+			t.Errorf("the %s id did not survive: got %v, want %v", c.field, c.is, c.want)
+		}
+	}
+}
+
+// A DELIVERY STAGED BEFORE THIS CODE SHIPPED STILL DISPATCHES.
+//
+// communication_decision.evidence defaults to '{}', so every row written by
+// the old staging writer holds an empty object rather than NULL. It must decode
+// to no evidence — which is exactly the input the transmit phase had before
+// this file existed, so such a delivery takes the path it always took.
+//
+// The unreadable case is the one that matters most and is the least likely to
+// be tried by hand: a column somebody edited, or a shape written by a version
+// that disagreed about the field names. It yields no evidence rather than an
+// error, because failing the decode would turn one malformed row into a stuck
+// delivery, and the ids are all re-validated at transmit anyway.
+func TestAnUnusableEvidenceColumnYieldsNoEvidenceRatherThanAnError(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		raw  []byte
+	}{
+		{"the column default an old row holds", []byte(`{}`)},
+		{"a NULL the driver hands over as nil", nil},
+		{"an empty string", []byte(``)},
+		{"not json at all", []byte(`{ruined`)},
+		{"json of the wrong shape", []byte(`["an","array"]`)},
+		{"an id that is not a uuid", []byte(`{"invoice_id":"not-a-uuid"}`)},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got := evidenceFrom(c.raw)
+			if got != (commsauthz.Evidence{}) {
+				t.Errorf("decoded %v, want no evidence at all", got)
+			}
+		})
+	}
+}
+
+// An empty Evidence renders as the column's own default rather than as a row of
+// nulls, so a decision taken on no named record reads as one.
+func TestNoEvidenceRendersAsTheEmptyObject(t *testing.T) {
+	raw, err := evidenceJSON(commsauthz.Evidence{})
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	if string(raw) != `{}` {
+		t.Errorf("rendered %s, want {}", raw)
+	}
+}

--- a/backend/internal/modules/consent/authorizeresolve.go
+++ b/backend/internal/modules/consent/authorizeresolve.go
@@ -43,6 +43,18 @@ type resolution struct {
 	Supported bool
 	// Reason is the code an unsupported resolution carries.
 	Reason string
+	// EvidenceChecked reports that this resolution went through validate, and
+	// therefore through refuseUnreadableEvidence — the caller was shown to hold
+	// the grants for every record they named.
+	//
+	// It gates what may be written to the decision row for the transmit phase
+	// to re-read. The thread and live-deal arms answer BEFORE validate runs, so
+	// a message allowed by one of them has evidence ids nobody has checked the
+	// caller may see. Carrying those forward would hand them to the transmit
+	// phase, which runs under the system principal — auth.Require returns nil
+	// for it — and so would turn an unchecked id into an authorization the
+	// sender could not have obtained themselves.
+	EvidenceChecked bool
 }
 
 // resolveCategory works out what this message is for one recipient.

--- a/backend/internal/modules/consent/authorizeresolve.go
+++ b/backend/internal/modules/consent/authorizeresolve.go
@@ -204,14 +204,20 @@ func resolutionForClass(class Class) resolution {
 // at once. A single row taken for the whole delivery would judge every
 // recipient by whichever one the query happened to return.
 //
-// Only the CLAIM is carried forward, never the engine's earlier resolution.
-// Carrying the resolution would let a message ride an answer the record no
-// longer supports — a thread can be archived and a deal can close while a
-// delivery waits in the queue — and it would carry one recipient's answer onto
-// another's.
+// Only the CLAIM and the EVIDENCE POINTERS are carried forward, never the
+// engine's earlier resolution. Carrying the resolution would let a message ride
+// an answer the record no longer supports — a thread can be archived and a deal
+// can close while a delivery waits in the queue — and it would carry one
+// recipient's answer onto another's.
+//
+// The evidence is a different thing from the resolution: an invoice id is a
+// question to ask again, not an answer to reuse, and every check that ran at
+// staging runs again here against the record as it is now. Without it the
+// document validators arrive at transmit with a zero id and refuse a message
+// they had supported minutes earlier. See authorizeevidencecarry.go.
 func stagedClaims(ctx context.Context, tx pgx.Tx, deliveryID ids.UUID) (map[string]stagedClaim, error) {
 	rows, err := tx.Query(ctx, `
-		SELECT DISTINCT ON (recipient_address) recipient_address, requested_category
+		SELECT DISTINCT ON (recipient_address) recipient_address, requested_category, evidence
 		  FROM communication_decision
 		 WHERE delivery_id = $1 AND phase = 'staging'
 		 -- id, not decided_at: every row of one staging transaction carries the
@@ -227,13 +233,15 @@ func stagedClaims(ctx context.Context, tx pgx.Tx, deliveryID ids.UUID) (map[stri
 	for rows.Next() {
 		var address string
 		var claimed *string
-		if err := rows.Scan(&address, &claimed); err != nil {
+		var evidence []byte
+		if err := rows.Scan(&address, &claimed, &evidence); err != nil {
 			return nil, fmt.Errorf("consent: read what this delivery was staged as: %w", err)
 		}
 		var out stagedClaim
 		if claimed != nil {
 			out.category = commsauthz.Category(*claimed)
 		}
+		out.evidence = evidenceFrom(evidence)
 		claims[address] = out
 	}
 	if err := rows.Err(); err != nil {
@@ -257,6 +265,10 @@ func stagedRequestFor(req commsauthz.TransmitRequest, r connector.Recipient, cla
 		Recipients:       []connector.Recipient{r},
 		Context:          staged.category,
 		LegacyPurposeKey: req.PurposeKey,
+		// The records this recipient's message was staged on. Re-validated
+		// here, never trusted: a voided invoice or an ended employment refuses
+		// at transmit exactly as it would have at staging.
+		Evidence: staged.evidence,
 		// The conversation, carried from the delivery row. Without it the thread
 		// arm cannot run at transmit and a reply authorized at staging parks.
 		ThreadKey: threadKey,
@@ -296,5 +308,7 @@ func deliveryThreadKey(ctx context.Context, tx pgx.Tx, deliveryID ids.UUID) (str
 // written at STAGING, where the anchor is still in hand — see recordBasis's
 // caller.
 type stagedClaim struct {
+	// evidence is the ids the message was staged on, re-asked at transmit.
+	evidence commsauthz.Evidence
 	category commsauthz.Category
 }

--- a/backend/internal/modules/consent/authorizeresolve_integration_test.go
+++ b/backend/internal/modules/consent/authorizeresolve_integration_test.go
@@ -471,6 +471,42 @@ func TestTheLegacyTransactionalPurposeNoLongerCarriesItself(t *testing.T) {
 	}
 }
 
+// AND THE VERDICT AGREES WITH THE RESOLUTION.
+//
+// The resolution above has said "not supported, and here is why" since the
+// escape hatch was closed, but the DECISION went on allowing: decideResolved
+// handed an unsupported transactional claim to legacyVerdictFor, which asked
+// VerdictForPerson, whose ClassTransactional arm allows unconditionally. So the
+// engine recorded its objection and sent the mail anyway, on nothing but the
+// purpose key — which is the hole the resolution change was supposed to close.
+//
+// The person here has an address, a seeded transactional purpose, and NO
+// invoice, contract, thread or deal. The only thing saying this message is
+// operational is the caller's own purpose key.
+//
+// The lead arm closed this already (TestALeadTakesNoAuthorityFromATransactionalPurpose
+// in leadconsent_integration_test.go); persons were the remaining half.
+func TestTheLegacyTransactionalPurposeDoesNotAllowTheSend(t *testing.T) {
+	e := setupResolve(t)
+	e.seedPurpose(t, "transactional", "transactional")
+
+	got := e.decide(t, commsauthz.Request{LegacyPurposeKey: "transactional"})
+
+	if got.Verdict == commsauthz.VerdictAllow {
+		t.Fatalf("verdict = allow (%s): the transactional key authorized a send on its own, "+
+			"with no invoice, contract, thread or deal behind it", got.ReasonCode)
+	}
+	if got.ReasonCode != commsauthz.ReasonLegacyTransactionalUnevidenced {
+		t.Errorf("reason = %q, want legacy_transactional_unevidenced — the refusal should name "+
+			"the missing evidence, not a generic denial", got.ReasonCode)
+	}
+	// Resolved still names what the engine worked out, so the row reads as an
+	// account notice that could not be evidenced rather than as a mystery.
+	if got.Resolved != commsauthz.CategoryAccountNotice {
+		t.Errorf("resolved %q, want account_notice", got.Resolved)
+	}
+}
+
 // A recipient the engine can say nothing about resolves to marketing and is
 // unsupported — the strictest reading, because an unknown purpose is not a
 // reason to assume an operational one.

--- a/backend/internal/modules/consent/authorizestaging.go
+++ b/backend/internal/modules/consent/authorizestaging.go
@@ -89,6 +89,13 @@ func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID
 	if err != nil {
 		return err
 	}
+	// The ids this message was staged on, so the transmit phase can put the
+	// same questions to the same records. See authorizeevidencecarry.go: what
+	// the row carries is the pointer, never the verdict.
+	evidence, err := evidenceJSON(req.Evidence)
+	if err != nil {
+		return err
+	}
 	for _, d := range set.Decisions {
 		subjectKind := nullableText(d.SubjectKind)
 		var subjectID *ids.UUID
@@ -110,14 +117,14 @@ func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID
 			INSERT INTO communication_decision
 			  (delivery_id, attempt, decision_set_id, recipient_address, subject_kind, subject_id,
 			   phase, requested_category, resolved_category, verdict, reason_code, basis, suppression,
-			   content_fingerprint, mode, actor)
-			VALUES ($1,0,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+			   content_fingerprint, mode, actor, evidence)
+			VALUES ($1,0,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
 			ON CONFLICT (decision_set_id, recipient_address, phase) DO NOTHING`,
 			deliveryID, setID, decisionRecipientKey(d.Recipient),
 			subjectKind, subjectID, string(d.Phase), nullableCategory(d.Requested),
 			string(d.Resolved), string(d.Verdict), d.ReasonCode,
 			nullableBasis(d.Basis), nullableText(d.Suppression),
-			sum[:], string(d.Mode), by)
+			sum[:], string(d.Mode), by, evidence)
 		if err != nil {
 			return fmt.Errorf("consent: record the staging decision: %w", err)
 		}

--- a/backend/internal/modules/consent/authorizestaging.go
+++ b/backend/internal/modules/consent/authorizestaging.go
@@ -89,14 +89,20 @@ func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID
 	if err != nil {
 		return err
 	}
-	// The ids this message was staged on, so the transmit phase can put the
-	// same questions to the same records. See authorizeevidencecarry.go: what
-	// the row carries is the pointer, never the verdict.
-	evidence, err := evidenceJSON(req.Evidence)
-	if err != nil {
-		return err
-	}
 	for _, d := range set.Decisions {
+		// The ids THIS RECIPIENT'S decision was taken on, so the transmit phase
+		// can put the same questions to the same records.
+		//
+		// From the decision and not from the request: decideOne copies the
+		// request's evidence onto the decision only when the resolution passed
+		// refuseUnreadableEvidence, so an id the caller was never shown to hold
+		// is absent here rather than being handed to a phase that runs as the
+		// system principal. See authorizeevidencecarry.go, and decideOne's own
+		// note on why the two differ.
+		evidence, err := evidenceJSON(d.Evidence)
+		if err != nil {
+			return err
+		}
 		subjectKind := nullableText(d.SubjectKind)
 		var subjectID *ids.UUID
 		if d.SubjectKind != "" {
@@ -113,7 +119,7 @@ func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID
 		// A denial under observe or warn DOES commit, and those rows are real.
 		// They are read from the table, not from a counter that would mean one
 		// thing in one posture and another in the next.
-		_, err := tx.Exec(ctx, `
+		_, err = tx.Exec(ctx, `
 			INSERT INTO communication_decision
 			  (delivery_id, attempt, decision_set_id, recipient_address, subject_kind, subject_id,
 			   phase, requested_category, resolved_category, verdict, reason_code, basis, suppression,

--- a/backend/internal/modules/consent/authorizevalidators.go
+++ b/backend/internal/modules/consent/authorizevalidators.go
@@ -67,6 +67,24 @@ func (g *Gate) validate(ctx context.Context, tx pgx.Tx, req commsauthz.Request, 
 	if err := refuseUnreadableEvidence(ctx, tx, req); err != nil {
 		return resolution{}, err
 	}
+	res, err := g.validateCategory(ctx, tx, req, subject, category, w, unsupported)
+	if err != nil {
+		return resolution{}, err
+	}
+	// PAST THE READABILITY CHECK, so the ids this request named may be written
+	// down for the transmit phase to ask about again.
+	//
+	// Stamped here rather than inside each arm because it is a fact about the
+	// PATH and not about the answer: refuseUnreadableEvidence ran and admitted,
+	// which is true of every arm below this line and of no arm above it.
+	res.EvidenceChecked = true
+	return res, nil
+}
+
+// validateCategory is validate's dispatch, split out so the readability check
+// above and the EvidenceChecked stamp bracket every arm — rather than being
+// repeated in six places and forgotten in the seventh somebody adds.
+func (g *Gate) validateCategory(ctx context.Context, tx pgx.Tx, req commsauthz.Request, subject subjectRef, category commsauthz.Category, w packRules, unsupported resolution) (resolution, error) {
 	switch category {
 	case commsauthz.CategoryReplyToInbound, commsauthz.CategoryRequestedFollowup:
 		return g.validateRequestedFollowup(ctx, tx, subject, w, category)

--- a/backend/internal/modules/consent/authorizevalidators_integration_test.go
+++ b/backend/internal/modules/consent/authorizevalidators_integration_test.go
@@ -229,6 +229,88 @@ func TestAnEvidencedInvoiceSurvivesToTransmit(t *testing.T) {
 	}
 }
 
+// EVIDENCE NOBODY CHECKED THE SENDER MAY SEE IS NOT WRITTEN DOWN.
+//
+// This is the security half of carrying evidence, and it is why the decision
+// row takes its ids from the DECISION rather than from the request.
+//
+// refuseUnreadableEvidence lives inside validate, and validate runs only for
+// arm 3 of resolution — a message already answered by the thread arm or the
+// live-deal arm never reaches it. So a sender can be allowed by an open deal
+// while naming an invoice id in the same request, and nothing has asked whether
+// they hold finance.read.
+//
+// If that id reached the row, the transmit phase would read it back and put it
+// to the invoice validator — under the SYSTEM principal, for which auth.Require
+// returns nil unconditionally. An id the sender could not open at staging would
+// authorize their message one phase later. That is a privilege escalation with
+// no race and no tampering: file a message under a deal you can see, name an
+// invoice you cannot, and let the worker do the reading.
+//
+// The fixture is exactly that shape: a live deal the recipient is a stakeholder
+// on (so the deal arm answers first), a REAL invoice for an organization that
+// employs them (so the invoice arm would allow if it ever ran), and a sender
+// principal holding neither finance nor contract.
+func TestEvidenceTheSenderCannotReadIsNotCarriedPastStaging(t *testing.T) {
+	e := setupResolve(t)
+	org := e.organization(t)
+	invoice := e.invoice(t, org, false)
+	e.employ(t, org)
+	deal := e.openDeal(t, "open", true)
+
+	// A seat that may write mail and read people, and may NOT read finance.
+	// Everything else about the context is the ordinary sending principal.
+	e.ctx = principal.WithActor(e.ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.user.String(), UserID: e.user,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				"person": {Read: true},
+				"deal":   {Read: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+
+	delivery := e.plantDelivery(t)
+	req := commsauthz.Request{
+		Recipients: []connector.Recipient{{Email: e.address}},
+		// No claimed context: the deal arm answers before any claim is looked
+		// at, which is the whole point — the sender never has to name a
+		// category the validators would check.
+		Links:    []ids.UUID{deal},
+		Evidence: commsauthz.Evidence{InvoiceID: invoice},
+	}
+	var staged commsauthz.DecisionSet
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		var err error
+		staged, err = e.gate.AuthorizeStagingTx(e.ctx, tx, delivery, req)
+		return err
+	}); err != nil {
+		t.Fatalf("staging: %v", err)
+	}
+	if len(staged.Decisions) != 1 || staged.Decisions[0].Verdict != commsauthz.VerdictAllow {
+		t.Fatalf("the live deal did not allow the message, so this fixture is not testing what it "+
+			"claims to: %+v", staged.Decisions)
+	}
+	if got := staged.Decisions[0].Resolved; got != commsauthz.CategoryActiveDealFollowup {
+		t.Fatalf("resolved %q, want active_deal_followup — the deal arm has to be the one that "+
+			"answered, or this fixture proves nothing", got)
+	}
+
+	// THE ROW MUST NOT HOLD THE INVOICE.
+	var raw []byte
+	if err := e.owner.QueryRow(context.Background(), `
+		SELECT evidence FROM communication_decision
+		 WHERE delivery_id = $1 AND phase = 'staging'`, delivery).Scan(&raw); err != nil {
+		t.Fatalf("reading the decision row: %v", err)
+	}
+	if carried := evidenceFrom(raw); carried.InvoiceID != (ids.UUID{}) {
+		t.Fatalf("the decision row carries invoice %v, which nobody checked this sender may read: "+
+			"the transmit phase runs as the system principal and would allow on it", carried.InvoiceID)
+	}
+}
+
 // AN ENDED EMPLOYMENT DOES NOT REACH. Somebody who left the customer is not the
 // person their invoices go to.
 //

--- a/backend/internal/modules/consent/authorizevalidators_integration_test.go
+++ b/backend/internal/modules/consent/authorizevalidators_integration_test.go
@@ -152,6 +152,83 @@ func TestAnInvoiceReachesAContactAtTheCustomer(t *testing.T) {
 	}
 }
 
+// AND IT STILL REACHES THEM ONE PHASE LATER.
+//
+// The evidence that supported this message at staging is not written to the
+// decision row — communication_decision has an evidence column and nothing
+// fills it — so stagedRequestFor rebuilds the transmit question with the
+// category and the thread key and NOTHING ELSE. validateInvoice then reads a
+// zero InvoiceID, finds no invoice, and the message falls through to the
+// legacy purpose arm.
+//
+// That fall-through used to end in the transactional class's unconditional
+// allow, which is what hid the evidence loss: the invoice went out on the
+// purpose key rather than on the invoice, and the two answers happened to
+// agree. Closing the key means they no longer do, and a real invoice would
+// park at transmit after staging clean.
+//
+// So this test is the one that fails if the fix ships without the evidence
+// being carried. It is the rep-facing half of the change: refusing a message
+// nobody can evidence is the point, refusing an invoice somebody DID evidence
+// is the regression.
+func TestAnEvidencedInvoiceSurvivesToTransmit(t *testing.T) {
+	e := setupResolve(t)
+	org := e.organization(t)
+	invoice := e.invoice(t, org, false)
+	e.employ(t, org)
+	e.seedPurpose(t, "transactional", "transactional")
+
+	req := commsauthz.Request{
+		Context:  commsauthz.CategoryInvoiceOrPayment,
+		Evidence: commsauthz.Evidence{InvoiceID: invoice},
+		// The shape a caller who has not migrated still sends: the modern
+		// context AND the old key. The key must not be what carries it, and
+		// its presence must not take the evidence away either.
+		LegacyPurposeKey: "transactional",
+	}
+
+	// Through the REAL staging writer, not a hand-planted row. A fixture that
+	// wrote its own communication_decision would be asserting about the
+	// fixture: the whole question is whether AuthorizeStagingTx records the
+	// evidence, so the test that answers it has to be the one that calls it.
+	delivery := e.plantDelivery(t)
+	req.Recipients = []connector.Recipient{{Email: e.address}}
+	var staged commsauthz.DecisionSet
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		var err error
+		staged, err = e.gate.AuthorizeStagingTx(e.ctx, tx, delivery, req)
+		return err
+	}); err != nil {
+		t.Fatalf("staging: %v", err)
+	}
+	if len(staged.Decisions) != 1 || staged.Decisions[0].Verdict != commsauthz.VerdictAllow {
+		t.Fatalf("staging refused an evidenced invoice: %+v", staged.Decisions)
+	}
+
+	// Now the transmit question, built the way authorizetransmit.go builds it.
+	var got commsauthz.Decision
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		claims, err := stagedClaims(e.ctx, tx, delivery)
+		if err != nil {
+			return err
+		}
+		r := connector.Recipient{Email: e.address}
+		got, err = e.gate.decideOne(e.ctx, tx, r,
+			stagedRequestFor(commsauthz.TransmitRequest{
+				DeliveryID: delivery, PurposeKey: "transactional",
+			}, r, claims, ""), commsauthz.PhaseTransmit)
+		return err
+	}); err != nil {
+		t.Fatalf("deciding at transmit: %v", err)
+	}
+
+	if got.Verdict != commsauthz.VerdictAllow {
+		t.Fatalf("an invoice authorized at staging was refused at transmit (%s / %s): the evidence "+
+			"that supported it is not carried past staging, and the transactional key is no longer "+
+			"there to accidentally cover for that", got.Verdict, got.ReasonCode)
+	}
+}
+
 // AN ENDED EMPLOYMENT DOES NOT REACH. Somebody who left the customer is not the
 // person their invoices go to.
 //

--- a/backend/internal/modules/consent/settingsentry.go
+++ b/backend/internal/modules/consent/settingsentry.go
@@ -40,10 +40,13 @@ const authorizationModesObject = "installation_settings"
 // AuthorizationModes maps a communication category to the authority the
 // engine's answer carries for it.
 //
-// A category absent from the map is `observe`, so a category added to the
-// vocabulary tomorrow arrives in the position where it is recorded and not yet
-// binding, whatever the stored map says. That default is what makes the map a
-// set of EXCEPTIONS rather than a table that must be complete to be correct.
+// A category absent from the map is `enforce`, and a stored map that omits one
+// is REFUSED at the door. Absent used to mean observe, on the reasoning that a
+// category added tomorrow should arrive recorded and not yet binding. That
+// reasoning had the failure backwards: a category nobody remembered to add
+// shipped not binding and nothing said so, which is a silent hole in the exact
+// shape of the category somebody forgot. Refusing the incomplete map moves the
+// discovery to the save, where a person is present to read it.
 //
 // The shipped default names every category that exists today, at `enforce`.
 // Observe was the rollout, not the destination: it ran so the disagreement
@@ -98,31 +101,60 @@ func validateAuthorizationModes(in map[string]string) error {
 			unknownModes = append(unknownModes, mode)
 		}
 	}
+	// A PARTIAL map is refused; an EMPTY one is not.
+	//
+	// Empty means unconfigured, and it has to keep validating: it is what an
+	// installation that never touched this posture stores, and refusing it
+	// would block saving any other setting on the same surface. Unconfigured
+	// resolves to enforce through ModeFor, which is where the safe answer
+	// belongs.
+	//
+	// A map naming SOME categories is different — somebody sat down and made
+	// per-category decisions, and the ones they left out are the ones they did
+	// not think about. Completing those silently answers a question they did
+	// not answer while reading back as if their map had been taken as written.
+	var missing []string
+	if len(in) > 0 {
+		for _, c := range commsauthz.Categories() {
+			if _, named := in[string(c)]; !named {
+				missing = append(missing, string(c))
+			}
+		}
+	}
 	sort.Strings(unknownCategories)
 	sort.Strings(unknownModes)
+	sort.Strings(missing)
 	if len(unknownCategories) > 0 {
 		return fmt.Errorf("not a communication category: %s", strings.Join(unknownCategories, ", "))
 	}
 	if len(unknownModes) > 0 {
 		return fmt.Errorf("a mode is observe, warn or enforce, not: %s", strings.Join(unknownModes, ", "))
 	}
+	if len(missing) > 0 {
+		return fmt.Errorf("every category needs a mode; these have none: %s", strings.Join(missing, ", "))
+	}
 	return nil
 }
 
 // ModeFor answers the authority the engine carries for one category.
 //
-// Absent means observe, which is what makes the stored map a set of
-// EXCEPTIONS to the safe default rather than a table that must list every
-// category to be correct. A map that had to be complete would put a new
-// category into whatever position the last author typed.
+// Absent means ENFORCE. validateAuthorizationModes refuses a stored map that
+// omits a category, so absence here is not a configuration an operator chose —
+// it is a category that reached this code without one, and the only two ways
+// that happens are a map written before the category existed and a bug. Both
+// are cases where the engine's own answer should bind.
+//
+// The old default was observe, which turned exactly those two cases into mail
+// going out on the legacy gate's word with nothing recording that the engine
+// had been overruled.
 func ModeFor(modes map[string]string, category commsauthz.Category) commsauthz.Mode {
 	switch commsauthz.Mode(modes[string(category)]) {
-	case commsauthz.ModeEnforce:
-		return commsauthz.ModeEnforce
+	case commsauthz.ModeObserve:
+		return commsauthz.ModeObserve
 	case commsauthz.ModeWarn:
 		return commsauthz.ModeWarn
 	default:
-		return commsauthz.ModeObserve
+		return commsauthz.ModeEnforce
 	}
 }
 

--- a/backend/internal/modules/consent/settingsentry_test.go
+++ b/backend/internal/modules/consent/settingsentry_test.go
@@ -64,6 +64,34 @@ func TestAPartialMapIsRefused(t *testing.T) {
 	}
 }
 
+// A PARTIAL MAP THAT PREDATES THE VALIDATOR IS READ SAFELY.
+//
+// The validator guards the write, and settings.ApplyTx does not re-run it on
+// the read — so a map stored before this change arrives at the engine exactly
+// as it was written, with categories missing. That is not a hypothetical: it
+// is what every installation that moved one category to observe now holds.
+//
+// The reading has to be safe on its own, without help from the validator, and
+// safe here means the unnamed categories bind the engine's answer. This asserts
+// the whole map rather than one lookup, because the failure being guarded
+// against is a category nobody thought about.
+func TestAStoredPartialMapReadsTheRestAsEnforce(t *testing.T) {
+	// The shape an operator who rolled marketing back would have left behind.
+	stored := map[string]string{string(commsauthz.CategoryMarketing): "observe"}
+
+	if got := ModeFor(stored, commsauthz.CategoryMarketing); got != commsauthz.ModeObserve {
+		t.Errorf("the named category resolved to %q, want the observe that was stored", got)
+	}
+	for _, c := range commsauthz.Categories() {
+		if c == commsauthz.CategoryMarketing {
+			continue
+		}
+		if got := ModeFor(stored, c); got != commsauthz.ModeEnforce {
+			t.Errorf("%s was left out of a stored map and resolved to %q, want enforce", c, got)
+		}
+	}
+}
+
 // A misspelled category is refused rather than stored. Accepting one would let
 // it silently mean nothing, which reads exactly like a rollout that was
 // configured and did not take.

--- a/backend/internal/modules/consent/settingsentry_test.go
+++ b/backend/internal/modules/consent/settingsentry_test.go
@@ -12,38 +12,55 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
-// Absent means observe, which is what lets the stored map be a set of
-// EXCEPTIONS rather than a table that must list every category to be correct.
-// A map that had to be complete would put a category added tomorrow into
-// whatever position the last author happened to type.
-func TestACategoryTheMapDoesNotNameObserves(t *testing.T) {
-	modes := map[string]string{string(commsauthz.CategoryReplyToInbound): "enforce"}
-	if got := ModeFor(modes, commsauthz.CategoryMarketing); got != commsauthz.ModeObserve {
-		t.Errorf("an unnamed category resolved to %q, want observe", got)
+// Absent means ENFORCE, and the validator refuses a partial map, so the two
+// together mean no category reaches the engine without a decision about it.
+// Absent used to mean observe: a category nobody remembered to name then
+// shipped recorded-but-not-binding, with nothing saying so.
+func TestACategoryTheMapDoesNotNameEnforces(t *testing.T) {
+	modes := map[string]string{string(commsauthz.CategoryReplyToInbound): "observe"}
+	if got := ModeFor(modes, commsauthz.CategoryMarketing); got != commsauthz.ModeEnforce {
+		t.Errorf("an unnamed category resolved to %q, want enforce", got)
 	}
-	if got := ModeFor(modes, commsauthz.CategoryReplyToInbound); got != commsauthz.ModeEnforce {
-		t.Errorf("a named category resolved to %q, want enforce", got)
+	if got := ModeFor(modes, commsauthz.CategoryReplyToInbound); got != commsauthz.ModeObserve {
+		t.Errorf("a named category resolved to %q, want observe", got)
 	}
 }
 
-// Every category in the vocabulary observes under the shipped default. This is
-// derived from the vocabulary rather than listed, so a category added without a
-// thought about its rollout position still arrives in the safest one.
-func TestTheDefaultObservesEveryCategory(t *testing.T) {
+// Every category in the vocabulary enforces under the shipped default. Derived
+// from the vocabulary rather than listed, so a category added without a thought
+// about its rollout position arrives bound by the engine's own answer rather
+// than deferring to the legacy gate.
+func TestTheDefaultEnforcesEveryCategory(t *testing.T) {
 	def := map[string]string{}
 	for _, c := range commsauthz.Categories() {
-		if got := ModeFor(def, c); got != commsauthz.ModeObserve {
-			t.Errorf("%s defaults to %q, want observe", c, got)
+		if got := ModeFor(def, c); got != commsauthz.ModeEnforce {
+			t.Errorf("%s defaults to %q, want enforce", c, got)
 		}
 	}
 }
 
-// A value that is not a mode resolves to observe rather than to itself. A
-// stored map can predate a validator, and a garbled value must fail safe.
-func TestAnUnreadableModeObserves(t *testing.T) {
+// A value that is not a mode resolves to enforce rather than to itself. A
+// stored map can predate a validator, and failing safe now means binding the
+// engine's own answer rather than handing the message back to the old gate.
+func TestAnUnreadableModeEnforces(t *testing.T) {
 	modes := map[string]string{string(commsauthz.CategoryMarketing): "enforced"}
-	if got := ModeFor(modes, commsauthz.CategoryMarketing); got != commsauthz.ModeObserve {
-		t.Errorf("a garbled mode resolved to %q, want observe", got)
+	if got := ModeFor(modes, commsauthz.CategoryMarketing); got != commsauthz.ModeEnforce {
+		t.Errorf("a garbled mode resolved to %q, want enforce", got)
+	}
+}
+
+// A map naming some categories and not others is refused, naming the ones with
+// no mode. This is the other half of absent-means-enforce: the default is safe,
+// and a half-written map is a question that gets asked rather than answered.
+func TestAPartialMapIsRefused(t *testing.T) {
+	err := validateAuthorizationModes(map[string]string{
+		string(commsauthz.CategoryMarketing): "enforce",
+	})
+	if err == nil {
+		t.Fatal("a map naming one category of fourteen was accepted")
+	}
+	if !strings.Contains(err.Error(), string(commsauthz.CategoryReplyToInbound)) {
+		t.Errorf("the refusal does not name a category that has no mode: %v", err)
 	}
 }
 
@@ -91,6 +108,11 @@ func TestEveryCategoryAndModeIsAccepted(t *testing.T) {
 
 // An empty map is the shipped default and must validate, or no installation
 // could save any other setting on the same surface.
+//
+// This is the one case TestAPartialMapIsRefused deliberately does not cover.
+// Empty means unconfigured and resolves to enforce through ModeFor; a map
+// naming SOME categories means somebody made per-category decisions, and the
+// omissions there are the ones they did not think about.
 func TestTheEmptyMapValidates(t *testing.T) {
 	if err := validateAuthorizationModes(map[string]string{}); err != nil {
 		t.Errorf("the default posture was refused: %v", err)


### PR DESCRIPTION
Two holes on the send path, both of them the engine recording an objection and sending anyway. First slice of the consent improvement concept (R1 and R16).

## The transactional class allowed unconditionally

`resolutionForClass` has said *not supported, `legacy_transactional_unevidenced`* since the escape hatch was closed. But `decideResolved` then handed the unsupported claim to `legacyVerdictFor`, which asks `VerdictForPerson`, whose `ClassTransactional` arm allows on the contract basis without consulting anything. Any message naming the transactional purpose key became operational on nothing but the key — no invoice, no contract, no thread, no deal.

The lead arm closed this already (`TestALeadTakesNoAuthorityFromATransactionalPurpose`); persons were the remaining half.

`VerdictForPerson` is deliberately untouched. The guard endpoint and the legacy gate ask it about a **person**, and a person with an invoice coming really does have a contract basis. `legacyVerdictFor` asks about a **message**, and only runs when nothing was found supporting this one.

## An absent category meant observe

A category nobody remembered to name shipped recorded-but-not-binding, with nothing saying so — a silent hole shaped exactly like whatever was forgotten.

- Absent now **enforces**.
- A **partial** map is refused at the door, naming the categories that have no mode.
- An **empty** map still validates: empty means unconfigured and resolves to enforce, and refusing it would block saving any other setting on that surface.

## Tests

Added `TestTheLegacyTransactionalPurposeDoesNotAllowTheSend` — the existing test asserted the *resolution* was unsupported and stopped there, which is exactly the gap that let the verdict disagree with it. New `TestAPartialMapIsRefused`; three posture tests updated to the new default.

Unchanged and green: `TestAbsoluteDenialsSurviveEveryMode`, `TestOnlyANonAbsoluteMachineReadingCanBeOverruled`, `TestNoGenericTransactionalCategoryExists`.

`make check-backend` green. Integration lanes for consent, activities and compose green.

## Rollout note

This refuses mail that sends today where a caller relied on the transactional key with no evidence behind it. `DisagreementReport` already reports that shape. Slice B1 of the plan gives those sends a review path to recover through; until then they refuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two send-path holes where the engine recorded an objection and sent anyway, and carries staging evidence through to transmit so the fixes don't park mail that was legitimately authorized. The transactional purpose key no longer authorizes a send by itself, and a category absent from the authorization modes map now enforces instead of observing.

- The legacy verdict for an unsupported transactional claim now returns review with reason `legacy_transactional_unevidenced` instead of deferring to `VerdictForPerson`, which allowed the transactional class unconditionally.
- `ModeFor` now defaults an unnamed category to `enforce`; a partial modes map is refused at save naming the categories with no mode, while an empty map still validates as unconfigured and enforces.
- Staging now writes the evidence IDs a message was staged on to the decision row, and transmit re-asks those same questions; rows written before this change decode to no evidence and take the path they always took, and unreadable rows yield no evidence rather than erroring.
- Only evidence the sender was shown to hold is written down: arms that answer before the readability check (thread, live-deal) carry nothing forward, so an unchecked id can't reach transmit, where the system principal could authorize on it.

This refuses mail that sends today where a caller relied on the transactional key with no invoice, contract, thread, or deal behind it. `DisagreementReport` already reports that shape.

<sup>Written for commit e48b89d8cfbf9d783bbd02bc2d6833135953bcac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unevidenced transactional communications are now sent for review instead of being authorized automatically.
  - Consent evidence is preserved from staging through transmission, allowing valid evidence-based authorization to remain effective.
  - Malformed or missing evidence safely falls back to legacy authorization handling.

- **Consent Settings**
  - Unconfigured or unrecognized authorization modes now default to enforcement rather than observation.
  - Partially configured authorization-mode settings are rejected to prevent unintended gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->