### PR TITLE
The deployment config names the workspace it creates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -994,7 +994,7 @@ jobs:
           chmod 600 "$RUNNER_TEMP/admin-password"
           cat > "$RUNNER_TEMP/margince.yaml" <<EOF
           version: 1
-          organization:
+          workspace:
             name: Demo Workspace
             base_currency: EUR
             timezone: Europe/Berlin

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -48,7 +48,7 @@ import (
 func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logger, cfg deployconfig.Config) error {
 	var create func() (identity.InstallationBootstrap, error)
 	if b := cfg.BootstrapAdmin; b != nil {
-		if cfg.Organization.Name == "" {
+		if cfg.Workspace.Name == "" {
 			return errors.New("compose: bootstrap_admin is configured but organization.name is missing — both are required to bootstrap an empty database")
 		}
 		// The password secret is read inside this closure, which bootstrap
@@ -62,10 +62,10 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 				return identity.InstallationBootstrap{}, err
 			}
 			return identity.InstallationBootstrap{
-				OrganizationName: cfg.Organization.Name,
-				BaseCurrency:     cfg.Organization.BaseCurrency,
-				BaseLanguage:     cfg.Organization.BaseLanguage,
-				Timezone:         cfg.Organization.Timezone,
+				OrganizationName: cfg.Workspace.Name,
+				BaseCurrency:     cfg.Workspace.BaseCurrency,
+				BaseLanguage:     cfg.Workspace.BaseLanguage,
+				Timezone:         cfg.Workspace.Timezone,
 				AdminEmail:       b.Email,
 				AdminName:        b.DisplayName,
 				AdminPassword:    pw,
@@ -91,7 +91,7 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 		return err
 	}
 	if created {
-		log.Info("installation bootstrapped", "workspace_id", wsID.String(), "organization", cfg.Organization.Name)
+		log.Info("installation bootstrapped", "workspace_id", wsID.String(), "workspace", cfg.Workspace.Name)
 	} else {
 		log.Info("installation bound to existing organization", "workspace_id", wsID.String())
 	}

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -44,15 +44,15 @@ import (
 // seeds atomically from cfg (requires organization + bootstrap_admin);
 // 1 → bind; >1 → refuse with the operator-facing invariant error.
 // Restarts are idempotent — bootstrap values never reconcile into an
-// existing organization.
+// existing workspace.
 func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logger, cfg deployconfig.Config) error {
 	var create func() (identity.InstallationBootstrap, error)
 	if b := cfg.BootstrapAdmin; b != nil {
 		if cfg.Workspace.Name == "" {
-			return errors.New("compose: bootstrap_admin is configured but organization.name is missing — both are required to bootstrap an empty database")
+			return errors.New("compose: bootstrap_admin is configured but workspace.name is missing — both are required to bootstrap an empty database")
 		}
 		// The password secret is read inside this closure, which bootstrap
-		// calls only when it is actually creating the organization. Reading it
+		// calls only when it is actually creating the workspace. Reading it
 		// here would read it on every boot, and ADR-0061 §2 permits deleting
 		// the secret once the organization exists — so an installation that
 		// followed the ADR would stop booting.

--- a/backend/internal/compose/installation_test.go
+++ b/backend/internal/compose/installation_test.go
@@ -20,7 +20,7 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-func TestEnsureInstallationRefusesAnAdminWithoutAnOrganization(t *testing.T) {
+func TestEnsureInstallationRefusesAnAdminWithoutAWorkspace(t *testing.T) {
 	cfg := deployconfig.Config{
 		Version: 1,
 		BootstrapAdmin: &deployconfig.BootstrapAdmin{
@@ -28,8 +28,8 @@ func TestEnsureInstallationRefusesAnAdminWithoutAnOrganization(t *testing.T) {
 		},
 	}
 	err := EnsureInstallation(context.Background(), nil, discardLogger(), cfg)
-	if err == nil || !strings.Contains(err.Error(), "organization.name") {
-		t.Fatalf("err = %v, want the missing-organization refusal", err)
+	if err == nil || !strings.Contains(err.Error(), "workspace.name") {
+		t.Fatalf("err = %v, want the missing-workspace refusal", err)
 	}
 }
 

--- a/backend/internal/compose/integration/apptest/appenv.go
+++ b/backend/internal/compose/integration/apptest/appenv.go
@@ -261,7 +261,7 @@ func (e *AppEnv) Call(t *testing.T, method, path string, body any, headers map[s
 //
 // It lives here rather than with a suite because BootstrapWorkspace above calls
 // it, and a non-test file cannot reach a helper declared in a _test.go one.
-func BootstrapWorkspaceSession(t *testing.T, e *AppEnv, organizationName, adminEmail, adminName string) {
+func BootstrapWorkspaceSession(t *testing.T, e *AppEnv, workspaceName, adminEmail, adminName string) {
 	t.Helper()
 	// The password an OPERATOR supplies, which a configured bootstrap flags for
 	// replacement. It is deliberately NOT the one the suites sign in with: the
@@ -273,8 +273,8 @@ func BootstrapWorkspaceSession(t *testing.T, e *AppEnv, organizationName, adminE
 		t.Fatal(err)
 	}
 	cfg := deployconfig.Config{
-		Version:      1,
-		Organization: deployconfig.Organization{Name: organizationName},
+		Version:   1,
+		Workspace: deployconfig.Workspace{Name: workspaceName},
 		BootstrapAdmin: &deployconfig.BootstrapAdmin{
 			Email: adminEmail, DisplayName: adminName, PasswordFile: pwFile,
 		},

--- a/backend/internal/compose/integration/installation_integration_test.go
+++ b/backend/internal/compose/integration/installation_integration_test.go
@@ -52,8 +52,8 @@ func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := deployconfig.Config{
-		Version:      1,
-		Organization: deployconfig.Organization{Name: "Configured Org", BaseCurrency: "USD", Timezone: "Europe/Berlin"},
+		Version:   1,
+		Workspace: deployconfig.Workspace{Name: "Configured Org", BaseCurrency: "USD", Timezone: "Europe/Berlin"},
 		BootstrapAdmin: &deployconfig.BootstrapAdmin{
 			Email: "ops@configured.test", DisplayName: "Ops", PasswordFile: pwFile,
 		},
@@ -214,8 +214,8 @@ func TestBootBindsWithoutReadingASpentBootstrapSecret(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := deployconfig.Config{
-		Version:      1,
-		Organization: deployconfig.Organization{Name: "Spent Secret Org", BaseCurrency: "EUR", Timezone: "Europe/Berlin"},
+		Version:   1,
+		Workspace: deployconfig.Workspace{Name: "Spent Secret Org", BaseCurrency: "EUR", Timezone: "Europe/Berlin"},
 		BootstrapAdmin: &deployconfig.BootstrapAdmin{
 			Email: "ops@spent.test", DisplayName: "Ops", PasswordFile: pwFile,
 		},
@@ -242,8 +242,8 @@ func TestBootBindsWithoutReadingASpentBootstrapSecret(t *testing.T) {
 func TestFirstBootStillFailsLoudlyOnAnUnreadableSecret(t *testing.T) {
 	e := apptest.SetupApp(t)
 	cfg := deployconfig.Config{
-		Version:      1,
-		Organization: deployconfig.Organization{Name: "No Secret Org", BaseCurrency: "EUR", Timezone: "Europe/Berlin"},
+		Version:   1,
+		Workspace: deployconfig.Workspace{Name: "No Secret Org", BaseCurrency: "EUR", Timezone: "Europe/Berlin"},
 		BootstrapAdmin: &deployconfig.BootstrapAdmin{
 			Email: "ops@nosecret.test", DisplayName: "Ops",
 			PasswordFile: filepath.Join(t.TempDir(), "never-written"),

--- a/backend/internal/compose/integration/rbacseedparity_integration_test.go
+++ b/backend/internal/compose/integration/rbacseedparity_integration_test.go
@@ -672,7 +672,7 @@ func bootstrapInstallation(t *testing.T, e *apptest.AppEnv) {
 		t.Fatalf("writing the bootstrap password: %v", err)
 	}
 	cfg, err := deployconfig.Parse([]byte(`version: 1
-organization:
+workspace:
   name: RBAC Seed Parity
 bootstrap_admin:
   email: admin@rbacparity.test

--- a/backend/internal/compose/integration/retention_authoring_integration_test.go
+++ b/backend/internal/compose/integration/retention_authoring_integration_test.go
@@ -324,8 +324,8 @@ func bootstrapWithRetentionPosture(t *testing.T, retention *deployconfig.Retenti
 		t.Fatal(err)
 	}
 	cfg := deployconfig.Config{
-		Version:      1,
-		Organization: deployconfig.Organization{Name: "Regulated Org", BaseCurrency: "EUR", Timezone: "Europe/Berlin"},
+		Version:   1,
+		Workspace: deployconfig.Workspace{Name: "Regulated Org", BaseCurrency: "EUR", Timezone: "Europe/Berlin"},
 		BootstrapAdmin: &deployconfig.BootstrapAdmin{
 			Email: "ops@regulated.test", DisplayName: "Ops", PasswordFile: pwFile,
 		},

--- a/backend/internal/compose/integration/routingbootstrapwiring_integration_test.go
+++ b/backend/internal/compose/integration/routingbootstrapwiring_integration_test.go
@@ -52,7 +52,7 @@ func TestADeclaredBindingReachesTheDatabaseThroughTheRealBootstrap(t *testing.T)
 	// is how the pointer-typed spelling of this field passed its tests while
 	// refusing every real binding.
 	cfg, err := deployconfig.Parse([]byte(`version: 1
-organization:
+workspace:
   name: Bootstrap Wiring
 bootstrap_admin:
   email: admin@wiring.test

--- a/backend/internal/compose/routingseed_test.go
+++ b/backend/internal/compose/routingseed_test.go
@@ -142,7 +142,7 @@ embeddings: {provider: ollama, model: embed, dimensions: 8}
 // resolveAliases handles both idioms; this is the half the schema can express.
 func TestABindingThatReferencesAnAnchorElsewhereInTheFileStillSeeds(t *testing.T) {
 	const doc = `version: 1
-organization:
+workspace:
   name: &v fake
 seeds:
   ai_routing:

--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -28,7 +28,7 @@ import (
 // additionally requires `organization` and `bootstrap_admin`.
 type Config struct {
 	Version        int             `yaml:"version"`
-	Organization   Organization    `yaml:"organization"`
+	Workspace      Workspace       `yaml:"workspace"`
 	BootstrapAdmin *BootstrapAdmin `yaml:"bootstrap_admin"`
 	Seeds          Seeds           `yaml:"seeds"`
 	Auth           Auth            `yaml:"auth"`
@@ -125,10 +125,16 @@ func (c CompanyContext) OnboardingEnabled() bool {
 	return c.EffectiveRollout() == CompanyContextOnboarding
 }
 
-// Organization names the installation's singleton organization. Consumed
-// only when the organization is created; it never reconciles into an
-// existing installation (§6.3 of the ratified concept).
-type Organization struct {
+// Workspace names the installation's singleton workspace — the tenant every
+// row is filed under, and what the schema has always called it. Consumed only
+// when the workspace is created; it never reconciles into an existing
+// installation (§6.3 of the ratified concept).
+//
+// It was spelled `organization` until the schema and the config disagreed
+// loudly enough to notice: `workspace` is the table, `workspace_id` is the
+// column on every tenant row, and an operator reading both had to know that
+// the two words meant one thing. Nothing here is the CRM's company record.
+type Workspace struct {
 	Name         string `yaml:"name"`
 	BaseCurrency string `yaml:"base_currency"`
 	BaseLanguage string `yaml:"base_language"`
@@ -137,7 +143,7 @@ type Organization struct {
 
 // BootstrapAdmin identifies the first administrator. The password is a
 // reference so the secret can be deleted after first boot — once the
-// organization exists this whole section may be removed.
+// workspace exists this whole section may be removed.
 type BootstrapAdmin struct {
 	Email       string `yaml:"email"`
 	DisplayName string `yaml:"display_name"`
@@ -341,15 +347,15 @@ func (c Config) validate() error {
 	if c.Version != 1 {
 		return fmt.Errorf("deployconfig: unsupported version %d (this build supports version 1)", c.Version)
 	}
-	if c.Organization.Timezone != "" {
-		if _, err := values.ParseTimezone(c.Organization.Timezone); err != nil {
+	if c.Workspace.Timezone != "" {
+		if _, err := values.ParseTimezone(c.Workspace.Timezone); err != nil {
 			return fmt.Errorf("deployconfig: organization.timezone: %w", err)
 		}
 	}
-	if cur := c.Organization.BaseCurrency; cur != "" && !values.ValidCurrency(cur) {
+	if cur := c.Workspace.BaseCurrency; cur != "" && !values.ValidCurrency(cur) {
 		return fmt.Errorf("deployconfig: organization.base_currency %q is not a 3-letter ISO 4217 code", cur)
 	}
-	if lang := c.Organization.BaseLanguage; lang != "" && !textlang.Known(lang) {
+	if lang := c.Workspace.BaseLanguage; lang != "" && !textlang.Known(lang) {
 		return fmt.Errorf("deployconfig: organization.base_language %q is not a language this build speaks (en, de, vi)", lang)
 	}
 	if err := c.Rates.validate(); err != nil {

--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -349,14 +349,14 @@ func (c Config) validate() error {
 	}
 	if c.Workspace.Timezone != "" {
 		if _, err := values.ParseTimezone(c.Workspace.Timezone); err != nil {
-			return fmt.Errorf("deployconfig: organization.timezone: %w", err)
+			return fmt.Errorf("deployconfig: workspace.timezone: %w", err)
 		}
 	}
 	if cur := c.Workspace.BaseCurrency; cur != "" && !values.ValidCurrency(cur) {
-		return fmt.Errorf("deployconfig: organization.base_currency %q is not a 3-letter ISO 4217 code", cur)
+		return fmt.Errorf("deployconfig: workspace.base_currency %q is not a 3-letter ISO 4217 code", cur)
 	}
 	if lang := c.Workspace.BaseLanguage; lang != "" && !textlang.Known(lang) {
-		return fmt.Errorf("deployconfig: organization.base_language %q is not a language this build speaks (en, de, vi)", lang)
+		return fmt.Errorf("deployconfig: workspace.base_language %q is not a language this build speaks (en, de, vi)", lang)
 	}
 	if err := c.Rates.validate(); err != nil {
 		return err

--- a/backend/internal/platform/deployconfig/deployconfig_test.go
+++ b/backend/internal/platform/deployconfig/deployconfig_test.go
@@ -17,7 +17,7 @@ import (
 
 const fullConfig = `
 version: 1
-organization:
+workspace:
   name: Gradion
   base_currency: EUR
   timezone: Europe/Berlin
@@ -53,8 +53,8 @@ func TestParseAcceptsTheFullDocumentedShape(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	if cfg.Organization.Name != "Gradion" || cfg.BootstrapAdmin.Email != "lars@example.com" {
-		t.Fatalf("parsed organization/admin = %+v / %+v", cfg.Organization, cfg.BootstrapAdmin)
+	if cfg.Workspace.Name != "Gradion" || cfg.BootstrapAdmin.Email != "lars@example.com" {
+		t.Fatalf("parsed organization/admin = %+v / %+v", cfg.Workspace, cfg.BootstrapAdmin)
 	}
 	if cfg.Seeds.Pipeline.Name != "Sales" || len(cfg.Seeds.Pipeline.Stages) != 2 {
 		t.Fatalf("parsed pipeline seed = %+v", cfg.Seeds.Pipeline)
@@ -82,8 +82,8 @@ func TestParseRejectsUnknownKeys(t *testing.T) {
 func TestParseValidatesFailClosed(t *testing.T) {
 	cases := map[string]string{ // #nosec G101 -- yaml documents that must FAIL validation, not credentials
 		"unsupported version":     "version: 2\n",
-		"bad timezone":            "version: 1\norganization: { name: X, timezone: Mars/Olympus }\n",
-		"bad currency":            "version: 1\norganization: { name: X, base_currency: euros }\n",
+		"bad timezone":            "version: 1\nworkspace: { name: X, timezone: Mars/Olympus }\n",
+		"bad currency":            "version: 1\nworkspace: { name: X, base_currency: euros }\n",
 		"admin without password":  "version: 1\nbootstrap_admin: { email: a@b.co, display_name: A }\n",
 		"inline secret refused":   "version: 1\nbootstrap_admin: { email: a@b.co, display_name: A, password: hunter2hunter2 }\n",
 		"empty pipeline":          "version: 1\nseeds: { pipeline: { name: Sales, stages: [] } }\n",
@@ -247,14 +247,14 @@ func writeTemp(t *testing.T, doc string) string {
 }
 
 func TestAllowTestMailboxGateDefaultsOff(t *testing.T) {
-	cfg, err := Load(writeTemp(t, "version: 1\norganization:\n  name: T\n"), runtimeenv.Production)
+	cfg, err := Load(writeTemp(t, "version: 1\nworkspace:\n  name: T\n"), runtimeenv.Production)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if cfg.Operations.AllowTestMailbox {
 		t.Fatal("AllowTestMailbox must default OFF — a capability that can fake a real send outcome is stated, never assumed")
 	}
-	on, err := Load(writeTemp(t, "version: 1\norganization:\n  name: T\noperations:\n  allow_test_mailbox: true\n"), runtimeenv.Production)
+	on, err := Load(writeTemp(t, "version: 1\nworkspace:\n  name: T\noperations:\n  allow_test_mailbox: true\n"), runtimeenv.Production)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,14 +264,14 @@ func TestAllowTestMailboxGateDefaultsOff(t *testing.T) {
 }
 
 func TestMCPConnectorGateDefaultsOff(t *testing.T) {
-	cfg, err := Load(writeTemp(t, "version: 1\norganization:\n  name: T\n"), runtimeenv.Production)
+	cfg, err := Load(writeTemp(t, "version: 1\nworkspace:\n  name: T\n"), runtimeenv.Production)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if cfg.MCP.ConnectorEnabled {
 		t.Fatal("the connector gate must default OFF — an unset flag must never expose /mcp")
 	}
-	on, err := Load(writeTemp(t, "version: 1\norganization:\n  name: T\nmcp:\n  connector_enabled: true\n"), runtimeenv.Production)
+	on, err := Load(writeTemp(t, "version: 1\nworkspace:\n  name: T\nmcp:\n  connector_enabled: true\n"), runtimeenv.Production)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/platform/deployconfig/layers_test.go
+++ b/backend/internal/platform/deployconfig/layers_test.go
@@ -31,7 +31,7 @@ func layered(t *testing.T, env runtimeenv.Environment, base, overlay string) (Co
 
 func TestTheOverlayForThisPostureWinsKeyByKey(t *testing.T) {
 	cfg, err := layered(t, runtimeenv.Development,
-		"version: 1\norganization:\n  name: Acme\n  timezone: Europe/Berlin\nmcp:\n  connector_enabled: false\n",
+		"version: 1\nworkspace:\n  name: Acme\n  timezone: Europe/Berlin\nmcp:\n  connector_enabled: false\n",
 		"mcp:\n  connector_enabled: true\n")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -41,8 +41,8 @@ func TestTheOverlayForThisPostureWinsKeyByKey(t *testing.T) {
 	}
 	// The keys the overlay is silent about are the reason for having a base at
 	// all: an overlay states a difference, not a whole configuration.
-	if cfg.Organization.Name != "Acme" || cfg.Organization.Timezone != "Europe/Berlin" {
-		t.Errorf("the base's organization did not survive the overlay: %+v", cfg.Organization)
+	if cfg.Workspace.Name != "Acme" || cfg.Workspace.Timezone != "Europe/Berlin" {
+		t.Errorf("the base's workspace did not survive the overlay: %+v", cfg.Workspace)
 	}
 }
 
@@ -103,13 +103,13 @@ func TestAMappingMergesAndAListReplaces(t *testing.T) {
 // still commented out — is a file a boot must read and shrug at.
 func TestACommentOnlyOverlayIsNotAFailure(t *testing.T) {
 	cfg, err := layered(t, runtimeenv.Development,
-		"version: 1\norganization:\n  name: Acme\n",
+		"version: 1\nworkspace:\n  name: Acme\n",
 		"# nothing to change for dev yet\n")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.Organization.Name != "Acme" {
-		t.Errorf("organization.name = %q, want Acme", cfg.Organization.Name)
+	if cfg.Workspace.Name != "Acme" {
+		t.Errorf("workspace.name = %q, want Acme", cfg.Workspace.Name)
 	}
 }
 
@@ -133,7 +133,7 @@ func TestATypoInTheOverlayFailsTheBootAndNamesTheFile(t *testing.T) {
 // its own admin, and validating the base alone would refuse it.
 func TestValidationRunsOverTheMergedResult(t *testing.T) {
 	cfg, err := layered(t, runtimeenv.Test,
-		"version: 1\norganization:\n  name: Acme\nbootstrap_admin:\n  email: admin@acme.test\n  display_name: Admin\n  password_file: /run/secrets/base-admin\n",
+		"version: 1\nworkspace:\n  name: Acme\nbootstrap_admin:\n  email: admin@acme.test\n  display_name: Admin\n  password_file: /run/secrets/base-admin\n",
 		"bootstrap_admin:\n  password_file: /run/secrets/test-admin\n")
 	if err != nil {
 		t.Fatalf("Load: %v", err)

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -25,7 +25,7 @@ version: 1
 # But base_currency stops being changeable once anything has converted against
 # it (a closed deal, a sent offer, a mirrored invoice, a loaded rate sheet), so
 # it is the one worth checking twice.
-organization:
+workspace:
   name: Demo Workspace
   base_currency: EUR
   # The language AI writes in for the whole team — en, de or vi. Not a person's

--- a/config/margince.schema.json
+++ b/config/margince.schema.json
@@ -9,8 +9,8 @@
     "version": {
       "type": "integer"
     },
-    "organization": {
-      "description": "Organization names the installation's singleton organization. Consumed only when the organization is created; it never reconciles into an existing installation (§6.3 of the ratified concept).",
+    "workspace": {
+      "description": "Workspace names the installation's singleton workspace — the tenant every row is filed under, and what the schema has always called it. Consumed only when the workspace is created; it never reconciles into an existing installation (§6.3 of the ratified concept).",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -29,7 +29,7 @@
       }
     },
     "bootstrap_admin": {
-      "description": "BootstrapAdmin identifies the first administrator. The password is a reference so the secret can be deleted after first boot — once the organization exists this whole section may be removed.",
+      "description": "BootstrapAdmin identifies the first administrator. The password is a reference so the secret can be deleted after first boot — once the workspace exists this whole section may be removed.",
       "type": [
         "object",
         "null"

--- a/desktop/launcher/layout.go
+++ b/desktop/launcher/layout.go
@@ -235,7 +235,7 @@ func (l layout) ensureConfig() (string, error) {
 # Restart Margince after changing anything here.
 version: 1
 
-organization:
+workspace:
   name: Margince
   base_currency: USD
   timezone: %s

--- a/desktop/launcher/layout_test.go
+++ b/desktop/launcher/layout_test.go
@@ -155,7 +155,7 @@ func TestConfiguredAdminEmailReadsTheInstallationsOwnAddress(t *testing.T) {
 		// The block test is what stops an `email:` belonging to some other
 		// section being reported as the sign-in address.
 		"an email under another key first": "" +
-			"organization:\n  email: billing@example.com\n\nbootstrap_admin:\n  email: admin@demo.test\n",
+			"workspace:\n  email: billing@example.com\n\nbootstrap_admin:\n  email: admin@demo.test\n",
 		// '#' is legal in the local part of an address (RFC 5322 atext), so a
 		// reader that cut at every one would announce a truncated address —
 		// the failure this whole function exists to prevent.
@@ -187,7 +187,7 @@ func TestConfiguredAdminEmailReadsTheInstallationsOwnAddress(t *testing.T) {
 func TestConfiguredAdminEmailFallsBackRatherThanFailing(t *testing.T) {
 	for name, yaml := range map[string]*string{
 		"no file at all":             nil,
-		"no bootstrap_admin block":   ptr("version: 1\n\norganization:\n  name: Margince\n"),
+		"no bootstrap_admin block":   ptr("version: 1\n\nworkspace:\n  name: Margince\n"),
 		"the block names no email":   ptr("bootstrap_admin:\n  display_name: Owner\n"),
 		"the email is commented out": ptr("bootstrap_admin:\n  # email: admin@demo.test\n"),
 		"the value is empty":         ptr("bootstrap_admin:\n  email:\n"),

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,7 +29,7 @@ configurable logger.
 | Flag | Env | Default | Meaning |
 |---|---|---|---|
 | `--dsn` | `MARGINCE_DSN` | — (required) | Postgres DSN, runtime app role |
-| `--config` | `MARGINCE_CONFIG` | `margince.yaml` | the deployment configuration file (bootstrap + auth — organization, bootstrap_admin, seeds, email; strict decoding, secrets as `*_file` references). A missing file boots an existing installation; bootstrapping an empty database requires `organization` + `bootstrap_admin` |
+| `--config` | `MARGINCE_CONFIG` | `margince.yaml` | the deployment configuration file (bootstrap + auth — workspace, bootstrap_admin, seeds, email; strict decoding, secrets as `*_file` references). A missing file boots an existing installation; bootstrapping an empty database requires `workspace` + `bootstrap_admin` |
 | `--schema-dsn` | `MARGINCE_SCHEMA_DSN` | — | Postgres DSN, **owner** role, for the customfields runtime-DDL pool; unset = `createCustomField`/`updateCustomFieldOptions` answer 501 |
 | `--addr` | — | `:8080` | listen address |
 | `--redis` | `MARGINCE_REDIS` | `localhost:16379` | Redis address (event bus). May name a logical database as `host:port/N` (0–15) — see below |
@@ -940,7 +940,7 @@ The **deployment configuration** (`--config`, default `margince.yaml`) is
 seeded the same way for local dev. The annotated reference is
 [`config/margince.example.yaml`](../../config/margince.example.yaml); `make dev`
 copies it to a gitignored `config/margince.yaml` on first run and then
-**leaves it** (create-if-missing / leave-if-exists), so an engineer's edits — organization,
+**leaves it** (create-if-missing / leave-if-exists), so an engineer's edits — workspace,
 `bootstrap_admin`, or the `ai.capture_payloads` posture — persist across
 `make dev-stop` / `make dev` rather than being regenerated each boot. The
 admin `password_file` it references (`config/margince-admin-password`) is


### PR DESCRIPTION
Split out of https://github.com/margince/margince/pull/5016, which renames the
CRM's record type. This is the part of it that was never about that record.

## The two words

The schema calls the tenant a workspace. Every tenant row carries
`workspace_id`, the table is `workspace`, and `WithWorkspaceTx` is the only way
to reach any of it. The bootstrap section that CREATES that row was called
`organization:`, so the config and the schema described one thing in two words
and an operator had to already know it.

The cost is not just the mismatch. `organization` is what the CRM's own record
type is called on the surface the ticket above is fixing, so a reader who knows
the product meets that word here naming something else entirely — the
installation's tenant, not a company in anybody's pipeline.

```yaml
# before                    # after
organization:               workspace:
  name: Acme                  name: Acme
  base_currency: EUR          base_currency: EUR
```

## What moves

The type and its yaml key, the four validations that read it, the shipped
example, the launcher's first-run template, and the file the live-boot lane
generates. `company_context` is untouched — that one really is about the
company record.

## What this is not

Not a compatibility shim. There is no live installation, so no deployed
`margince.yaml` carries the old key, and strict decoding (`KnownFields(true)`)
means a stale dev file fails loudly at boot with the field named rather than
booting with a silently empty tenant. That is the right failure: the section is
consumed only when the workspace is first created, so a config that misses it
would otherwise bootstrap an unnamed workspace.

## Verified

`make check` — backend suite, lint, drift, arch-lint, the 38 root script gates,
and the frontend half. The integration lane compiles (`go vet -tags integration`);
its own harness constructs this config, which is how the two remaining call
sites were found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Renamed the top-level deployment configuration key from `organization` to `workspace`.
  - Updated generated templates, validation, and installation setup to use workspace settings.
  - Workspace name, currency, language, timezone, and bootstrap administrator settings continue to work as before.

- **Documentation**
  - Updated configuration reference materials and schema descriptions to use “workspace” terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->