### PR TITLE
fix(compose): pin the case-study attribution guard, not just its outcome

### DIFF
--- a/backend/internal/compose/sitereadvocab_test.go
+++ b/backend/internal/compose/sitereadvocab_test.go
@@ -6,31 +6,34 @@ package compose
 import (
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/people"
 )
 
-// categoryGuidance's "offering" and "market" prompt text is the only defense
-// against a case study, testimonial or customer story getting attributed to
-// this company instead of the customer it is about (margince#3403) — no
-// deterministic code path enforces it, only the model reading the prompt. The
-// aicert corpus (site_fact_extract/customer_story_01.yaml) pins the resulting
-// MODEL OUTCOME, but nothing pinned the guard TEXT itself: deleting these
-// sentences would fail no Go test, only degrade a probabilistic cert score
-// over time. This test is that missing deterministic layer.
-func TestCategoryGuidanceGuardsAgainstAttributingACustomersStoryToThisCompany(t *testing.T) {
+// The offering and market guidance is the only thing that stops a customer
+// story's facts being filed under this company instead of the customer it is
+// about — no code path enforces it, only the model reading the prompt. The
+// aicert corpus pins the model's resulting outcome on a live run; this pins
+// the sentences themselves, through the same menuGuidance seam the real
+// prompt assembles from (menuGuidance has its own history of silently
+// dropping a whole category from its hardcoded list, per its own comment),
+// so both the guard text AND its routing into the prompt are held.
+func TestMenuGuidanceKeepsTheCustomerStoryGuardOutOfThisCompanysOwnFacts(t *testing.T) {
 	tests := map[string]struct {
-		category    string
+		fields      []string
 		mustContain []string
 	}{
 		"offering": {
-			category: "offering",
+			fields: []string{people.FactService},
 			mustContain: []string{
 				"case study, testimonial or customer story",
 				"NAMED CUSTOMER, not this company",
 				"never this company's offering",
+				"is still this company's offering",
 			},
 		},
 		"market": {
-			category: "market",
+			fields: []string{people.FactServedIndustry},
 			mustContain: []string{
 				"case study, testimonial or customer story names a customer's own",
 				"never a market this company serves",
@@ -40,13 +43,10 @@ func TestCategoryGuidanceGuardsAgainstAttributingACustomersStoryToThisCompany(t 
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			guidance, ok := categoryGuidance[tt.category]
-			if !ok {
-				t.Fatalf("categoryGuidance has no entry for %q", tt.category)
-			}
+			guidance := menuGuidance(tt.fields)
 			for _, want := range tt.mustContain {
 				if !strings.Contains(guidance, want) {
-					t.Errorf("categoryGuidance[%q] lost its customer-story guard: missing %q", tt.category, want)
+					t.Errorf("menuGuidance(%v) lost its customer-story guard: missing %q", tt.fields, want)
 				}
 			}
 		})

--- a/backend/internal/compose/sitereadvocab_test.go
+++ b/backend/internal/compose/sitereadvocab_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"strings"
+	"testing"
+)
+
+// categoryGuidance's "offering" and "market" prompt text is the only defense
+// against a case study, testimonial or customer story getting attributed to
+// this company instead of the customer it is about (margince#3403) — no
+// deterministic code path enforces it, only the model reading the prompt. The
+// aicert corpus (site_fact_extract/customer_story_01.yaml) pins the resulting
+// MODEL OUTCOME, but nothing pinned the guard TEXT itself: deleting these
+// sentences would fail no Go test, only degrade a probabilistic cert score
+// over time. This test is that missing deterministic layer.
+func TestCategoryGuidanceGuardsAgainstAttributingACustomersStoryToThisCompany(t *testing.T) {
+	tests := map[string]struct {
+		category    string
+		mustContain []string
+	}{
+		"offering": {
+			category: "offering",
+			mustContain: []string{
+				"case study, testimonial or customer story",
+				"NAMED CUSTOMER, not this company",
+				"never this company's offering",
+			},
+		},
+		"market": {
+			category: "market",
+			mustContain: []string{
+				"case study, testimonial or customer story names a customer's own",
+				"never a market this company serves",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			guidance, ok := categoryGuidance[tt.category]
+			if !ok {
+				t.Fatalf("categoryGuidance has no entry for %q", tt.category)
+			}
+			for _, want := range tt.mustContain {
+				if !strings.Contains(guidance, want) {
+					t.Errorf("categoryGuidance[%q] lost its customer-story guard: missing %q", tt.category, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

margince#3403's case-study attribution guard (`sitereadvocab.go`'s `categoryGuidance["offering"]`/`["market"]` — the AI extraction prompt text that stops a customer's own case-study facts from being filed under this company) had no deterministic test behind it at all. The only coverage was the `aicert` corpus fixture (`site_fact_extract/customer_story_01.yaml`), which pins the model's *outcome* on a live, probabilistic run — deleting the guard sentences themselves would fail no Go test, only degrade a cert score over time. Per this repo's own `AGENTS.md` ("a claim with no test behind it is not a claim this tree accepts"), this adds the missing deterministic layer.

The test goes through `menuGuidance` (the seam that actually assembles the prompt from `categoryGuidance`), not the raw map — `menuGuidance` has its own documented history of silently dropping a whole category from its hardcoded list (the comment above it records "market" was once missing, reaching the model with zero guidance for `company_size`/`served_industry`). A map-only test would stay green over a repeat of that exact regression; this one does not (mutation-tested — see Test plan).

## Scope notes

- **No AI prompt content changed** — `sitereadvocab.go` is untouched, only a new test file. No aicert re-run needed.
- **No UAT/video** — this is a backend-only prompt-guard test with no screen or agent door to exercise; mutation testing (below) is the equivalent proof.
- **Coverage** — no new production code; the coverage bar doesn't apply to a test-only change.
- Left the `signal`/`technology` guard (precedent from #3127) out of scope — margince#3403 is specifically about `offering`/`market` attribution; `technology`'s own gap is the identical shape but a separate, unfiled concern.

## Review

Reviewed by both Fable and Codex before push. Fable's MAJOR finding (test only covered the raw map, missing `menuGuidance`'s own regression history) drove the seam-level rewrite; both Fable and Codex flagged the same comment craft issue (ticket-number/fix-narration residue), fixed.

## Test plan

- [x] `TestMenuGuidanceKeepsTheCustomerStoryGuardOutOfThisCompanysOwnFacts` passes for both `offering` and `market`
- [x] Mutation-tested: stripped each pinned guard clause from `sitereadvocab.go` — test goes red, restores clean
- [x] Mutation-tested: reproduced the exact historical `menuGuidance` regression (dropped `"market"` from its hardcoded category list) — test goes red, restores clean
- [x] `make check-go` green (build, vet, lint, arch-lint, unit + fitness tests, contract drift) on the rebased branch
- [x] Pre-push `craft static --strict` — 0 blocker/major/minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRuXiSKkD1X1D1U5yRF4Qn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic test that pins the case-study attribution guard — the `offering`/`market` prompt text in `categoryGuidance` that stops a customer's own case-study facts from being filed under this company (margince#3403). Previously the only coverage came from the `aicert` corpus fixture, which pins the model's outcome on a live probabilistic run rather than the guard sentences themselves, so this is a test-only change with no `aicert` re-run needed.

- Routes assertions through `menuGuidance` (the seam that assembles the prompt) rather than the raw map, since `menuGuidance` has its own documented history of silently dropping a whole category from its hardcoded list.
- Mutation-tested both directions: removing a guard clause and reproducing the historical `menuGuidance` regression both turn the test red.
- The `technology` guard is left out of scope as a separate, unfiled concern.

<sup>Written for commit 0c5730dbfa211079fb92eb571064921d3eddc9b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that generated menu guidance preserves safeguards distinguishing customer stories from the company’s own facts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->