### PR TITLE
Claiming a contact refreshes the list it is filed under

### DIFF
--- a/frontend/src/screens/claim-list-key-coverage.test.ts
+++ b/frontend/src/screens/claim-list-key-coverage.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Fitness function for a claim that refreshes a list nobody is reading.
+//
+// `useClaimRecord` invalidates the list its record is filed under. It used to
+// derive that key as `${recordType}s`, which is right for three of the four
+// claimable kinds and wrong for the one whose plural is not its singular plus
+// an s: contacts are filed under "people", so claiming a person asked React
+// Query to invalidate "persons".
+//
+// Nothing failed. `invalidateQueries` matching no cache is not an error — it
+// finds nothing and returns. So the claim was written, the control settled,
+// and the list in front of the reader went on showing the record as unowned
+// until some other event happened to refetch it. A refresh that silently
+// refreshes nothing is the shape this holds.
+//
+// The census reads the KEYS the module declares and looks for each one in the
+// screens that actually query, rather than pinning the four names here. A
+// fifth claimable kind is therefore covered the day it is added, and a key
+// renamed on the reading side fails here rather than going quiet.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function declaredListKeys(): string[] {
+  const source = readFileSync(resolve(here, "claimrecord.ts"), "utf8");
+  const table =
+    /const LIST_KEY: Record<ClaimableRecordType, string> = \{([^}]*)\}/s.exec(
+      source,
+    );
+  if (!table) {
+    throw new Error(
+      "claimrecord.ts no longer declares LIST_KEY as an object literal — this census reads it textually",
+    );
+  }
+  return [...table[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+// Every .ts/.tsx under src, because the reader of a list key is not always a
+// screen: a rail, a hook or an app-level prefetch files under the same name.
+function sourcesUnder(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) return sourcesUnder(full);
+    if (!/\.tsx?$/.test(entry.name) || /\.d\.ts$/.test(entry.name)) return [];
+    return [full];
+  });
+}
+
+describe("the key a claim invalidates is a key something reads", () => {
+  const keys = declaredListKeys();
+  const corpus = sourcesUnder(resolve(here, ".."))
+    .filter(
+      (f) =>
+        !f.endsWith("claimrecord.ts") &&
+        !f.endsWith("claim-list-key-coverage.test.ts"),
+    )
+    .map((f) => readFileSync(f, "utf8"))
+    .join("\n");
+
+  it("declares one key per claimable kind", () => {
+    expect(keys.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each(keys)("%s is queried somewhere", (key) => {
+    expect(corpus).toContain(`"${key}"`);
+  });
+});

--- a/frontend/src/screens/claimrecord.ts
+++ b/frontend/src/screens/claimrecord.ts
@@ -6,6 +6,21 @@ import { throwProblem } from "./common";
 /** The record kinds the claim endpoint accepts. */
 export type ClaimableRecordType = "organization" | "person" | "lead" | "deal";
 
+// The list each kind is filed under. Spelled out rather than derived, because
+// one of the four is not the type with an "s" on the end: contacts are filed
+// under "people", and `${recordType}s` asks for "persons", which nothing reads.
+//
+// A key that matches no cache is not an error anywhere — invalidateQueries
+// simply finds nothing to invalidate. So the claim succeeded, the button
+// settled, and the list the reader was looking at went on showing the record
+// as unowned until something else happened to refetch it.
+const LIST_KEY: Record<ClaimableRecordType, string> = {
+  organization: "organizations",
+  person: "people",
+  lead: "leads",
+  deal: "deals",
+};
+
 // useClaimRecord is the claim door: POST /records/{type}/{id}/claim makes the
 // caller the owner of an unowned record (or re-confirms one already theirs)
 // and refreshes what shows it. Used wherever an owner control lets a reader
@@ -31,7 +46,7 @@ export function useClaimRecord(
     if (error) {
       throwProblem(error);
     }
-    await queryClient.invalidateQueries({ queryKey: [`${recordType}s`] });
+    await queryClient.invalidateQueries({ queryKey: [LIST_KEY[recordType]] });
     await queryClient.invalidateQueries({ queryKey: [`${recordType}360`, id] });
     await queryClient.invalidateQueries({ queryKey: [recordType, id] });
   };


### PR DESCRIPTION
Split out of https://github.com/margince/margince/pull/5016. This one is a bug
on `main` today and has nothing to do with that rename — it was found while
reading the same file.

## What happens

`useClaimRecord` refreshes the list its record is filed under:

```ts
await queryClient.invalidateQueries({ queryKey: [`${recordType}s`] });
```

That is right for three of the four claimable kinds. Contacts are filed under
`["people"]`, so claiming a **person** asks React Query to invalidate
`"persons"` — a key nothing reads.

Nothing fails. `invalidateQueries` that matches no cache finds nothing and
returns. So the claim is written, the button settles, and the list in front of
the reader goes on showing the record as unowned until some unrelated event
happens to refetch it. The reader's next move is to claim it again.

Measured across `frontend/src`, which is what says which of the four is wrong:

| kind | key it asked for | uses in the tree |
|---|---|---:|
| person | `persons` | **0** |
| organization | `organizations` | 7 |
| lead | `leads` | 2 |
| deal | `deals` | 7 |

## The fix

The key becomes a table rather than a derivation, and a census holds it. The
census reads the keys the module declares and looks for each one in the code
that queries, so it pins no names of its own: a fifth claimable kind is covered
the day it is added, and a key renamed on the reading side fails here rather
than going quiet.

Mutation-checked — putting `"persons"` back fails it with
`× persons is queried somewhere`.

## Not changed

The hook also invalidates `${recordType}360` for kinds that have no such key
(`lead360`, `deal360` are used nowhere). That is a no-op rather than a defect —
it refreshes nothing because there is nothing to refresh — and tightening it
would be a guess about which kinds are meant to grow a 360 view.

## Verified

`make check-fe` — 8,511 tests. No backend surface.
