### PR TITLE
fix(people): the organization logo endpoint answers 304 without touching blob storage

### DIFF
--- a/backend/internal/compose/integration/knowledgeorphan_integration_test.go
+++ b/backend/internal/compose/integration/knowledgeorphan_integration_test.go
@@ -34,15 +34,16 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// countingBlobstore records what was written and what was removed, so a test
+// countingBlobstore records what was written, removed and read, so a test
 // can assert the difference rather than the calls. It wraps the real memory
-// store rather than replacing it: the upload's behaviour must be measured
+// store rather than replacing it: the behaviour under test must be measured
 // against a store that actually stores.
 type countingBlobstore struct {
 	blobstore.Store
 	mu   sync.Mutex
 	put  []string
 	gone map[string]bool
+	gets int
 }
 
 func newCountingBlobstore() *countingBlobstore {
@@ -54,6 +55,20 @@ func (c *countingBlobstore) Put(ctx context.Context, key string, r io.Reader, si
 	c.put = append(c.put, key)
 	c.mu.Unlock()
 	return c.Store.Put(ctx, key, r, size, contentType)
+}
+
+func (c *countingBlobstore) Get(ctx context.Context, key string) (io.ReadCloser, blobstore.Object, error) {
+	c.mu.Lock()
+	c.gets++
+	c.mu.Unlock()
+	return c.Store.Get(ctx, key)
+}
+
+// getCount reports how many times Get was called so far.
+func (c *countingBlobstore) getCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gets
 }
 
 func (c *countingBlobstore) Delete(ctx context.Context, key string) error {

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -173,6 +173,58 @@ func TestOrganizationLogoRemovesLegacyTransparentCanvasAtTheDisplayBoundary(t *t
 	}
 }
 
+// margince#4913: streamLogo used to decode, per-pixel-scan and re-encode the
+// stored PNG on every request, including a repeat of one already answered.
+// The ETag lets a client that already holds today's picture be told so
+// without the endpoint touching blob storage at all. countingBlobstore is
+// shared with knowledgeorphan_integration_test.go.
+func TestOrganizationLogoAnswers304WithoutTouchingBlobStorageWhenTheClientAlreadyHasIt(t *testing.T) {
+	e := Setup(t)
+	blob := newCountingBlobstore()
+	handlers := people.NewHandlers(e.DB()).WithBlobstore(blob)
+	ctx := e.Admin()
+	orgID := seedLoggedOrg(ctx, t, e, blob, logoPNG(t))
+	url := "/v1/organizations/" + orgID.String() + "/logo"
+
+	first := httptest.NewRecorder()
+	handlers.GetOrganizationLogo(first, httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx), crmcontracts.Id(orgID.UUID))
+	if first.Code != http.StatusOK {
+		t.Fatalf("first GET = %d, want 200: %s", first.Code, first.Body.String())
+	}
+	etag := first.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("the 200 response carries no ETag")
+	}
+	if got := blob.getCount(); got != 1 {
+		t.Fatalf("blob.Get calls after the first request = %d, want 1", got)
+	}
+
+	matching := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx)
+	req.Header.Set("If-None-Match", etag)
+	handlers.GetOrganizationLogo(matching, req, crmcontracts.Id(orgID.UUID))
+	if matching.Code != http.StatusNotModified {
+		t.Fatalf("GET with a matching If-None-Match = %d, want 304: %s", matching.Code, matching.Body.String())
+	}
+	if matching.Body.Len() != 0 {
+		t.Fatalf("a 304 response body = %d bytes, want none", matching.Body.Len())
+	}
+	if got := blob.getCount(); got != 1 {
+		t.Fatalf("blob.Get calls after the matching request = %d, want still 1 (the cache hit must not touch blob storage)", got)
+	}
+
+	stale := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx)
+	req.Header.Set("If-None-Match", `"stale-revision"`)
+	handlers.GetOrganizationLogo(stale, req, crmcontracts.Id(orgID.UUID))
+	if stale.Code != http.StatusOK {
+		t.Fatalf("GET with a stale If-None-Match = %d, want 200: %s", stale.Code, stale.Body.String())
+	}
+	if got := blob.getCount(); got != 2 {
+		t.Fatalf("blob.Get calls after the stale-etag request = %d, want 2", got)
+	}
+}
+
 func TestOrganizationLogoIs404WithoutOneAnd501WithoutAnObjectStore(t *testing.T) {
 	e := Setup(t)
 	blob := blobstore.NewMemory()

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"image/png"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -173,11 +174,10 @@ func TestOrganizationLogoRemovesLegacyTransparentCanvasAtTheDisplayBoundary(t *t
 	}
 }
 
-// margince#4913: streamLogo used to decode, per-pixel-scan and re-encode the
-// stored PNG on every request, including a repeat of one already answered.
-// The ETag lets a client that already holds today's picture be told so
-// without the endpoint touching blob storage at all. countingBlobstore is
-// shared with knowledgeorphan_integration_test.go.
+// A client that already holds today's picture is told so — 304, no body —
+// without the endpoint decoding, scanning or re-encoding the stored PNG, or
+// even opening it in blob storage. countingBlobstore is shared with
+// knowledgeorphan_integration_test.go.
 func TestOrganizationLogoAnswers304WithoutTouchingBlobStorageWhenTheClientAlreadyHasIt(t *testing.T) {
 	e := Setup(t)
 	blob := newCountingBlobstore()
@@ -199,6 +199,19 @@ func TestOrganizationLogoAnswers304WithoutTouchingBlobStorageWhenTheClientAlread
 		t.Fatalf("blob.Get calls after the first request = %d, want 1", got)
 	}
 
+	// The ETag and LogoURL's own cache-busting query token are meant to be
+	// the SAME digest of the same key (logoRevisionDigest) — pin that they
+	// still are, so the two spellings cannot silently drift apart.
+	key, err := e.People.OrganizationLogoKey(ctx, orgID, people.LogoWide)
+	if err != nil {
+		t.Fatalf("read the stored logo key: %v", err)
+	}
+	wantURL := *people.LogoURL(orgID.UUID, &key, people.LogoWide)
+	wantDigest := wantURL[strings.LastIndex(wantURL, "=")+1:]
+	if gotDigest := strings.Trim(etag, `"`); gotDigest != wantDigest {
+		t.Fatalf("ETag digest = %q, want %q (LogoURL's own query token)", gotDigest, wantDigest)
+	}
+
 	matching := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx)
 	req.Header.Set("If-None-Match", etag)
@@ -211,6 +224,20 @@ func TestOrganizationLogoAnswers304WithoutTouchingBlobStorageWhenTheClientAlread
 	}
 	if got := blob.getCount(); got != 1 {
 		t.Fatalf("blob.Get calls after the matching request = %d, want still 1 (the cache hit must not touch blob storage)", got)
+	}
+
+	// RFC 9110 §13.1.2: If-None-Match comparison is WEAK, so a proxy that
+	// prefixes this server's own strong tag with "W/" must still count as a
+	// match rather than falling through to the full decode/re-encode path.
+	weak := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx)
+	req.Header.Set("If-None-Match", "W/"+etag)
+	handlers.GetOrganizationLogo(weak, req, crmcontracts.Id(orgID.UUID))
+	if weak.Code != http.StatusNotModified {
+		t.Fatalf("GET with a weak (W/-prefixed) matching If-None-Match = %d, want 304: %s", weak.Code, weak.Body.String())
+	}
+	if got := blob.getCount(); got != 1 {
+		t.Fatalf("blob.Get calls after the weak-match request = %d, want still 1", got)
 	}
 
 	stale := httptest.NewRecorder()

--- a/backend/internal/modules/people/handlers_organizationlogo.go
+++ b/backend/internal/modules/people/handlers_organizationlogo.go
@@ -24,6 +24,11 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
+// logoCacheControl is the private, short-lived cache every logo response
+// carries — 200 and 304 alike, so a client revalidating gets the same
+// freshness window as one that fetched fresh bytes.
+const logoCacheControl = "private, max-age=300"
+
 // GetOrganizationLogo streams the organization's wide mark — the lockup a
 // record page and an expanded sidebar draw.
 func (h Handlers) GetOrganizationLogo(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
@@ -51,16 +56,16 @@ func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontr
 		httperr.NotImplemented(w, r, operation)
 		return
 	}
-	// The object key is minted fresh per upload (orglogowrite.go), so it
-	// already names these exact bytes — the same digest LogoURL bakes into
-	// its cache-busting query token doubles as the ETag. A match means the
-	// client already holds today's picture: answer before touching blob
-	// storage or spending a decode and a per-pixel scan on bytes it will
-	// throw away.
+	// The object key is minted fresh per upload (organizationLogoKey /
+	// siteReadLogoKey, compose/sitelogo.go), so it already names these exact
+	// bytes — the same digest LogoURL bakes into its cache-busting query
+	// token doubles as the ETag. A match means the client already holds
+	// today's picture: answer before touching blob storage or spending a
+	// decode and a per-pixel scan on bytes it will throw away.
 	etag := `"` + logoRevisionDigest(key) + `"`
-	if r.Header.Get("If-None-Match") == etag {
+	if httperr.IfNoneMatchHit(r, etag) {
 		w.Header().Set("ETag", etag)
-		w.Header().Set("Cache-Control", "private, max-age=300")
+		w.Header().Set("Cache-Control", logoCacheControl)
 		w.WriteHeader(http.StatusNotModified)
 		return
 	}
@@ -102,7 +107,7 @@ func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontr
 	// replacement takes a fresh cache entry. A company list asks for one image
 	// per row, and this short private cache saves the repeated reads of each —
 	// the ETag above extends that saving past the cache's own expiry too.
-	w.Header().Set("Cache-Control", "private, max-age=300")
+	w.Header().Set("Cache-Control", logoCacheControl)
 	w.Header().Set("ETag", etag)
 	httperr.StreamObject(w, r, httperr.StreamedObject{
 		Download: httperr.Download{ContentType: imagenorm.ContentType, Inline: true, Size: int64(len(logo))},

--- a/backend/internal/modules/people/handlers_organizationlogo.go
+++ b/backend/internal/modules/people/handlers_organizationlogo.go
@@ -51,6 +51,19 @@ func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontr
 		httperr.NotImplemented(w, r, operation)
 		return
 	}
+	// The object key is minted fresh per upload (orglogowrite.go), so it
+	// already names these exact bytes — the same digest LogoURL bakes into
+	// its cache-busting query token doubles as the ETag. A match means the
+	// client already holds today's picture: answer before touching blob
+	// storage or spending a decode and a per-pixel scan on bytes it will
+	// throw away.
+	etag := `"` + logoRevisionDigest(key) + `"`
+	if r.Header.Get("If-None-Match") == etag {
+		w.Header().Set("ETag", etag)
+		w.Header().Set("Cache-Control", "private, max-age=300")
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
 	rc, _, err := h.blob.Get(r.Context(), key)
 	if err != nil {
 		if errors.Is(err, blobstore.ErrNotFound) {
@@ -87,8 +100,10 @@ func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontr
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox")
 	// The URL carries a revision token derived from the stored object key, so a
 	// replacement takes a fresh cache entry. A company list asks for one image
-	// per row, and this short private cache saves the repeated reads of each.
+	// per row, and this short private cache saves the repeated reads of each —
+	// the ETag above extends that saving past the cache's own expiry too.
 	w.Header().Set("Cache-Control", "private, max-age=300")
+	w.Header().Set("ETag", etag)
 	httperr.StreamObject(w, r, httperr.StreamedObject{
 		Download: httperr.Download{ContentType: imagenorm.ContentType, Inline: true, Size: int64(len(logo))},
 		Body:     io.NopCloser(bytes.NewReader(logo)),

--- a/backend/internal/modules/people/organizationlogo.go
+++ b/backend/internal/modules/people/organizationlogo.go
@@ -302,6 +302,21 @@ func (s *Store) OrganizationLogoKey(ctx context.Context, id ids.OrganizationID, 
 	return *key, nil
 }
 
+// logoRevisionDigest names one slot's stored bytes on the wire: LogoURL bakes
+// it into a cache-busting query token, and streamLogo answers with the same
+// value as an ETag — one spelling, so the two mechanisms naming the same
+// bytes can never drift into disagreeing about which revision they mean.
+//
+// The prefix versions the representation as well as the object. Version 2
+// removes the transparent square canvas written by older logo uploads, so a
+// browser that cached that letterboxed response must fetch the wide one. The
+// slot needs no version of its own: each slot has its own path, and a key is
+// minted per upload (orglogowrite.go), so two marks can never share a digest.
+func logoRevisionDigest(objectKey string) string {
+	digest := sha256.Sum256([]byte("logo-display-v2\x00" + objectKey))
+	return fmt.Sprintf("%x", digest[:6])
+}
+
 // LogoURL renders where a client fetches one slot's logo bytes, or nil when the
 // organization wears no mark there. Its query token changes with the object key,
 // so replacing a logo cannot leave a browser showing the previous cached image
@@ -315,12 +330,6 @@ func LogoURL(id ids.UUID, objectKey *string, slot LogoSlot) *string {
 	if objectKey == nil || *objectKey == "" {
 		return nil
 	}
-	// The prefix versions the representation as well as the object. Version 2
-	// removes the transparent square canvas written by older logo uploads, so a
-	// browser that cached that letterboxed response must fetch the wide one.
-	// The slot needs no version of its own: each slot has its own path, and a
-	// key is minted per upload, so two marks can never share a cache entry.
-	digest := sha256.Sum256([]byte("logo-display-v2\x00" + *objectKey))
-	path := fmt.Sprintf("/v1/organizations/%s/logo%s?v=%x", id.String(), slot.urlSuffix(), digest[:6])
+	path := fmt.Sprintf("/v1/organizations/%s/logo%s?v=%s", id.String(), slot.urlSuffix(), logoRevisionDigest(*objectKey))
 	return &path
 }

--- a/backend/internal/modules/people/organizationlogo.go
+++ b/backend/internal/modules/people/organizationlogo.go
@@ -311,7 +311,8 @@ func (s *Store) OrganizationLogoKey(ctx context.Context, id ids.OrganizationID, 
 // removes the transparent square canvas written by older logo uploads, so a
 // browser that cached that letterboxed response must fetch the wide one. The
 // slot needs no version of its own: each slot has its own path, and a key is
-// minted per upload (orglogowrite.go), so two marks can never share a digest.
+// minted per upload (organizationLogoKey / siteReadLogoKey,
+// compose/sitelogo.go), so two marks can never share a digest.
 func logoRevisionDigest(objectKey string) string {
 	digest := sha256.Sum256([]byte("logo-display-v2\x00" + objectKey))
 	return fmt.Sprintf("%x", digest[:6])

--- a/backend/internal/platform/httperr/wire.go
+++ b/backend/internal/platform/httperr/wire.go
@@ -355,6 +355,54 @@ func IfMatchVersion(w http.ResponseWriter, r *http.Request) (*int64, bool) {
 	return &v, true
 }
 
+// IfNoneMatchHit reports whether r's If-None-Match already names etag (a
+// quoted strong validator, e.g. `"abc123"`), so a caller can answer 304
+// before doing the work a fresh response would need. Per RFC 9110 §13.1.2 the
+// header is a comma-separated list, "*" matches anything, and comparison is
+// WEAK — a proxy that adds a `W/` prefix to this server's own strong tag must
+// still be recognised, or every hop that does that silently pays for the full
+// response this header exists to let it skip. The list is split respecting
+// quoting, not on every comma: a comma is a legal byte inside a quoted
+// etag-value, so a naive split could cut a single candidate in two and miss
+// it, or the request could carry several header lines (Go's Header.Values,
+// each itself comma-separated in the same way).
+func IfNoneMatchHit(r *http.Request, etag string) bool {
+	for _, line := range r.Header.Values("If-None-Match") {
+		for _, candidate := range splitUnquoted(line, ',') {
+			candidate = strings.TrimSpace(candidate)
+			if candidate == "*" {
+				return true
+			}
+			if strings.TrimPrefix(candidate, "W/") == etag {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// splitUnquoted splits s on sep, except where sep falls inside a
+// double-quoted span — the shape an ETag list needs, since RFC 9110's
+// etag-value allows a comma as one of its own bytes.
+func splitUnquoted(s string, sep byte) []string {
+	var parts []string
+	inQuotes := false
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			inQuotes = !inQuotes
+		case sep:
+			if !inQuotes {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
 // ClearedFields names the top-level keys the body sent as an explicit null.
 //
 // A nullable contract field decodes to a nil pointer whether the caller sent

--- a/backend/internal/platform/httperr/wire_test.go
+++ b/backend/internal/platform/httperr/wire_test.go
@@ -39,3 +39,39 @@ func TestDecodeCapsTheBody(t *testing.T) {
 		t.Fatalf("oversized body → ok=%v status=%d, want refusal 413", ok, status)
 	}
 }
+
+// RFC 9110 §13.1.2: If-None-Match is a comma-separated list, "*" matches
+// anything, and comparison is WEAK — a proxy prefixing this server's own
+// strong tag with "W/" must still count as a match, or a caller that adds
+// one silently loses the conditional-GET saving the header exists to give it.
+func TestIfNoneMatchHit(t *testing.T) {
+	tests := map[string]struct {
+		etag   string
+		header string
+		want   bool
+	}{
+		"no header":                {etag: `"abc123"`, header: "", want: false},
+		"exact match":              {etag: `"abc123"`, header: `"abc123"`, want: true},
+		"wildcard":                 {etag: `"abc123"`, header: "*", want: true},
+		"weak-prefixed match":      {etag: `"abc123"`, header: `W/"abc123"`, want: true},
+		"one of several, matches":  {etag: `"abc123"`, header: `"other", "abc123"`, want: true},
+		"one of several, no match": {etag: `"abc123"`, header: `"other", "third"`, want: false},
+		"different tag":            {etag: `"abc123"`, header: `"xyz789"`, want: false},
+		"substring is not a match": {etag: `"abc123"`, header: `"abc1234"`, want: false},
+		// A comma is a legal byte inside a quoted etag-value (RFC 9110's
+		// etag-value grammar), so splitting the list on every comma would cut
+		// this single candidate into two pieces, neither equal to the etag.
+		"comma inside the etag value itself": {etag: `"a,b"`, header: `"a,b"`, want: true},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/v1/things", nil)
+			if tt.header != "" {
+				r.Header.Set("If-None-Match", tt.header)
+			}
+			if got := IfNoneMatchHit(r, tt.etag); got != tt.want {
+				t.Errorf("IfNoneMatchHit(If-None-Match: %q, etag: %q) = %v, want %v", tt.header, tt.etag, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

margince#4913 — `GET /v1/organizations/{id}/logo` decoded, per-pixel-scanned and PNG-re-encoded the stored logo bytes (`imagenorm.TrimTransparentPNG`) on **every** request, including a repeat of one already answered — there was no way to answer `304`.

The object's storage key is minted fresh per upload (`organizationLogoKey`/`siteReadLogoKey`, `compose/sitelogo.go`), so it already names these exact bytes. The fix reuses the same digest `LogoURL` already bakes into its cache-busting query token (factored into one shared `logoRevisionDigest` function so the two can never drift into naming a revision differently) as the response's `ETag`, checked against `If-None-Match` **before** blob storage is touched at all.

## Review

Reviewed by both Fable and Codex before push; both independently caught the same MAJOR: comparing `If-None-Match` by exact string equality ignores RFC 9110 §13.1.2 — weak validators (`W/` prefix, common behind a gzip/CDN hop), multi-value lists, and `*`. Added `httperr.IfNoneMatchHit` (quote-aware comma split, since a comma is a legal byte inside an `etag-value`; weak comparison; wildcard; multiple header lines) with its own unit tests, including a case that would break a naive `strings.Split` — mutation-tested to confirm. Also fixed two comments that pointed at the wrong file for where a logo's object key is minted, and one carrying ticket-number/fix-narration residue (both flagged independently by Fable and Codex).

## Scope notes

- **No AI prompt content changed**, no aicert re-run needed.
- **Scope boundary, not silently left out**: `compose/sitelogo.go` still writes new machine-resolved logos through `imagenorm.SquarePNG` (the letterboxed shape), not `FitPNG` — so `TrimTransparentPNG`'s own doc comment ("exists for logos stored before FitPNG") is already stale for *current* writes too, and a cold (never-cached) request still pays the full decode+scan cost once. This PR fixes the *repeat-request* half (the QC report's literal complaint: "on every request"); switching `sitelogo.go` to `FitPNG` plus a one-off backfill of already-stored objects is a separate, larger change with its own review surface (touches blob storage semantics, not just a response header) and isn't bundled here.
- **No UAT video** — this is a response-header/caching change with no visual difference; the integration test (below) exercises the exact HTTP behavior a browser would rely on, and is stronger evidence than a screen recording would be for this kind of fix.
- **Coverage**: the new `httperr.IfNoneMatchHit`/`splitUnquoted` functions are 100% covered by their own unit tests; the handler's new branches are covered by the integration test.

## Test plan

- [x] `TestOrganizationLogoAnswers304WithoutTouchingBlobStorageWhenTheClientAlreadyHasIt` — proves a matching `If-None-Match` (including a `W/`-prefixed weak one) returns `304` with an empty body **without calling `blob.Get`** (via an extended `countingBlobstore` test helper), and a stale one still returns the full `200`
- [x] Pins that the ETag and `LogoURL`'s own cache-busting query token share the exact same digest (the "can never drift" claim, held by an assertion rather than left as a comment)
- [x] `TestIfNoneMatchHit` unit tests: exact match, wildcard, weak prefix, multi-value list, stale tag, and a comma-inside-the-etag-value case that a naive comma split would miss
- [x] Mutation-tested: reverted the quote-aware split to a plain `strings.Split` — the comma-in-etag case goes red; reverted the early-return branch entirely — the 304 case goes red; both restore clean
- [x] `make check-go` green (build, vet, lint, arch-lint, unit + fitness tests, contract drift) on the rebased branch
- [x] `make test-it DIR=backend/internal/compose/integration RUN=TestOrganizationLogo` green against real Postgres
- [x] Pre-push `craft static --strict` — 0 blocker/major/minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRuXiSKkD1X1D1U5yRF4Qn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the organization logo endpoint answer 304 when the client already holds the current bytes, so repeats no longer decode, scan, and re-encode the stored PNG or open it in blob storage.

Previously every request ran `TrimTransparentPNG` on the stored logo; there was no ETag, so nothing could ever be conditional.

- The ETag reuses the same digest `LogoURL` bakes into its cache-busting query token, factored into `logoRevisionDigest` so the two cannot drift apart.
- `httperr.IfNoneMatchHit` implements RFC 9110 §13.1.2: weak (`W/`-prefixed) matching, wildcards, multi-value lists, and quote-aware comma splitting (commas are legal inside an etag-value).
- An integration test proves a matching or weak-matching `If-None-Match` returns 304 without calling `blob.Get`; a stale tag still returns 200.
- Scope boundary: a cold request still pays the decode once; switching composed writes to `FitPNG` and backfilling stored objects is a separate change.

<sup>Written for commit a23e9b55dcba9d73afaada35615b4a853e5a3f22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

