### PR TITLE
fix(export): an exported row does not name a record its reader cannot open

### DIFF
--- a/backend/gates/exportedreferences_test.go
+++ b/backend/gates/exportedreferences_test.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+//go:build !integration
+
+package gates
+
+// Every reference an exported row carries to a row-scoped record is one the
+// export withholds from a reader who could not open it.
+//
+// The pairs live in compose (referencesByTable) and this derives the SAME set
+// from the schema's own foreign keys, so the two cannot drift. A column added
+// next year that names an organization is covered the day its FK is declared,
+// rather than the day somebody remembers the export.
+//
+// UNDER-RECOGNITION is the whole risk here. A missing pair is not a failing
+// test anywhere: the export keeps working, the column keeps going out, and what
+// leaves is the id of a record the reader's own list would have withheld. There
+// is nothing to notice, which is why this is derived rather than reviewed.
+//
+// BETWEEN row-scoped tables only. A column naming a table every reader may read
+// discloses nothing by naming it, and withholding one would blank a field for
+// no reason — the availability regression that wears a security fix's clothes.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// foreignKeyToRowScoped matches a catalog line declaring one table's FK to
+// another: `public.<table>.<name> FOREIGN KEY (<column>) REFERENCES <target>(id)`.
+var foreignKeyToRowScoped = regexp.MustCompile(
+	`^public\.(\w+)\.\w+ FOREIGN KEY \((\w+)\) REFERENCES (\w+)\(id\)`)
+
+func TestEveryExportedReferenceToARowScopedTableIsWithheld(t *testing.T) {
+	t.Parallel()
+
+	scoped := rowScopedTables(t)
+	if len(scoped) < 5 {
+		t.Fatalf("read %d row-scoped tables from auth — far fewer than this product has, so a green result here would mean nothing", len(scoped))
+	}
+
+	want := map[string][]string{}
+	catalog, err := os.ReadFile("migrations/testdata/head_catalog.txt")
+	if err != nil {
+		t.Fatalf("reading the head catalog: %v", err)
+	}
+	for _, line := range strings.Split(string(catalog), "\n") {
+		m := foreignKeyToRowScoped.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		table, column, target := m[1], m[2], m[3]
+		if !scoped[table] || !scoped[target] {
+			continue
+		}
+		want[table] = append(want[table], column+"->"+target)
+	}
+	if len(want) == 0 {
+		t.Fatal("the catalog declared no foreign key between two row-scoped tables — the scan read the wrong file or the wrong shape, and an empty expectation passes against anything")
+	}
+
+	got := declaredExportReferences(t)
+	for table, columns := range want {
+		sort.Strings(columns)
+		declared := got[table]
+		sort.Strings(declared)
+		if !slices.Equal(columns, declared) {
+			t.Errorf("compose's referencesByTable[%q] = %v, want %v — a reference the export does not withhold leaves the id of a record this reader's own list would have withheld, and nothing fails to say so",
+				table, declared, columns)
+		}
+	}
+	for table := range got {
+		if _, expected := want[table]; !expected {
+			t.Errorf("compose's referencesByTable declares %q, which the catalog gives no row-scoped reference — withholding a column for no reason blanks a field a reader is entitled to", table)
+		}
+	}
+}
+
+// declaredExportReferences reads compose's pairs as `column->target` strings,
+// the same spelling the catalog side is rendered in.
+func declaredExportReferences(t *testing.T) map[string][]string {
+	t.Helper()
+	const declaration = "internal/compose/exportreferences.go"
+	file, err := parser.ParseFile(token.NewFileSet(), declaration, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", declaration, err)
+	}
+	constants := composeStringConstants(t)
+	out := map[string][]string{}
+	for _, spec := range valueSpecsNamed(file, "referencesByTable") {
+		lit, ok := spec.Values[0].(*ast.CompositeLit)
+		if !ok {
+			t.Fatalf("referencesByTable is not a composite literal; this gate can only read one")
+		}
+		for _, entry := range lit.Elts {
+			kv, ok := entry.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			table := stringValue(t, constants, kv.Key)
+			refs, ok := kv.Value.(*ast.CompositeLit)
+			if !ok {
+				t.Fatalf("referencesByTable[%q] is not a list", table)
+			}
+			for _, r := range refs.Elts {
+				ref, ok := r.(*ast.CompositeLit)
+				if !ok {
+					continue
+				}
+				var column, target string
+				for _, f := range ref.Elts {
+					fkv, ok := f.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					name, _ := fkv.Key.(*ast.Ident)
+					switch {
+					case name == nil:
+					case name.Name == "column":
+						column = stringValue(t, constants, fkv.Value)
+					case name.Name == "target":
+						target = stringValue(t, constants, fkv.Value)
+					}
+				}
+				out[table] = append(out[table], column+"->"+target)
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatalf("%s declares no referencesByTable entries — the export withholds nothing and this gate read nothing", declaration)
+	}
+	return out
+}
+
+func valueSpecsNamed(file *ast.File, name string) []*ast.ValueSpec {
+	var out []*ast.ValueSpec
+	for _, decl := range file.Decls {
+		general, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range general.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if ok && len(value.Names) == 1 && value.Names[0].Name == name && len(value.Values) == 1 {
+				out = append(out, value)
+			}
+		}
+	}
+	return out
+}
+
+// composeStringConstants reads every string constant the compose package
+// declares. referencesByTable names its tables and columns through those
+// constants rather than repeating literals, and the constants are spread over
+// the files that own each vocabulary — so this reads the package, not one file.
+func composeStringConstants(t *testing.T) map[string]string {
+	t.Helper()
+	sources, err := filepath.Glob("internal/compose/*.go")
+	if err != nil {
+		t.Fatalf("listing compose sources: %v", err)
+	}
+	out := map[string]string{}
+	for _, source := range sources {
+		if strings.HasSuffix(source, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), source, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", source, err)
+		}
+		for _, decl := range file.Decls {
+			general, ok := decl.(*ast.GenDecl)
+			if !ok || general.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range general.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok || len(value.Names) != 1 || len(value.Values) != 1 {
+					continue
+				}
+				if lit, ok := value.Values[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					unquoted, err := strconv.Unquote(lit.Value)
+					if err != nil {
+						t.Fatalf("unquoting %s in %s: %v", lit.Value, source, err)
+					}
+					out[value.Names[0].Name] = unquoted
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("compose declares no string constants — the scan read the wrong directory, and every name would then resolve to nothing")
+	}
+	return out
+}
+
+// stringValue reads a literal, or the value of the constant an identifier names.
+func stringValue(t *testing.T, constants map[string]string, e ast.Expr) string {
+	t.Helper()
+	switch node := e.(type) {
+	case *ast.BasicLit:
+		if node.Kind != token.STRING {
+			t.Fatalf("expected a string literal, got %s", node.Kind)
+		}
+		v, err := strconv.Unquote(node.Value)
+		if err != nil {
+			t.Fatalf("unquoting %s: %v", node.Value, err)
+		}
+		return v
+	case *ast.Ident:
+		v, declared := constants[node.Name]
+		if !declared {
+			t.Fatalf("referencesByTable names %s, which compose declares no string constant for", node.Name)
+		}
+		return v
+	default:
+		t.Fatalf("expected a string literal or a constant name, got %T", e)
+		return ""
+	}
+}

--- a/backend/gates/exportedreferences_test.go
+++ b/backend/gates/exportedreferences_test.go
@@ -230,3 +230,47 @@ func stringValue(t *testing.T, constants map[string]string, e ast.Expr) string {
 		return ""
 	}
 }
+
+// The literal-scanning census cannot see these reads at all. Every OTHER
+// compose reader of a row-scoped reference names its column in a SQL string,
+// which is how TestEveryComposeReadOfARecordReferenceAppliesItsRowScope finds
+// its sites; the export builds its select list from the live catalog, so
+// export.go, filteredexport.go and filterpreview.go contain no such literal and
+// were never subjects of it. Not waived there — invisible to it, which is the
+// failure mode that reports PASS.
+//
+// So the class gets its own census, keyed on the mechanism that creates the
+// blind spot rather than on the three functions that have it today: a read
+// whose columns come from the catalog serves whatever the catalog holds,
+// including a column added next year by a migration nobody read.
+func TestEveryCatalogColumnedReadWithholdsWhatItCannotShow(t *testing.T) {
+	t.Parallel()
+
+	const (
+		catalogSource = "exportableColumns"
+		withholding   = "withholdUnreadableReferences"
+	)
+	graph := packageCallGraph(t, "internal/compose")
+	if _, declared := graph[withholding]; !declared {
+		t.Fatalf("compose declares no %s — this gate's obligation does not exist, so every subject would pass it", withholding)
+	}
+
+	var roots []string
+	for fn, entry := range graph {
+		if fn != catalogSource && entry.calls[catalogSource] {
+			roots = append(roots, fn)
+		}
+	}
+	if len(roots) == 0 {
+		t.Fatalf("no compose function calls %s — the call graph read nothing, and an empty census passes against anything", catalogSource)
+	}
+	sort.Strings(roots)
+
+	for _, root := range roots {
+		if reaches(graph, root, withholding) {
+			continue
+		}
+		t.Errorf("compose's %s takes its columns from the catalog but never reaches %s — it serves whatever the catalog holds, so a reference column added by a later migration leaves without anyone deciding it should",
+			root, withholding)
+	}
+}

--- a/backend/internal/compose/export.go
+++ b/backend/internal/compose/export.go
@@ -292,6 +292,13 @@ func readMember(ctx context.Context, tx pgx.Tx, m exportMember) (memberData, err
 	if err := pgRows.Err(); err != nil {
 		return memberData{}, err
 	}
+	// The bundle reads every column of every row in scope and applies neither
+	// the role masks nor this — so a private company's id left through the deal
+	// member while the organization member of the same bundle correctly omitted
+	// the company itself.
+	if err := withholdUnreadableReferences(ctx, tx, m.table, columns, data.rows); err != nil {
+		return memberData{}, err
+	}
 	return data, nil
 }
 

--- a/backend/internal/compose/exportreferences.go
+++ b/backend/internal/compose/exportreferences.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What an exported row may say about the records it POINTS AT.
+//
+// A row the caller may read is not a licence to read everything it names. An
+// organization can be capture-private to the colleague who captured it and a
+// project keeps its own/team scope, so a deal — which every seat of the
+// workspace reads, because a deal is customer identity — carries references
+// its reader's own organization and project reads would refuse.
+//
+// Field masks do not answer this. maskedRowSelects applies the caller's ROLE
+// masks, which ask what this role may see of any row — never what THIS reader
+// may see of the row this one names. Without the second question an export
+// hands back the id of a company whose own row the same bundle withholds, and
+// an id is an existence oracle: it says the record is there and that someone
+// in this workspace has it.
+//
+// DERIVED, not listed. The pairs come from the schema's own foreign keys to
+// row-scoped tables, so a column added next year is covered the day it is
+// declared rather than the day somebody remembers this file;
+// TestEveryExportedReferenceToARowScopedTableIsWithheld holds the derivation
+// against the head catalog and fails on a pair nobody added.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// exportedReference is one column that names a row-scoped record.
+type exportedReference struct {
+	column string
+	// target is the table the column references — what a visibility probe is
+	// asked about, and why two columns of one table can need different answers
+	// (a deal's partner and its customer are both organizations; its project
+	// is not).
+	target string
+}
+
+// The reference columns, prefixed for what they are.
+//
+// NOT report.go's colPartnerOrgID and friends, which carry the same words with
+// a `t.` alias in front: those name a column inside one report's own SELECT,
+// and these name a column of a row the export hands back. Two vocabularies
+// that happen to share their spelling.
+const (
+	refColMergedInto        = "merged_into_id"
+	refColOrganization      = "organization_id"
+	refColPartnerOrg        = "partner_org_id"
+	refColProject           = "project_id"
+	refColPromotedPerson    = "promoted_person_id"
+	refColQualifiedDeal     = "qualified_deal_id"
+	refColConvertedFromLead = "converted_from_lead_id"
+	refColParentOrg         = "parent_org_id"
+)
+
+// referencesByTable is every column an exported row carries that names a
+// record the reader may not be able to open.
+//
+// Only references BETWEEN row-scoped tables are here. A column naming a table
+// every reader may read discloses nothing by naming it, and withholding one
+// would blank a field for no reason — the availability regression that wears a
+// security fix's clothes.
+//
+// Held by: TestEveryExportedReferenceToARowScopedTableIsWithheld (backend/gates/exportedreferences_test.go)
+//
+// Keyed by replayscope.go's table constants: these are DATABASE tables, the
+// same vocabulary a row-scope clause is built on, and not the agent record
+// types or report dimensions that happen to share their spelling.
+var referencesByTable = map[string][]exportedReference{
+	tableDeal: {
+		{column: refColOrganization, target: tableOrganization},
+		{column: refColPartnerOrg, target: tableOrganization},
+		{column: refColProject, target: tableProject},
+	},
+	tableLead: {
+		{column: refColMergedInto, target: tableLead},
+		{column: refColProject, target: tableProject},
+		{column: refColPromotedPerson, target: tablePerson},
+		{column: refColQualifiedDeal, target: tableDeal},
+	},
+	tableOrganization: {
+		{column: refColMergedInto, target: tableOrganization},
+		{column: refColParentOrg, target: tableOrganization},
+	},
+	tablePerson: {
+		{column: refColConvertedFromLead, target: tableLead},
+		{column: refColMergedInto, target: tablePerson},
+	},
+	tableProject: {
+		{column: refColOrganization, target: tableOrganization},
+	},
+}
+
+// withholdUnreadableReferences blanks, in place, every reference an exported
+// row carries to a record this reader could not open.
+//
+// Positional because the export carries rows as value slices beside their
+// column names; the index is resolved once per reference rather than per row.
+//
+// ONE probe per referenced table for the whole page, never one per row: an
+// export is the shape most likely to turn a per-row question into thousands of
+// round trips, and VisibleSubset answers a whole id set in one statement.
+func withholdUnreadableReferences(
+	ctx context.Context, tx pgx.Tx, table string, columns []string, rows [][]any,
+) error {
+	refs := referencesByTable[table]
+	if len(refs) == 0 || len(rows) == 0 {
+		return nil
+	}
+	for _, ref := range refs {
+		at := indexOfColumn(columns, ref.column)
+		if at < 0 {
+			// The export does not carry this column, so there is nothing to
+			// withhold. Not an error: exportableColumns is the live catalog's
+			// answer and a member may legitimately export a subset.
+			continue
+		}
+		referenced := referencedIDs(rows, at)
+		// VisibleSubset answers an empty set without a round trip, so a page
+		// naming nothing pays for nothing.
+		visible, err := auth.VisibleSubset(ctx, tx, ref.target, referenced)
+		if err != nil {
+			return fmt.Errorf("compose: reading which %s rows the exporter may open: %w", ref.target, err)
+		}
+		for _, row := range rows {
+			id, named := referencedID(row, at)
+			if named && !visible[id] {
+				row[at] = nil
+			}
+		}
+	}
+	return nil
+}
+
+func indexOfColumn(columns []string, want string) int {
+	for i, c := range columns {
+		if c == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// referencedIDs collects the ids one column of the page names, duplicates and
+// all — VisibleSubset keys its answer by id, so a repeated reference costs
+// nothing extra and de-duplicating here would be a second pass for no gain.
+func referencedIDs(rows [][]any, at int) []ids.UUID {
+	out := make([]ids.UUID, 0, len(rows))
+	for _, row := range rows {
+		if id, named := referencedID(row, at); named {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// referencedID reads one row's reference, and says whether there is one.
+//
+// A row may carry the column as nil (nothing linked) or as a value a mask
+// already blanked, and both are "names nothing" rather than an error: pgx
+// hands a uuid column back as [16]byte, and anything else here is a column
+// that is not the reference this pair declared.
+func referencedID(row []any, at int) (ids.UUID, bool) {
+	if at >= len(row) || row[at] == nil {
+		return ids.UUID{}, false
+	}
+	switch v := row[at].(type) {
+	case [16]byte:
+		return ids.UUID(v), true
+	case ids.UUID:
+		return v, true
+	default:
+		return ids.UUID{}, false
+	}
+}

--- a/backend/internal/compose/exportreferences_test.go
+++ b/backend/internal/compose/exportreferences_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// A member may export fewer columns than the table holds — exportableColumns
+// reads the live catalog, and a reference the page does not carry has nothing
+// to withhold. Reaching the visibility probe here would mean asking about a
+// column that is not in the answer, on a transaction the caller has every right
+// not to have opened.
+func TestAPageWithoutTheReferenceColumnAsksNothing(t *testing.T) {
+	rows := [][]any{{ids.NewV7(), "Reisser"}}
+	// A nil transaction is the assertion: the probe is what would use it, and
+	// the columns say there is nothing to probe.
+	if err := withholdUnreadableReferences(t.Context(), nil, tableDeal, []string{"id", "name"}, rows); err != nil {
+		t.Fatalf("a page carrying no reference column: %v", err)
+	}
+	if len(rows[0]) != 2 || rows[0][1] != "Reisser" {
+		t.Fatalf("the page was altered: %v", rows)
+	}
+}
+
+// A table that references nothing row-scoped is answered before any column is
+// resolved, which is what keeps the withholding off the tables it has no
+// question about.
+func TestATableWithNoReferencesAsksNothing(t *testing.T) {
+	if err := withholdUnreadableReferences(t.Context(), nil, "product", []string{"id", "sku"}, [][]any{{ids.NewV7(), "A-1"}}); err != nil {
+		t.Fatalf("a table with no declared references: %v", err)
+	}
+}
+
+func TestIndexOfColumnAnswersMinusOneForAColumnThePageLacks(t *testing.T) {
+	if at := indexOfColumn([]string{"id", "name"}, refColOrganization); at != -1 {
+		t.Fatalf("a column the page lacks resolved to %d", at)
+	}
+	if at := indexOfColumn([]string{"id", refColOrganization}, refColOrganization); at != 1 {
+		t.Fatalf("the reference column resolved to %d", at)
+	}
+}
+
+// pgx hands a uuid column back as [16]byte, and the same value can arrive
+// already typed when a row was assembled in Go. Both are the same reference,
+// and reading only one of them would leave the other unprobed — a silent pass
+// rather than a failure, because an unrecognised value looks exactly like a
+// row that names nothing.
+func TestAReferenceIsReadFromEitherSpellingOfAUUID(t *testing.T) {
+	id := ids.NewV7()
+	for _, c := range []struct {
+		name string
+		row  []any
+	}{
+		{"as pgx returns it", []any{[16]byte(id)}},
+		{"already typed", []any{id}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got, named := referencedID(c.row, 0)
+			if !named || got != id {
+				t.Fatalf("read %v (named=%v), want %v", got, named, id)
+			}
+		})
+	}
+}
+
+// Anything else names nothing. A masked column arrives as a value this pair
+// never declared, and a row shorter than the index is a page that does not
+// carry the column at all — neither is an error, and treating either as a
+// reference would probe a value that is not one.
+func TestAValueThatIsNotAReferenceNamesNothing(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		row  []any
+		at   int
+	}{
+		{"a masked column", []any{"withheld"}, 0},
+		{"an absent value", []any{nil}, 0},
+		{"past the end of the row", []any{}, 0},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if _, named := referencedID(c.row, c.at); named {
+				t.Fatalf("%s was read as a reference", c.name)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/filteredexport.go
+++ b/backend/internal/compose/filteredexport.go
@@ -198,6 +198,12 @@ func readRowsByID(ctx context.Context, tx pgx.Tx, table string, columns []string
 	if err := pgRows.Err(); err != nil {
 		return nil, err
 	}
+	// The masks above answer what this ROLE may see of a row. This answers what
+	// THIS READER may see of the rows it names, which is a different question
+	// and the one the export never asked.
+	if err := withholdUnreadableReferences(ctx, tx, table, columns, out); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 

--- a/backend/internal/compose/integration/exportreferences_integration_test.go
+++ b/backend/internal/compose/integration/exportreferences_integration_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// An exported row does not name a record the exporter could not open.
+//
+// A deal is customer identity — every seat of the workspace reads every deal —
+// and the organization it points at is not: capture privacy makes a company
+// private to the colleague who captured it. So the two halves of one bundle can
+// disagree about the same record: the organization member omits a company the
+// exporter may not open, while deal.csv names its id in a reference column.
+//
+// Field masking cannot close that. It asks what this role may see of any row,
+// never what THIS reader may see of the row this one names — so these cover
+// both answers, because a withholding that also blanks a readable reference is
+// a regression wearing a security fix's clothes.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// seedDealOnAPrivateCompany is one deal, readable by everyone, pointing at a
+// company that is capture-private to Rep3.
+func seedDealOnAPrivateCompany(t *testing.T, e *SearchEnv) (deal, hidden ids.UUID) {
+	t.Helper()
+	pipelineID := e.SeedID(t, `INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Sales', true, 0)`)
+	stageID := e.SeedID(t, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, pipelineID)
+	hidden = e.SeedID(t, `INSERT INTO organization (id, display_name, owner_id, visibility, source, captured_by)
+		VALUES ($1, 'Meridian Labs', $2, 'owner', 'manual', 'human:x')`, e.Rep3)
+	deal = e.SeedID(t, `INSERT INTO deal (id, owner_id, name, pipeline_id, stage_id, organization_id,
+		forecast_category, source, captured_by)
+		VALUES ($1, $2, 'Meridian renewal', $3, $4, $5, 'commit', 'manual', 'human:x')`,
+		e.Rep1, pipelineID, stageID, hidden)
+	return deal, hidden
+}
+
+// dealAndCompanyReader holds deal AND organization read at team scope.
+//
+// Both grants, deliberately. VisibleSubset withholds every id when the OBJECT
+// grant is missing, so a reader holding only `deal` blanks the reference
+// whatever capture privacy says — and a fixture built on one would pass for the
+// wrong reason, proving nothing about the arm this closes.
+func (e *SearchEnv) dealAndCompanyReader(user ids.UUID) context.Context {
+	actor := principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		TeamIDs: []ids.UUID{e.Team1},
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				"deal":             {Read: true},
+				"organization":     {Read: true},
+				objInstallSettings: {Read: true},
+			},
+			RowScope: principal.RowScopeTeam,
+		},
+	}
+	return principal.WithActor(principal.WithWorkspaceID(context.Background(), e.WS), actor)
+}
+
+func TestAFilteredExportWithholdsACompanyTheExporterCannotOpen(t *testing.T) {
+	e := SetupSearch(t)
+	deal, hidden := seedDealOnAPrivateCompany(t, e)
+
+	ctx := e.dealAndCompanyReader(e.Rep1)
+	result, err := compose.NewFilteredExportWriter(e.Pool).WriteFiltered(
+		ctx, dealEngine(ctx, t, e), storekit.Predicate{Field: "forecast_category", Op: "eq", Value: "commit"}, "csv",
+	)
+	if err != nil {
+		t.Fatalf("filtered export: %v", err)
+	}
+
+	// The DEAL is exported — it is identity and this reader may read it. Only
+	// what it names is withheld, so a test that saw no rows would be proving
+	// the wrong thing.
+	ids := CSVColumn(t, result.Body, "id")
+	if len(ids) != 1 || ids[0] != deal.String() {
+		t.Fatalf("exported ids = %v, want the one visible deal %s", ids, deal)
+	}
+
+	for _, got := range CSVColumn(t, result.Body, "organization_id") {
+		if got == hidden.String() {
+			t.Errorf("the export names organization %s, which this exporter's own organization read would refuse — the id alone is an existence oracle over a capture-private company", hidden)
+		}
+		if got != "" {
+			t.Errorf("organization_id = %q, want empty for a company this exporter cannot open", got)
+		}
+	}
+}
+
+// And the reader who CAN open it still gets it, so the rule withholds from a
+// reader rather than emptying the column for everyone.
+func TestAFilteredExportKeepsACompanyTheExporterCanOpen(t *testing.T) {
+	e := SetupSearch(t)
+	_, hidden := seedDealOnAPrivateCompany(t, e)
+
+	ctx := e.dealAndCompanyReader(e.Rep3)
+	result, err := compose.NewFilteredExportWriter(e.Pool).WriteFiltered(
+		ctx, dealEngine(ctx, t, e), storekit.Predicate{Field: "forecast_category", Op: "eq", Value: "commit"}, "csv",
+	)
+	if err != nil {
+		t.Fatalf("filtered export: %v", err)
+	}
+	named := CSVColumn(t, result.Body, "organization_id")
+	if len(named) != 1 || named[0] != hidden.String() {
+		t.Errorf("organization_id = %v, want %s — the company is private TO this reader, so the export owes them the reference", named, hidden)
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (103)
+## Parity (104)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -55,6 +55,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `dsrqueueishumanonly_test.go` | H2 | The subject-request queue is human-only in the contract because it is human-only in the store. |
 | `emailsplitterparity_test.go` | H3 | The server composes a row's preview and the browser folds the quoted tail in the drawer, from two copies of one vocabulary. |
 | `enumsync_test.go` | H3 | The enum-vocabulary sync as a fitness function: where domain logic branches on a typed Go enum, its constant set must equal the schema's CHECK (col IN (...)) set for the column it mirrors. |
+| `exportedreferences_test.go` | H2 | Every reference an exported row carries to a row-scoped record is one the export withholds from a reader who could not open it. |
 | `filtervocabularyparity_test.go` | H3 | Two surfaces answer a filtered question: the list/segment compiler in `platform/database/storekit`, and the query compiler in `modules/search`. |
 | `forecastperiodparity_test.go` | H3 | Every period the contract offers must be a window the server can resolve. |
 | `forwardmeasureparity_test.go` | H3 | Every forward measure must be spelled the same on all three sides. |


### PR DESCRIPTION
Closes the export half of #2004.

## The leak

A row the caller may read is not a licence to read everything it names. A deal is customer identity — every seat of the workspace reads every deal — while the organization it points at is not: capture privacy makes a company private to the colleague who captured it.

So the two halves of one export bundle could disagree about the same record. `organization.csv` correctly omitted a company the exporter may not open; `deal.csv` named its id in `organization_id` anyway. An id is an existence oracle — it says the record is there, and that someone in this workspace has it.

Field masking cannot close this. `maskedRowSelects` applies the caller's **role** masks, which ask what this role may see of *any* row — never what **this** reader may see of the row this one names. Different question, so it was never going to be the answer.

## The fix

Both export paths (`readMember` in `export.go`, `readRowsByID` in `filteredexport.go`) now put every reference through `auth.VisibleSubset` before handing the page back. One probe per referenced table per page, never one per row — an export is the shape most likely to turn a per-row question into thousands of round trips.

References **between row-scoped tables only**. A column naming a table every reader may read discloses nothing by naming it, and withholding one would blank a field for no reason — the availability regression that wears a security fix's clothes.

## Derived, not listed

`backend/gates/exportedreferences_test.go` reads the head catalog's foreign keys between row-scoped tables and compares them against the declaration in compose. A column added next year is covered the day its FK lands, not the day somebody remembers this file.

Under-recognition is the whole risk here, which is why it is derived rather than reviewed: a missing pair fails nothing anywhere. The export keeps working, the column keeps going out, and what leaves is the id of a record the reader's own list would have withheld. There is no failing assertion to notice.

Mutation-verified in both directions:

- drop a declared pair → `referencesByTable["deal"] = [organization_id->organization project_id->project], want [... partner_org_id->organization ...]`
- point a column constant at a name the schema does not have → same gate, names the wrong column

The second matters because the gate resolves constants to their values rather than matching their names — the pairs are spelled through `replayscope.go`'s table constants and this file's `refCol*` constants, so a gate reading identifiers would have compared spelling and proved nothing.

## Verification

- `make check-backend` green
- `make test-it DIR=backend/internal/compose/integration RUN=TestAFilteredExport` — both cases pass

The integration pair covers **both** answers: a reference the exporter cannot open is withheld, and one they can open survives. With the guard removed the first fails with the leaked id named:

```
the export names organization 01a08485-…, which this exporter's own organization
read would refuse — the id alone is an existence oracle over a capture-private company
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exported records now omit references to related records the viewer cannot access.
  * Filtered exports preserve accessible data while withholding inaccessible related-record identifiers.
  * Export operations now report errors when reference visibility checks fail.

* **Tests**
  * Added coverage for reference visibility across standard and filtered exports.

* **Documentation**
  * Updated the gate inventory to include export reference visibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->