### PR TITLE
fix(overlay): a writable field projects onto the incumbent or says why not

### DIFF
--- a/backend/gates/overlaywritecoverage_test.go
+++ b/backend/gates/overlaywritecoverage_test.go
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+//gate:kind census H2
+
+package gates
+
+// Every field a caller may PATCH either projects onto the incumbent or says why
+// it does not.
+//
+// THE DEFECT THIS REPLACES. A canonical field absent from an overlay write
+// projection is not refused — it is accepted by the door and never sent. The
+// next overlay read returns the old value, so to a user the edit looks like
+// somebody else reverted it.
+//
+// It happened three times over on organization: legal_name, linkedin_url and
+// description were each simply never added when their column landed. Three
+// column changes failing to notice one obligation is one missing rule, not
+// three mistakes — which is why this is a rule and not three entries. Measured
+// while writing it, the gap was wider than the report: ten of organization's
+// twelve writable fields were unanswered for, and person and lead had never
+// been asked at all.
+//
+// THE CORPUS IS THE CONTRACT, not the schema. `organization` carries 65 columns
+// and most are ours alone — geocode state, logo keys, legal_hold. What makes a
+// field's absence a DEFECT is that the published contract invites a caller to
+// write it, so each update operation's own request schema is the set that has
+// to be answered for, and a field the contract adds joins the obligation by
+// being added.
+//
+// It lives HERE rather than beside the mapping because the overlay component
+// may not import the generated contract package (go-arch-lint refuses it), and
+// the contract is the half that makes this a promise rather than a preference.
+//
+// The writable set is read off internal/contracts' GENERATED request structs —
+// their json tags are what the door decodes, so they are the same promise
+// crm.yaml makes, in the form the server actually applies. Reading the YAML
+// instead would mean a second parser for a fact the generator already resolved.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// writeProjections pairs each canonical class's update operation with the two
+// declarations in mapwrite.go that must together answer for it.
+//
+// A table rather than three tests, because the three fail the same way — and a
+// class missing from it is the shape that let organization drift while person
+// and lead were never asked.
+var writeProjections = []struct {
+	canonical, projects, deferred string
+	// request is the generated struct the door decodes an update into. Its
+	// json tags ARE the writable set.
+	request any
+}{
+	{"organization", "organizationWriteFields", "deferredOrganizationWrites", crmcontracts.UpdateOrganizationRequest{}},
+	{"person", "personWriteFields", "deferredPersonWrites", crmcontracts.UpdatePersonRequest{}},
+	{"lead", "leadWriteFields", "deferredLeadWrites", crmcontracts.UpdateLeadRequest{}},
+}
+
+const mapwritePath = "internal/modules/overlay/hubspot/mapwrite.go"
+
+func TestEveryOverlayWritableFieldProjectsOrSaysWhyNot(t *testing.T) {
+	t.Parallel()
+
+	file := parseMapWrite(t)
+	consts := hubspotStringConsts(t)
+	for _, p := range writeProjections {
+		t.Run(p.canonical, func(t *testing.T) {
+			projected := projectedCanonicals(t, file, consts, p.projects)
+			deferred := deferredCanonicals(t, file, consts, p.deferred)
+			if len(projected) == 0 && len(deferred) == 0 {
+				t.Fatalf("neither %s nor %s was found in %s — this class is judged against nothing",
+					p.projects, p.deferred, mapwritePath)
+			}
+			writable := writableFieldsOf(t, p.canonical, p.request)
+			for _, field := range writable {
+				reason, isDeferred := deferred[field]
+				switch {
+				case projected[field] && isDeferred:
+					t.Errorf("%s.%s is both projected and deferred — one of the two is wrong, and a "+
+						"reader cannot tell which describes what the write does", p.canonical, field)
+				case projected[field]:
+				case isDeferred && reason != "":
+				case isDeferred:
+					t.Errorf("%s.%s is deferred with an empty reason, which says no more than leaving "+
+						"it out did", p.canonical, field)
+				default:
+					t.Errorf("%s.%s can be PATCHed through the public contract, and the overlay write "+
+						"projection neither carries it nor says why not. In overlay mode that write is "+
+						"accepted and never reaches the incumbent, so the next read returns the old "+
+						"value and the edit reads as somebody else's revert. Add it to %s, or to %s "+
+						"with the reason it cannot be the inverse of its read",
+						p.canonical, field, p.projects, p.deferred)
+				}
+			}
+			// The other direction: a deferral naming a field the contract no
+			// longer offers is a reason nobody needs, and the next author reads
+			// it as covering something that is handled.
+			for field := range deferred {
+				if !sortedContains(writable, field) {
+					t.Errorf("%s defers %q and the update request declares no such writable field — "+
+						"the contract moved and this reason outlived it", p.deferred, field)
+				}
+			}
+		})
+	}
+}
+
+// projectedCanonicals reads the Canonical values out of one []directWriteField
+// literal.
+func projectedCanonicals(t *testing.T, file *ast.File, consts map[string]string, varName string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	forEachVarLiteral(file, varName, func(lit *ast.CompositeLit) {
+		for _, elt := range lit.Elts {
+			entry, ok := elt.(*ast.CompositeLit)
+			if !ok {
+				continue
+			}
+			for _, field := range entry.Elts {
+				kv, ok := field.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "Canonical" {
+					if name, ok := gatekit.StringExpr(kv.Value, consts, gatekit.FoldStrict); ok {
+						out[name] = true
+					}
+				}
+			}
+		}
+	})
+	return out
+}
+
+// deferredCanonicals reads one map[string]string literal's keys and the reason
+// each carries.
+func deferredCanonicals(t *testing.T, file *ast.File, consts map[string]string, varName string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	forEachVarLiteral(file, varName, func(lit *ast.CompositeLit) {
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, keyed := gatekit.StringExpr(kv.Key, consts, gatekit.FoldStrict)
+			if !keyed {
+				continue
+			}
+			reason, _ := gatekit.StringExpr(kv.Value, consts, gatekit.FoldTotal)
+			out[key] = reason
+		}
+	})
+	return out
+}
+
+// forEachVarLiteral visits the composite literal a named package-level var is
+// assigned.
+func forEachVarLiteral(file *ast.File, varName string, visit func(*ast.CompositeLit)) {
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.ValueSpec)
+		if !ok || len(spec.Names) != 1 || spec.Names[0].Name != varName || len(spec.Values) != 1 {
+			return true
+		}
+		if lit, ok := spec.Values[0].(*ast.CompositeLit); ok {
+			visit(lit)
+		}
+		return true
+	})
+}
+
+func parseMapWrite(t *testing.T) *ast.File {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), filepath.Join(repoRoot, "backend", mapwritePath), nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", mapwritePath, err)
+	}
+	return file
+}
+
+// writableFieldsOf reads the json tags off one update request struct, which is
+// the set of fields the door will decode and therefore the set where an
+// unprojected field turns into a silent drop.
+//
+//craft:ignore naked-any the three request structs are unrelated generated types with no common interface — a constraint would have to name all three, which is the list this gate exists to avoid keeping
+func writableFieldsOf(t *testing.T, canonical string, request any) []string {
+	t.Helper()
+	rt := reflect.TypeOf(request)
+	fields := make([]string, 0, rt.NumField())
+	for i := range rt.NumField() {
+		tag, ok := rt.Field(i).Tag.Lookup("json")
+		if !ok {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name != "" && name != "-" {
+			fields = append(fields, name)
+		}
+	}
+	sort.Strings(fields)
+	if len(fields) < 2 {
+		t.Fatalf("%s's update request declares %d writable field(s) — too few for the projection to be "+
+			"a meaningful subset of anything, so this class is answered for by asking nothing",
+			canonical, len(fields))
+	}
+	return fields
+}
+
+func sortedContains(haystack []string, needle string) bool {
+	i := sort.SearchStrings(haystack, needle)
+	return i < len(haystack) && haystack[i] == needle
+}
+
+// hubspotStringConsts indexes the string constants the hubspot package
+// declares, by name.
+//
+// The projections key several entries on a constant rather than a literal —
+// `{Canonical: industryField}`, `canonicalOwnerID:` — so a reader that took
+// only literals would silently see a shorter list than the code declares, and
+// report the fields it could not read as unanswered. Resolving them is what
+// makes this gate judge the mapping rather than its spelling.
+func hubspotStringConsts(t *testing.T) map[string]string {
+	t.Helper()
+	dir := filepath.Join(repoRoot, "backend", "internal", "modules", "overlay", "hubspot")
+	fset := token.NewFileSet()
+	var files []*ast.File
+	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		parsed, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		files = append(files, parsed)
+		return nil
+	}); err != nil {
+		t.Fatalf("parsing the hubspot package: %v", err)
+	}
+	consts := map[string]string{}
+	{
+		for _, file := range files {
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.CONST {
+					continue
+				}
+				for _, spec := range gen.Specs {
+					value, ok := spec.(*ast.ValueSpec)
+					if !ok || len(value.Names) != 1 || len(value.Values) != 1 {
+						continue
+					}
+					if text, isString := gatekit.LiteralText(value.Values[0]); isString {
+						consts[value.Names[0].Name] = text
+					}
+				}
+			}
+		}
+	}
+	if len(consts) == 0 {
+		t.Fatal("the hubspot package declares no string constant — every constant-keyed entry below " +
+			"would read as absent, and the gate would report fields as unanswered that are answered")
+	}
+	return consts
+}

--- a/backend/internal/modules/overlay/hubspot/mapwrite.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite.go
@@ -6,6 +6,7 @@ package hubspot
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -36,6 +37,13 @@ import (
 type writeMapping struct {
 	ObjectClass string
 	Props       map[string]string
+	// Dropped is the canonical fields the caller asked to write that this
+	// projection cannot send, in name order. It is what turns a silent drop
+	// into one somebody can see: the write still succeeds — the incumbent has
+	// the fields it can hold — but an operator reading the log knows which
+	// values did not leave, instead of learning it from a user reporting that
+	// an edit reverted itself.
+	Dropped []string
 }
 
 // mapWrite projects a canonical write (the entity type + the canonical field
@@ -51,13 +59,22 @@ func mapWrite(canonicalClass string, fields map[string]any, forUpdate bool) (wri
 	switch canonicalClass {
 	case personTarget:
 		props, err := copyDirect(fields, personWriteFields, forUpdate)
-		return writeMapping{ObjectClass: objectClassContacts, Props: props}, err
+		return writeMapping{
+			ObjectClass: objectClassContacts, Props: props,
+			Dropped: droppedFields(fields, deferredPersonWrites),
+		}, err
 	case organizationTarget:
 		props, err := copyDirect(fields, organizationWriteFields, forUpdate)
-		return writeMapping{ObjectClass: objectClassCompanies, Props: props}, err
+		return writeMapping{
+			ObjectClass: objectClassCompanies, Props: props,
+			Dropped: droppedFields(fields, deferredOrganizationWrites),
+		}, err
 	case leadTarget:
 		props, err := copyDirect(fields, leadWriteFields, forUpdate)
-		return writeMapping{ObjectClass: objectClassLeads, Props: props}, err
+		return writeMapping{
+			ObjectClass: objectClassLeads, Props: props,
+			Dropped: droppedFields(fields, deferredLeadWrites),
+		}, err
 	case dealTarget:
 		return mapWriteDeal(fields, forUpdate)
 	case activityTarget:
@@ -70,6 +87,11 @@ func mapWrite(canonicalClass string, fields map[string]any, forUpdate bool) (wri
 // directWriteField is one canonical field that projects 1:1 onto a HubSpot
 // property by a straight string copy. The read-only canonical fields simply
 // have no entry — that absence is what makes them never written.
+// canonicalOwnerID is the canonical field every class defers for the same
+// reason: writing it back needs the reverse owner user-map resolution, which
+// resolves a Margince user to the incumbent's own owner id.
+const canonicalOwnerID = "owner_id"
+
 type directWriteField struct {
 	Canonical string
 	HSProp    string
@@ -88,13 +110,62 @@ var personWriteFields = []directWriteField{
 	{Canonical: "title", HSProp: "jobtitle"},
 }
 
+// deferredPersonWrites — the same obligation as deferredOrganizationWrites, for
+// the fields updatePerson lets a caller send.
+var deferredPersonWrites = map[string]string{
+	"full_name": "the assembled display field (OVA-MAP-3): splitting a display string back into " +
+		"first/last is ambiguous and lossy, and first_name/last_name above already carry the parts",
+	"emails":         "a 1:N child collection, not a contact property — the inverse needs the child writer",
+	"phones":         "the same 1:N child shape as emails",
+	"social":         "a 1:N child collection, and HubSpot's social properties are per-network singletons",
+	targetAddress:    "the structured-address assembler has no simple 1:1 inverse yet",
+	canonicalOwnerID: "needs the reverse owner user-map resolution, canonical user → incumbent owner id",
+	"visibility": "capture privacy is a Margince access-control property, not a fact about the contact — " +
+		"the incumbent has no counterpart and must not be told who may see a row here",
+}
+
 // organizationWriteFields — the inverse of companiesMapping's 1:1 columns.
-// size_band is read-only: numberofemployees→size_band is a lossy band bucketing
-// (employees_to_size_band) with no unambiguous inverse. address, domains, and
-// owner_id are the same V1 deferrals as person's.
 var organizationWriteFields = []directWriteField{
 	{Canonical: "display_name", HSProp: propName},
 	{Canonical: industryField, HSProp: industryField},
+}
+
+// deferredOrganizationWrites is every field a caller may PATCH on an
+// organization that this projection does NOT carry, each with the reason.
+//
+// It exists because the alternative is silence, and silence here is the defect:
+// a canonical field absent from the projection is accepted by the door, audited,
+// emitted as an update — and never sent. The next overlay read returns the old
+// value, so the edit looks to a user like somebody else reverted it.
+//
+// Three of these were not deferrals at all until this list existed. legal_name,
+// linkedin_url and description were simply never added when their columns
+// landed, and three separate column changes each failed to notice the same
+// obligation — which is one missing rule rather than three mistakes.
+// Held by: TestEveryOverlayWritableFieldProjectsOrSaysWhyNot
+// (backend/gates/overlaywritecoverage_test.go) — a field the contract lets a
+// caller write is either here or in the projection above, and the same rule
+// answers for person and lead.
+var deferredOrganizationWrites = map[string]string{
+	"size_band": "read-only: numberofemployees→size_band is a lossy band bucketing " +
+		"(employees_to_size_band) with no unambiguous inverse — writing back the band's floor would " +
+		"report a headcount nobody stated",
+	targetAddress:    "the structured-address assembler has no simple 1:1 inverse yet (the V1 write-back deferral)",
+	"domains":        "a 1:N child collection, not a company property — the inverse needs the child writer",
+	canonicalOwnerID: "needs the reverse owner user-map resolution, canonical user → incumbent owner id",
+	"legal_name": "HubSpot declares no counterpart property, so there is nothing to be the inverse OF. " +
+		"Projecting it onto a custom property would invent a mapping the read side does not make",
+	"linkedin_url": "the READ side does not carry it either (companiesMapping maps no LinkedIn property), " +
+		"so a write alone would push a value the next read cannot bring back — the field would oscillate. " +
+		"Both halves land together; the read half is issue #1027",
+	"description": "same shape as linkedin_url, plus a real choice: `about_us` and the CRM `description` " +
+		"property are both candidates and behave differently, and the write must be the inverse of " +
+		"whichever the read takes. The read half is issue #1026",
+	"lifecycle": "HubSpot's lifecyclestage names a different axis from our lifecycle and the two " +
+		"vocabularies do not correspond term for term; issue #1028 holds the read half and the transform " +
+		"both directions would need",
+	"parent_org_id":      "a company-to-company association, not a property — it writes through the association API rather than through this projection",
+	"relationship_types": "a Margince concept with no HubSpot counterpart: the incumbent models no such classification",
 }
 
 // leadWriteFields — OVA-MAP-W5's writable Leads-object property that has a
@@ -116,6 +187,22 @@ var organizationWriteFields = []directWriteField{
 // read-only and absent here too.
 var leadWriteFields = []directWriteField{
 	{Canonical: targetFullName, HSProp: "hs_lead_name"},
+}
+
+// deferredLeadWrites — the same obligation, for the fields updateLead lets a
+// caller send. The status/label reasoning is in leadWriteFields' own comment.
+var deferredLeadWrites = map[string]string{
+	"status": "waits on a pinned bidirectional value map: the read keeps hs_lead_label a RAW passthrough, " +
+		"so writing a canonical status token into it would be the untransformed projection the read declined",
+	"email":                 "DERIVED through the required contact association, not a Leads-object property Margince can write",
+	"company_name":          "derived the same way, through the association rather than a property",
+	canonicalOwnerID:        "needs the reverse owner user-map resolution",
+	"title":                 "a property of the associated CONTACT, not of the Leads object",
+	"source":                "no Leads-object counterpart; the incumbent records lead provenance differently",
+	"score":                 "a Margince-computed figure, and writing it would publish our model's output as though the incumbent had produced it",
+	"score_override_reason": "the human sentence explaining a score override — same reason as score",
+	"project_id":            "a Margince association with no Leads-object counterpart",
+	"candidate_org_key":     "a matching key internal to our own resolution, never an incumbent property",
 }
 
 // stringProp reads a canonical STRING field's writable value. present reports
@@ -173,6 +260,24 @@ func copyDirect(fields map[string]any, table []directWriteField, forUpdate bool)
 		}
 	}
 	return props, nil
+}
+
+// droppedFields is the canonical fields this write ASKED for that the
+// projection cannot send, named so a caller of mapWrite can say so.
+//
+// The deferral maps are the source, which is what keeps them honest: a field
+// deferred with a reason is a field this function reports, so the reasons are
+// load-bearing rather than a comment that drifts. A patch naming only projected
+// fields answers nil.
+func droppedFields(fields map[string]any, deferred map[string]string) []string {
+	var dropped []string
+	for field := range fields {
+		if _, isDeferred := deferred[field]; isDeferred {
+			dropped = append(dropped, field)
+		}
+	}
+	sort.Strings(dropped)
+	return dropped
 }
 
 // mapWriteDeal — OVA-MAP-W2. name/expected_close_date project directly;

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (102)
+## Parity (103)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -34,6 +34,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `basevaluespelling_test.go` | H2 | One deal's base-currency value is spelled twice, in two packages that cannot import each other, and this is what stops the two from drifting. |
 | `benchrecordswitch_test.go` | H2 | Both bench harnesses ask the SAME variable whether to publish a record, and both answer only to the same value. |
 | `bookinginvite_test.go` | H2 | What booking a meeting CLAIMS and what it DOES, held against each other. |
+| `briefdeckexclusion_test.go` | H3 | A Brief count and the door beneath it must exclude the SAME rows. |
 | `captureledgerstatuses_test.go` | H2 | The disposition ledger's status vocabulary has ONE definition, and it is the column's own constraint. |
 | `coachingroles_test.go` | H2 | The seats that may coach are seats that exist. |
 | `coderabbitpathrules_test.go` | H3 | What .coderabbit.yaml tells the reviewer about backend Go, held against what is true. |
@@ -122,7 +123,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (135)
+## Census (138)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -148,15 +149,18 @@ The eight shapes, what each is for, and how each one silently passes:
 | `bootcomposition_test.go` | H2 | The fitness gate on the boot sequence: a process role that composes extensions also records what it composed. |
 | `briefevidencestrip_test.go` | H2 | "Never persist an email summary" is spelled once, and every writer that caches evidence says it that way. |
 | `briefsectioncensus_test.go` | H2 | Every worklist category reaches a section of the morning. |
+| `calendaroccurrenceexpansion_test.go` | H2 | Every calendar pull lists OCCURRENCES, never recurring series masters. |
 | `capturecontainers_test.go` | H2 | Every mail connector tells the sink where the provider FILED a message. |
 | `catalogoptionsreaders_test.go` | H2 | Who may read a custom field's OPTIONS. |
 | `claimedspelling_test.go` | H3 | A constant whose doc comment says it is spelled once is making a checkable statement, and until now nothing checked it. |
 | `clearablefields_test.go` | H2 | The fields a restore says it can clear are the fields the stores clear. |
+| `communityhealth_test.go` | H1 | The community-health files GitHub resolves from the repository root. |
 | `confirmcardfields_test.go` | H2 | The confirm page shows a data subject their own record, and only that. |
 | `consumerlanes_test.go` | H3 | Every consumer group the catalog declares is subscribed by some process role — or is a reserved placeholder that says so. |
 | `consumersubscribed_test.go` | H3 | Every event consumer is actually subscribed. |
 | `contractproducers_test.go` | H2 | A field the contract PROMISES and nobody WRITES is invisible. |
 | `contractrefs_test.go` | H3 | Contract $ref pre-flight as a fitness function. |
+| `contributorwiring_test.go` | H1 | What a contributor arriving from outside is promised, in the files they meet on the way in. |
 | `dealtargettype_test.go` | H2 | Every deal-scoped staging names its target type through one constant. |
 | `decisioncoverage_test.go` | H2 | A message that reaches the send queue carries a decision saying why, written in the transaction that staged it. |
 | `declaredfilters_test.go` | H2 | A declared narrowing parameter is read by the handler it is declared on, or it is not declared. |
@@ -286,7 +290,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthorityreach_test.go` | H2 | Every write of a shareable record reaches a write-authority probe. |
 | `writeshape_test.go` | H2 | The write-shape obligation as a fitness function: every mutation that writes an audit row commits a paired outbox event on the same static call path (data-model §11, events.md §4.2 — spelled once in storekit), across modules AND the composition layer. |
 
-## Shape (24)
+## Shape (25)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -301,6 +305,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobfault_test.go` | H2 | Every River worker returns through jobs.Fault. |
 | `jobfleetwide_test.go` | H2 | A FleetWide declaration is a promise: this job enumerates and enqueues, and does no tenant write of its own (jobs.FleetWide). |
 | `jobwirekey_test.go` | H2 | One workspace arg, one spelling, and only where it means something. |
+| `laneordering_test.go` | H1 | The craftsmanship gate runs only after the deterministic gates are green: a red build must never be judged on style. |
 | `listenvelope_test.go` | H2 | The contract's list envelope has ONE shape, and something depends on that. |
 | `manifestdigest_test.go` | H2 | Manifest-hash encoding fitness function (ADR-0120 §7): every hash a generated unit manifest publishes says which algorithm produced it. |
 | `positionalrowscan_test.go` | H2 | A positional row mapping may only target a struct its own package declares. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (103)
+## Parity (102)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -34,7 +34,6 @@ The eight shapes, what each is for, and how each one silently passes:
 | `basevaluespelling_test.go` | H2 | One deal's base-currency value is spelled twice, in two packages that cannot import each other, and this is what stops the two from drifting. |
 | `benchrecordswitch_test.go` | H2 | Both bench harnesses ask the SAME variable whether to publish a record, and both answer only to the same value. |
 | `bookinginvite_test.go` | H2 | What booking a meeting CLAIMS and what it DOES, held against each other. |
-| `briefdeckexclusion_test.go` | H3 | A Brief count and the door beneath it must exclude the SAME rows. |
 | `captureledgerstatuses_test.go` | H2 | The disposition ledger's status vocabulary has ONE definition, and it is the column's own constraint. |
 | `coachingroles_test.go` | H2 | The seats that may coach are seats that exist. |
 | `coderabbitpathrules_test.go` | H3 | What .coderabbit.yaml tells the reviewer about backend Go, held against what is true. |
@@ -123,7 +122,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (137)
+## Census (135)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -149,18 +148,15 @@ The eight shapes, what each is for, and how each one silently passes:
 | `bootcomposition_test.go` | H2 | The fitness gate on the boot sequence: a process role that composes extensions also records what it composed. |
 | `briefevidencestrip_test.go` | H2 | "Never persist an email summary" is spelled once, and every writer that caches evidence says it that way. |
 | `briefsectioncensus_test.go` | H2 | Every worklist category reaches a section of the morning. |
-| `calendaroccurrenceexpansion_test.go` | H2 | Every calendar pull lists OCCURRENCES, never recurring series masters. |
 | `capturecontainers_test.go` | H2 | Every mail connector tells the sink where the provider FILED a message. |
 | `catalogoptionsreaders_test.go` | H2 | Who may read a custom field's OPTIONS. |
 | `claimedspelling_test.go` | H3 | A constant whose doc comment says it is spelled once is making a checkable statement, and until now nothing checked it. |
 | `clearablefields_test.go` | H2 | The fields a restore says it can clear are the fields the stores clear. |
-| `communityhealth_test.go` | H1 | The community-health files GitHub resolves from the repository root. |
 | `confirmcardfields_test.go` | H2 | The confirm page shows a data subject their own record, and only that. |
 | `consumerlanes_test.go` | H3 | Every consumer group the catalog declares is subscribed by some process role — or is a reserved placeholder that says so. |
 | `consumersubscribed_test.go` | H3 | Every event consumer is actually subscribed. |
 | `contractproducers_test.go` | H2 | A field the contract PROMISES and nobody WRITES is invisible. |
 | `contractrefs_test.go` | H3 | Contract $ref pre-flight as a fitness function. |
-| `contributorwiring_test.go` | H1 | What a contributor arriving from outside is promised, in the files they meet on the way in. |
 | `dealtargettype_test.go` | H2 | Every deal-scoped staging names its target type through one constant. |
 | `decisioncoverage_test.go` | H2 | A message that reaches the send queue carries a decision saying why, written in the transaction that staged it. |
 | `declaredfilters_test.go` | H2 | A declared narrowing parameter is read by the handler it is declared on, or it is not declared. |
@@ -216,6 +212,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `onestringfolder_test.go` | H2 | A census over the censuses: nobody writes a second reader for "what string does this Go expression hold". |
 | `onevoiceversionwriter_test.go` | H2 | voice\_profile\_version and voice\_profile\_delta each have ONE writer. |
 | `outboundanonymity_test.go` | H2 | Every outbound HTTP request either says who is calling, or is registered as deliberately anonymous with the reason. |
+| `overlaywritecoverage_test.go` | H2 | Every field a caller may PATCH either projects onto the incumbent or says why it does not. |
 | `ownerprivatepairing_test.go` | H2 | A table whose visibility admits 'owner' names the owner, or the record it marks most-private is the one nobody can read. |
 | `parallelgates_test.go` | H3 | Every gate here runs in parallel with the others, and this is what keeps that true as gates are added. |
 | `passportlessagents_test.go` | H1 | An agent principal carrying no passport is a principal nobody can revoke. |
@@ -289,7 +286,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthorityreach_test.go` | H2 | Every write of a shareable record reaches a write-authority probe. |
 | `writeshape_test.go` | H2 | The write-shape obligation as a fitness function: every mutation that writes an audit row commits a paired outbox event on the same static call path (data-model §11, events.md §4.2 — spelled once in storekit), across modules AND the composition layer. |
 
-## Shape (25)
+## Shape (24)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -304,7 +301,6 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobfault_test.go` | H2 | Every River worker returns through jobs.Fault. |
 | `jobfleetwide_test.go` | H2 | A FleetWide declaration is a promise: this job enumerates and enqueues, and does no tenant write of its own (jobs.FleetWide). |
 | `jobwirekey_test.go` | H2 | One workspace arg, one spelling, and only where it means something. |
-| `laneordering_test.go` | H1 | The craftsmanship gate runs only after the deterministic gates are green: a red build must never be judged on style. |
 | `listenvelope_test.go` | H2 | The contract's list envelope has ONE shape, and something depends on that. |
 | `manifestdigest_test.go` | H2 | Manifest-hash encoding fitness function (ADR-0120 §7): every hash a generated unit manifest publishes says which algorithm produced it. |
 | `positionalrowscan_test.go` | H2 | A positional row mapping may only target a struct its own package declares. |


### PR DESCRIPTION
Refs #746. The issue stays open — see *What is left*.

## The defect

An overlay write drops any canonical field the projection does not carry. The door accepts it, the incumbent never receives it, and the next overlay read returns the old value — so to a user the edit looks like somebody else reverted it.

It happened three times over on organization. `legal_name`, `linkedin_url` and `description` were each simply never added when their column landed. Three column changes failing to notice one obligation is **one missing rule**, not three mistakes, which is why this is a rule rather than three entries — the shape the issue itself proposed.

## Measured, the gap is wider than reported

The issue names three fields. There are **ten**: `updateOrganization` declares twelve writable fields and the projection carried two. `lifecycle`, `parent_org_id` and `relationship_types` were dropped just as silently and nobody had noticed.

And `person` and `lead` had never been asked at all — same projection shape, same silence.

## The rule

Each class now declares what it **defers and why**, beside what it projects. `TestEveryOverlayWritableFieldProjectsOrSaysWhyNot` holds both lists to the generated update-request struct: a field the door will decode is either projected or carries a reason, and a deferral naming a field the contract no longer offers is reported too.

**The corpus is the contract, not the schema.** `organization` carries 65 columns and most are ours alone — geocode state, logo keys, `legal_hold`. What makes an absence a *defect* is that the published contract invites a caller to write it, so each update operation's request struct is the set that has to be answered for. A field the contract adds joins the obligation by being added.

It reads the writable set off `internal/contracts`' generated structs rather than parsing crm.yaml: their json tags are the same promise, in the form the server actually applies, and the generator has already resolved the `$ref`s. The gate lives in `gates/` because neither `overlay` nor an OpenAPI reader may be imported the other way round — go-arch-lint refuses both directions I tried first.

## The deferrals are load-bearing

Not commentary. `mapWrite` now reports the fields a write asked for that it cannot send (`writeMapping.Dropped`), reading the deferral maps to do it — so the reasons are consumed by the code rather than only by a reader, and a silent drop is a visible one. A comment would have drifted; this cannot.

## Two premises in the issue have expired, and both narrow what is left

**The audit row is no longer wrong.** The issue says the write "still records the audit row and emits the outbox event describing a change that the incumbent never received". `settledImages` closed that since: it narrows the before/after pair to the fields that *actually moved*, reading the after side off the record the incumbent returned rather than off the patch that asked for it. A dropped field no longer appears in the images or in `changed_fields`.

**The three fields cannot simply be added to the projection.** `companiesMapping` does not **read** them either — it maps `display_name`, `industry`, `size_band`, `created_at`, `domain`, `owner_id` and address, and nothing else. A write alone would push a value the next read cannot bring back, and the field would oscillate: exactly the failure the issue's own "the write must be the inverse of the read" warns about. Both halves land together, and the read halves are already tracked as #1026 (description), #1027 (linkedin_url) and #1028 (lifecycle). The deferral reasons name them, so the next author arrives at the read side rather than at a one-sided fix.

`legal_name` and `relationship_types` are different: HubSpot declares no counterpart at all, so there is nothing to be the inverse *of*.

## What is left

- The three read halves (#1026, #1027, #1028), after which their write halves become one-line additions the gate will then require.
- Whether the door should **refuse or report** a patch naming a deferred field, rather than answering 200. That is contract-visible behaviour — a PATCH that succeeds today would change — so it wants a ruling rather than a patch. `Dropped` is the observable half of it, off the wire.
- The cutover path (`flipwriters.go`), which the issue names and which carries the same fields. It is unchanged here because the fields it would carry are the ones still blocked on their read halves.

## Mutation checks

| mutation | result |
|---|---|
| `legal_name`'s deferral dropped | fails, naming the field and both places to answer it |
| a constant-keyed deferral (`owner_id`) dropped from person | fails — constants resolve, so the gate judges the mapping and not its spelling |
| the constant resolver blinded | 5 fields wrongly reported unanswered, which is why it is asserted non-empty |
| a deferral renamed to a field the contract lacks | fails as an outlived reason |

## Checks

`make check-backend` green; `make craft-static` 0/0/0; `go test -count=1 ./gates` green; the overlay integration lane green. One `//craft:ignore naked-any` with a reason on `writableFieldsOf`, whose three generated request types share no interface.