### PR TITLE
fix(deals): a stage cannot close while open deals are still in it

### DIFF
--- a/backend/internal/modules/deals/exitcriteria_integration_test.go
+++ b/backend/internal/modules/deals/exitcriteria_integration_test.go
@@ -17,7 +17,10 @@ package deals
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
@@ -326,4 +329,161 @@ func TestAnArchivedStagesCriteriaAreStillReadable(t *testing.T) {
 	if len(criteria) != 1 {
 		t.Fatalf("the archived stage answered %d criteria; the evidence citing them cannot be read back", len(criteria))
 	}
+}
+
+// A stage cannot become terminal while deals are still sitting in it.
+//
+// THE BYPASS THIS CLOSES. Moving a deal into an OPEN stage is ungated — an
+// ordinary pipeline step. Closing one as won is not: it passes the evidence
+// gate, which is what makes a won deal a claim somebody stood behind. Without
+// this, a caller holding pipeline:update takes the first route and then flips
+// the stage's semantic, and every deal already in it sits in a won stage having
+// passed nothing.
+//
+// The deals' own status stays `open` with a NULL reason, so the column report
+// and the deal_won_without_contract_only_when_won CHECK both stay consistent —
+// which is precisely why nothing else notices, and why this is a refusal at the
+// flip rather than an assertion somewhere downstream.
+func TestAStageCannotCloseWhileOpenDealsAreStillInIt(t *testing.T) {
+	e := setupConfigEnv(t)
+	ctx := e.as()
+	stageID := openStage(t, e, SemanticOpen)
+	dealID := seedDealInStage(t, e, stageID)
+
+	won := string(SemanticWon)
+	_, err := e.store.UpdateStage(ctx, stageID, UpdateStageInput{Semantic: &won})
+
+	var parse *values.ParseError
+	if !errors.As(err, &parse) || parse.Code != codeTerminalStageHoldsOpenDeals {
+		t.Fatalf("an open stage holding an undecided deal closed as won (%v) — every deal in it now "+
+			"reads as won to any reader taking the stage's semantic, having passed no evidence gate", err)
+	}
+	// No count on the wire: the refusal is read by whoever holds
+	// pipeline:update, who is not necessarily entitled to every deal in it.
+	if strings.ContainsAny(parse.Message, "0123456789") {
+		t.Errorf("the refusal names a number (%q) — how many deals an admin cannot see through is a "+
+			"fact about the estate, and the way forward does not need it", parse.Message)
+	}
+	// And it refused BEFORE writing: the stage is still open.
+	if got := storedStageSemantic(t, e, stageID); got != SemanticOpen {
+		t.Errorf("the stage reads %q after a refused flip, want it left open", got)
+	}
+
+	// MOVING the deal is the way forward the refusal names, and it works with
+	// the grants an admin already holds — no wider authority is needed to get
+	// past this guard than to have caused it.
+	moveDealToAnotherOpenStage(t, e, stageID, dealID)
+	if _, err := e.store.UpdateStage(ctx, stageID, UpdateStageInput{Semantic: &won}); err != nil {
+		t.Fatalf("the stage still refused to close after its only deal left it: %v", err)
+	}
+}
+
+// A stage holding a DECIDED deal closes normally.
+//
+// The complement, and the assertion that keeps the guard from being "refuse
+// whenever any deal is here": a deal already won or lost carries its own
+// decided status and was never resting on the stage's semantic, so the flip
+// cannot make it unevidenced. Without this case the guard could tighten to
+// refuse every flip and still pass the test above.
+func TestAStageHoldingOnlyDecidedDealsStillCloses(t *testing.T) {
+	e := setupConfigEnv(t)
+	ctx := e.as()
+	stageID := openStage(t, e, SemanticOpen)
+	dealID := seedDealInStage(t, e, stageID)
+
+	// Archived through the real writer, so the row is shaped as production
+	// shapes it rather than by an UPDATE this test invented. Archiving takes
+	// deal:delete, which asDealWriter deliberately lacks — widening that shared
+	// context would weaken every other test standing on it, so this one act
+	// gets its own authority.
+	if _, err := e.store.ArchiveDeal(e.asDealArchiver(), dealID, nil); err != nil {
+		t.Fatalf("taking the deal out of the open set: %v", err)
+	}
+
+	won := string(SemanticWon)
+	if _, err := e.store.UpdateStage(ctx, stageID, UpdateStageInput{Semantic: &won}); err != nil {
+		t.Fatalf("a stage holding no open deal refused to close (%v) — the guard is refusing on the "+
+			"presence of a deal rather than on an undecided one", err)
+	}
+}
+
+// seedDealInStage puts one live, open deal in a stage through the real writer.
+func seedDealInStage(t *testing.T, e *configEnv, stageID ids.StageID) ids.DealID {
+	t.Helper()
+	var pipelineID ids.PipelineID
+	if err := e.store.Tx(e.as(), func(tx pgx.Tx) error {
+		return tx.QueryRow(e.as(), `SELECT pipeline_id FROM stage WHERE id = $1`, stageID).Scan(&pipelineID)
+	}); err != nil {
+		t.Fatalf("reading the stage's pipeline: %v", err)
+	}
+	owner := ids.From[ids.UserKind](e.admin)
+	deal, err := e.store.CreateDeal(e.asDealWriter(), CreateDealInput{
+		Name: "Warehouse rollout", PipelineID: pipelineID, StageID: stageID,
+		OwnerID: &owner, OwnerExact: true,
+	})
+	if err != nil {
+		t.Fatalf("seeding a deal: %v", err)
+	}
+	return ids.From[ids.DealKind](ids.UUID(deal.Id))
+}
+
+// storedStageSemantic reads the stage's stored semantic through the module's
+// own reader, which is what a refusal must have left alone.
+func storedStageSemantic(t *testing.T, e *configEnv, stageID ids.StageID) StageSemantic {
+	t.Helper()
+	var semantic StageSemantic
+	if err := e.store.Tx(e.as(), func(tx pgx.Tx) error {
+		var err error
+		semantic, err = stageSemanticOf(e.as(), tx, stageID)
+		return err
+	}); err != nil {
+		t.Fatalf("reading the stage's semantic: %v", err)
+	}
+	return semantic
+}
+
+// moveDealToAnotherOpenStage is the remedy the refusal names: a second open
+// stage in the same pipeline, and the deal moved into it.
+func moveDealToAnotherOpenStage(t *testing.T, e *configEnv, from ids.StageID, dealID ids.DealID) {
+	t.Helper()
+	var pipelineID ids.PipelineID
+	if err := e.store.Tx(e.as(), func(tx pgx.Tx) error {
+		return tx.QueryRow(e.as(), `SELECT pipeline_id FROM stage WHERE id = $1`, from).Scan(&pipelineID)
+	}); err != nil {
+		t.Fatalf("reading the stage's pipeline: %v", err)
+	}
+	probability := 0
+	next, err := e.store.CreateStage(e.as(), CreateStageInput{
+		PipelineID: pipelineID, Name: "Negotiating", Position: 1,
+		Semantic: string(SemanticOpen), WinProbability: &probability,
+	})
+	if err != nil {
+		t.Fatalf("seeding the stage to move to: %v", err)
+	}
+	target := ids.From[ids.StageKind](ids.UUID(next.Id))
+	if _, err := e.store.AdvanceDeal(e.asDealWriter(), dealID, AdvanceDealInput{ToStageID: target}); err != nil {
+		t.Fatalf("moving the deal out of the closing stage: %v", err)
+	}
+}
+
+// asDealArchiver is asDealWriter plus the one grant an archive needs.
+//
+// Separate rather than widened, for the reason archiveRepPerms is separate one
+// module over: a shared fixture handed a grant it does not need makes every
+// refusal proven through it weaker, and deal:delete is exactly the authority
+// several of those refusals are about.
+func (e *configEnv) asDealArchiver() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.admin.String(), UserID: e.admin,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"admin"},
+			RowScope: principal.RowScopeAll,
+			Objects: map[string]principal.ObjectGrant{
+				"deal":     {Create: true, Read: true, Update: true, Delete: true},
+				"pipeline": {Create: true, Read: true, Update: true},
+			},
+		},
+	})
 }

--- a/backend/internal/modules/deals/stages.go
+++ b/backend/internal/modules/deals/stages.go
@@ -22,6 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 type UpdatePipelineInput struct {
@@ -271,6 +272,9 @@ func (s *Store) UpdateStage(ctx context.Context, id ids.StageID, in UpdateStageI
 		if err := refuseTerminalWithCriteria(ctx, tx, id, current.semantic, in.Semantic); err != nil {
 			return err
 		}
+		if err := refuseTerminalWithOpenDeals(ctx, tx, id, current.semantic, in.Semantic); err != nil {
+			return err
+		}
 		// An update naming no field changes nothing, and an audit row for it
 		// would record a transition that never happened.
 		if patch := stageUpdatePatch(current, in); !patch.Empty() {
@@ -366,4 +370,62 @@ func readStage(ctx context.Context, tx pgx.Tx, id ids.StageID, archived storekit
 	out.Id = openapi_types.UUID(stageID)
 	out.PipelineId = openapi_types.UUID(pipelineID)
 	return out, nil
+}
+
+// codeTerminalStageHoldsOpenDeals is what a semantic flip answers when the
+// stage still holds deals nobody has decided.
+const codeTerminalStageHoldsOpenDeals = "terminal_stage_holds_open_deals"
+
+// refuseTerminalWithOpenDeals stops a stage becoming won or lost while deals
+// are still sitting in it, undecided.
+//
+// THE BYPASS. Moving a deal into an OPEN stage is ungated — it is an ordinary
+// pipeline step. Closing one as won is not: it passes the evidence gate, which
+// is what makes `deal.status = 'won'` a claim somebody stood behind. A caller
+// holding pipeline:update could take the first route and then flip the stage's
+// semantic, and the deals already in it would sit in a won stage having passed
+// nothing. Their own `status` stays `open` with a NULL reason, so the column
+// report and the deal_won_without_contract_only_when_won CHECK both stay
+// consistent — which is exactly why nothing notices. Any reader deriving "won"
+// from the stage rather than from the deal counts wins that never happened.
+//
+// REFUSE rather than re-run the evidence question. The alternative — closing
+// those deals as part of the flip — decides an unbounded number of deals on a
+// write that named none of them, each needing its own reason, from an admin
+// editing pipeline configuration who is not looking at any deal. A refusal
+// leaves every deal where it is and says what to do.
+//
+// LIVE and OPEN only. An archived deal is out of the pipeline's story, and one
+// already won or lost carries its own decided status — the flip cannot make it
+// unevidenced, because it was never resting on the stage's semantic. This is
+// the sibling of refuseTerminalWithCriteria and takes the same shape: the flip
+// is refused while something in the stage still contradicts it, and the way
+// forward is stated rather than taken silently.
+//
+// It runs under the stage's row lock, so a deal arriving between this count and
+// the write queues behind it — the same unit the version check relies on.
+func refuseTerminalWithOpenDeals(
+	ctx context.Context, tx pgx.Tx, stageID ids.StageID, currentSemantic string, wanted *string,
+) error {
+	if wanted == nil || !StageSemantic(*wanted).Terminal() || StageSemantic(currentSemantic).Terminal() {
+		return nil
+	}
+	var open int
+	if err := tx.QueryRow(ctx, `
+		SELECT count(*) FROM deal
+		 WHERE stage_id = $1 AND archived_at IS NULL AND status = $2`,
+		stageID, string(DealOpen)).Scan(&open); err != nil {
+		return fmt.Errorf("count the stage's open deals: %w", err)
+	}
+	if open == 0 {
+		return nil
+	}
+	// NO COUNT in the message. How many deals an admin cannot see the pipeline
+	// through is a fact about the estate, and this refusal is read by whoever
+	// holds pipeline:update — not necessarily by somebody entitled to every
+	// deal in it. The way forward does not need the number.
+	return &values.ParseError{
+		Field: stageSemanticField, Code: codeTerminalStageHoldsOpenDeals,
+		Message: "this stage still holds open deals; decide or move them before closing it as won or lost",
+	}
 }


### PR DESCRIPTION
Closes #1403.

## The bypass

Moving a deal into an **open** stage is ungated — an ordinary pipeline step. Closing one as won is not: it passes the evidence gate, which is what makes `deal.status = 'won'` a claim somebody stood behind.

So a caller holding only `pipeline:update` could take the first route and then flip the stage's semantic to `won`. Every deal already sitting in it is then in a won stage having passed nothing.

The deals' own `status` stays `open` with a NULL reason, so the column-level report and the `deal_won_without_contract_only_when_won` CHECK both stay consistent. That is exactly why nothing notices — and why this has to be refused at the flip rather than asserted downstream. Any reader deriving "won" from the stage rather than from the deal counts wins that never happened.

## Premise check

The issue flags itself as *"plausible rather than confirmed — the review found no reader in the deals module that uses the semantic instead of the status."* Still true: I searched for a reader deriving won from `stage.semantic` and found none.

The guard is worth having anyway, and the issue says why — #1402's win gate made the semantic newly load-bearing. It is also the **mirror** of a guard that already exists: `refuseAMoveTheGateDidNotAdmit` holds the case where a stage is flipped under a move already in flight; this holds the case where the deals were already there. Same invariant, opposite direction, and neither covers the other.

## Refused, not re-decided

The issue offers both. Refusing is the right half:

Closing those deals as part of the flip decides an unbounded number of them on a write that named none of them, each needing its own reason, from an admin editing pipeline configuration who is not looking at any deal. The refusal leaves every deal where it is and says what to do.

**Live and open only.** An archived deal is out of the pipeline's story, and one already won or lost carries its own decided status — the flip cannot make it unevidenced, because it was never resting on the semantic. `TestAStageHoldingOnlyDecidedDealsStillCloses` holds that half, so the guard cannot tighten into "refuse whenever any deal is here" and still pass.

It sits beside `refuseTerminalWithCriteria`, under the same row lock, taking the same shape: the flip is refused while something in the stage still contradicts it, and the way forward is stated rather than taken silently.

## Two smaller things

**The refusal states no count.** How many deals an admin cannot see the pipeline through is a fact about the estate, and this refusal is read by whoever holds `pipeline:update` — not necessarily somebody entitled to every deal in it. The test asserts the message carries no digit.

**The remedy is reachable with the grants that caused the problem.** The test gets past the guard by *moving* the deal, which needs only what the admin already had — no wider authority is required to clear the refusal than to have triggered it. The archive case needs `deal:delete`, so it gets its own narrow context rather than widening the shared `asDealWriter`: a fixture handed a grant it does not need makes every refusal proven through it weaker, and `deal:delete` is exactly what several of those refusals are about.

## Mutation checks

| mutation | result |
|---|---|
| the guard not called (the state before this change) | the flip succeeds; the first test fails |
| the guard counts every deal, decided ones included | the second test fails, naming the over-tightening |

## Checks

`make check-backend` green; `make craft-static` 0/0/0; the deals integration lane green.