### PR TITLE
claim: main-red — TestEveryHandWrittenDocsPageFitsItsBudget

### DIFF
--- a/docs/explanation/company-record-page.md
+++ b/docs/explanation/company-record-page.md
@@ -6,13 +6,6 @@ composite surface in the product and it is assembled almost entirely in
 `internal/compose` — thirteen gated section reads inside one transaction, plus
 two cross-module orchestration groups that own view state of their own.
 
-> **Name collision, worth clearing up once.**
-> [company-context.md](company-context.md) is about the **installation's own**
-> company — the singleton organization profile born in onboarding. This page is
-> about the company **record** page: any customer, prospect or partner
-> organization in the CRM. They share the word "company" and almost nothing
-> else.
-
 ## The shape at a glance
 
 Six endpoints serve one screen. Which one owns which part:


### PR DESCRIPTION
**Claims `TestEveryHandWrittenDocsPageFitsItsBudget`** (`backend/gates/docspagelength_test.go`), and nothing else. No other `claim: main-red` was open when I looked.

## What

`docs/explanation/company-record-page.md` comes back under its section budget, 626 → 619 lines, by dropping the name-collision callout at the top of the page.

## Why

`main` is red on this gate, and every PR opened against it inherits the failure:

```
docs/explanation/company-record-page.md is 626 lines,
over the 620-line budget for its section.
This budget is not waivable for a new page.
```

| commit | lines |
| --- | --- |
| `83e5e6c` | 594 |
| `b8eaa52` (#5110) | **626** |
| `9170e7a` (current `main`) | 626 |

#5110 added 32 lines — the "What needs you, and the one answer it gives" section and the account-scan settle rules. That is new behaviour being documented where it belongs, so it is not what should come out. The cut comes from the cheapest lines on the page instead, which is what the gate's own failure message suggests looking for.

The callout it removes said, in six lines under the opening paragraph, what the page's "Where to go next" footer already says in a clause: `company-context.md` is the **installation's** own company, this page is the company **record**. One distinction, stated twice. The surviving statement sits next to the link a reader who followed the wrong one is looking for.

What this costs, stated plainly rather than glossed: the disambiguation was deliberate ("worth clearing up once") and it moves from the top of the page to the bottom, so a reader who lands here by mistake meets it later than they used to. I judged that the cheaper loss against removing documentation of behaviour that has no other home — but it is #5110's page more than mine, and if its author would rather spend the seven lines elsewhere, say so and I will move the cut.

This leaves the page **one line under** its ceiling. That is a ratchet tooth, not headroom: the next line added to this page has to displace one. At 619 of 620 the page's real answer is a split, which is a bigger change than a red `main` should wait on.

Not a draft: the rulebook asks for one so a claim is visible before the work starts, and here the work is already finished in the same push. The `claim: main-red` label is what marks the claim.

## How verified

- `go test ./gates/ -run TestEveryHandWrittenDocsPageFitsItsBudget -count=1` — **ok** (fails on `main` without this).
- Whole `./gates` package run: the only other failure is `TestBaselineEraFixtureIsTheMatrixTheBaselineSeeded`, which needs full git history and is an artifact of my shallow checkout (`git rev-parse --is-shallow-repository` → `true`); the gate says so in its own message, and CI gives that lane `fetch-depth: 0`.
- Prose only — one markdown file, seven deleted lines, no code and no Go.

- [x] `make check` is green — this diff is a documentation deletion; the gate that governs it is run above
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — it touches neither
- [x] `make craft-static` reports no new blockers — it sweeps the Go trees, and this diff has none
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by Claude Code. Found while driving #5124 (an unrelated CSS change) to green: that PR's `extension-reference` check failed on this gate, and reading the base branch showed the failure was `main`'s rather than the PR's. The choice of which seven lines to cut is the one judgment call in it, and it is flagged above rather than buried.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2aCVf6LYWCaY69FdK97Xc

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2aCVf6LYWCaY69FdK97Xc)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red docs page budget gate by trimming `company-record-page.md` from 626 to 619 lines, one under its 620-line ceiling.

Removes the name-collision callout at the top of the page — it duplicates what the "Where to go next" footer already says in one clause. The 32 lines that pushed the page over budget document new behavior and stay; the callout was the cheapest cut.

<sup>Written for commit 50f33b6ce5b618d54340ad3c9c5484978835dbc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

