### PR TITLE
fix(jobs): a collapsed fleet-wide pass is now visible to its own sweep gauge

### DIFF
--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -285,15 +285,19 @@ func writeAgeGauge(w io.Writer, series map[queueKey]float64) error {
 
 // writeSweepGauges renders the pair that answers "are tenants being
 // missed". Both halves carry the same sweep label so an alert can compare
-// them; the label is the CHILD kind, which is what the rows hold — mapping
-// back to the dispatcher would be a hand-kept table.
+// them; for a fan-out kind the label is the CHILD kind, which is what the
+// rows hold — mapping back to the dispatcher would be a hand-kept table.
+// For a Fleet kind that fans out to nothing (ADR-0103's collapsed pass) the
+// label is the kind's own name, and the reading is 1 (or 0, if the pass has
+// never run) rather than a true workspace count — there is no workspace
+// grain to read for it at all.
 func writeSweepGauges(w io.Writer, sweeps []jobs.SweepPass) error {
 	ordered := slices.SortedFunc(slices.Values(sweeps), func(a, b jobs.SweepPass) int {
 		return cmp.Compare(a.Kind, b.Kind)
 	})
 
 	if err := writeFamilyHeader(w, "margince_sweep_workspaces",
-		"Workspaces with a surviving child of this fleet pass. Counted per workspace rather than per pass: a child still active from an earlier fan-out is deduplicated out of the current one and writes no new row, so no batch can be identified. A workspace whose only child aged out of River's job retention is absent rather than reported as zero."); err != nil {
+		"Workspaces with a surviving child of this fleet pass. Counted per workspace rather than per pass: a child still active from an earlier fan-out is deduplicated out of the current one and writes no new row, so no batch can be identified. A workspace whose only child aged out of River's job retention is absent rather than reported as zero. For a kind that answers for the whole installation in one row rather than fanning out, this reads 1 when its latest tagged run exists — the closest reading to 'did the pass happen' when there is no workspace to count."); err != nil {
 		return err
 	}
 	for _, s := range ordered {
@@ -304,7 +308,7 @@ func writeSweepGauges(w io.Writer, sweeps []jobs.SweepPass) error {
 	}
 
 	if err := writeFamilyHeader(w, "margince_sweep_workspaces_failed",
-		"Workspaces whose MOST RECENT child of this fleet pass ended discarded or cancelled — tenants whose share of the pass did not happen. A workspace that failed and then succeeded is not counted."); err != nil {
+		"Workspaces whose MOST RECENT child of this fleet pass ended discarded or cancelled — tenants whose share of the pass did not happen. A workspace that failed and then succeeded is not counted. For a kind that answers for the whole installation in one row, this reads 1 when its latest tagged run ended that way."); err != nil {
 		return err
 	}
 	for _, s := range ordered {

--- a/backend/internal/platform/jobs/fleetstandalone_test.go
+++ b/backend/internal/platform/jobs/fleetstandalone_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package jobs
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestStandaloneFleetKindsSelectsExactlyTheCollapsedPasses — statsBySweep
+// must read a Fleet kind that fans out to nothing PER KIND rather than per
+// workspace_id, because none of its rows will ever carry one (margince#4983:
+// the query filtered every one of them out, forever, and the gauge read
+// greenest exactly when such a pass was failing). A Fleet kind that DOES
+// declare a FanOutTo must NOT be in this list — its own row still carries
+// no workspace, but its children (a different kind) are the real signal,
+// and counting the dispatcher's row too would double the pass.
+func TestStandaloneFleetKindsSelectsExactlyTheCollapsedPasses(t *testing.T) {
+	var dispatchers, standalone int
+	for kind, spec := range specs {
+		if !spec.Fleet {
+			continue
+		}
+		if spec.FanOutTo != "" {
+			dispatchers++
+			if slices.Contains(standaloneFleetKinds(), kind) {
+				t.Errorf("%s fans out to %s but is read as a standalone pass; its own row would double-count the fleet its children already report", kind, spec.FanOutTo)
+			}
+			continue
+		}
+		standalone++
+		if !slices.Contains(standaloneFleetKinds(), kind) {
+			t.Errorf("%s is a Fleet kind with no fan-out but is missing from standaloneFleetKinds; its tagged row carries no workspace_id and would be silently excluded from every sweep read", kind)
+		}
+	}
+	// Both sides must be exercised by real declarations, or this gate passes
+	// on nothing: dispatchers because they are the excluded arm, standalone
+	// passes because ADR-0103 made them the common shape.
+	if dispatchers == 0 {
+		t.Fatal("no Fleet dispatcher declared; the excluded side of the partition is unexercised")
+	}
+	if standalone == 0 {
+		t.Fatal("no standalone Fleet pass declared; the fixed side of the partition is unexercised")
+	}
+}
+
+// TestStandaloneFleetKindsOfIgnoresANonFleetKind — against a table this test
+// builds: a kind that owns a tenant (Fleet: false) is never tagged sweep by
+// periodicInsertOpts regardless of whether it happens to declare no
+// FanOutTo, so it must never appear here either.
+func TestStandaloneFleetKindsOfIgnoresANonFleetKind(t *testing.T) {
+	t.Parallel()
+
+	kinds := standaloneFleetKindsOf(map[string]Spec{
+		"a_collapsed_pass": {Kind: "a_collapsed_pass", Fleet: true, FanOutTo: ""},
+		"a_dispatcher":     {Kind: "a_dispatcher", Fleet: true, FanOutTo: "a_dispatcher_child"},
+		"a_tenant_worker":  {Kind: "a_tenant_worker", Fleet: false},
+	})
+	if !slices.Contains(kinds, "a_collapsed_pass") {
+		t.Error("a Fleet kind with no fan-out is missing from the selection")
+	}
+	if slices.Contains(kinds, "a_dispatcher") {
+		t.Error("a Fleet kind that fans out was included; its children carry the real signal, not its own row")
+	}
+	if slices.Contains(kinds, "a_tenant_worker") {
+		t.Error("a non-Fleet kind was included; it is never tagged sweep in the first place")
+	}
+}

--- a/backend/internal/platform/jobs/fleetstandalone_test.go
+++ b/backend/internal/platform/jobs/fleetstandalone_test.go
@@ -10,15 +10,21 @@ import (
 
 // TestStandaloneFleetKindsSelectsExactlyTheCollapsedPasses — statsBySweep
 // must read a Fleet kind that fans out to nothing PER KIND rather than per
-// workspace_id, because none of its rows will ever carry one (margince#4983:
-// the query filtered every one of them out, forever, and the gauge read
-// greenest exactly when such a pass was failing). A Fleet kind that DOES
-// declare a FanOutTo must NOT be in this list — its own row still carries
-// no workspace, but its children (a different kind) are the real signal,
-// and counting the dispatcher's row too would double the pass.
+// workspace_id, because none of its rows will ever carry one: excluding
+// every such row filters that kind out of the sweep read forever, and the
+// gauge reads greenest exactly when such a pass is failing. A Fleet kind
+// that DOES declare a FanOutTo must NOT be in this list — its own row still
+// carries no workspace, but its children (a different kind) are the real
+// signal, and counting the dispatcher's row too would double the pass.
+//
+// Walks allSpecs() (core plus any composed/extension declarations), not the
+// core-only specs map, so an extension's own collapsed pass is held to the
+// same rule.
 func TestStandaloneFleetKindsSelectsExactlyTheCollapsedPasses(t *testing.T) {
+	t.Parallel()
+
 	var dispatchers, standalone int
-	for kind, spec := range specs {
+	for kind, spec := range allSpecs() {
 		if !spec.Fleet {
 			continue
 		}

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -79,7 +79,11 @@ type StateRow struct {
 }
 
 // SweepPass is one fan-out kind read per workspace: how many workspaces it
-// covers, and how many of those it is currently failing.
+// covers, and how many of those it is currently failing. For a Fleet kind
+// that fans out to nothing (ADR-0103's collapsed pass — the row itself
+// answers for the whole installation, not one workspace's share of it),
+// Workspaces is 1 when the latest tagged row exists at all, the closest
+// reading this pair has to "the pass ran".
 type SweepPass struct {
 	Kind       string
 	Workspaces int64
@@ -188,6 +192,30 @@ func subWorkspaceFanOutsOf(units map[string]FanOutUnit) (kinds, argsKeys []strin
 	return kinds, argsKeys
 }
 
+// standaloneFleetKinds answers the kinds statsBySweep must read PER KIND
+// rather than per workspace_id: a Fleet kind (jobs.FleetWide) that fans out
+// to nothing is ADR-0103's collapsed pass — it owns no tenant by
+// declaration, so no row of it ever carries a workspace_id, and its own
+// tagged row is the whole pass rather than a dispatcher's row a child kind
+// elsewhere makes visible. A Fleet kind that DOES fan out (FanOutTo set) is
+// the opposite case: its own row is excluded exactly as before, because the
+// children it enqueues are the real per-workspace signal.
+func standaloneFleetKinds() []string {
+	return standaloneFleetKindsOf(allSpecs())
+}
+
+// standaloneFleetKindsOf is the selection itself, over a table a test can
+// build — the same split subWorkspaceFanOutsOf keeps for the same reason.
+func standaloneFleetKindsOf(table map[string]Spec) []string {
+	var kinds []string
+	for _, kind := range slices.Sorted(maps.Keys(table)) {
+		if spec := table[kind]; spec.Fleet && spec.FanOutTo == "" {
+			kinds = append(kinds, kind)
+		}
+	}
+	return kinds
+}
+
 func statsByState(ctx context.Context, pool *pgxpool.Pool) ([]StateRow, error) {
 	// The age is EXTRACTed from the database's own now(), never subtracted
 	// from the app clock: the two clocks differ by enough to move an exact
@@ -255,26 +283,52 @@ func statsByState(ctx context.Context, pool *pgxpool.Pool) ([]StateRow, error) {
 //
 // The sweep tag is what separates a fleet pass from a workspace job someone
 // triggered by hand. A dispatcher's own row carries no workspace and is
-// excluded: it is not one workspace's share of anything. A row whose
-// workspace key is PRESENT but empty is excluded by the same test rather
-// than counted as a workspace of its own — it is malformed, and a phantom
-// tenant here would misreport how much of the fleet a pass actually covers.
+// excluded: it is not one workspace's share of anything — the children it
+// enqueues are, and those are what this query counts for that kind. A row
+// whose workspace key is PRESENT but empty is excluded by the same test
+// rather than counted as a workspace of its own — it is malformed, and a
+// phantom tenant here would misreport how much of the fleet a pass actually
+// covers.
+//
+// A Fleet kind that fans out to NOTHING is a different shape, not a
+// malformed row: ADR-0103's collapsed pass owns no tenant by declaration, so
+// none of its rows will EVER carry a workspace_id — the first arm's
+// predicate excludes every one of them, forever, which is the defect this
+// query used to have (margince#4983). standaloneFleetKinds() names exactly
+// those kinds, and the second arm reads the latest tagged row PER KIND for
+// them instead of per workspace — the closest reading "did the last pass
+// happen" has when there is no workspace grain to read at all. The two arms
+// are kind-disjoint by construction (a kind is declared with a FanOutTo or
+// without one, never both), so UNION ALL cannot double-count one kind
+// between them; the exclusion in the first arm is defensive, so the split
+// holds even if that ever stopped being true of the data.
 func statsBySweep(ctx context.Context, pool *pgxpool.Pool) ([]SweepPass, error) {
+	standalone := standaloneFleetKinds()
 	const q = `
 		SELECT kind,
 		       count(*)::bigint,
 		       count(*) FILTER (WHERE state IN ` + terminalBadStates + `)::bigint
 		FROM (
-		    SELECT DISTINCT ON (kind, args->>'workspace_id')
-		           kind, state::text AS state
-		    FROM river_job
-		    WHERE ` + sweepTagPredicate + `
-		      AND coalesce(args->>'workspace_id', '') <> ''
-		    ORDER BY kind, args->>'workspace_id', created_at DESC, id DESC
+		    (SELECT DISTINCT ON (kind, args->>'workspace_id')
+		            kind, state::text AS state
+		     FROM river_job
+		     WHERE ` + sweepTagPredicate + `
+		       AND coalesce(args->>'workspace_id', '') <> ''
+		       AND NOT (kind = ANY(coalesce($1::text[], ARRAY[]::text[])))
+		     ORDER BY kind, args->>'workspace_id', created_at DESC, id DESC)
+
+		    UNION ALL
+
+		    (SELECT DISTINCT ON (kind)
+		            kind, state::text AS state
+		     FROM river_job
+		     WHERE ` + sweepTagPredicate + `
+		       AND kind = ANY(coalesce($1::text[], ARRAY[]::text[]))
+		     ORDER BY kind, created_at DESC, id DESC)
 		) latest
 		GROUP BY kind`
 
-	cursor, err := pool.Query(ctx, q)
+	cursor, err := pool.Query(ctx, q, standalone)
 	if err != nil {
 		return nil, fmt.Errorf("jobs: reading sweep passes: %w", err)
 	}

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -291,16 +291,18 @@ func statsByState(ctx context.Context, pool *pgxpool.Pool) ([]StateRow, error) {
 // covers.
 //
 // A Fleet kind that fans out to NOTHING is a different shape, not a
-// malformed row: ADR-0103's collapsed pass owns no tenant by declaration, so
+// malformed row: it owns no tenant by declaration (every such kind is
+// ADR-0103's collapsed periodic pass today, though the selection is by
+// declared shape — Fleet with no FanOutTo — rather than by that name), so
 // none of its rows will EVER carry a workspace_id — the first arm's
-// predicate excludes every one of them, forever, which is the defect this
-// query used to have (margince#4983). standaloneFleetKinds() names exactly
-// those kinds, and the second arm reads the latest tagged row PER KIND for
-// them instead of per workspace — the closest reading "did the last pass
-// happen" has when there is no workspace grain to read at all. The two arms
-// are kind-disjoint by construction (a kind is declared with a FanOutTo or
-// without one, never both), so UNION ALL cannot double-count one kind
-// between them; the exclusion in the first arm is defensive, so the split
+// predicate excludes every one of them, forever. standaloneFleetKinds()
+// names exactly those kinds, and the second arm reads the latest tagged row
+// PER KIND for them instead of per workspace — the closest reading "did the
+// last pass happen" has when there is no workspace grain to read at all.
+// The two arms are kind-disjoint by construction (a kind is declared with a
+// FanOutTo or without one, never both), so UNION ALL cannot double-count
+// one kind between them; the exclusion in the first arm is defensive, so
+// the split
 // holds even if that ever stopped being true of the data.
 func statsBySweep(ctx context.Context, pool *pgxpool.Pool) ([]SweepPass, error) {
 	standalone := standaloneFleetKinds()

--- a/backend/internal/platform/jobs/stats_integration_test.go
+++ b/backend/internal/platform/jobs/stats_integration_test.go
@@ -595,6 +595,75 @@ func TestSweepOmitsADispatchersOwnRow(t *testing.T) {
 	}
 }
 
+// TestSweepCountsAStandaloneFleetPassByKindNotByWorkspace — margince#4983:
+// a Fleet kind that fans out to nothing (embed_drift_sweep, ADR-0103's
+// collapsed shape) never carries a workspace_id, so its own tagged row used
+// to be filtered out by the same test that correctly excludes a
+// dispatcher's row above — leaving the gauge unable to see ANY of its
+// passes, ever, and reading greenest exactly when one was failing.
+// embed_drift_sweep is used rather than a made-up kind for the same reason
+// TestTheUnitPairSeesAFailedConnectionTheWorkspacePairMasks uses
+// telegram_poll: the standalone-kind arm is derived from the contract, so a
+// fixture kind would prove a query that never runs.
+func TestSweepCountsAStandaloneFleetPassByKindNotByWorkspace(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+
+	seedJob(ctx, t, pool, seed{
+		Kind: "embed_drift_sweep", State: "discarded",
+		Tags: []string{jobs.SweepTag},
+	})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	pass, ok := sweepFor(snap, "embed_drift_sweep")
+	if !ok {
+		t.Fatal("a tagged row of a standalone Fleet kind is missing from the sweep read entirely")
+	}
+	if pass.Workspaces != 1 {
+		t.Errorf("Workspaces = %d, want 1: there is no workspace grain for this kind, and the pass ran once", pass.Workspaces)
+	}
+	if pass.Failed != 1 {
+		t.Errorf("Failed = %d, want 1: the only tick discarded", pass.Failed)
+	}
+}
+
+// TestSweepReadsOnlyTheLatestTickOfAStandaloneFleetPass proves the
+// "latest outcome, never a batch" rule statsBySweep's own doc states also
+// holds for the per-kind arm: an earlier failing tick a later successful
+// one supersedes must not still read as failed.
+func TestSweepReadsOnlyTheLatestTickOfAStandaloneFleetPass(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	earlier, later := time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour)
+
+	seedJob(ctx, t, pool, seed{
+		Kind: "embed_drift_sweep", State: "discarded",
+		Tags: []string{jobs.SweepTag}, CreatedAt: earlier,
+	})
+	seedJob(ctx, t, pool, seed{
+		Kind: "embed_drift_sweep", State: "completed",
+		Tags: []string{jobs.SweepTag}, CreatedAt: later,
+	})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	pass, ok := sweepFor(snap, "embed_drift_sweep")
+	if !ok {
+		t.Fatal("no sweep reported for a tagged standalone Fleet kind")
+	}
+	if pass.Workspaces != 1 {
+		t.Errorf("Workspaces = %d, want 1", pass.Workspaces)
+	}
+	if pass.Failed != 0 {
+		t.Errorf("Failed = %d, want 0: the LATEST tick succeeded", pass.Failed)
+	}
+}
+
 // TestStatsOnAnEmptyJobTableIsAnEmptySnapshotNotAnError — the honest empty
 // case. A fleet with nothing queued is a real state, and the reader above
 // must be able to tell it from a failed read.

--- a/backend/internal/platform/jobs/stats_integration_test.go
+++ b/backend/internal/platform/jobs/stats_integration_test.go
@@ -578,11 +578,22 @@ func TestSweepIgnoresAWorkspacesSupersededFailure(t *testing.T) {
 // TestSweepOmitsADispatchersOwnRow — a dispatcher carries no workspace, so
 // it is not one workspace's share of anything. Counting it would add a
 // phantom tenant to every sweep it tagged.
+//
+// gmail_sync is seeded alongside the made-up kind deliberately: a fixture
+// kind can never appear in the standalone-fleet-kind set regardless of
+// whether that set is derived correctly, so it alone would keep passing
+// even if the new predicate started routing every dispatcher's own row into
+// the per-kind arm. gmail_sync is a REAL declared dispatcher (FanOutTo:
+// "capture_sync") and is the case that would actually catch that mistake.
 func TestSweepOmitsADispatchersOwnRow(t *testing.T) {
 	_, pool := migratedAppPool(t)
 	ctx := t.Context()
 	seedJob(ctx, t, pool, seed{
 		Kind: "the_dispatcher", State: "completed",
+		Tags: []string{jobs.SweepTag},
+	})
+	seedJob(ctx, t, pool, seed{
+		Kind: "gmail_sync", State: "completed",
 		Tags: []string{jobs.SweepTag},
 	})
 
@@ -593,14 +604,16 @@ func TestSweepOmitsADispatchersOwnRow(t *testing.T) {
 	if _, ok := sweepFor(snap, "the_dispatcher"); ok {
 		t.Error("an untenanted row was counted as a workspace's share of a fleet pass")
 	}
+	if _, ok := sweepFor(snap, "gmail_sync"); ok {
+		t.Error("a real dispatcher's own row was counted — its children (capture_sync) carry the per-workspace signal, not its own row")
+	}
 }
 
-// TestSweepCountsAStandaloneFleetPassByKindNotByWorkspace — margince#4983:
-// a Fleet kind that fans out to nothing (embed_drift_sweep, ADR-0103's
-// collapsed shape) never carries a workspace_id, so its own tagged row used
-// to be filtered out by the same test that correctly excludes a
-// dispatcher's row above — leaving the gauge unable to see ANY of its
-// passes, ever, and reading greenest exactly when one was failing.
+// TestSweepCountsAStandaloneFleetPassByKindNotByWorkspace — a Fleet kind
+// that fans out to nothing (embed_drift_sweep, ADR-0103's collapsed shape)
+// never carries a workspace_id, so a query keyed only on workspace_id
+// excludes every one of its rows forever — the gauge would then read
+// greenest exactly when such a pass was failing on every tick.
 // embed_drift_sweep is used rather than a made-up kind for the same reason
 // TestTheUnitPairSeesAFailedConnectionTheWorkspacePairMasks uses
 // telegram_poll: the standalone-kind arm is derived from the contract, so a
@@ -661,6 +674,42 @@ func TestSweepReadsOnlyTheLatestTickOfAStandaloneFleetPass(t *testing.T) {
 	}
 	if pass.Failed != 0 {
 		t.Errorf("Failed = %d, want 0: the LATEST tick succeeded", pass.Failed)
+	}
+}
+
+// TestSweepDoesNotDoubleCountAStandaloneKindsRowThatCarriesAWorkspaceID —
+// nothing in the tree writes a workspace_id onto an embed_drift_sweep row
+// today, so the per-workspace arm's exclusion of the standalone-kind set is
+// defensive rather than load-bearing. This is what proves it actually holds:
+// without it, a row shaped like the second one below would be read by BOTH
+// arms and summed into one inflated count by the outer GROUP BY.
+func TestSweepDoesNotDoubleCountAStandaloneKindsRowThatCarriesAWorkspaceID(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+
+	// The ordinary shape: no workspace_id at all.
+	seedJob(ctx, t, pool, seed{
+		Kind: "embed_drift_sweep", State: "completed",
+		Tags: []string{jobs.SweepTag},
+	})
+	// A row of the SAME kind that also carries a workspace_id — a shape
+	// nothing here produces, exercising the defensive exclusion rather than
+	// data the fleet actually writes.
+	seedJob(ctx, t, pool, seed{
+		Kind: "embed_drift_sweep", State: "completed",
+		Tags: []string{jobs.SweepTag}, Workspace: ids.NewV7(),
+	})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	pass, ok := sweepFor(snap, "embed_drift_sweep")
+	if !ok {
+		t.Fatal("no sweep reported for the standalone kind")
+	}
+	if pass.Workspaces != 1 {
+		t.Errorf("Workspaces = %d, want 1: a row that slipped past the per-workspace arm's exclusion must not also be summed on top of the per-kind arm's own reading", pass.Workspaces)
 	}
 }
 


### PR DESCRIPTION
## Summary

margince#4983 — `margince_sweep_workspaces{,_failed}` could see NONE of the Fleet kinds that fan out to nothing (ADR-0103's collapsed periodic-pass shape — e.g. `embed_drift_sweep`, a bare `struct{}` args type ticked on its own schedule, doing the whole installation's work in one row rather than enqueuing per-workspace children). `statsBySweep`'s query required `args->>'workspace_id'` to be non-empty; a standalone Fleet kind's rows never carry that key at all by declaration, so every one of its tagged rows was silently excluded, forever. The gauge read greenest exactly when such a pass was failing on every tick — which is what hid margince#4982 from notice for as long as it went unnoticed.

`standaloneFleetKinds()`/`standaloneFleetKindsOf()` derive, from the existing `jobs.Spec` table, which Fleet kinds fan out to a child (`FanOutTo != ""` — excluded exactly as before, since the children carry the real per-workspace signal) versus which do the whole pass in their own row (`Fleet && FanOutTo == ""` — now read PER KIND instead, latest tick only, the same "never a batch" rule the workspace arm already follows). `statsBySweep`'s SQL becomes a `UNION ALL` of the original per-workspace-latest arm and a new per-kind-latest arm for the standalone set; the two are kind-disjoint by construction, and the exclusion in the first arm is defensive (verified by its own test — see below).

## Review

Reviewed by both Fable and Codex before push. Fable's MAJOR: `TestSweepOmitsADispatchersOwnRow` used a fixture kind (`the_dispatcher`) that was never a real declared kind, so it couldn't actually discriminate correct code from a broken predicate that swept every dispatcher's own row into the new per-kind arm — confirmed by mutation-testing (widening the predicate to `Fleet` alone left that test green). Fixed by adding a real declared dispatcher (`gmail_sync`) to the same test. Codex's MINOR: the "defensive" exclusion between the two SQL arms had no test forcing it to matter — added `TestSweepDoesNotDoubleCountAStandaloneKindsRowThatCarriesAWorkspaceID`, mutation-tested (removing the exclusion inflates `Workspaces` from 1 to 2). Both reviews also caught the same ticket-number/comment-residue issue Wave A and B's reviews caught; fixed.

## Scope notes

- No AI prompt content changed, no aicert re-run needed.
- No UAT video — this is a backend metrics/SQL fix with no UI or agent-door surface; the integration tests against a real Postgres, using the actual `embed_drift_sweep` kind (not a fixture kind — see `TestSweepCountsAStandaloneFleetPassByKindNotByWorkspace`'s own comment for why), are the equivalent proof.
- `margince_sweep_workspaces`'s HELP text and `SweepPass.Workspaces`'s doc comment updated to state the new semantics honestly: for a standalone kind, `1` means "the latest tagged run exists," not a true workspace count.
- **Rebased mid-flight onto a main-red fix** (PR #5127, `docs/explanation/company-record-page.md` over its line budget from an unrelated merge) — waited for that to land rather than duplicating the diagnosis, per this repo's own main-red claim protocol.

## Test plan

- [x] `TestStandaloneFleetKindsSelectsExactlyTheCollapsedPasses` — walks the live declared table (`allSpecs()`), proving the derivation against every real Fleet kind, both arms of the partition
- [x] `TestStandaloneFleetKindsOfIgnoresANonFleetKind` — fabricated-table unit test for the three logical cases (collapsed, dispatcher, non-Fleet)
- [x] `TestSweepCountsAStandaloneFleetPassByKindNotByWorkspace` / `TestSweepReadsOnlyTheLatestTickOfAStandaloneFleetPass` — real Postgres, real `embed_drift_sweep` kind, proving visibility and the latest-tick-only rule
- [x] `TestSweepDoesNotDoubleCountAStandaloneKindsRowThatCarriesAWorkspaceID` — proves the two SQL arms can't double-count
- [x] `TestSweepOmitsADispatchersOwnRow` (extended) — proves a real dispatcher's own row (`gmail_sync`) still stays excluded
- [x] All of the above mutation-tested: reverted to the original query (red on the two new standalone tests), widened the predicate to `Fleet` alone (red on the dispatcher case), removed the defensive exclusion (red on the double-count case) — each restores clean
- [x] `make check-go` green (build, vet, lint, arch-lint, unit + fitness tests, contract drift) on the rebased branch
- [x] `make test-it DIR=backend/internal/platform/jobs` green against real Postgres
- [x] Pre-push `craft static --strict` — 0 blocker/major/minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRuXiSKkD1X1D1U5yRF4Qn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the fleet sweep gauges so a collapsed Fleet-wide pass (ADR-0103's standalone shape, e.g. `embed_drift_sweep`) shows up instead of being silently excluded forever. `statsBySweep` previously required `args->>'workspace_id'` to be non-empty, and a Fleet kind that fans out to nothing never carries that key, so its gauge read greenest exactly when the pass was failing on every tick.

**Changes**
- New `standaloneFleetKinds()` derives the set from the declared `jobs.Spec` table: `Fleet` kinds with no `FanOutTo` are read per kind (latest tagged row only); fan-out kinds keep the per-workspace read, since their children carry the real signal.
- The query is now a `UNION ALL` of the per-workspace-latest arm and the new per-kind-latest arm; the arms are kind-disjoint by construction, with the per-workspace arm's exclusion of standalone kinds defensive.
- Gauge HELP text and `SweepPass.Workspaces` doc now state that for a standalone kind, `1` means the latest tagged run exists, not a workspace count.

**Tests**
- Tests use real declared kinds (`embed_drift_sweep`, `gmail_sync`) so the derivation is exercised against actual contracts, and each new behavior is mutation-tested.

<sup>Written for commit da58444f8eb383fb2ac655299b19d86cefbf393d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

