### PR TITLE
fix(search): a predicate on a reference carries the referenced record's scope

### DIFF
--- a/backend/internal/compose/integration/queryworkspace_integration_test.go
+++ b/backend/internal/compose/integration/queryworkspace_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -380,4 +381,55 @@ func evidenceByRow(answer agents.QueryWorkspaceResult) map[ids.UUID][]agents.Que
 		out[row.Record.ID] = row.Evidence
 	}
 	return out
+}
+
+// The DIRECT form of the same question. A hop is scoped; a predicate naming
+// the reference column is the same read with the join written out, and it
+// carries the same answer.
+//
+// Filtering by an id is asking whether it is there. The rep sends a company id
+// they cannot open, and the deals that come back would say it is on the books
+// and which deals are its — masking the id on the way out makes that answer
+// quieter, not different, because the ROW is the disclosure and the rep chose
+// the predicate that selected it.
+func TestAPredicateNamingARecordTheCallerCannotSeeAdmitsNothing(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	registry := compose.NewRegistry(q.Pool, compose.SendPath{})
+	plan := fmt.Sprintf(`{"plan":{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "organization_id", "op": "eq", "value": %q}]}}`, f.rep3Org)
+
+	admin := queryPayload(t, invokeQuery(q.admin(), t, registry, plan).Data)
+	if _, err := q.Owner.Exec(context.Background(),
+		`UPDATE organization SET visibility = 'owner' WHERE id = $1`, f.rep3Org); err != nil {
+		t.Fatalf("capturing the organization privately: %v", err)
+	}
+	rep := queryPayload(t, invokeQuery(q.teamRep(q.Rep1, q.Team1), t, registry, plan).Data)
+
+	// The unbounded reader is what proves the plan asks a real question: an
+	// empty answer for the rep means nothing if it is empty for everybody.
+	if len(admin.Rows) == 0 {
+		t.Fatalf("the unbounded reader sees no deal at the seeded company, so this plan asks nothing")
+	}
+	if len(rep.Rows) != 0 {
+		t.Errorf("the rep selected %d deals by a company they cannot open — the rows answer that it exists", len(rep.Rows))
+	}
+}
+
+// The same predicate over a company the rep CAN open still answers. A guard
+// that refused both would pass the case above perfectly while making the field
+// useless, which is the availability regression a security fix smuggles in.
+func TestAPredicateNamingARecordTheCallerCanSeeStillAnswers(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	registry := compose.NewRegistry(q.Pool, compose.SendPath{})
+	plan := fmt.Sprintf(`{"plan":{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "organization_id", "op": "eq", "value": %q}]}}`, f.rep1Org)
+
+	rep := queryPayload(t, invokeQuery(q.teamRep(q.Rep1, q.Team1), t, registry, plan).Data)
+	if len(rep.Rows) == 0 {
+		t.Error("the rep cannot filter by their own company, so the guard withholds a reference they are entitled to")
+	}
 }

--- a/backend/internal/modules/search/querybind.go
+++ b/backend/internal/modules/search/querybind.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// One JSON operand becomes one bound parameter, under the FIELD's kind rather
+// than the JSON's own shape.
+//
+// Split out of the statement assembly because it answers a different question:
+// querysql.go decides what the statement says, and this decides what a value
+// the caller wrote means when the column it is compared against says it is a
+// date, a uuid or a number. A refusal here names the operand, not the clause.
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// bind turns one JSON operand into a bound parameter under the field's kind,
+// with the cast the comparison needs.
+//
+// This is where a FORMAT is checked. The validator deliberately left it here
+// ("their format is the executor's business"): it had a shape to compare
+// against and no calendar, and refusing `"next tuesday"` at the moment it
+// would become a parameter is what keeps a malformed date a refusal rather
+// than a query that quietly matches nothing.
+//
+//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
+func (c *planCompiler) bind(at string, field Field, raw json.RawMessage) (any, string, *apperrors.FieldRefusal) {
+	switch field.Kind {
+	case KindNumber:
+		return bindNumber(at, field, raw)
+	case KindBoolean:
+		var value bool
+		return value, "", decodeOperand(at, field, raw, &value, "true or false")
+	case KindID:
+		return bindID(at, field, raw)
+	case KindDate:
+		return bindTemporal(at, field, raw, dateLayout, "::date", "a date, as YYYY-MM-DD")
+	case KindTimestamp:
+		return bindTemporal(at, field, raw, time.RFC3339, "", "an instant, as RFC 3339 (2026-08-08T09:00:00Z)")
+	case KindText:
+		var value string
+		return value, "", decodeOperand(at, field, raw, &value, "text")
+	case KindGeo:
+		// A place is never compared: within_radius answers
+		// distance_ranking_unavailable and the executor stops before here.
+		return nil, "", operandFault(at, field, "a place, which this deployment cannot rank by")
+	default:
+		return nil, "", operandFault(at, field, "a value of a kind this workspace can compare")
+	}
+}
+
+//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
+func bindNumber(at string, field Field, raw json.RawMessage) (any, string, *apperrors.FieldRefusal) {
+	var value json.Number
+	if refusal := decodeOperand(at, field, raw, &value, "a number"); refusal != nil {
+		return nil, "", refusal
+	}
+	// A whole number binds as one, so a bigint column compares against a
+	// bigint rather than against a float that rounded on the way in.
+	if whole, err := value.Int64(); err == nil {
+		return whole, "", nil
+	}
+	// A FRACTIONAL number binds as its own digits, cast to numeric. Through a
+	// float64 it would not: 0.1 is not representable in binary, so a `numeric`
+	// column holding exactly 0.1 would compare unequal to the 0.1 the caller
+	// wrote — an exact predicate answering "no rows" for a value that is
+	// there. The digits are the caller's own text and go through a bind
+	// parameter, so nothing is interpolated.
+	if _, err := value.Float64(); err != nil {
+		return nil, "", operandFault(at, field, "a number")
+	}
+	return value.String(), "::numeric", nil
+}
+
+//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
+func bindID(at string, field Field, raw json.RawMessage) (any, string, *apperrors.FieldRefusal) {
+	var text string
+	if refusal := decodeOperand(at, field, raw, &text, "an identifier"); refusal != nil {
+		return nil, "", refusal
+	}
+	id, err := ids.Parse(text)
+	if err != nil {
+		return nil, "", operandFault(at, field, "an identifier, as a UUID")
+	}
+	return id, "", nil
+}
+
+// bindTemporal parses a date or an instant in the contract's own encoding and
+// binds it as TEXT with an explicit cast where one is needed. A date compared
+// through a timestamp would be resolved at the session's time zone, which
+// makes the same plan answer differently on two servers.
+//
+//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
+func bindTemporal(at string, field Field, raw json.RawMessage, layout, cast, shape string) (any, string, *apperrors.FieldRefusal) {
+	var text string
+	if refusal := decodeOperand(at, field, raw, &text, shape); refusal != nil {
+		return nil, "", refusal
+	}
+	parsed, err := time.Parse(layout, text)
+	if err != nil {
+		return nil, "", operandFault(at, field, shape)
+	}
+	if cast == "" {
+		return parsed, "", nil
+	}
+	return parsed.Format(layout), cast, nil
+}
+
+// decodeOperand decodes one operand into its Go type, which IS the check: a
+// number offered where text belongs fails at the decode rather than after it.
+//
+//craft:ignore naked-any `into` is the caller's own destination for one operand; decoding INTO its Go type is the check, and a narrower signature would have to name every kind
+func decodeOperand(at string, field Field, raw json.RawMessage, into any, shape string) *apperrors.FieldRefusal {
+	if len(raw) == 0 || isJSONNull(raw) || json.Unmarshal(raw, into) != nil {
+		return operandFault(at, field, shape)
+	}
+	return nil
+}
+
+func operandFault(at string, field Field, shape string) *apperrors.FieldRefusal {
+	return &apperrors.FieldRefusal{
+		Field: at, Code: CodeValueTypeMismatch,
+		Message: quote(field.Name) + " is a " + string(field.Kind) + " field; its operand must be " + shape,
+	}
+}

--- a/backend/internal/modules/search/querygeo_test.go
+++ b/backend/internal/modules/search/querygeo_test.go
@@ -262,8 +262,11 @@ func TestARadiusInsideATraversalRefusesRatherThanBeingDropped(t *testing.T) {
 	}
 	clauses := []Predicate{{Field: "address", Op: OpWithinRadius, Value: operand}}
 
-	fragments, refusals := c.predicates("h", unfilteredStorage(),
+	fragments, refusals, err := c.predicates(t.Context(), "h", unfilteredStorage(),
 		TargetVocabulary{Target: "organization"}, "traverse.where", clauses, false)
+	if err != nil {
+		t.Fatalf("compiling the hop predicates: %v", err)
+	}
 	if len(fragments) != 0 {
 		t.Errorf("a hop radius compiled to %v; nothing binds it there", fragments)
 	}
@@ -277,8 +280,11 @@ func TestARadiusInsideATraversalRefusesRatherThanBeingDropped(t *testing.T) {
 
 	// The ROOT is the opposite: skipped here on purpose, because radius()
 	// renders it. Neither a fragment nor a refusal.
-	fragments, refusals = c.predicates("t", unfilteredStorage(),
+	fragments, refusals, err = c.predicates(t.Context(), "t", unfilteredStorage(),
 		TargetVocabulary{Target: "organization"}, "where", clauses, true)
+	if err != nil {
+		t.Fatalf("compiling the root predicates: %v", err)
+	}
 	if len(fragments) != 0 || len(refusals) != 0 {
 		t.Errorf("the root radius produced fragments %v and refusals %v; radius() renders it",
 			fragments, refusals)

--- a/backend/internal/modules/search/queryreferencecensus_test.go
+++ b/backend/internal/modules/search/queryreferencecensus_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// The reference resolver's census, derived from the schema's own foreign keys.
+//
+// UNDER-RECOGNITION is the whole risk. A column the resolver cannot place is
+// not a failure anywhere: referenceGuard returns "", the predicate compiles to
+// a bare comparison, and the answer is a well-formed page that says which rows
+// name a record the caller may not open. There is nothing to notice, which is
+// exactly how `partner_org_id` stayed open while `organization_id` beside it
+// was closed — one is spelled for its target and the other for its role.
+//
+// So the expectation is read off the catalog rather than kept as a list beside
+// the one it would be checking.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// searchableReference matches a catalog line declaring one table's foreign key:
+// `public.<table>.<name> FOREIGN KEY (<column>) REFERENCES <target>(id)`.
+var searchableReference = regexp.MustCompile(
+	`^public\.(\w+)\.\w+ FOREIGN KEY \((\w+)\) REFERENCES (\w+)\(id\)`)
+
+func TestEveryQueryableReferenceResolvesToItsRecordType(t *testing.T) {
+	catalog, err := os.ReadFile("../../../migrations/testdata/head_catalog.txt")
+	if err != nil {
+		t.Fatalf("reading the head catalog: %v", err)
+	}
+
+	found := 0
+	for _, line := range strings.Split(string(catalog), "\n") {
+		m := searchableReference.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		table, column, target := m[1], m[2], m[3]
+		// Both ends must be records this surface searches. A reference to a
+		// pipeline or an app user names nothing a query plan can traverse, and
+		// demanding a branch for it would fail on a column that discloses
+		// nothing.
+		if _, searchable := branchFor(table); !searchable {
+			continue
+		}
+		if _, searchable := branchFor(target); !searchable {
+			continue
+		}
+		found++
+
+		branch, resolved := referencedBranch(table, Field{Name: column, Kind: KindID})
+		if !resolved {
+			t.Errorf("%s.%s references %s and the resolver places it nowhere, so a predicate on it compiles to a bare comparison — the row's presence then answers about a record the caller may not open, and nothing fails to say so",
+				table, column, target)
+			continue
+		}
+		if branch.entity != target {
+			t.Errorf("%s.%s references %s but the resolver places it on %s — the guard would ask about the wrong record while looking present, which reads as a passing fix",
+				table, column, target, branch.entity)
+		}
+	}
+	if found == 0 {
+		t.Fatal("the catalog declared no foreign key between two searchable records — the scan read the wrong file or the wrong shape, and an empty expectation passes against anything")
+	}
+}
+
+// A declaration nothing needs is a claim the schema does not make. It costs
+// nothing at runtime, but it is the half of the list that goes stale silently:
+// a column renamed by a migration leaves its old spelling here, resolving a
+// name no table has.
+func TestEveryDeclaredRoleNameIsAColumnTheSchemaHolds(t *testing.T) {
+	catalog, err := os.ReadFile("../../../migrations/testdata/head_catalog.txt")
+	if err != nil {
+		t.Fatalf("reading the head catalog: %v", err)
+	}
+	declared := map[string]bool{}
+	for column := range roleNamedReferences {
+		declared[column] = false
+	}
+	for column := range selfReferences {
+		declared[column] = false
+	}
+	for _, line := range strings.Split(string(catalog), "\n") {
+		m := searchableReference.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if _, held := declared[m[2]]; held {
+			declared[m[2]] = true
+		}
+	}
+	for column, held := range declared {
+		if !held {
+			t.Errorf("the resolver declares %q, which the schema holds no foreign key for — it resolves a name no table has", column)
+		}
+	}
+}

--- a/backend/internal/modules/search/queryreferencescope.go
+++ b/backend/internal/modules/search/queryreferencescope.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// A predicate on a REFERENCE column is a question about the record it names.
+//
+// `deal.organization_id eq <uuid>` compiles to a comparison under the deal's
+// own scope, and every seat of the workspace reads every deal. So the rows that
+// come back answer "is this company on our books, and which deals are its" for
+// a company the same caller's ordinary read would refuse — capture privacy on
+// organization, own/team scope on project. Hydration masks the id on the way
+// out, which makes the answer quieter without making it different: the row is
+// still there, and the predicate that selected it is still the caller's own.
+//
+// The TRAVERSAL form of the same question is already scoped — lateralHop runs
+// branchScope over the hop record. This is the direct-field form of the hop,
+// and it gets the same clause from the same place, so the two arms of one
+// question cannot answer differently.
+//
+// Scoped on the ROW's value rather than on the id the caller sent, which is
+// what makes it operator-agnostic: `ne`, `in` and a range each disclose the
+// binding by which rows they leave out, and only a guard on the row itself
+// covers all of them.
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// referenceGuard is the extra conjunct a predicate on a reference column
+// carries, or "" for a column that names nothing row-scoped.
+//
+// A NULL reference passes. The row names no record, so there is no target to
+// be admitted to — and without this arm `organization_id is_null` would answer
+// nothing at all, having asked the guard about a row that has no company by
+// the caller's own choice of question.
+func referenceGuard(
+	ctx context.Context, entity string, field Field, expr, alias string, arg func(any) int,
+) (string, error) {
+	branch, ok := referencedBranch(entity, field)
+	if !ok {
+		return "", nil
+	}
+	scope, admitted, err := branchScope(ctx, branch, alias, arg)
+	if err != nil {
+		return "", err
+	}
+	// Object RBAC refuses the record type outright. The reference then names
+	// something this caller may not read at all, so only the rows naming
+	// nothing survive — the same answer the row scope gives when it admits no
+	// row, reached one gate earlier.
+	if !admitted {
+		return storekit.SQLf("%s IS NULL", expr), nil
+	}
+	// Every row of that table is readable, so there is nothing to narrow and
+	// the EXISTS would only re-prove the foreign key.
+	if scope == "" {
+		return "", nil
+	}
+	return storekit.SQLf(
+		"(%s IS NULL OR EXISTS (SELECT 1 FROM %s %s WHERE %s.id = %s AND %s))",
+		expr, branch.table, alias, alias, expr, scope), nil
+}
+
+// referencedBranch resolves the record type a reference field names.
+//
+// Three spellings, because the schema has three and a resolver that knew only
+// the first would read green over the other two — which is how `partner_org_id`
+// stayed unguarded while `organization_id` beside it was closed:
+//
+//   - the contract's own, `<record type>_id`, which is also what
+//     contractRelations traverses on, so the direct form and the hop agree
+//     about which columns are references;
+//   - a NESTED member, `employer.organization_id`, whose target is spelled in
+//     its last segment and whose leading path names the member rather than a
+//     record type;
+//   - a ROLE, `partner_org_id`, which names what the reference is FOR instead
+//     of what it points at. Those cannot be derived from the name at all and
+//     are declared below.
+//
+// A branch that reads workspace-wide is not excluded here: branchScope answers
+// it with an empty clause, and letting it through keeps ONE place deciding what
+// a record type's row scope is.
+func referencedBranch(entity string, field Field) (searchBranch, bool) {
+	if field.Kind != KindID || !strings.HasSuffix(field.Name, relationSuffix) {
+		return searchBranch{}, false
+	}
+	column := field.Name
+	if _, member, nested := strings.Cut(column, memberPathSeparator); nested {
+		column = lastMember(member)
+	}
+	if selfReferences[column] {
+		return branchFor(entity)
+	}
+	if target, declared := roleNamedReferences[column]; declared {
+		return branchFor(target)
+	}
+	return branchFor(strings.TrimSuffix(column, relationSuffix))
+}
+
+// lastMember answers the final segment of a dotted member path.
+func lastMember(path string) string {
+	for {
+		_, rest, nested := strings.Cut(path, memberPathSeparator)
+		if !nested {
+			return path
+		}
+		path = rest
+	}
+}
+
+// memberPathSeparator joins a nested contract member to its parent.
+const memberPathSeparator = "."
+
+// roleNamedReferences are the columns that name what a reference is FOR rather
+// than what it points at. A deal's `partner_org_id` and an organization's
+// `parent_org_id` are both organizations, and no derivation from the name can
+// say so.
+//
+// Declared here and checked against the schema's own foreign keys by
+// TestEveryQueryableReferenceResolvesToItsRecordType, so a role-named column
+// added later fails rather than quietly resolving to nothing — which is the
+// only way this list can be wrong and the only way that would not be noticed.
+var roleNamedReferences = map[string]string{
+	"partner_org_id":         entityOrganization,
+	"parent_org_id":          entityOrganization,
+	"counterparty_org_id":    entityOrganization,
+	"promoted_person_id":     entityPerson,
+	"qualified_deal_id":      entityDeal,
+	"converted_from_lead_id": entityLead,
+	"source_activity_id":     entityActivity,
+}
+
+// selfReferences name another row of the SAME record type, so their target is
+// whatever record carries them: a person's `merged_into_id` is a person, an
+// organization's is an organization. Resolving them from the name would need
+// one entry per record type saying the same thing.
+var selfReferences = map[string]bool{"merged_into_id": true}
+
+// refAlias names one guard's subquery. Each predicate gets its own, because a
+// plan may filter on two references at once and a repeated alias would make the
+// second EXISTS read the first's row.
+func refAlias(n int) string {
+	return "ref" + strconv.Itoa(n)
+}

--- a/backend/internal/modules/search/queryreferencescope_test.go
+++ b/backend/internal/modules/search/queryreferencescope_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// A direct predicate on a reference column is the SAME question the traversal
+// asks, so it carries the same scope. Without this a caller filters deals by a
+// company they cannot open and reads the binding off which rows come back —
+// masking the id afterwards makes the answer quieter, not different.
+func TestAPredicateOnAReferenceCarriesTheReferencedRecordsScope(t *testing.T) {
+	sql, _ := compilePlanDoc(teamReaderFor(entityDeal, entityOrganization), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "organization_id", "op": "eq",
+		           "value": "01a08485-fac3-7543-b543-59cc991bbdd7"}]}`)
+	if !strings.Contains(sql, "EXISTS (SELECT 1 FROM organization ref0") {
+		t.Fatalf("the predicate carries no organization scope: %s", sql)
+	}
+	// Decided about the ORGANIZATION row, under the guard's own alias. Rendered
+	// against `t` it would decide about the deal — a visibility rule answering
+	// about a different record, which is the defect and not the fix.
+	if !strings.Contains(sql, "ref0.owner_id") {
+		t.Fatalf("the guard's scope is not rendered against the referenced row: %s", sql)
+	}
+	if strings.Contains(sql, "t.owner_id") {
+		t.Fatalf("the guard's scope filters the deal instead: %s", sql)
+	}
+}
+
+// A project is read by every seat that holds the grant — it is an identity
+// table, and its row scope renders nothing. So a predicate on `project_id`
+// carries no guard: there is no row to withhold, and the EXISTS would only
+// re-prove the foreign key at a subquery per row.
+//
+// This is the arm that keeps the fix from becoming an availability regression,
+// and it is why the guard asks branchScope rather than deciding for itself
+// which record types narrow.
+func TestAPredicateOnAReferenceEverySeatReadsCarriesNoGuard(t *testing.T) {
+	sql, _ := compilePlanDoc(teamReaderFor(entityDeal, entityProject), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "project_id", "op": "eq",
+		           "value": "01a08485-fac3-7543-b543-59cc991bbdd7"}]}`)
+	if strings.Contains(sql, "EXISTS (SELECT 1 FROM project") {
+		t.Fatalf("a reference every seat may read still paid for a guard: %s", sql)
+	}
+}
+
+// A row naming nothing has no target to be admitted to, and the guard lets it
+// through.
+//
+// `neq` is what makes this load-bearing rather than tidy. It renders IS
+// DISTINCT FROM, which is TRUE for a deal with no company at all — a caller
+// asking for "not company X" is answered with those deals today. A guard
+// without the null arm would drop them, which is a WRONG answer rather than a
+// narrower one: the rows it removes disclose nothing about X.
+func TestAReferenceThatNamesNothingSurvivesTheGuard(t *testing.T) {
+	sql, _ := compilePlanDoc(teamReaderFor(entityDeal, entityOrganization), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "organization_id", "op": "neq",
+		           "value": "01a08485-fac3-7543-b543-59cc991bbdd7"}]}`)
+	if !strings.Contains(sql, `IS DISTINCT FROM`) {
+		t.Fatalf("neq no longer renders IS DISTINCT FROM, so this case no longer asks what it was written to ask: %s", sql)
+	}
+	if !strings.Contains(sql, `t."organization_id" IS NULL OR EXISTS`) {
+		t.Fatalf("the guard has no null arm, so a deal with no company is dropped from an answer it belongs in: %s", sql)
+	}
+}
+
+// Object RBAC refusing the record type outright is one gate earlier than the
+// row scope and answers the same way: only the rows naming nothing survive. A
+// caller who may not read organizations at all must not learn which deals have
+// one.
+func TestAReferenceToARecordTypeTheCallerCannotReadAdmitsOnlyNulls(t *testing.T) {
+	sql, _ := compilePlanDoc(teamReaderFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "organization_id", "op": "eq",
+		           "value": "01a08485-fac3-7543-b543-59cc991bbdd7"}]}`)
+	if strings.Contains(sql, "EXISTS (SELECT 1 FROM organization") {
+		t.Fatalf("a caller with no organization grant got a row-scope guard rather than a refusal: %s", sql)
+	}
+	if !strings.Contains(sql, `t."organization_id" IS NULL`) {
+		t.Fatalf("the predicate still answers about the reference: %s", sql)
+	}
+}
+
+// Two references in one plan get two aliases. Sharing one would make the second
+// EXISTS read the first's row, so the guard would answer about the wrong record
+// while looking present — the failure that reads as a passing fix.
+func TestTwoReferenceGuardsInOnePlanDoNotShareAnAlias(t *testing.T) {
+	// Both references are organizations — the customer and the partner — which
+	// is the case that would go unnoticed: one alias, one table, and an EXISTS
+	// that reads as correct while answering about the customer twice.
+	sql, _ := compilePlanDoc(teamReaderFor(entityDeal, entityOrganization), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "organization_id", "op": "eq",
+		           "value": "01a08485-fac3-7543-b543-59cc991bbdd7"},
+		          {"field": "partner_org_id", "op": "eq",
+		           "value": "01a08485-fac3-7543-b543-59cc991bbdd8"}]}`)
+	if !strings.Contains(sql, "organization ref0") || !strings.Contains(sql, "organization ref1") {
+		t.Fatalf("the two guards do not carry distinct aliases: %s", sql)
+	}
+	if !strings.Contains(sql, `ref1.id = t."partner_org_id"`) {
+		t.Fatalf("the second guard does not ask about the partner: %s", sql)
+	}
+}

--- a/backend/internal/modules/search/querysql.go
+++ b/backend/internal/modules/search/querysql.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -91,6 +90,10 @@ type planBinding struct {
 // planCompiler accumulates the statement's bound arguments.
 type planCompiler struct {
 	args []any
+	// refs counts the reference guards rendered so far, so each gets a subquery
+	// alias of its own — two guards sharing one would make the second EXISTS
+	// read the first's row.
+	refs int
 }
 
 //craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
@@ -116,7 +119,10 @@ func (c *planCompiler) compileStatement(ctx context.Context, plan ValidatedPlan,
 	if scope != "" {
 		where = append(where, scope)
 	}
-	predicates, refusals := c.predicates("t", binding.columns, plan.Target, "where", plan.Plan.Where, true)
+	predicates, refusals, err := c.predicates(ctx, "t", binding.columns, plan.Target, "where", plan.Plan.Where, true)
+	if err != nil {
+		return "", false, err
+	}
 	where = append(where, predicates...)
 
 	// The radius, when the plan carries one this deployment can answer. The
@@ -205,7 +211,10 @@ func (c *planCompiler) lateralHop(ctx context.Context, plan ValidatedPlan, bindi
 	if scope != "" {
 		where = append(where, scope)
 	}
-	predicates, refusals := c.predicates("h", hop.columns, plan.HopVocabulary, "traverse.where", plan.Plan.Traverse.Where, false)
+	predicates, refusals, err := c.predicates(ctx, "h", hop.columns, plan.HopVocabulary, "traverse.where", plan.Plan.Traverse.Where, false)
+	if err != nil {
+		return "", "", nil, false, err
+	}
 	where = append(where, predicates...)
 
 	// ORDER BY keeps the evidence deterministic when several hop rows match;
@@ -237,7 +246,10 @@ func (c *planCompiler) edgeCondition(hop hopBinding) string {
 // root says whether these predicates are the ones on the record being searched
 // for, as opposed to a traversal's. It decides one thing: whether a radius is
 // bound elsewhere (root) or has nowhere to go (a hop).
-func (c *planCompiler) predicates(alias string, columns *storage, vocab TargetVocabulary, path string, clauses []Predicate, root bool) ([]string, []apperrors.FieldRefusal) {
+func (c *planCompiler) predicates(
+	ctx context.Context, alias string, columns *storage, vocab TargetVocabulary,
+	path string, clauses []Predicate, root bool,
+) ([]string, []apperrors.FieldRefusal, error) {
 	var (
 		fragments []string
 		refusals  []apperrors.FieldRefusal
@@ -265,38 +277,61 @@ func (c *planCompiler) predicates(alias string, columns *storage, vocab TargetVo
 			}
 			continue
 		}
-		fragment, refusal := c.clause(alias, columns, vocab, at, clause)
+		field, expr, refusal := c.resolve(alias, columns, vocab, at, clause)
 		if refusal != nil {
 			refusals = append(refusals, *refusal)
 			continue
 		}
+		fragment, refusal := c.clause(expr, at, field, clause)
+		if refusal != nil {
+			refusals = append(refusals, *refusal)
+			continue
+		}
+		// The guard rides the predicate rather than the statement's where-list
+		// so a traversal's own clauses carry it too — predicates renders both.
+		guard, err := referenceGuard(ctx, vocab.Target, field, expr, refAlias(c.refs), c.arg)
+		if err != nil {
+			return nil, nil, err
+		}
+		if guard != "" {
+			c.refs++
+			fragment = "(" + fragment + ") AND " + guard
+		}
 		fragments = append(fragments, fragment)
 	}
-	return fragments, refusals
+	return fragments, refusals, nil
 }
 
-// clause renders one `field op value`.
-func (c *planCompiler) clause(alias string, columns *storage, vocab TargetVocabulary, at string, clause Predicate) (string, *apperrors.FieldRefusal) {
+// resolve reads the field a clause names and the expression it compiles to,
+// refusing a name this workspace cannot answer.
+//
+// Both refusals are unreachable through Execute: the validator settled
+// membership against this same vocabulary, and a published field compiles.
+// Reaching either means the executor was handed a plan that never passed
+// validation, which is a wiring fault to fail loudly on rather than a caller to
+// explain it to.
+func (c *planCompiler) resolve(
+	alias string, columns *storage, vocab TargetVocabulary, at string, clause Predicate,
+) (Field, string, *apperrors.FieldRefusal) {
 	field, ok := vocab.Field(clause.Field)
 	if !ok {
-		// Unreachable through Execute: the validator settled membership first,
-		// against this same vocabulary. Reaching it means the executor was
-		// handed a plan that never passed validation, which is a wiring fault
-		// to fail loudly on rather than a caller to explain it to.
-		return "", &apperrors.FieldRefusal{
+		return Field{}, "", &apperrors.FieldRefusal{
 			Field: at + ".field", Code: CodeUnknownField,
 			Message: "the query plan cannot name " + quote(clause.Field) + " on " + quote(vocab.Target),
 		}
 	}
 	expr, ok := columns.expr(alias, field)
 	if !ok {
-		// Same shape, same reason: a published field compiles, and the fitness
-		// function is what keeps that true.
-		return "", &apperrors.FieldRefusal{
+		return Field{}, "", &apperrors.FieldRefusal{
 			Field: at + ".field", Code: CodeUnknownField,
 			Message: quote(clause.Field) + " cannot be answered by this workspace's records",
 		}
 	}
+	return field, expr, nil
+}
+
+// clause renders one `field op value`.
+func (c *planCompiler) clause(expr, at string, field Field, clause Predicate) (string, *apperrors.FieldRefusal) {
 	if clause.Op == OpIn {
 		return c.inClause(expr, at, field, clause)
 	}
@@ -358,116 +393,6 @@ var sqlComparators = map[string]string{
 // own timestamp encoding instead (time.RFC3339, at the one call site that binds
 // one), so there is nothing to name twice.
 const dateLayout = "2006-01-02"
-
-// bind turns one JSON operand into a bound parameter under the field's kind,
-// with the cast the comparison needs.
-//
-// This is where a FORMAT is checked. The validator deliberately left it here
-// ("their format is the executor's business"): it had a shape to compare
-// against and no calendar, and refusing `"next tuesday"` at the moment it
-// would become a parameter is what keeps a malformed date a refusal rather
-// than a query that quietly matches nothing.
-//
-//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
-func (c *planCompiler) bind(at string, field Field, raw json.RawMessage) (any, string, *apperrors.FieldRefusal) {
-	switch field.Kind {
-	case KindNumber:
-		return bindNumber(at, field, raw)
-	case KindBoolean:
-		var value bool
-		return value, "", decodeOperand(at, field, raw, &value, "true or false")
-	case KindID:
-		return bindID(at, field, raw)
-	case KindDate:
-		return bindTemporal(at, field, raw, dateLayout, "::date", "a date, as YYYY-MM-DD")
-	case KindTimestamp:
-		return bindTemporal(at, field, raw, time.RFC3339, "", "an instant, as RFC 3339 (2026-08-08T09:00:00Z)")
-	case KindText:
-		var value string
-		return value, "", decodeOperand(at, field, raw, &value, "text")
-	case KindGeo:
-		// A place is never compared: within_radius answers
-		// distance_ranking_unavailable and the executor stops before here.
-		return nil, "", operandFault(at, field, "a place, which this deployment cannot rank by")
-	default:
-		return nil, "", operandFault(at, field, "a value of a kind this workspace can compare")
-	}
-}
-
-//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
-func bindNumber(at string, field Field, raw json.RawMessage) (any, string, *apperrors.FieldRefusal) {
-	var value json.Number
-	if refusal := decodeOperand(at, field, raw, &value, "a number"); refusal != nil {
-		return nil, "", refusal
-	}
-	// A whole number binds as one, so a bigint column compares against a
-	// bigint rather than against a float that rounded on the way in.
-	if whole, err := value.Int64(); err == nil {
-		return whole, "", nil
-	}
-	// A FRACTIONAL number binds as its own digits, cast to numeric. Through a
-	// float64 it would not: 0.1 is not representable in binary, so a `numeric`
-	// column holding exactly 0.1 would compare unequal to the 0.1 the caller
-	// wrote — an exact predicate answering "no rows" for a value that is
-	// there. The digits are the caller's own text and go through a bind
-	// parameter, so nothing is interpolated.
-	if _, err := value.Float64(); err != nil {
-		return nil, "", operandFault(at, field, "a number")
-	}
-	return value.String(), "::numeric", nil
-}
-
-//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
-func bindID(at string, field Field, raw json.RawMessage) (any, string, *apperrors.FieldRefusal) {
-	var text string
-	if refusal := decodeOperand(at, field, raw, &text, "an identifier"); refusal != nil {
-		return nil, "", refusal
-	}
-	id, err := ids.Parse(text)
-	if err != nil {
-		return nil, "", operandFault(at, field, "an identifier, as a UUID")
-	}
-	return id, "", nil
-}
-
-// bindTemporal parses a date or an instant in the contract's own encoding and
-// binds it as TEXT with an explicit cast where one is needed. A date compared
-// through a timestamp would be resolved at the session's time zone, which
-// makes the same plan answer differently on two servers.
-//
-//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
-func bindTemporal(at string, field Field, raw json.RawMessage, layout, cast, shape string) (any, string, *apperrors.FieldRefusal) {
-	var text string
-	if refusal := decodeOperand(at, field, raw, &text, shape); refusal != nil {
-		return nil, "", refusal
-	}
-	parsed, err := time.Parse(layout, text)
-	if err != nil {
-		return nil, "", operandFault(at, field, shape)
-	}
-	if cast == "" {
-		return parsed, "", nil
-	}
-	return parsed.Format(layout), cast, nil
-}
-
-// decodeOperand decodes one operand into its Go type, which IS the check: a
-// number offered where text belongs fails at the decode rather than after it.
-//
-//craft:ignore naked-any `into` is the caller's own destination for one operand; decoding INTO its Go type is the check, and a narrower signature would have to name every kind
-func decodeOperand(at string, field Field, raw json.RawMessage, into any, shape string) *apperrors.FieldRefusal {
-	if len(raw) == 0 || isJSONNull(raw) || json.Unmarshal(raw, into) != nil {
-		return operandFault(at, field, shape)
-	}
-	return nil
-}
-
-func operandFault(at string, field Field, shape string) *apperrors.FieldRefusal {
-	return &apperrors.FieldRefusal{
-		Field: at, Code: CodeValueTypeMismatch,
-		Message: quote(field.Name) + " is a " + string(field.Kind) + " field; its operand must be " + shape,
-	}
-}
 
 // idsIn renders a membership test over already-resolved ids. They are this
 // server's own, so the list is bound rather than rendered, and it exists only

--- a/backend/internal/modules/search/querysql_test.go
+++ b/backend/internal/modules/search/querysql_test.go
@@ -19,7 +19,7 @@ import (
 // enough of each record type to ask a real question, and deliberately missing
 // the derived members (`stalled`) no table holds.
 var planTables = map[string][]StoredColumn{
-	"deal": columnsOf("id:uuid", "name", "status", "amount_minor:bigint",
+	"deal": columnsOf("id:uuid", "name", "status", "amount_minor:bigint", "partner_org_id:uuid",
 		"expected_close_date:date", "closed_at:timestamp with time zone",
 		"owner_id:uuid", "organization_id:uuid", "project_id:uuid"),
 	"organization": columnsOf("id:uuid", "display_name", "owner_id:uuid",
@@ -373,7 +373,7 @@ func TestTheRankedLaneNarrowsTheStatementToItsCandidates(t *testing.T) {
 func TestAFieldWithNoStoragePathRefusesRatherThanCompiling(t *testing.T) {
 	compiler := &planCompiler{}
 	vocab := TargetVocabulary{Target: entityDeal, Fields: []Field{newField("stalled", KindBoolean)}}
-	_, refusal := compiler.clause("t", newStorage(planTables["deal"]), vocab, "where[0]",
+	_, _, refusal := compiler.resolve("t", newStorage(planTables["deal"]), vocab, "where[0]",
 		Predicate{Field: "stalled", Op: OpEq, Value: []byte("true")})
 	if refusal == nil || refusal.Code != CodeUnknownField {
 		t.Fatalf("refusal is %v", refusal)
@@ -384,7 +384,7 @@ func TestAFieldWithNoStoragePathRefusesRatherThanCompiling(t *testing.T) {
 // naming a field the vocabulary does not carry.
 func TestAFieldOutsideTheVocabularyRefusesAtCompileTime(t *testing.T) {
 	compiler := &planCompiler{}
-	_, refusal := compiler.clause("t", newStorage(planTables["deal"]),
+	_, _, refusal := compiler.resolve("t", newStorage(planTables["deal"]),
 		TargetVocabulary{Target: entityDeal}, "where[0]",
 		Predicate{Field: "invented", Op: OpEq, Value: []byte(`"x"`)})
 	if refusal == nil || refusal.Code != CodeUnknownField {
@@ -397,8 +397,12 @@ func TestAFieldOutsideTheVocabularyRefusesAtCompileTime(t *testing.T) {
 func TestAnOperatorWithNoSQLSpellingIsRefused(t *testing.T) {
 	compiler := &planCompiler{}
 	vocab := TargetVocabulary{Target: entityDeal, Fields: []Field{newField("status", KindText)}}
-	_, refusal := compiler.clause("t", newStorage(planTables["deal"]), vocab, "where[0]",
-		Predicate{Field: "status", Op: "matches", Value: []byte(`"open"`)})
+	predicate := Predicate{Field: "status", Op: "matches", Value: []byte(`"open"`)}
+	field, expr, refusal := compiler.resolve("t", newStorage(planTables["deal"]), vocab, "where[0]", predicate)
+	if refusal != nil {
+		t.Fatalf("the field itself was refused: %v", refusal)
+	}
+	_, refusal = compiler.clause(expr, "where[0]", field, predicate)
 	if refusal == nil || refusal.Code != CodeUnknownOperator {
 		t.Fatalf("refusal is %v", refusal)
 	}


### PR DESCRIPTION
Closes the `agents-mcp` reader of #2004 (reader 3).

## The leak

Filtering by an id is asking whether it is there. `organization_id eq <uuid>` compiled to a comparison under the **deal's** own scope, and every seat of the workspace reads every deal. So the rows that came back answered *"is this company on our books, and which deals are its"* — for a company the same caller's ordinary read refuses, because capture privacy makes it private to the colleague who captured it.

Hydration masks the id on the way out. That makes the answer quieter without making it different: the **row** is the disclosure, and the caller chose the predicate that selected it.

The **traversal** form of the same question was already scoped — `lateralHop` runs `branchScope` over the hop record. This is the direct form of that hop, and it now gets the same clause from the same place, so the two arms of one question cannot answer differently.

## Shape

Scoped on the **row's value**, not on the id the caller sent. That is what makes it operator-agnostic: `neq` and `in` each disclose the binding by which rows they leave *out*.

A null reference passes, and that arm is load-bearing rather than tidy: `neq` renders `IS DISTINCT FROM`, which is TRUE for a deal with no company at all. Dropping those would be a **wrong** answer rather than a narrower one — the rows it removes disclose nothing about the company asked about.

## Three spellings, because the schema has three

A resolver that knew only `<record type>_id` would have closed `organization_id` while leaving `partner_org_id` beside it open — the same role-named blind spot `composerowscope_test.go` already records for `parent_org_id`. Confirmed by probe before the fix:

```
deal.partner_org_id  guarded=false
SELECT t.id, name AS title FROM deal t WHERE t.archived_at IS NULL AND t."partner_org_id" = $1 ...
```

- the contract's own, `<record type>_id` — the same derivation `contractRelations` traverses on;
- **nested** members, `employer.organization_id`, resolved by their last segment;
- **roles**, `partner_org_id`, which name what the reference is FOR. Those cannot be derived from the name and are declared.

The declaration is held against the schema's own foreign keys **in both directions** — a column the resolver cannot place fails, and a declared name the schema has no key for fails too. Mutation-verified:

- drop `partner_org_id` → `deal.partner_org_id references organization and the resolver places it nowhere`
- point `promoted_person_id` at `deal` → `the resolver places it on deal — the guard would ask about the wrong record while looking present`
- declare `invented_org_id` → `resolves a name no table has`

Under-recognition is the whole risk: a column the resolver cannot place is not a failure anywhere. `referenceGuard` returns `""`, the predicate compiles to a bare comparison, and the answer is a well-formed page. Nothing notices.

## Two premises had moved

Checked against current source before patching:

- **`project` is an identity table now** — every seat that holds the grant reads every project, so `ScopeClauseFor` renders nothing and `project_id` needs no guard. The issue says project "keeps own/team row scope"; that was true when it was filed. `TestAPredicateOnAReferenceEverySeatReadsCarriesNoGuard` is the case, and it is what keeps this from becoming the availability regression a security fix smuggles in.
- **`activity.source_activity_id`** is a reference to a row-scoped record the issue does not mention. The catalog census found it.

## Verification

- `make check-go`, `make check-gates`, `make craft-static` green
- `make test-it DIR=backend/internal/compose/integration RUN=TestAPredicateNaming` — both cases pass

The integration pair is the direct twin of the existing `TestAHopThroughARecordTheCallerCannotSeeAdmitsNothing`. Removing the guard separates them exactly as intended:

```
--- FAIL: TestAPredicateNamingARecordTheCallerCannotSeeAdmitsNothing
    the rep selected 1 deals by a company they cannot open — the rows answer that it exists
--- PASS: TestAPredicateNamingARecordTheCallerCanSeeStillAnswers
```

The second passing under the mutation is the point: a guard that refused everything would pass the first perfectly while making the field useless.

## Also

`querysql.go` crossed the 500-line ceiling, so operand binding moves to `querybind.go` — `querysql.go` decides what the statement says, and that decides what a value means under the column's kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC