### PR TITLE
fix(deals): the offer document says no more about its buyer than the read does

### DIFF
--- a/backend/internal/compose/integration/offerreferences_integration_test.go
+++ b/backend/internal/compose/integration/offerreferences_integration_test.go
@@ -46,6 +46,23 @@ var offerDeskCompanyPerms = principal.Permissions{
 	},
 }
 
+// offerDeskWideNoCompanyPerms is the seat the RENDER needs: workspace-wide
+// authority over deals and offers, and no organization grant at all.
+//
+// The render asks a harder question than the read — EnsureWritable on the deal,
+// not EnsureVisible — so an own-scoped colleague never reaches the buyer block
+// to be refused it. A deal desk operating across the workspace without CRM
+// company access does, and it is the seat that would have printed the name.
+var offerDeskWideNoCompanyPerms = principal.Permissions{
+	RoleKeys: []string{"deal_desk"},
+	RowScope: principal.RowScopeAll,
+	Objects: map[string]principal.ObjectGrant{
+		"deal":                  {Create: true, Read: true, Update: true},
+		"offer":                 {Create: true, Read: true, Update: true},
+		"installation_settings": {Read: true},
+	},
+}
+
 // seedOfferOnAPrivateOrg is one sent offer whose buyer is capture-private to a
 // colleague, created and sent by an admin who can see it.
 //
@@ -236,5 +253,59 @@ func TestTheSendFreezesTheRealBuyerWhateverTheResponseWithholds(t *testing.T) {
 	}
 	if !strings.Contains(frozen, privateOrg.String()) {
 		t.Errorf("the stored buyer snapshot does not name the organization the offer was sent to: %s", frozen)
+	}
+}
+
+// The DOCUMENT says no more than the read does.
+//
+// PrepareRender gathers the buyer legal block the PDF prints — display name
+// and, where the record carries one, legal name. That block is read from the
+// live organization while the offer is a draft and from the frozen snapshot
+// once sent, and neither read asked whether this seat may open the company. So
+// the API withheld the buyer while the PDF printed its name: the two halves of
+// one offer disagreeing about the same record, with the more disclosing half
+// being the one that gets stored and sent.
+func TestARenderSaysNoMoreAboutTheBuyerThanTheReadDoes(t *testing.T) {
+	e := Setup(t)
+	offer, _, privateOrg := seedOfferOnAPrivateOrg(t, e)
+	desk := e.As(e.Rep1, []ids.UUID{e.Team1}, offerDeskWideNoCompanyPerms)
+
+	ingredients, err := e.Deals.PrepareRender(desk, offer)
+	if err != nil {
+		t.Fatalf("preparing the render: %v — the offer is anchored on a deal this seat writes, so the render itself must reach its ingredients", err)
+	}
+	if ingredients.Offer.BuyerOrgId != nil {
+		t.Errorf("the render's offer names buyer organization %v, which this seat's own organization read would refuse", *ingredients.Offer.BuyerOrgId)
+	}
+	if ingredients.BuyerBlock != nil {
+		t.Errorf("the buyer block %v reaches the document — it carries the company's display name and legal name, which is strictly more than the id the API withholds beside it",
+			ingredients.BuyerBlock)
+	}
+	// Named so a future reader can see which company the block would have been
+	// about; the assertions above are what fail.
+	t.Logf("the buyer withheld from this seat is %v", privateOrg)
+}
+
+// And the colleague who CAN open the company still gets a complete document. A
+// render that omitted the buyer for everyone would pass the case above while
+// producing an offer PDF with no buyer on it, which is not a quieter answer but
+// a broken one.
+func TestARenderKeepsTheBuyerBlockForASeatThatCanOpenIt(t *testing.T) {
+	e := Setup(t)
+	offer, _, _ := seedOfferOnAPrivateOrg(t, e)
+	owner := e.As(e.Rep3, []ids.UUID{e.Team1}, offerDeskCompanyPerms)
+
+	ingredients, err := e.Deals.PrepareRender(owner, offer)
+	if err != nil {
+		t.Fatalf("preparing the render: %v", err)
+	}
+	if ingredients.Offer.BuyerOrgId == nil {
+		t.Error("the render's offer names no buyer for the seat that owns the company")
+	}
+	if ingredients.BuyerBlock == nil {
+		t.Fatal("the document carries no buyer block for the seat that owns the company — the withholding emptied the field for everyone")
+	}
+	if ingredients.BuyerBlock["display_name"] == nil {
+		t.Errorf("the buyer block names no company: %v", ingredients.BuyerBlock)
 	}
 }

--- a/backend/internal/compose/integration/offerrender_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_integration_test.go
@@ -45,9 +45,16 @@ import (
 var offerRenderDeskPerms = principal.Permissions{
 	RoleKeys: []string{"deal_desk"},
 	Objects: map[string]principal.ObjectGrant{
-		"deal":                  {Create: true, Read: true, Update: true},
-		"offer":                 {Create: true, Read: true, Update: true},
-		"offer_template":        {Create: true, Read: true},
+		"deal":           {Create: true, Read: true, Update: true},
+		"offer":          {Create: true, Read: true, Update: true},
+		"offer_template": {Create: true, Read: true},
+		// The buyer block names an organization, and a seat with no
+		// organization grant is refused that reference everywhere else on this
+		// surface — GetOffer and even CreateOffer's own response answer
+		// buyer_org_id as null for it. The cases below are about which block
+		// the render resolves (live while draft, frozen once sent), not about
+		// who may see one, so the seat holds the grant that question assumes.
+		"organization":          {Read: true},
 		"installation_settings": {Read: true},
 	},
 	RowScope: principal.RowScopeAll,

--- a/backend/internal/modules/deals/offer_buyerwithhold_test.go
+++ b/backend/internal/modules/deals/offer_buyerwithhold_test.go
@@ -80,3 +80,22 @@ func TestAnOfferWithNoBuyerIsLeftAlone(t *testing.T) {
 		t.Errorf("an offer with no buyer gained one: id=%v snapshot=%v", offer.BuyerOrgId, offer.BuyerSnapshot)
 	}
 }
+
+// No principal, no verdict — and the offer does not travel.
+//
+// The withholding decides visibility against the caller; with no actor bound
+// there is no caller to decide about, and the honest answer is an error rather
+// than an offer whose buyer was never judged. Returning the offer unchanged
+// would be the worst reading of "could not tell": the reference reaches whoever
+// asked, on a path that failed to ask the question.
+func TestWithholdingFailsRatherThanPassingAnUnjudgedBuyerThrough(t *testing.T) {
+	org := ids.NewV7()
+	offer := offerNamingBuyer(org)
+	err := withholdUnreadableBuyerOn(context.Background(), nil, &offer)
+	if err == nil {
+		t.Fatal("withholding answered nil with no actor bound — the buyer travelled without anyone deciding it could")
+	}
+	if offer.BuyerOrgId == nil || ids.UUID(*offer.BuyerOrgId) != org {
+		t.Errorf("the offer was rewritten on a failed verdict (id=%v) — a caller that ignores the error would then read a withholding that never happened", offer.BuyerOrgId)
+	}
+}

--- a/backend/internal/modules/deals/offer_buyerwithhold_test.go
+++ b/backend/internal/modules/deals/offer_buyerwithhold_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+import (
+	"context"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// A seat holding no organization grant at all. VisibleSubset consults the
+// object grant before any row scope and answers an empty set for this caller
+// without issuing a statement, which is why these cases need no transaction —
+// the nil tx is the assertion that none is reached.
+func deskWithoutCompanyAccess() context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:test", UserID: ids.NewV7(),
+		Permissions: principal.Permissions{
+			RowScope: principal.RowScopeAll,
+			Objects: map[string]principal.ObjectGrant{
+				"deal":  {Read: true, Update: true},
+				"offer": {Read: true, Update: true},
+			},
+		},
+	})
+}
+
+func offerNamingBuyer(org ids.UUID) crmcontracts.Offer {
+	buyer := openapi_types.UUID(org)
+	snapshot := map[string]interface{}{"display_name": "Meridian Labs"}
+	return crmcontracts.Offer{BuyerOrgId: &buyer, BuyerSnapshot: &snapshot}
+}
+
+// The read-back is the whole reason this spelling exists. Withholding against
+// a slice literal mutates a COPY, so a caller that forgets to read the element
+// back keeps the reference — and nothing fails, because the offer still reads
+// correctly and the buyer is still on it.
+func TestWithholdingABuyerReachesTheCallersOwnOffer(t *testing.T) {
+	offer := offerNamingBuyer(ids.NewV7())
+	if err := withholdUnreadableBuyerOn(deskWithoutCompanyAccess(), nil, &offer); err != nil {
+		t.Fatalf("withholding the buyer: %v", err)
+	}
+	if offer.BuyerOrgId != nil {
+		t.Errorf("the caller's own offer still names buyer organization %v", *offer.BuyerOrgId)
+	}
+	if offer.BuyerSnapshot != nil {
+		t.Errorf("the caller's own offer still carries the buyer snapshot %v — the frozen block names the company, which is strictly more than the id withheld beside it", *offer.BuyerSnapshot)
+	}
+}
+
+// Both fields or neither. Withholding the id and leaving the snapshot hands
+// back the NAME of an organization whose id was judged too much to disclose,
+// which is the worse half of the pair rather than a partial fix.
+func TestWithholdingTakesTheSnapshotWithTheReference(t *testing.T) {
+	offers := []crmcontracts.Offer{offerNamingBuyer(ids.NewV7()), offerNamingBuyer(ids.NewV7())}
+	if err := withholdUnreadableBuyer(deskWithoutCompanyAccess(), nil, offers); err != nil {
+		t.Fatalf("withholding across the page: %v", err)
+	}
+	for i, o := range offers {
+		if o.BuyerOrgId != nil || o.BuyerSnapshot != nil {
+			t.Errorf("offer %d still names its buyer (id=%v snapshot=%v)", i, o.BuyerOrgId, o.BuyerSnapshot)
+		}
+	}
+}
+
+// An offer with no buyer names nothing to probe, so the page costs nothing and
+// the fields stay as they were rather than being rewritten to the same value.
+func TestAnOfferWithNoBuyerIsLeftAlone(t *testing.T) {
+	offer := crmcontracts.Offer{}
+	if err := withholdUnreadableBuyerOn(deskWithoutCompanyAccess(), nil, &offer); err != nil {
+		t.Fatalf("withholding on an offer with no buyer: %v", err)
+	}
+	if offer.BuyerOrgId != nil || offer.BuyerSnapshot != nil {
+		t.Errorf("an offer with no buyer gained one: id=%v snapshot=%v", offer.BuyerOrgId, offer.BuyerSnapshot)
+	}
+}

--- a/backend/internal/modules/deals/offer_read.go
+++ b/backend/internal/modules/deals/offer_read.go
@@ -205,6 +205,20 @@ func withholdUnreadableBuyer(ctx context.Context, tx pgx.Tx, offers []crmcontrac
 	return nil
 }
 
+// withholdUnreadableBuyerOn is the single-offer spelling, and it exists so the
+// two callers cannot get the read-back wrong: a slice literal copies the offer,
+// so withholding against `[]Offer{offer}` mutates the copy and leaves the
+// caller's own value carrying the reference. That failure is silent — the read
+// path keeps working and the buyer is still there.
+func withholdUnreadableBuyerOn(ctx context.Context, tx pgx.Tx, offer *crmcontracts.Offer) error {
+	single := []crmcontracts.Offer{*offer}
+	if err := withholdUnreadableBuyer(ctx, tx, single); err != nil {
+		return err
+	}
+	*offer = single[0]
+	return nil
+}
+
 func readOffer(ctx context.Context, tx pgx.Tx, id ids.OfferID, archived storekit.ArchivedFilter) (crmcontracts.Offer, error) {
 	q := `SELECT ` + offerColumns + ` FROM offer WHERE id = $1`
 	if archived == storekit.LiveOnly {
@@ -232,11 +246,9 @@ func readOfferWithLines(ctx context.Context, tx pgx.Tx, id ids.OfferID, archived
 	if err != nil {
 		return crmcontracts.Offer{}, err
 	}
-	single := []crmcontracts.Offer{offer}
-	if err := withholdUnreadableBuyer(ctx, tx, single); err != nil {
+	if err := withholdUnreadableBuyerOn(ctx, tx, &offer); err != nil {
 		return crmcontracts.Offer{}, err
 	}
-	offer = single[0]
 	lines, err := readOfferLines(ctx, tx, id)
 	if err != nil {
 		return crmcontracts.Offer{}, err

--- a/backend/internal/modules/deals/offer_render.go
+++ b/backend/internal/modules/deals/offer_render.go
@@ -77,6 +77,19 @@ func (s *Store) PrepareRender(ctx context.Context, id ids.OfferID) (RenderIngred
 		if err != nil {
 			return err
 		}
+		// The document says no more about the buyer than this caller's own
+		// read of the offer does. An offer is anchored on its DEAL, which
+		// every seat reads; the organization it names is not, and the block
+		// below carries the buyer's display name and legal name — strictly
+		// more than the id the API withholds.
+		//
+		// Applied to the OFFER rather than probed inside the block, so the
+		// two spellings of the same withholding cannot diverge: with the
+		// reference gone, the live read has nothing to look up and the frozen
+		// snapshot has nothing to return.
+		if err := withholdUnreadableBuyerOn(ctx, tx, &offer); err != nil {
+			return err
+		}
 		lines, err := readOfferLines(ctx, tx, id)
 		if err != nil {
 			return err


### PR DESCRIPTION
Closes the `deals` reader of #2004 (reader 4).

## The leak

`PrepareRender` gathers the buyer legal block the PDF prints — display name and, where the record carries one, **legal name**. That block came from the live organization while the offer is a draft and from the frozen `buyer_snapshot` once sent, and neither read asked whether this seat may open the company.

So the API withheld the buyer while the document printed its name — the two halves of one offer disagreeing about the same record, with the more disclosing half being the one that gets **stored and sent**.

An offer is anchored on its **deal**, and every seat of the workspace reads every deal because a deal is customer identity. The organization it names is not: capture privacy makes a company private to the colleague who captured it.

## Premise check

#1986's `withholdUnreadableBuyer` already closed `GetOffer`, `ListDealOffers` and every mutation response. Two of the paths the issue names were already covered:

- `resolveBuyerOrg` gates a **client-supplied** `buyer_org_id` with `EnsureLinkTarget`; the inherited one is what `withholdUnreadableBuyer` catches.
- `GetOffer` discards `visibleOffer`'s copy and re-reads through `readOfferWithLines`, which withholds.

The render was the one path left, and it is the one that produces the artifact.

## Shape

Applied to the **offer** rather than probed inside the block, so the two spellings of one withholding cannot diverge: with the reference gone, the live read has nothing to look up and the frozen snapshot has nothing to return.

The read-back gets its own helper. Withholding against `[]Offer{offer}` mutates a **copy** and leaves the caller's own value carrying the reference — a silent failure, because the path keeps working and the buyer is still there. Two callers spelling that out separately is one of them getting it wrong eventually.

## The seat this needed

The render asks a harder question than the read — `EnsureWritable` on the deal, not `EnsureVisible` — so an own-scoped colleague never reaches the buyer block to be refused it. The seat that would have printed the name is a deal desk operating **workspace-wide over deals with no organization grant at all**, and the fixture had to be built for it. My first attempt used the existing own-scoped fixture and got `permission denied` from the render itself, which proved nothing.

## Verification

- `make check-go`, `make check-gates`, `make craft-static` green
- `make test-it DIR=backend/internal/compose/integration RUN=TestARender` — both pass

Removing the withholding separates the two cases exactly as intended:

```
--- FAIL: TestARenderSaysNoMoreAboutTheBuyerThanTheReadDoes
    the buyer block map[display_name:Meridian Labs organization_id:01a08503-…]
    reaches the document — it carries the company's display name and legal name,
    which is strictly more than the id the API withholds beside it
--- PASS: TestARenderKeepsTheBuyerBlockForASeatThatCanOpenIt
```

The second passing under the mutation is the point: a render that omitted the buyer for **everyone** would pass the leak case perfectly while producing an offer PDF with no buyer on it — not a quieter answer, a broken one.

## One thing worth a reviewer's eye

A seat that cannot open the buyer now renders a document with **no buyer block** rather than being refused. That is consistent with what the same seat's API read shows them, and it is the option that invents no new refusal policy — but a stored PDF missing its buyer is arguably worse than an error, and the alternative (refuse the render, naming the remedy) leaks that a buyer exists at all, which their read says it does not. I took consistency; if the product view is that a document must never be silently incomplete, that is a small follow-up and I will take it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Offer rendering now consistently protects buyer details when the viewer cannot access the buyer’s organization.
  * PDF previews no longer expose the buyer organization or buyer block to unauthorized viewers.
  * Authorized viewers continue to receive complete offer documents, including the buyer block.
  * Offer reading and rendering now apply consistent access controls for buyer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->