### PR TITLE
fix(overlay): the projection fingerprint encodes its values rather than rendering them

### DIFF
--- a/backend/internal/compose/jobs_overlay_refetch.go
+++ b/backend/internal/compose/jobs_overlay_refetch.go
@@ -250,7 +250,18 @@ func (w *overlayRefetchWorker) dropFailedRead(ctx context.Context, ms *overlay.M
 	// never the incumbent's own name for it, and the fingerprint recorded is
 	// the one StaleProjections derives its comparison from — so the record and
 	// the skip agree by construction.
-	fingerprint := overlay.Fingerprint(m)
+	fingerprint, fpErr := overlay.Fingerprint(m)
+	if fpErr != nil {
+		// Same bookkeeping posture as the record below, and for a stronger
+		// reason: the read this note is about has already failed, and a
+		// declaration that cannot be fingerprinted is a fault in the mapping
+		// rather than in this row. Failing the job would retry a read that will
+		// not succeed, to report a note that cannot be written either way.
+		w.log.ErrorContext(ctx, "overlay refetch: the declaration cannot be fingerprinted, so the re-projection failure goes unrecorded; the row stays in the stale set",
+			"workspace", args.Workspace, "class", args.IncumbentClass, "id", args.ExternalID,
+			"read_err", readErr, "err", fpErr)
+		return
+	}
 	// Bookkeeping, not the job's purpose: this read has already failed in a way
 	// no retry changes, and failing the job to report that the note could not be
 	// written would turn a bounded waste into a retried one.

--- a/backend/internal/compose/jobs_overlay_reprojection_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_reprojection_integration_test.go
@@ -395,7 +395,7 @@ func TestStaleProjectionsSkipARowThatFailedAgainstTheCurrentDeclaration(t *testi
 		t.Fatalf("before the failure is recorded StaleProjections reports %v, want [%s] — "+
 			"the skip below would prove nothing about a row the sweep never named", stale, staleRowExternalID)
 	}
-	if err := r.ms.RecordReprojectionFailure(r.sweepCtx, m.Target, staleRowExternalID, overlay.Fingerprint(m)); err != nil {
+	if err := r.ms.RecordReprojectionFailure(r.sweepCtx, m.Target, staleRowExternalID, declarationFingerprint(t, m)); err != nil {
 		t.Fatalf("RecordReprojectionFailure: %v", err)
 	}
 
@@ -413,7 +413,7 @@ func TestStaleProjectionsRetryARowWhoseDeclarationChanged(t *testing.T) {
 	r := setupReprojection(t)
 	m := r.mirrorContactsAndDeclaration(t)
 
-	if err := r.ms.RecordReprojectionFailure(r.sweepCtx, m.Target, staleRowExternalID, overlay.Fingerprint(m)); err != nil {
+	if err := r.ms.RecordReprojectionFailure(r.sweepCtx, m.Target, staleRowExternalID, declarationFingerprint(t, m)); err != nil {
 		t.Fatalf("RecordReprojectionFailure: %v", err)
 	}
 	if stale := r.staleProjections(t, m); len(stale) != 0 {
@@ -500,10 +500,11 @@ func TestSweepReprojectionRecordsARefetchThatCannotLand(t *testing.T) {
 	// The mirror keys on the CANONICAL class a declaration projects onto
 	// ("person"), never the incumbent's own name for it ("contacts"), and the
 	// fingerprint is the one StaleProjections compares against.
-	if recorded := r.reprojectionFailureRecord(t, m.Target); recorded != overlay.Fingerprint(m) {
+	declared := declarationFingerprint(t, m)
+	if recorded := r.reprojectionFailureRecord(t, m.Target); recorded != declared {
 		t.Fatalf("%s/%s records %q, want %q — the declaration the re-fetch failed to reach, keyed the way the mirror is keyed; "+
 			"a record the row never receives is silent, and the skip below is the only thing that would ever notice",
-			m.Target, staleRowExternalID, recorded, overlay.Fingerprint(m))
+			m.Target, staleRowExternalID, recorded, declared)
 	}
 
 	r.inc.enqueued = nil
@@ -638,4 +639,16 @@ func TestSweepReprojectionCoalescesRepeatedPassesIntoOneJob(t *testing.T) {
 				"for a row still queued spends one live incumbent read per tick on a record already waiting to be read", got, pass)
 		}
 	}
+}
+
+// declarationFingerprint digests the declaration under test, failing the test
+// if it cannot: an unencodable declaration is a broken fixture, never the
+// answer any of these cases is about.
+func declarationFingerprint(t *testing.T, m overlay.ObjectMapping) string {
+	t.Helper()
+	digest, err := overlay.Fingerprint(m)
+	if err != nil {
+		t.Fatalf("fingerprinting the declaration under test: %v", err)
+	}
+	return digest
 }

--- a/backend/internal/modules/overlay/fingerprint.go
+++ b/backend/internal/modules/overlay/fingerprint.go
@@ -16,6 +16,7 @@ package overlay
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"hash"
 	"sort"
@@ -25,14 +26,21 @@ import (
 // Fingerprint digests one object mapping's declaration. Two mappings that
 // would project the same raw record identically share a fingerprint; any
 // difference that could change a projected payload changes it.
-func Fingerprint(m ObjectMapping) string {
+//
+// It returns an error because the declaration values are ENCODED rather than
+// rendered — see writeSortedMap. A declaration carrying a value JSON cannot
+// represent has no fingerprint, and answering one anyway would be answering
+// about a mapping this code cannot project.
+func Fingerprint(m ObjectMapping) (string, error) {
 	h := sha256.New()
 	writeField(h, "source", m.Source)
 	writeField(h, "target", m.Target)
 	writeField(h, "external_key", m.ExternalKey)
 	writeField(h, "baseline", m.Baseline)
 	writeField(h, "unmapped_policy", m.UnmappedPolicy)
-	writeSortedMap(h, "const", m.Const)
+	if err := writeSortedMap(h, "const", m.Const); err != nil {
+		return "", fmt.Errorf("overlay: fingerprinting %s's const declaration: %w", m.Source, err)
+	}
 	for i, f := range m.Fields {
 		// The index is hashed conservatively, not because a reorder is known to
 		// matter: order-independence rests on guards declared elsewhere —
@@ -59,10 +67,12 @@ func Fingerprint(m ObjectMapping) string {
 		writeField(h, fmt.Sprintf("field.%d.always_emit", i), strconv.FormatBool(f.AlwaysEmit))
 		if f.Child != nil {
 			writeField(h, fmt.Sprintf("field.%d.child.position", i), strconv.Itoa(f.Child.Position))
-			writeSortedMap(h, fmt.Sprintf("field.%d.child.attrs", i), f.Child.Attrs)
+			if err := writeSortedMap(h, fmt.Sprintf("field.%d.child.attrs", i), f.Child.Attrs); err != nil {
+				return "", fmt.Errorf("overlay: fingerprinting %s's field %d child attributes: %w", m.Source, i, err)
+			}
 		}
 	}
-	return hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // writeField feeds one named value into the digest length-prefixed, so no
@@ -78,23 +88,51 @@ func writeField(h hash.Hash, name, value string) {
 // iteration order varies per run and a fingerprint that varied would mark
 // every mirrored row stale forever.
 //
-// Values carry their dynamic type and their Go-syntax form, because Const and
-// Attrs are copied verbatim into the projected payload and a plain rendering is
-// type-blind: the bool true and the string "true" both render as "true", and
-// so do 1, 1.0 and "1" — a declaration edit that flips one for the other
-// changes the mirrored JSON. The Go-syntax form quotes strings and delimits
-// container members, so the same separation holds a level down into the nested
-// values a decoded-JSON declaration can carry. fmt sorts map keys, so a nested
-// map is as stable across runs as the ordering above.
+// Values are ENCODED as JSON, and the distinction from rendering them is the
+// whole point. Const and Attrs are copied verbatim into the projected payload,
+// so the digest has to separate values the payload separates: the bool true
+// from the string "true", and 1 from 1.0 from "1" — a declaration edit that
+// flips one for the other changes the mirrored JSON.
+//
+// %#v did that too, and was chosen for it. What it is not is a FORMAT. It is a
+// documented rendering of Go syntax, and a toolchain upgrade that changed it
+// would move every fingerprint in the estate at once — every mirrored row
+// reading as stale and re-projecting, spending a full estate's worth of metered
+// incumbent API budget for a declaration nobody edited. Not incorrect, since a
+// fingerprint change is exactly the event the sweep converges, but paid for
+// nothing. json.Marshal is a specified format with a stability guarantee the
+// rendering does not carry.
+//
+// The value's Go TYPE is deliberately not written alongside it, and that is a
+// change from the rendering this replaced. %#v needed the type because it is
+// type-blind where the payload is not — it renders the bool true and the string
+// "true" identically. JSON is not: `true` and `"true"` are different bytes, as
+// are `1` and `"1"`. The encoding already draws every distinction the payload
+// draws.
+//
+// Writing the type as well would draw one the payload does NOT: an int 1 and a
+// float64 1.0 both reach the mirror as `1`, so they project the same record and
+// belong under the same fingerprint. Separating them would mark an estate stale
+// for a declaration edit that changed nothing a reader can see — the same
+// pointless re-projection this issue is about, arriving by a different route.
+//
+// encoding/json sorts object keys, so a map one level down is as ordered as the
+// loop below makes the top level — and it draws the same distinctions there,
+// which a type prefix could not have done at depth anyway.
 //
 //craft:ignore naked-any the declaration maps hold decoded JSON values; the any is the declared type, not a missed one
-func writeSortedMap(h hash.Hash, name string, values map[string]any) {
+func writeSortedMap(h hash.Hash, name string, values map[string]any) error {
 	keys := make([]string, 0, len(values))
 	for k := range values {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		writeField(h, name+"."+k, fmt.Sprintf("%T=%#v", values[k], values[k]))
+		encoded, err := json.Marshal(values[k])
+		if err != nil {
+			return fmt.Errorf("encoding %s.%s: %w", name, k, err)
+		}
+		writeField(h, name+"."+k, string(encoded))
 	}
+	return nil
 }

--- a/backend/internal/modules/overlay/fingerprint_test.go
+++ b/backend/internal/modules/overlay/fingerprint_test.go
@@ -6,6 +6,7 @@ package overlay_test
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/modules/overlay"
@@ -50,7 +51,7 @@ func baseMapping() overlay.ObjectMapping {
 // mapping edit leaves already-mirrored rows claiming to be current when the
 // projection they hold is one this code would never produce again.
 func TestFingerprintChangesWithEveryDeclarationDetail(t *testing.T) {
-	base := overlay.Fingerprint(baseMapping())
+	base := fingerprint(t, baseMapping())
 	for _, tc := range []struct {
 		name   string
 		mutate func(*overlay.ObjectMapping)
@@ -81,7 +82,7 @@ func TestFingerprintChangesWithEveryDeclarationDetail(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m := baseMapping()
 			tc.mutate(&m)
-			if got := overlay.Fingerprint(m); got == base {
+			if got := fingerprint(t, m); got == base {
 				t.Errorf("changing the %s left the fingerprint at %s, so rows projected by the old "+
 					"declaration would read as current. Include it in Fingerprint.", tc.name, got)
 			}
@@ -185,10 +186,10 @@ func TestFingerprintSeparatesDeclarationsThatFlattenAlike(t *testing.T) {
 			left, right := baseMapping(), baseMapping()
 			tc.left(&left)
 			tc.right(&right)
-			if overlay.Fingerprint(left) == overlay.Fingerprint(right) {
+			if fingerprint(t, left) == fingerprint(t, right) {
 				t.Errorf("both declarations fingerprint to %s, so switching between them would leave every "+
 					"mirrored row reading as current — but %s. Feed the difference into Fingerprint.",
-					overlay.Fingerprint(left), tc.because)
+					fingerprint(t, left), tc.because)
 			}
 		})
 	}
@@ -202,7 +203,7 @@ func TestFingerprintTreatsAnAbsentAndAnEmptyFromAlike(t *testing.T) {
 	nilFrom.Fields[0].From = nil
 	emptyFrom.Fields[0].From = []string{}
 
-	got, want := overlay.Fingerprint(nilFrom), overlay.Fingerprint(emptyFrom)
+	got, want := fingerprint(t, nilFrom), fingerprint(t, emptyFrom)
 	if got != want {
 		t.Errorf("a nil From fingerprints to %s and an empty one to %s, but neither gathers a raw property, "+
 			"so the two project identically; re-projecting the estate to move between them buys nothing. "+
@@ -215,13 +216,88 @@ func TestFingerprintTreatsAnAbsentAndAnEmptyFromAlike(t *testing.T) {
 // and a digest that took that order in would mark every row stale forever and
 // block the flip permanently.
 func TestFingerprintDoesNotVaryWithMapIterationOrder(t *testing.T) {
-	first := overlay.Fingerprint(baseMapping())
+	first := fingerprint(t, baseMapping())
 	for i := 0; i < 50; i++ {
-		if got := overlay.Fingerprint(baseMapping()); got != first {
+		if got := fingerprint(t, baseMapping()); got != first {
 			t.Fatalf("run %d produced %s, want %s — an unstable fingerprint marks every row stale forever", i, got, first)
 		}
 	}
 	if first == "" {
 		t.Fatal("Fingerprint answered the empty string; a row stamped with it could never be compared")
+	}
+}
+
+// fingerprint digests a declaration and fails the test if it cannot.
+//
+// Every case in this file is about which declarations SHARE a digest and which
+// do not, so an error is never the answer under test — it means the fixture
+// carries a value the encoding cannot represent, which is a broken fixture
+// rather than a finding about fingerprinting.
+func fingerprint(t *testing.T, m overlay.ObjectMapping) string {
+	t.Helper()
+	digest, err := overlay.Fingerprint(m)
+	if err != nil {
+		t.Fatalf("fingerprinting the declaration: %v", err)
+	}
+	return digest
+}
+
+// A declaration carrying a value JSON cannot encode has NO fingerprint, and
+// says so.
+//
+// This is what the error return buys, and it is the difference between an
+// encoding and a rendering: %#v answers for anything, including values the
+// projected payload could never hold, so a declaration that could not be
+// projected still got a confident digest. A channel is the cheapest such value
+// to write down; the real ones would be a func or a cyclic structure reaching a
+// declaration through decoded JSON that was not decoded from JSON.
+//
+// Refusing matters because the digest's whole job is to say which declaration
+// produced a row. Answering for a declaration this code cannot project would
+// stamp rows with a fingerprint no projection can ever match, and every one of
+// them would read as stale forever.
+func TestADeclarationJSONCannotEncodeHasNoFingerprint(t *testing.T) {
+	m := baseMapping()
+	m.Const = map[string]any{"unencodable": make(chan int)}
+
+	digest, err := overlay.Fingerprint(m)
+
+	if err == nil {
+		t.Fatalf("a declaration carrying a value JSON cannot encode answered the digest %q — it names a "+
+			"projection this code cannot produce, and every row stamped with it reads as stale forever", digest)
+	}
+	if digest != "" {
+		t.Errorf("the refusal still answered %q; a caller taking the value before the error would stamp it", digest)
+	}
+	// The message names the declaration and the key, because the reader is
+	// whoever just edited a mapping and needs to know which one.
+	if !strings.Contains(err.Error(), m.Source) || !strings.Contains(err.Error(), "unencodable") {
+		t.Errorf("the refusal reads %q; it names neither the declaration nor the key that could not be "+
+			"encoded, which are the two things the reader needs", err)
+	}
+}
+
+// An int and the same number as a float share a fingerprint, because they
+// project the same record.
+//
+// The inverse of the cases above, and it guards the encoding from the other
+// side: `1` and `1.0` both reach the mirrored payload as `1`, so a declaration
+// edit between them changes nothing a reader can see. A digest that separated
+// them would mark every row of that declaration stale and re-project the estate
+// for no observable change — which is the cost this whole issue is about,
+// arriving by a different route.
+//
+// It is asserted rather than left implicit because the encoding this replaced
+// carried the value's Go type alongside it, and keeping that habit under JSON
+// would have bought exactly this over-separation.
+func TestFingerprintSharesADigestForNumbersThatProjectAlike(t *testing.T) {
+	asInt, asFloat := baseMapping(), baseMapping()
+	asInt.Const = map[string]any{"weight": 1}
+	asFloat.Const = map[string]any{"weight": 1.0}
+
+	if got, want := fingerprint(t, asInt), fingerprint(t, asFloat); got != want {
+		t.Errorf("an int const and the same number as a float fingerprint differently (%s vs %s) — they "+
+			"project the identical payload, so this marks an estate stale for an edit nobody can observe",
+			got, want)
 	}
 }

--- a/backend/internal/modules/overlay/fingerprintrefusal_test.go
+++ b/backend/internal/modules/overlay/fingerprintrefusal_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// What each caller does when a declaration cannot be fingerprinted.
+//
+// The refusal itself is fingerprint_test.go's subject. These are the arms that
+// carry it — a caller that swallowed the error would stamp or compare against a
+// digest that names a projection this code cannot produce, and every row under
+// it would read as stale forever.
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// unencodableDeclaration is a mapping carrying a value JSON cannot encode. A
+// channel is the cheapest to write down; the real one would be a func or a
+// cyclic structure reaching a declaration through decoded JSON that was not
+// decoded from JSON.
+func unencodableDeclaration() ObjectMapping {
+	return ObjectMapping{
+		Source: "contacts", Target: "person", ExternalKey: "hs_object_id",
+		Const: map[string]any{"unencodable": make(chan int)},
+	}
+}
+
+// A child attribute JSON cannot encode is refused, and names the field.
+//
+// Const has its own case one file over; this is the second site, and it is a
+// separate arm rather than the same one — a mapping whose Const encodes and
+// whose Child.Attrs does not would pass the first check and reach the second.
+func TestAnUnencodableChildAttributeIsRefused(t *testing.T) {
+	m := ObjectMapping{
+		Source: "contacts", Target: "person", ExternalKey: "hs_object_id",
+		Fields: []FieldMapping{{
+			From: []string{"email"}, To: "person_email.email", Kind: TargetChild,
+			Child: &ChildRow{Attrs: map[string]any{"unencodable": make(chan int)}},
+		}},
+	}
+
+	digest, err := Fingerprint(m)
+
+	if err == nil {
+		t.Fatalf("a child attribute JSON cannot encode answered the digest %q", digest)
+	}
+	// The field INDEX, because a declaration has many and the reader is
+	// whoever just edited one.
+	if !strings.Contains(err.Error(), "field 0") {
+		t.Errorf("the refusal reads %q and does not say which field carries the value", err)
+	}
+}
+
+// StaleProjections answers the refusal rather than comparing against a digest
+// it does not have.
+//
+// The store is nil on purpose: the refusal has to come BEFORE any database
+// work, so a test that reached one would be proving something else.
+//
+// The error's IDENTITY is asserted, not merely its presence, and that is what
+// makes this evidence. A nil store fails on its own the moment anything touches
+// it, so "an error came back" is true whether or not the fingerprint was
+// checked — swallowing the refusal still answers an error, from one line
+// further down. Naming the key that could not be encoded is what separates the
+// two.
+func TestStaleProjectionsRefusesADeclarationItCannotFingerprint(t *testing.T) {
+	store := NewMirrorStore(nil, noOwnerEmailsForUnitTest{})
+
+	ids, err := store.StaleProjections(context.Background(), unencodableDeclaration(), 10)
+
+	if err == nil {
+		t.Fatal("StaleProjections answered a stale set for a declaration it cannot fingerprint — the " +
+			"comparison it makes is against that digest, so the answer describes nothing")
+	}
+	if !strings.Contains(err.Error(), "unencodable") {
+		t.Errorf("it refused with %q, which is not the fingerprint refusal — the declaration was never "+
+			"checked and this failed somewhere further down, so the check above proves nothing", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("it answered %d id(s) alongside the refusal; a caller taking the value would re-fetch them", len(ids))
+	}
+}

--- a/backend/internal/modules/overlay/hubspot/adapter.go
+++ b/backend/internal/modules/overlay/hubspot/adapter.go
@@ -439,6 +439,10 @@ func mapRecord(m overlay.ObjectMapping, objectClass string, raw ObjectRecord) (o
 
 	ownerID, _ := out["owner_id"].(string)
 
+	fingerprint, err := overlay.Fingerprint(m)
+	if err != nil {
+		return overlay.Record{}, err
+	}
 	return overlay.Record{
 		ExternalID: externalID,
 		// The mirror is keyed by canonical entity type, not the incumbent
@@ -453,7 +457,7 @@ func mapRecord(m overlay.ObjectMapping, objectClass string, raw ObjectRecord) (o
 		// Stamped from the declaration that produced Fields just above, so the
 		// row the mirror stores names its own projection rather than whichever
 		// declaration is current when someone later asks.
-		ProjectionFingerprint: overlay.Fingerprint(m),
+		ProjectionFingerprint: fingerprint,
 	}, nil
 }
 

--- a/backend/internal/modules/overlay/hubspot/declarationfingerprint_test.go
+++ b/backend/internal/modules/overlay/hubspot/declarationfingerprint_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package hubspot
+
+// The declarations this package ships can all be fingerprinted, and a record
+// projected through one that cannot is refused rather than stamped.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/overlay"
+)
+
+// Every declaration this package ships fingerprints cleanly.
+//
+// This is what makes ProjectionFingerprints' panic a composition-time assertion
+// rather than a live failure mode: the mappings are constants of this package,
+// so if they all encode here they encode at boot too. It is also the reason the
+// error arms in the callers are defensive rather than reachable — a declaration
+// that could trip them would have to be written first, and this fails the
+// moment one is.
+//
+// Derived from objectMappings, so a declaration added tomorrow is checked by
+// being added.
+func TestEveryShippedDeclarationCanBeFingerprinted(t *testing.T) {
+	if len(objectMappings) == 0 {
+		t.Fatal("this package declares no object mapping — the assertion below asks nothing, and " +
+			"ProjectionFingerprints would answer an empty map every staleness verdict reads from")
+	}
+	seen := make(map[string]string, len(objectMappings))
+	for _, m := range objectMappings {
+		digest, err := overlay.Fingerprint(m)
+		if err != nil {
+			t.Errorf("the %s declaration cannot be fingerprinted (%v) — ProjectionFingerprints panics on "+
+				"this at boot, which is where a declaration carrying an unencodable value should be found",
+				m.Source, err)
+			continue
+		}
+		if digest == "" {
+			t.Errorf("the %s declaration fingerprints to the empty string, which every stamped row would "+
+				"then carry and every comparison would match", m.Source)
+		}
+		// Two declarations sharing a digest would make one indistinguishable
+		// from the other on a mirror row, so a re-projection could not tell
+		// which produced it.
+		if other, clash := seen[digest]; clash {
+			t.Errorf("%s and %s fingerprint identically, so a row stamped with it names neither", m.Source, other)
+		}
+		seen[digest] = m.Source
+	}
+}
+
+// A record projected through a declaration that cannot be fingerprinted is
+// refused, never stamped.
+//
+// This is the arm that matters most of the four the refusal reaches: it is the
+// one that would WRITE a bad fingerprint onto a mirror row, where every later
+// staleness verdict reads it. A row stamped with a digest naming no projection
+// reads as stale forever and re-fetches on every pass.
+func TestARecordIsNotStampedWithAFingerprintThatCannotBeMade(t *testing.T) {
+	// Baseline and its property are supplied so the projection gets PAST the
+	// watermark check: without them the mapper refuses earlier, for a reason
+	// that has nothing to do with fingerprinting, and this test would pass
+	// while never reaching the arm it names.
+	m := overlay.ObjectMapping{
+		Source: objectClassContacts, Target: "person", ExternalKey: propHSObjectID,
+		Baseline: baselineHSLastModifiedDate,
+		Const:    map[string]any{"unencodable": make(chan int)},
+	}
+	raw := ObjectRecord{ID: "1", Properties: Property{baselineHSLastModifiedDate: "2026-01-02T03:04:05.000Z"}}
+
+	rec, err := mapRecord(m, objectClassContacts, raw)
+
+	if err == nil {
+		t.Fatalf("a record projected through an unfingerprintable declaration came back stamped %q — "+
+			"the mirror would hold a row naming a projection this code cannot produce", rec.ProjectionFingerprint)
+	}
+	if rec.ProjectionFingerprint != "" {
+		t.Errorf("the refusal still carried the fingerprint %q; a caller ignoring the error would store it",
+			rec.ProjectionFingerprint)
+	}
+	if !strings.Contains(err.Error(), "unencodable") {
+		t.Errorf("the refusal reads %q and does not name the key that could not be encoded", err)
+	}
+}

--- a/backend/internal/modules/overlay/hubspot/mapping_hs.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs.go
@@ -7,7 +7,11 @@
 // expressed in the overlay package's mapping IR.
 package hubspot
 
-import "github.com/margince/margince/backend/internal/modules/overlay"
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/modules/overlay"
+)
 
 // The five HubSpot object classes design.md §9 maps — the one spelling
 // shared with adapter.go's per-object watermark-property switch (design.md
@@ -127,10 +131,24 @@ var objectMappings = []overlay.ObjectMapping{
 //
 // Derived from objectMappings, never a second hand-written list, so a mapping
 // added or removed here can never leave a stale fingerprint behind.
+//
+// A declaration this package cannot fingerprint PANICS rather than answering a
+// partial map, and this is the one place that is right: the mappings are
+// compile-time constants of this package, so a failure here is a declaration
+// somebody just wrote carrying a value JSON cannot encode — a build-time
+// mistake, found at startup, on a map every staleness verdict is read from. An
+// error return would push that decision out to callers who have no better
+// answer than to stop, and a map missing one entry would silently spare every
+// row that declaration projected.
 func ProjectionFingerprints() map[string]string {
 	out := make(map[string]string, len(objectMappings))
 	for _, m := range objectMappings {
-		out[m.Source] = overlay.Fingerprint(m)
+		fingerprint, err := overlay.Fingerprint(m)
+		if err != nil {
+			//craft:ignore panic-in-domain composition-time declaration assertion — the mappings are this package constants, so this fires only while cmd wiring runs, never on a request path
+			panic(fmt.Sprintf("hubspot: the %s declaration cannot be fingerprinted: %v", m.Source, err))
+		}
+		out[m.Source] = fingerprint
 	}
 	return out
 }

--- a/backend/internal/modules/overlay/projectionstaleness.go
+++ b/backend/internal/modules/overlay/projectionstaleness.go
@@ -169,7 +169,10 @@ func (s *MirrorStore) StaleProjections(ctx context.Context, m ObjectMapping, lim
 	// m.Target: the namespace filter has already narrowed the rows to the
 	// ones m produced, so a sibling declaration's fingerprint cannot appear
 	// among them — and admitting one would spare a row nothing re-projects.
-	fingerprint := Fingerprint(m)
+	fingerprint, err := Fingerprint(m)
+	if err != nil {
+		return nil, err
+	}
 	current, err := encodeFingerprintSets(map[string][]string{m.Target: {fingerprint}})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #1145.

## The defect

`Const` and `ChildRow.Attrs` were digested with `fmt.Sprintf("%T=%#v", v, v)`. That is injective and deterministic today and was chosen for it — the issue is explicit that `%T=%v` would have left a collision one level down.

But `%#v` is a documented **rendering**, not a serialization format. A Go toolchain upgrade that changed it would move every fingerprint in the estate at once, and every mirrored row would read as stale and re-project. Not incorrect — a fingerprint change is precisely the event the sweep converges — but it spends a full estate's worth of metered incumbent API budget for a declaration nobody edited.

`json.Marshal` is a specified format with a stability guarantee the rendering does not carry.

## Why now

The issue's own argument, in its strongest form: *"doing it before many installations have stamped rows is cheaper than after"* — and no installation has stamped a row anywhere. Changing the encoding today re-projects nothing, costs no metered calls, and needs no migration. That stops being true at go-live.

## `Fingerprint` returns an error now

Because a declaration carrying a value JSON cannot encode **has no fingerprint**. Answering one anyway would stamp rows with a digest no projection can ever match, and every one of them would read as stale forever — the failure the digest exists to prevent, caused by the digest.

Four callers, each answering where it can:

- `StaleProjections` and the re-fetch job return or log it — a declaration that cannot be fingerprinted is a fault in the mapping, not in the row, and failing the job would retry a read that cannot succeed.
- `hubspot.ProjectionFingerprints` **panics**, and that is right in exactly one place: the mappings are compile-time constants of that package, so a failure is a declaration somebody just wrote, found at startup, on a map every staleness verdict reads from. A partial map would silently spare every row that declaration projected. Waived with the reason, matching the composition-time assertions in `capture/registry.go` and `approvalinbox.go`.

## The type prefix is gone, and that is the interesting half

`%#v` needed `%T` alongside it, because it renders the bool `true` and the string `"true"` identically. **JSON does not** — `true` and `"true"` are different bytes, as are `1` and `"1"`. The encoding already draws every distinction the payload draws.

Keeping the type would draw one the payload does **not**: an int `1` and a float64 `1.0` both reach the mirror as `1`, so they project the same record and belong under the same fingerprint. Separating them would mark an estate stale for an edit nobody can observe — this issue's own cost, arriving by another route.

**I found that by writing the test, not by reading the code.** The mutation dropping the type prefix survived every existing case, so I wrote the case that should have caught it — a nested `map[string]any` with an int against a float. It failed. Investigating why showed the old comment's claim that the separation *"holds a level down into the nested values"* was never true for numbers, under either encoding: both nest to the same `map[string]interface {}{"weight":1}`.

So the assertion now runs the other way: `TestFingerprintSharesADigestForNumbersThatProjectAlike` asserts they share a digest, and re-introducing the type prefix fails it.

## Mutation checks

| mutation | result |
|---|---|
| the encoding error swallowed | the refusal test fails — a digest is answered for a declaration nothing can project |
| the type prefix re-introduced | the shared-digest test fails, naming the pointless re-projection |
| `json.Marshal` replaced by a rendering again | five cases fail (bool-vs-string, numeric-vs-string, both value-type cases) |

The third had to be rewritten to compile — my first attempt left `encoded` unused, and a mutation that does not build proves nothing.

## Checks

`make check-backend` green; `make craft-static` 0/0/0; the overlay and compose integration lanes green.