### PR TITLE
fix(e2e-llm): the judge reads a fenced reply, and one argument names one file

### DIFF
--- a/e2e/llm/judge-eval.py
+++ b/e2e/llm/judge-eval.py
@@ -42,12 +42,26 @@ RECORDS = os.path.join(
 # that says the judge was scored against fixtures.
 JUDGED = re.compile(r"^case\d+/")
 
+# The model id becomes a file name under RECORDS, so it is checked before it is
+# joined rather than trusted because a person typed it. This script is driven by
+# agents that assemble their own argument list, and `os.path.join` with a value
+# carrying a separator writes wherever the caller pointed it — the one directory
+# this script owns is the only place its record belongs.
+MODEL_ID = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
 
 def main():
     if len(sys.argv) != 2:
         print(__doc__.strip().splitlines()[-3].strip(), file=sys.stderr)
         return 2
     model = sys.argv[1]
+    if not MODEL_ID.match(model):
+        print(
+            f"not a model id: {model!r} — expected something like "
+            "claude-haiku-4-5-20251001",
+            file=sys.stderr,
+        )
+        return 2
     done = subprocess.run(
         [os.path.join(ROOT, "scripts", "test-e2e-llm-check.sh")],
         capture_output=True,

--- a/e2e/llm/judge.py
+++ b/e2e/llm/judge.py
@@ -131,7 +131,13 @@ def _fenced(criterion, answer):
     )
 
 
-_FENCE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE)
+# The two fences, matched separately and each anchored to one end of the reply.
+# One alternation over `\s*` read the same and was two defects: neither branch
+# was anchored, so the engine retried its whitespace run from every position in
+# the reply, and nothing said which branch owned a run of blank lines between
+# them.
+_OPEN_FENCE = re.compile(r"\A```(?:json)?[^\S\n]*\n?")
+_CLOSE_FENCE = re.compile(r"\n?[^\S\n]*```\Z")
 
 
 def parse_verdict(text):
@@ -143,7 +149,8 @@ def parse_verdict(text):
     latitude is a markdown fence, which is what a fenced reply actually looks
     like when a model ignores the instruction not to write one.
     """
-    stripped = _FENCE.sub("", text).strip()
+    unfenced = _OPEN_FENCE.sub("", text.strip())
+    stripped = _CLOSE_FENCE.sub("", unfenced).strip()
     try:
         reply = json.loads(stripped)
     except json.JSONDecodeError as err:

--- a/e2e/llm/judge.py
+++ b/e2e/llm/judge.py
@@ -131,13 +131,14 @@ def _fenced(criterion, answer):
     )
 
 
-# The two fences, matched separately and each anchored to one end of the reply.
-# One alternation over `\s*` read the same and was two defects: neither branch
-# was anchored, so the engine retried its whitespace run from every position in
-# the reply, and nothing said which branch owned a run of blank lines between
-# them.
+# The opening fence, anchored to the start of the reply. One alternation over
+# `\s*` covered both fences in a line and was two defects: neither branch was
+# anchored, so the engine retried its whitespace run from every position in the
+# reply, and nothing said which branch owned a run of blank lines between them.
+# The closing fence is not a pattern at all — a regex for it can only be
+# anchored at the END, which leaves the same scan-from-everywhere cost the
+# alternation had. `endswith` asks the question once.
 _OPEN_FENCE = re.compile(r"\A```(?:json)?[^\S\n]*\n?")
-_CLOSE_FENCE = re.compile(r"\n?[^\S\n]*```\Z")
 
 
 def parse_verdict(text):
@@ -149,8 +150,10 @@ def parse_verdict(text):
     latitude is a markdown fence, which is what a fenced reply actually looks
     like when a model ignores the instruction not to write one.
     """
-    unfenced = _OPEN_FENCE.sub("", text.strip())
-    stripped = _CLOSE_FENCE.sub("", unfenced).strip()
+    unfenced = _OPEN_FENCE.sub("", text.strip()).rstrip()
+    if unfenced.endswith("```"):
+        unfenced = unfenced[: -len("```")]
+    stripped = unfenced.strip()
     try:
         reply = json.loads(stripped)
     except json.JSONDecodeError as err:

--- a/scripts/test-e2e-llm-check.sh
+++ b/scripts/test-e2e-llm-check.sh
@@ -396,6 +396,18 @@ judge_is "a judge that says no fails the run" \
 	"cmd:printf '{\"verdict\":\"no\",\"reason\":\"it did not\"}'" \
 	1 "the judge says NO to:"
 
+# A REPLY WHOSE FENCE THE MODEL INDENTED. The parse is strict everywhere else and
+# the docstring names the fence as its one latitude, so the latitude owes a case
+# — and this is the shape that decides whether the stripping is anchored to the
+# reply or hunting for a fence line by line. A pattern matching at the start of
+# any LINE never sees this one, leaves the fence in place, and the reply is
+# refused as unreadable. Asserted through the "no" verdict rather than a pass: an
+# unstripped fence raises "not the expected JSON object" and exits 2, so the two
+# outcomes are told apart by exit code alone rather than by a message.
+judge_is "a reply whose fence is indented is read, not refused" \
+	"cmd:printf '  \`\`\`json\\n{\"verdict\":\"no\",\"reason\":\"it did not\"}\\n\`\`\`'" \
+	1 "the judge says NO to:"
+
 # A VERDICT ONE MODEL GAVE IS NOT ANOTHER MODEL'S. The recorded corpus is what
 # says this judge decides these fixtures correctly, and replaying it while a
 # different judge is pinned would report a model as held that has never been
@@ -1036,6 +1048,30 @@ cat >"$work/usage.renamed.jsonl" <<'JSONL'
 JSONL
 usage_is "usage/a renamed token field is unmeasured, not zero" 1 "0/1 runs measured" \
 	"$work/usage.renamed.jsonl"
+
+# --- judge-eval.py's one argument ------------------------------------------------
+#
+# The model id names the record file this script writes under its own records
+# directory, so an argument carrying a path separator would put that file
+# anywhere the caller pointed. The script is run by agents assembling their own
+# argument list, and the refusal has to land BEFORE the suite runs — a guard that
+# fires after a live judge has billed a run is a guard that costs money to
+# enforce.
+eval_refuses() {
+	local name="$1" argument="$2" out status=0
+	out="$(python3 "$root/e2e/llm/judge-eval.py" "$argument" 2>&1)" || status=$?
+	if [[ $status -ne 2 ]] || [[ "$out" != *"not a model id"* ]]; then
+		echo "FAIL: judge-eval/$name — exit $status, want 2 carrying 'not a model id'"
+		echo "$out" | sed 's/^/    /'
+		failures=$((failures + 1))
+		return
+	fi
+	echo "ok: judge-eval/$name"
+}
+
+eval_refuses "a relative escape is refused" "../../../tmp/escape"
+eval_refuses "an absolute path is refused" "/tmp/escape"
+eval_refuses "a bare separator is refused" "a/b"
 
 if [[ $failures -ne 0 ]]; then
 	echo "FAIL: $failures e2e-llm checker case(s) did not hold" >&2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -229,9 +229,13 @@ sonar.cpd.exclusions=\
 # `webgl-program.ts` is the shader compile and link both renderers share, which
 # is context calls end to end. Same rationale as *_windows.go: an honest
 # exclusion beats a gap no work would close.
-# e2e/llm/check.py is the e2e-llm lane's own judge script — CI-only dev tooling
-# on the same footing as backend/tools above, not shippable
-# product code. No python coverage report is wired into this scan (no
+# e2e/llm/*.py is the e2e-llm lane's own tooling — the checker, the judge, the
+# probe and the judge-eval driver — CI-only dev tooling on the same footing as
+# backend/tools above, not shippable product code. The whole directory rather
+# than one file named in it: the reasoning below is about how these scripts are
+# RUN, so it held for every sibling the day `check.py` was listed alone, and
+# three of them landed later and were counted. That is the shape a hand-kept
+# list fails in. No python coverage report is wired into this scan (no
 # sonar.python.coverage.reportPaths, no coverage.py step in any workflow), so
 # any new line here reads as 0% regardless of whether it is exercised, which is
 # a gap this file's own docstring already explains the tradeoff for: it is kept
@@ -250,7 +254,7 @@ sonar.coverage.exclusions=\
   backend/cmd/**,\
   backend/tools/**,\
   backend/internal/platform/testdb/**,\
-  e2e/llm/check.py,\
+  e2e/llm/*.py,\
   frontend/src/main.tsx,\
   frontend/vite.config.ts,\
   frontend/playwright.config.ts,\


### PR DESCRIPTION
Fixes https://github.com/margince/margince/issues/5117.

## What

The judge reads a reply whose markdown fence the model indented, instead of refusing it as unreadable, and `judge-eval.py` refuses an argument that is not a model id instead of writing its record wherever the argument points.

## Why

The SonarCloud quality gate on `main` is `ERROR`, on two conditions:

```
failing: new_reliability_rating GT 1 (actual 3)
failing: new_security_rating   GT 1 (actual 3)
```

Three findings, all in the new-code period, all in the two Python files that landed with the judge-eval lane:

| rule | file:line | quality |
| --- | --- | --- |
| `pythonsecurity:S8707` | `e2e/llm/judge-eval.py:79` | SECURITY, HIGH |
| `python:S5850` | `e2e/llm/judge.py:134` | RELIABILITY, MEDIUM |
| `python:S8786` | `e2e/llm/judge.py:134` | RELIABILITY, MEDIUM |

**The fence.** Both reliability findings are one line:

```python
_FENCE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE)
```

Neither branch of the alternation is anchored, so the engine retried its whitespace run from every position in the reply — quadratic in the reply's length, which is S8786 — and nothing said which branch owned a run of blank lines between the two fences, which is S5850.

The ambiguity was hiding a defect rather than only reading badly. `^` under `MULTILINE` matches at the start of a LINE, so a fence the model indented by two spaces matched nothing, survived the strip, and the reply was refused with "the judge's reply is not the expected JSON object" — a real reply thrown away as unreadable. Anchoring each fence to its own end of the stripped reply answers all three: the pattern is linear, each branch owns one end, and an indented fence is read.

**The argument.** `judge-eval.py` took `sys.argv[1]` straight into `os.path.join(RECORDS, model + ".json")`. An argument carrying a separator writes the record anywhere the caller points it, and this script is driven by agents that assemble their own argument list — which is exactly the threat model `S8707` names. The guard is a code fix rather than a waiver because this file's containment root really is one fixed directory. That is what separates it from `check.py`'s standing `e14` waiver, where the roots are the repo tree and the system temp directory and no fixed sanitizer boundary exists to recognise.

The refusal lands before `subprocess.run`, not after: a guard that fires once a live judge has already billed a run is a guard that costs money to enforce.

**What the PR's own scan then said, and the second commit.** The first cut cleared both failing conditions — `new_reliability_rating` and `new_security_rating` back to `1`, so Sonar's dataflow does accept the `MODEL_ID` check as a sanitizer for `S8707`. It left two things standing, both fixed in the second commit:

- **`S8786` survived, on `_CLOSE_FENCE`.** Correctly. A regex for a *closing* fence can only be anchored at the END, so `re.sub` still tries every start position and retries the whitespace run at each — I had moved the scan-from-everywhere cost rather than removed it. `rstrip()` and `endswith("```")` ask the question once, and the closing fence stops being a pattern at all.
- **`new_coverage 0.0`**, which is `sonar.coverage.exclusions` naming `e2e/llm/check.py` and no sibling. Its stated reason is about how these scripts are RUN — CI-only dev tooling, no python coverage report wired into the scan, so any new line reads as 0% whether or not it is exercised. That was true of every sibling on the day `check.py` was listed alone, and three of them landed later and were counted: `judge.py`, `judge-eval.py`, `probe.py`. The exclusion now names `e2e/llm/*.py`, which is the shape a hand-kept list cannot fail short of.

## How verified

Both fixes are held by cases in `scripts/test-e2e-llm-check.sh`, which runs in the `check-backend` gate fan-out. Each case was mutation-tested — reverted to the pre-fix source and re-run — so none of them passes for free:

| case | with the fix | with the old source |
| --- | --- | --- |
| a reply whose fence is indented is read, not refused | ok | **FAIL — exit 2, want 1** |
| judge-eval/a relative escape is refused | ok | **FAIL — exit 1, want 2** |
| judge-eval/an absolute path is refused | ok | **FAIL — exit 1, want 2** |
| judge-eval/a bare separator is refused | ok | **FAIL — exit 1, want 2** |

The first case is deliberately the INDENTED fence rather than a plain one. A plain fenced reply passes under both patterns, so a case asserting it would have reported green over the defect — which is what the first cut of this test did, and why it was retargeted.

The stripping was diffed against the original over nine realistic replies (plain, `json`-tagged, untagged, one-line, blank-line-padded, a reply containing a literal fence inside its reason). They agree on all of them but two — an indented opening fence and an indented closing fence — where the new code reads a reply the old pattern refused outright. No behaviour is lost in either direction.

- [x] `make check` is green — `check-backend` and `check-fe` both run below
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — it touches neither; there is no Go and no SQL in this diff
- [x] `make craft-static` reports no new blockers — it sweeps the Go trees, and this diff has none
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by Claude Code. Found by reading the `quality-gate` job of the scheduled run this issue was filed from, and then querying SonarCloud's own API for the three issues behind the two failing conditions rather than inferring them from the ratings.

Two judgement calls, flagged rather than buried:

1. **`[A-Za-z0-9][A-Za-z0-9._-]*` is the model-id shape**, chosen from the ids this lane actually passes (`claude-haiku-4-5-20251001`). It admits no separator on any platform, which is the property that matters; it is not a claim about what model ids may look like in general, and widening it later costs nothing.
2. **The fence stripping is now anchored to the whole reply** rather than to any line. A fence in the MIDDLE of a reply is no longer stripped — but such a reply has non-JSON text around it and was refused by `json.loads` anyway, so nothing that used to parse stops parsing.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
