### PR TITLE
fix(compose): the restore route reverses a machine correction, not just its receipt

### DIFF
--- a/backend/internal/compose/correctionrevert_integration_test.go
+++ b/backend/internal/compose/correctionrevert_integration_test.go
@@ -16,12 +16,15 @@ package compose
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/margince/margince/backend/internal/compose/magic"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -75,7 +78,7 @@ func TestACorrectionIsTakenBackWithEveryFieldItMoved(t *testing.T) {
 		t.Fatal("the rolled date should be provisional")
 	}
 
-	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal), nil); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal), nil, nil); err != nil {
 		t.Fatalf("taking the correction back: %v", err)
 	}
 
@@ -118,7 +121,7 @@ func TestAReversedCorrectionIsNotReappliedTomorrow(t *testing.T) {
 	if err := e.sweep(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal), nil); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal), nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -155,7 +158,7 @@ func TestATakenBackCorrectionRefusesToOverwriteALaterEdit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := e.Deals.RevertCorrection(e.Admin(), correction, nil)
+	_, err := e.Deals.RevertCorrection(e.Admin(), correction, nil, nil)
 	var conflict *deals.CorrectionReversalError
 	if !errors.As(err, &conflict) {
 		t.Fatalf("undo after a human edit → %v, want a conflict that names the field", err)
@@ -175,10 +178,10 @@ func TestTakingACorrectionBackTwiceIsOneReversal(t *testing.T) {
 		t.Fatal(err)
 	}
 	correction := e.correctionFor(t, deal)
-	if _, err := e.Deals.RevertCorrection(e.Admin(), correction, nil); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), correction, nil, nil); err != nil {
 		t.Fatal(err)
 	}
-	_, err := e.Deals.RevertCorrection(e.Admin(), correction, nil)
+	_, err := e.Deals.RevertCorrection(e.Admin(), correction, nil, nil)
 	var conflict *deals.CorrectionReversalError
 	if !errors.As(err, &conflict) {
 		t.Errorf("second undo → %v, want a refusal saying it is already taken back", err)
@@ -225,7 +228,7 @@ func TestConfirmingACardAfterAnUndoDoesNotReapplyIt(t *testing.T) {
 		   AND target_entity_id = $1 AND status = 'pending'`, deal).Scan(&approvalID); err != nil {
 		t.Fatalf("the sweep staged no confirm: %v", err)
 	}
-	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal), nil); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal), nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -292,7 +295,7 @@ func TestTheReceiptOffersUndoOnARealCorrection(t *testing.T) {
 
 	// And once taken back, the same line stops offering it: a second Undo on a
 	// reversed correction is a control that can only refuse.
-	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, e.firstDealID(t)), nil); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, e.firstDealID(t)), nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	after, err := e.magicReceipt(t, since)
@@ -345,9 +348,105 @@ func TestTheGenericRestoreRouteHonorsACorrectionTheReceiptOffersUndoOn(t *testin
 	}
 
 	// A second Undo on the same route now finds the correction already
-	// reversed rather than falling into the generic evaluator a second time.
-	if _, err := seam.Restore(e.Admin(), "deal", deal, auditID, currentVersion(t, e.Env, "deal", deal)); err == nil {
-		t.Error("a second restore of an already-reversed correction succeeded")
+	// reversed rather than falling into the generic evaluator a second time
+	// — and says so with the SAME word and the SAME wire status every other
+	// refusal on this route carries, not a 500: a correction's own refusal
+	// must be as legible as the generic evaluator's.
+	_, err = seam.Restore(e.Admin(), "deal", deal, auditID, currentVersion(t, e.Env, "deal", deal))
+	var refused RefusedRestore
+	if !errors.As(err, &refused) {
+		t.Fatalf("second restore of an already-reversed correction = %v, want a RefusedRestore", err)
+	}
+	if refused.Reason != ReasonAlreadyUndone {
+		t.Errorf("second restore's reason = %q, want %q", refused.Reason, ReasonAlreadyUndone)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok || fault.Status != http.StatusConflict {
+		t.Errorf("second restore classifies as %+v (ok=%v), want a 409", fault, ok)
+	}
+}
+
+// TestTheGenericRestoreRouteRefusesACorrectionOverwrittenByALaterEdit is the
+// write-side half of TestATakenBackCorrectionRefusesToOverwriteALaterEdit,
+// reached through the SAME route the previous test drives — the refusal
+// RevertCorrection returns for its own reasons (a later field edit, as
+// opposed to the "already reversed" case the seam catches before ever
+// calling it) must reach the caller as the same 409 shape too, not the raw
+// *deals.CorrectionReversalError a 500 would fall through to.
+func TestTheGenericRestoreRouteRefusesACorrectionOverwrittenByALaterEdit(t *testing.T) {
+	e := setupCloseDate(t)
+	deal := e.seedSweepDeal(t, "Corrected then re-dated, undone through the real route", e.early, nil, intp(-12), 3)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	auditID := e.correctionAuditIDFor(t, deal)
+
+	// The rep puts their own date on it — a real answer, not the machine's —
+	// so RevertCorrection's own per-field conflict check refuses, not the
+	// early "already reversed" shortcut.
+	chosen := today().AddDate(0, 0, 45)
+	if _, err := e.Deals.UpdateDeal(e.Admin(), ids.From[ids.DealKind](deal), deals.UpdateDealInput{
+		ExpectedClose: &chosen,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	seam := NewRestoreSeam(e.Pool, NewDispatcher(NewProvider(e.Pool),
+		NewOverlayProvider(e.Pool, failClosedOverlayMeter(), nil), e.Pool),
+		deals.NewStore(e.DB(), DealsInstallation()))
+	_, err := seam.Restore(e.Admin(), "deal", deal, auditID, currentVersion(t, e.Env, "deal", deal))
+	var refused RefusedRestore
+	if !errors.As(err, &refused) {
+		t.Fatalf("restore over a later human edit = %v, want a RefusedRestore", err)
+	}
+	if refused.Reason != ReasonNotRestorableByThisPath {
+		t.Errorf("reason = %q, want %q", refused.Reason, ReasonNotRestorableByThisPath)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok || fault.Status != http.StatusConflict {
+		t.Errorf("classifies as %+v (ok=%v), want a 409", fault, ok)
+	}
+
+	kept := e.readSwept(t, deal)
+	if kept.expectedClose == nil || !kept.expectedClose.Equal(chosen) {
+		t.Errorf("the rep's own date was overwritten: %v", kept.expectedClose)
+	}
+}
+
+// TestTheGenericRestoreRouteRefusesAStaleVersionOnACorrection — the per-field
+// conflict check above catches a later edit to a CORRECTED field by VALUE,
+// which is exactly what lets an unrelated rename through deliberately. It is
+// not a substitute for ifVersion: a caller's If-Match names the record they
+// looked at, not any one field, and a stale one must refuse regardless of
+// which field moved under it.
+func TestTheGenericRestoreRouteRefusesAStaleVersionOnACorrection(t *testing.T) {
+	e := setupCloseDate(t)
+	deal := e.seedSweepDeal(t, "Corrected, then renamed by someone else", e.early, nil, intp(-12), 3)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	auditID := e.correctionAuditIDFor(t, deal)
+	stale := currentVersion(t, e.Env, "deal", deal)
+
+	// An edit to a field the correction never touched — the shape the
+	// per-field check deliberately lets an undo through over. The version
+	// pin does not make that distinction: it moved, so a caller holding the
+	// version from before it must be told so.
+	renamed := "Renamed after the correction"
+	if _, err := e.Deals.UpdateDeal(e.Admin(), ids.From[ids.DealKind](deal), deals.UpdateDealInput{
+		Name: &renamed,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	seam := NewRestoreSeam(e.Pool, NewDispatcher(NewProvider(e.Pool),
+		NewOverlayProvider(e.Pool, failClosedOverlayMeter(), nil), e.Pool),
+		deals.NewStore(e.DB(), DealsInstallation()))
+	_, err := seam.Restore(e.Admin(), "deal", deal, auditID, stale)
+	if !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Errorf("restore with a stale If-Match = %v, want ErrVersionSkew", err)
 	}
 }
 

--- a/backend/internal/compose/correctionrevert_integration_test.go
+++ b/backend/internal/compose/correctionrevert_integration_test.go
@@ -37,6 +37,21 @@ func (e *closeDateEnv) correctionFor(t *testing.T, dealID ids.UUID) ids.UUID {
 	return id
 }
 
+// correctionAuditIDFor reads the AUDIT ROW a correction records — the id the
+// receipt names on its Undo control and the id a real client's restore
+// request carries, as opposed to correctionFor's deal_correction.id, which
+// never reaches the wire.
+func (e *closeDateEnv) correctionAuditIDFor(t *testing.T, dealID ids.UUID) ids.UUID {
+	t.Helper()
+	var id ids.UUID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT audit_log_id FROM deal_correction WHERE deal_id = $1 AND reversed_at IS NULL
+		  ORDER BY applied_at DESC LIMIT 1`, dealID).Scan(&id); err != nil {
+		t.Fatalf("no live correction recorded for the deal: %v", err)
+	}
+	return id
+}
+
 // The undo the generic restore path could not perform.
 //
 // Two walls stop it there: rejectPastCloseDate refuses any past close date on an
@@ -60,7 +75,7 @@ func TestACorrectionIsTakenBackWithEveryFieldItMoved(t *testing.T) {
 		t.Fatal("the rolled date should be provisional")
 	}
 
-	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal)); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal), nil); err != nil {
 		t.Fatalf("taking the correction back: %v", err)
 	}
 
@@ -103,7 +118,7 @@ func TestAReversedCorrectionIsNotReappliedTomorrow(t *testing.T) {
 	if err := e.sweep(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal)); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -140,7 +155,7 @@ func TestATakenBackCorrectionRefusesToOverwriteALaterEdit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := e.Deals.RevertCorrection(e.Admin(), correction)
+	_, err := e.Deals.RevertCorrection(e.Admin(), correction, nil)
 	var conflict *deals.CorrectionReversalError
 	if !errors.As(err, &conflict) {
 		t.Fatalf("undo after a human edit → %v, want a conflict that names the field", err)
@@ -160,10 +175,10 @@ func TestTakingACorrectionBackTwiceIsOneReversal(t *testing.T) {
 		t.Fatal(err)
 	}
 	correction := e.correctionFor(t, deal)
-	if _, err := e.Deals.RevertCorrection(e.Admin(), correction); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), correction, nil); err != nil {
 		t.Fatal(err)
 	}
-	_, err := e.Deals.RevertCorrection(e.Admin(), correction)
+	_, err := e.Deals.RevertCorrection(e.Admin(), correction, nil)
 	var conflict *deals.CorrectionReversalError
 	if !errors.As(err, &conflict) {
 		t.Errorf("second undo → %v, want a refusal saying it is already taken back", err)
@@ -210,7 +225,7 @@ func TestConfirmingACardAfterAnUndoDoesNotReapplyIt(t *testing.T) {
 		   AND target_entity_id = $1 AND status = 'pending'`, deal).Scan(&approvalID); err != nil {
 		t.Fatalf("the sweep staged no confirm: %v", err)
 	}
-	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal)); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, deal), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -277,7 +292,7 @@ func TestTheReceiptOffersUndoOnARealCorrection(t *testing.T) {
 
 	// And once taken back, the same line stops offering it: a second Undo on a
 	// reversed correction is a control that can only refuse.
-	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, e.firstDealID(t))); err != nil {
+	if _, err := e.Deals.RevertCorrection(e.Admin(), e.correctionFor(t, e.firstDealID(t)), nil); err != nil {
 		t.Fatal(err)
 	}
 	after, err := e.magicReceipt(t, since)
@@ -290,6 +305,49 @@ func TestTheReceiptOffersUndoOnARealCorrection(t *testing.T) {
 	}
 	if reversed.Undo == nil || reversed.Undo.Undoable {
 		t.Error("a correction already taken back still offers an Undo")
+	}
+}
+
+// The write-side half of TestTheReceiptOffersUndoOnARealCorrection: the
+// receipt's AuditId is what a real client's Undo control sends to the
+// generic restore ROUTE, never to RevertCorrection directly, so this is the
+// path that must actually put the deal back. Before this path knew about
+// corrections, the receipt read a line as undoable and pressing Undo
+// refused it every time — the generic evaluator refuses exactly what a
+// correction writes.
+func TestTheGenericRestoreRouteHonorsACorrectionTheReceiptOffersUndoOn(t *testing.T) {
+	e := setupCloseDate(t)
+	deal := e.seedSweepDeal(t, "Corrected overnight, undone through the real route", e.early, nil, intp(-12), 3)
+	wasClosing := today().AddDate(0, 0, -12)
+
+	if err := e.sweep(); err != nil {
+		t.Fatal(err)
+	}
+	auditID := e.correctionAuditIDFor(t, deal)
+
+	seam := NewRestoreSeam(e.Pool, NewDispatcher(NewProvider(e.Pool),
+		NewOverlayProvider(e.Pool, failClosedOverlayMeter(), nil), e.Pool),
+		deals.NewStore(e.DB(), DealsInstallation()))
+	entry, err := seam.Restore(e.Admin(), "deal", deal, auditID, currentVersion(t, e.Env, "deal", deal))
+	if err != nil {
+		t.Fatalf("putting a correction back through the generic restore route: %v — the receipt "+
+			"said this line was undoable, and pressing Undo must not disagree", err)
+	}
+	if entry.UndidAuditLogID == nil || *entry.UndidAuditLogID != auditID {
+		t.Errorf("the restore entry names %v as undone, want the correction's own audit row %s",
+			entry.UndidAuditLogID, auditID)
+	}
+
+	restored := e.readSwept(t, deal)
+	if restored.expectedClose == nil || !restored.expectedClose.Equal(wasClosing) {
+		t.Errorf("restored close date = %v, want the original %s",
+			restored.expectedClose, wasClosing.Format(time.DateOnly))
+	}
+
+	// A second Undo on the same route now finds the correction already
+	// reversed rather than falling into the generic evaluator a second time.
+	if _, err := seam.Restore(e.Admin(), "deal", deal, auditID, currentVersion(t, e.Env, "deal", deal)); err == nil {
+		t.Error("a second restore of an already-reversed correction succeeded")
 	}
 }
 

--- a/backend/internal/compose/edgereverserace_integration_test.go
+++ b/backend/internal/compose/edgereverserace_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/privacy"
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -34,7 +35,8 @@ import (
 // pool.
 func restoreSeamFor(e *integration.Env) RestoreSeam {
 	return NewRestoreSeam(e.Pool, NewDispatcher(NewProvider(e.Pool),
-		NewOverlayProvider(e.Pool, failClosedOverlayMeter(), nil), e.Pool))
+		NewOverlayProvider(e.Pool, failClosedOverlayMeter(), nil), e.Pool),
+		deals.NewStore(e.DB(), DealsInstallation()))
 }
 
 // reversalsOf counts the audit rows that name this entry as the one they put

--- a/backend/internal/compose/integration/autoapply_integration_test.go
+++ b/backend/internal/compose/integration/autoapply_integration_test.go
@@ -360,7 +360,7 @@ func TestAnAutomaticChangeCanBePutBack(t *testing.T) {
 	})
 	undoCtx = principal.WithCorrelationID(undoCtx, ids.NewV7())
 	seam := compose.NewRestoreSeam(e.Pool, compose.NewDispatcher(
-		compose.NewProvider(e.Pool), nil, e.Pool))
+		compose.NewProvider(e.Pool), nil, e.Pool), nil)
 	if _, err := seam.Restore(undoCtx, "organization", org, auditID, version); err != nil {
 		t.Fatalf("undoing what the product applied on its own: %v", err)
 	}

--- a/backend/internal/compose/recordrestore.go
+++ b/backend/internal/compose/recordrestore.go
@@ -91,8 +91,15 @@ func (s RestoreSeam) Restore(ctx context.Context, entityType string, id, auditID
 	// the receipt by: a machine correction has its own reversal, and the
 	// generic evaluator refuses exactly those rows (they write a field the
 	// ordinary update shape cannot spell), so asking it first would refuse
-	// every change the receipt just told the caller it could undo.
-	if entry, decided, err := s.reverseCorrection(ctx, entityType, id, row); err != nil || decided {
+	// every change the receipt just told the caller it could undo. ifVersion
+	// still travels all the way down to it: RevertCorrection's own per-field
+	// conflict check is deliberately looser than a whole-record pin (a rename
+	// leaves an undo of an unrelated date correction available — see
+	// deals/correctionrevert.go's own header), but it compares VALUES, not
+	// versions, so an unrelated field edited away and back to what the
+	// correction would itself produce needs the version pin to be caught at
+	// all.
+	if entry, decided, err := s.reverseCorrection(ctx, entityType, id, row, ifVersion); err != nil || decided {
 		return entry, err
 	}
 	patch, err := s.decide(ctx, row)
@@ -116,7 +123,7 @@ func (s RestoreSeam) Restore(ctx context.Context, entityType string, id, auditID
 // answered false here and decided by the generic evaluator below, same as
 // before this branch existed.
 func (s RestoreSeam) reverseCorrection(
-	ctx context.Context, entityType string, id ids.UUID, row AuditRow,
+	ctx context.Context, entityType string, id ids.UUID, row AuditRow, ifVersion int64,
 ) (privacy.RecordHistoryEntry, bool, error) {
 	if s.corrections == nil || row.EntityType != entityTypeDeal {
 		return privacy.RecordHistoryEntry{}, false, nil
@@ -133,14 +140,24 @@ func (s RestoreSeam) reverseCorrection(
 	if err != nil {
 		return privacy.RecordHistoryEntry{}, true, err
 	}
-	// The correction's own reversal path decides and writes in one
-	// transaction — its own row lock, not ifVersion, is what closes its
-	// decide/write gap, so ifVersion plays no part here. The evidence is what
-	// lets readRestoreEntry below find this write the same way it finds any
-	// other restore's: by the row it names as undone, not by which mechanism
-	// undid it.
-	if _, err := s.corrections.RevertCorrection(ctx, correction.ID,
+	// The same word judgeCorrection already offers the reader: a correction
+	// somebody else took back in the gap between the read and this write
+	// refuses the same way a page load after that reversal would have.
+	if correction.Reversed() {
+		return privacy.RecordHistoryEntry{}, true, RefusedRestore{Reason: ReasonAlreadyUndone}
+	}
+	if _, err := s.corrections.RevertCorrection(ctx, correction.ID, &ifVersion,
 		map[string]any{undidAuditLogID: row.ID.String()}); err != nil {
+		// RevertCorrection's own refusals (already reversed under its own
+		// lock, a later edit to a corrected field, or its audit row aged out
+		// of history) are a 409 on every other route this seam serves — the
+		// receipt read this line as undoable, so a plain 500 here would be a
+		// harder disagreement between the two than the refusal itself is.
+		var conflict *deals.CorrectionReversalError
+		if errors.As(err, &conflict) {
+			return privacy.RecordHistoryEntry{}, true,
+				RefusedRestore{Reason: ReasonNotRestorableByThisPath, Detail: conflict.Reason}
+		}
 		return privacy.RecordHistoryEntry{}, true, err
 	}
 	entry, err := s.readRestoreEntry(ctx, entityType, id, row.ID)

--- a/backend/internal/compose/recordrestore.go
+++ b/backend/internal/compose/recordrestore.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/privacy"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/httperr"
@@ -49,6 +50,14 @@ type RestoreSeam struct {
 	// edges performs a LINK's inverse. It is a port because `relationship` is the
 	// people module's table, and the rules an edge write obeys are that module's.
 	edges EdgeReverser
+	// corrections answers whether an audit row is a machine correction with its
+	// own reversal, and performs that reversal — the SAME store magicUndoJudge
+	// asks the identical question of, so the line offering an Undo and the
+	// write performing it can never name different rows undoable. Nil is a
+	// real state: an installation wired without it simply has no corrections
+	// to offer, and every row falls through to the generic evaluator below,
+	// exactly as it always has.
+	corrections *deals.Store
 	// afterEdgeDecision is entered between the binding edge decision and the edge
 	// write — the ONE window in which a second reverser of the same link can
 	// overtake this one. It exists so a test can hold the path open there, and it
@@ -78,6 +87,14 @@ func (s RestoreSeam) Restore(ctx context.Context, entityType string, id, auditID
 	if row.EntityType == edgeEntityType {
 		return s.reverseEdge(ctx, entityType, id, row, ifVersion)
 	}
+	// THE CORRECTION PATH FIRST, the same order magicUndoJudge.judgeOne reads
+	// the receipt by: a machine correction has its own reversal, and the
+	// generic evaluator refuses exactly those rows (they write a field the
+	// ordinary update shape cannot spell), so asking it first would refuse
+	// every change the receipt just told the caller it could undo.
+	if entry, decided, err := s.reverseCorrection(ctx, entityType, id, row); err != nil || decided {
+		return entry, err
+	}
 	patch, err := s.decide(ctx, row)
 	if err != nil {
 		return privacy.RecordHistoryEntry{}, err
@@ -86,6 +103,48 @@ func (s RestoreSeam) Restore(ctx context.Context, entityType string, id, auditID
 		return privacy.RecordHistoryEntry{}, err
 	}
 	return s.readRestoreEntry(ctx, entityType, id, auditID)
+}
+
+// reverseCorrection answers for an audit row that is a machine correction's
+// own entry, and reports whether it decided at all — false for every entry
+// this branch does not serve, so Restore falls through to the generic
+// evaluator exactly as it always has.
+//
+// The lookup asks the SAME question magicUndoJudge.judgeCorrection asks of
+// the SAME store: a deal-scoped row with a live deal_correction naming it.
+// Anything else — a person, an organization, a deal edit a human made — is
+// answered false here and decided by the generic evaluator below, same as
+// before this branch existed.
+func (s RestoreSeam) reverseCorrection(
+	ctx context.Context, entityType string, id ids.UUID, row AuditRow,
+) (privacy.RecordHistoryEntry, bool, error) {
+	if s.corrections == nil || row.EntityType != entityTypeDeal {
+		return privacy.RecordHistoryEntry{}, false, nil
+	}
+	var correction deals.DealCorrection
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		var err error
+		correction, err = s.corrections.CorrectionForAudit(ctx, tx, row.ID)
+		return err
+	})
+	if errors.Is(err, apperrors.ErrNotFound) {
+		return privacy.RecordHistoryEntry{}, false, nil
+	}
+	if err != nil {
+		return privacy.RecordHistoryEntry{}, true, err
+	}
+	// The correction's own reversal path decides and writes in one
+	// transaction — its own row lock, not ifVersion, is what closes its
+	// decide/write gap, so ifVersion plays no part here. The evidence is what
+	// lets readRestoreEntry below find this write the same way it finds any
+	// other restore's: by the row it names as undone, not by which mechanism
+	// undid it.
+	if _, err := s.corrections.RevertCorrection(ctx, correction.ID,
+		map[string]any{undidAuditLogID: row.ID.String()}); err != nil {
+		return privacy.RecordHistoryEntry{}, true, err
+	}
+	entry, err := s.readRestoreEntry(ctx, entityType, id, row.ID)
+	return entry, true, err
 }
 
 // readRow loads the target entry — an entry of the path record's HISTORY, which

--- a/backend/internal/compose/recordrestoredate_integration_test.go
+++ b/backend/internal/compose/recordrestoredate_integration_test.go
@@ -55,7 +55,7 @@ func TestADateFieldGoesBackWhereItWas(t *testing.T) {
 	entry := latestAuditRowID(t, e, "deal", id, "update")
 
 	seam := NewRestoreSeam(e.Pool, NewDispatcher(NewProvider(e.Pool),
-		NewOverlayProvider(e.Pool, failClosedOverlayMeter(), nil), e.Pool))
+		NewOverlayProvider(e.Pool, failClosedOverlayMeter(), nil), e.Pool), nil)
 	if _, err := seam.Restore(ctx, "deal", id, entry, currentVersion(t, e, "deal", id)); err != nil {
 		t.Fatalf("putting the close date back answered %v — nothing moved under it, "+
 			"the audit image and the live row are just spelling the same day differently", err)

--- a/backend/internal/compose/recordrestoremoney_integration_test.go
+++ b/backend/internal/compose/recordrestoremoney_integration_test.go
@@ -58,7 +58,7 @@ func TestAnAmountRestoreIsRefusedWhenTheCurrencyMovedUnderIt(t *testing.T) {
 	}
 
 	seam := NewRestoreSeam(e.Pool, NewDispatcher(NewProvider(e.Pool),
-		NewOverlayProvider(e.Pool, failClosedOverlayMeter(), nil), e.Pool))
+		NewOverlayProvider(e.Pool, failClosedOverlayMeter(), nil), e.Pool), nil)
 	_, err = seam.Restore(ctx, "deal", id, entry, currentVersion(t, e, "deal", id))
 
 	var refusal RefusedRestore

--- a/backend/internal/compose/recordrestoreseam.go
+++ b/backend/internal/compose/recordrestoreseam.go
@@ -27,16 +27,21 @@ import (
 
 // NewRestoreSeam assembles the reversal executor over the installation pool and
 // the update dispatcher, with the evaluator's ports bound to the real readers.
-func NewRestoreSeam(pool *pgxpool.Pool, dispatcher *Dispatcher) RestoreSeam {
+//
+// corrections is nil-safe: an installation wired without it simply offers no
+// correction-aware reversal, every row falling through to the generic
+// evaluator exactly as before this seam knew corrections existed.
+func NewRestoreSeam(pool *pgxpool.Pool, dispatcher *Dispatcher, corrections *deals.Store) RestoreSeam {
 	// The edge's rules are the people module's, and so is its table. This seam
 	// reaches them through that module's own store rather than restating any of
 	// them, which is also why it owns no relationship SQL.
 	edges := people.NewStore(InstallationDB(pool))
 	return RestoreSeam{
-		pool:       pool,
-		dispatcher: dispatcher,
-		visible:    recordIsVisibleToCaller,
-		edges:      edges,
+		pool:        pool,
+		dispatcher:  dispatcher,
+		visible:     recordIsVisibleToCaller,
+		edges:       edges,
+		corrections: corrections,
 		evaluator: Evaluator{
 			Archived:      recordIsArchived,
 			Writable:      recordIsWritableByCaller,
@@ -146,6 +151,11 @@ func edgeIsWritableByCaller(edges *people.Store) func(context.Context, pgx.Tx, p
 // entityTypeActivity is the record kind whose row-scope checks dispatch
 // differently, named rather than typed inline at the branch above.
 const entityTypeActivity = "activity"
+
+// entityTypeDeal is the record kind a machine correction is always about —
+// deals.DealCorrection has no other subject today, so reverseCorrection
+// filters an audit row on it before asking the corrections store anything.
+const entityTypeDeal = "deal"
 
 // rowIsBehindTheErasureBoundary reuses privacy's own boundary predicate rather
 // than restating it. An Art. 17 erasure is one of the few rules where a second
@@ -263,7 +273,14 @@ var _ privacy.ChangeRestorer = RestoreSeam{}
 // makes — and two answers to that question is what the dispatcher exists to
 // prevent.
 func (s *Server) wireReversal(pool *pgxpool.Pool) {
-	seam := NewRestoreSeam(pool, s.sorDispatch)
+	// ONE instance, given to the seam that WRITES a reversal and to the judge
+	// that READS whether one is offered — the same reason the seam itself is
+	// shared below. Two separately constructed stores would still ask the
+	// database the same question, but a future difference between them (a
+	// second gate, a second cache) is exactly the kind of drift this line
+	// exists to make impossible rather than merely unlikely.
+	corrections := deals.NewStore(InstallationDB(pool), DealsInstallation())
+	seam := NewRestoreSeam(pool, s.sorDispatch, corrections)
 	s.privacyHandlers = s.privacyHandlers.
 		WithChangeRestorer(seam).
 		WithUndoabilityReader(NewUndoabilityPage(seam))
@@ -283,6 +300,6 @@ func (s *Server) wireReversal(pool *pgxpool.Pool) {
 		// The corrections store is what lets a machine close-date change read
 		// as undoable at all: the generic evaluator refuses exactly those rows,
 		// because they write a field the ordinary update shape cannot spell.
-		corrections: deals.NewStore(InstallationDB(pool), DealsInstallation()),
+		corrections: corrections,
 	})
 }

--- a/backend/internal/modules/deals/correctionrevert.go
+++ b/backend/internal/modules/deals/correctionrevert.go
@@ -77,8 +77,14 @@ func (e *CorrectionReversalError) Error() string { return e.Reason }
 // apart, a failure between them leaves the deal restored while the correction
 // still reads live, and the next sweep would take the reversal for a fresh
 // correction to repeat.
+//
+// evidence rides straight into the reversal's own audit row (nil is fine — it
+// is operational context ABOUT the write, not a fact this store has an opinion
+// on). A caller reversing this on a reader's behalf, rather than redoing the
+// module's own record of what it did, is what lets that reader's read and this
+// write agree on which audit row the result belongs to.
 func (s *Store) RevertCorrection(
-	ctx context.Context, correctionID ids.UUID,
+	ctx context.Context, correctionID ids.UUID, evidence map[string]any,
 ) (crmcontracts.Deal, error) {
 	if err := auth.Require(ctx, "deal", principal.ActionUpdate); err != nil {
 		return crmcontracts.Deal{}, err
@@ -108,7 +114,7 @@ func (s *Store) RevertCorrection(
 		if correction.Reversed() {
 			return &CorrectionReversalError{Reason: alreadyTakenBack}
 		}
-		if err := s.restoreCorrectedFields(ctx, tx, correction); err != nil {
+		if err := s.restoreCorrectedFields(ctx, tx, correction, evidence); err != nil {
 			return err
 		}
 		// Read inside the transaction that just took write authority on this
@@ -126,7 +132,7 @@ func (s *Store) RevertCorrection(
 //
 // Split from RevertCorrection so each function holds one question: that one
 // decides WHETHER this correction may be taken back, this one performs it.
-func (s *Store) restoreCorrectedFields(ctx context.Context, tx pgx.Tx, correction DealCorrection) error {
+func (s *Store) restoreCorrectedFields(ctx context.Context, tx pgx.Tx, correction DealCorrection, evidence map[string]any) error {
 	before, err := priorImage(ctx, tx, correction)
 	if err != nil {
 		return err
@@ -148,8 +154,8 @@ func (s *Store) restoreCorrectedFields(ctx context.Context, tx pgx.Tx, correctio
 	if err := applyDealPatchLocked(ctx, tx, patch, lock); err != nil {
 		return fmt.Errorf("restore the corrected fields: %w", err)
 	}
-	auditID, err := storekit.Audit(ctx, tx, "update", "deal",
-		correction.DealID.UUID, patch.Before(), patch.After())
+	auditID, err := storekit.AuditWithEvidence(ctx, tx, "update", "deal",
+		correction.DealID.UUID, patch.Before(), patch.After(), evidence)
 	if err != nil {
 		return fmt.Errorf("audit the reversal: %w", err)
 	}

--- a/backend/internal/modules/deals/correctionrevert.go
+++ b/backend/internal/modules/deals/correctionrevert.go
@@ -83,8 +83,20 @@ func (e *CorrectionReversalError) Error() string { return e.Reason }
 // on). A caller reversing this on a reader's behalf, rather than redoing the
 // module's own record of what it did, is what lets that reader's read and this
 // write agree on which audit row the result belongs to.
+//
+// ifVersion is the deal's last-seen version, checked under the row lock below
+// (nil skips the check — a caller with no client-observed version to pin, the
+// same posture ClaimDeal/ArchiveDeal/UpdateDeal already take). It is a
+// different guard from buildReversalPatch's own per-field conflict check
+// below, and both matter: the per-field check is what lets a rename between
+// read and Undo through while a re-date does not (deliberate — see this
+// file's own header), but it compares VALUES, and an unrelated field edited
+// away and back to the value the correction itself would produce reads as no
+// conflict at all under a value-only compare — an ABA gap a monotonic version
+// pin closes because it does not care what the value became, only that it
+// moved.
 func (s *Store) RevertCorrection(
-	ctx context.Context, correctionID ids.UUID, evidence map[string]any,
+	ctx context.Context, correctionID ids.UUID, ifVersion *int64, evidence map[string]any,
 ) (crmcontracts.Deal, error) {
 	if err := auth.Require(ctx, "deal", principal.ActionUpdate); err != nil {
 		return crmcontracts.Deal{}, err
@@ -114,7 +126,7 @@ func (s *Store) RevertCorrection(
 		if correction.Reversed() {
 			return &CorrectionReversalError{Reason: alreadyTakenBack}
 		}
-		if err := s.restoreCorrectedFields(ctx, tx, correction, evidence); err != nil {
+		if err := s.restoreCorrectedFields(ctx, tx, correction, ifVersion, evidence); err != nil {
 			return err
 		}
 		// Read inside the transaction that just took write authority on this
@@ -132,7 +144,9 @@ func (s *Store) RevertCorrection(
 //
 // Split from RevertCorrection so each function holds one question: that one
 // decides WHETHER this correction may be taken back, this one performs it.
-func (s *Store) restoreCorrectedFields(ctx context.Context, tx pgx.Tx, correction DealCorrection, evidence map[string]any) error {
+func (s *Store) restoreCorrectedFields(
+	ctx context.Context, tx pgx.Tx, correction DealCorrection, ifVersion *int64, evidence map[string]any,
+) error {
 	before, err := priorImage(ctx, tx, correction)
 	if err != nil {
 		return err
@@ -140,6 +154,23 @@ func (s *Store) restoreCorrectedFields(ctx context.Context, tx pgx.Tx, correctio
 	lock, err := storekit.LockRow(ctx, tx, dealTable, correction.DealID.UUID, storekit.LiveOnly)
 	if err != nil {
 		return err
+	}
+	// UNDER THE LOCK, not before it: a version read taken earlier could still
+	// see a value RevertCorrection's own caller never observed, between that
+	// read and this one acquiring the row. ifVersion is a fact about VERSION,
+	// not about any field's value, so it is what closes the ABA gap the
+	// per-field conflict check below cannot — a field edited away and back to
+	// the exact value this correction would also produce compares equal there
+	// and would otherwise pass unnoticed.
+	if ifVersion != nil {
+		var version int64
+		if err := tx.QueryRow(ctx, `SELECT version FROM `+dealTable+` WHERE id = $1`,
+			correction.DealID.UUID).Scan(&version); err != nil {
+			return fmt.Errorf("read the deal's version to check against If-Match: %w", err)
+		}
+		if version != *ifVersion {
+			return apperrors.ErrVersionSkew
+		}
 	}
 	patch := storekit.NewPatch()
 	if err := s.buildReversalPatch(ctx, tx, correction, before, patch); err != nil {


### PR DESCRIPTION
## Summary

margince#5060 — the "magic" undo receipt (`magicUndoJudge`) reads `undoable: true` for an unreversed machine close-date correction by checking `deals.Store.CorrectionForAudit` **before** falling back to a generic evaluator. But the actual restore route (`RestoreSeam.Restore` — what the receipt's `AuditId` is what a real client's Undo control actually sends to) only ever asked the generic evaluator, which explicitly refuses a correction's own audit row (it writes `close_date_provisional`, a field the ordinary update shape cannot spell). Pressing the Undo the receipt offered refused every time with `409 not_restorable_by_this_path` — confirmed live on two different deals, two different owning seats, per the original report.

`deals.RevertCorrection` (the correction-aware reversal) already existed, worked, and had its own integration suite — but had **zero production callers anywhere in the tree**. `RestoreSeam` now asks the same question `magicUndoJudge` already asks, of the same `*deals.Store` instance (`wireReversal` now constructs one and hands it to both, instead of building two), and dispatches to `RevertCorrection` before the generic evaluator ever runs — mirroring the read side's own "correction path first" order.

## Review

Reviewed by both Fable and Codex before push; both converged on real, distinct findings, all fixed and mutation-tested in a follow-up commit:

- **BLOCKER (Fable)**: `deals.CorrectionReversalError` implements no `Unwrap`, so `httperr.Classify` never recognized it — every refusal from the correction branch (already reversed, a later field edit) fell to a raw `500`, a *harder* disagreement with the receipt than the original bug. Fixed: translated into `RefusedRestore` with the matching `Reason` word (`ReasonAlreadyUndone` / `ReasonNotRestorableByThisPath`), so it's a `409` like every other refusal on this route.
- **MAJOR (both)**: `ifVersion` was silently discarded on the correction branch. Codex's review produced a concrete ABA scenario: an unrelated field edited away and back to the exact value the correction's own after-image holds compares equal under the existing per-field VALUE check, so a stale caller's restore would pass unnoticed — where the generic path's version pin would have caught it. Fixed: `RevertCorrection` now takes `ifVersion *int64`, checked under the deal's own row lock as a pure version comparison, kept deliberately separate from the per-field check (the two guard different things — a rename must pass where a re-date must not, *and* a value round-trip must still be caught by a version that moved).
- **MAJOR (Fable)**: the original "second Undo" test assertion (`err == nil` check) passed against a `500` as readily as a `409` — proved nothing about the fix. Tightened to assert the specific `Reason` and wire status.

## Scope notes

- No AI prompt content changed, no aicert re-run needed.
- No UAT video — this is a backend write-path fix behind an existing frontend control; the integration tests below (through the real `RestoreSeam.Restore`, not `RevertCorrection` called directly) are the equivalent proof, and are stronger evidence for a race/version-skew case than a screen recording would be.
- `deals.RevertCorrection`'s signature changed (`ifVersion *int64`, `evidence map[string]any` added) — safe, since it had no other caller before this diff.

## Test plan

- [x] `TestTheGenericRestoreRouteHonorsACorrectionTheReceiptOffersUndoOn` — the write-side half of the existing `TestTheReceiptOffersUndoOnARealCorrection`: drives the real `RestoreSeam.Restore` (not `RevertCorrection` directly) with the receipt's own audit id, asserts the deal is actually restored and the resulting history entry names the right undone row
- [x] `TestTheGenericRestoreRouteRefusesACorrectionOverwrittenByALaterEdit` — a real per-field conflict, reached through the seam, is a `409` with the right `Reason`, not a `500`
- [x] `TestTheGenericRestoreRouteRefusesAStaleVersionOnACorrection` — an unrelated field edit bumping the deal's version is refused with `ErrVersionSkew` even though the corrected field itself is untouched
- [x] Tightened second-Undo assertion — same reason word and wire status every other refusal on this route carries
- [x] All of the above mutation-tested: reverted the correction dispatch (red — reproduces the original `409 not_restorable_by_this_path` bug verbatim), removed the error translation (red — raw `CorrectionReversalError` text surfaces instead of a `RefusedRestore`), removed the version check (red — a stale restore silently succeeds); each restores clean
- [x] Full existing `correctionrevert_integration_test.go` suite and `recordrestoredate_integration_test.go` green — no regression
- [x] `make check-go` green (build, vet, lint, arch-lint, unit + fitness tests, contract drift) on the rebased branch
- [x] `make test-it DIR=backend/internal/compose` (full package, 118s) and `DIR=backend/internal/modules/deals` green against real Postgres
- [x] Pre-push `craft static --strict` — 0 blocker/major/minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRuXiSKkD1X1D1U5yRF4Qn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The restore route now reverses a machine correction when the receipt's Undo is pressed, instead of refusing every time with `409 not_restorable_by_this_path`.

- Routes correction audit rows to `deals.RevertCorrection`, which existed and worked but had no production caller.
- `RevertCorrection` takes an `ifVersion` and writes `undid_audit_log_id` evidence; safe since it had no other callers.
- Correction refusals map to `RefusedRestore` 409s instead of raw 500s.
- The version pin closes an ABA gap where an unrelated field round-trip could let a stale restore pass.

<sup>Written for commit cd701923f0481520540f300ae516ba74cffcd911. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

