### PR TITLE
Every set-bearing refusal bounds its caller token, and echoSafe escapes what does not print

### DIFF
--- a/backend/internal/compose/analyticsquery/ir.go
+++ b/backend/internal/compose/analyticsquery/ir.go
@@ -212,7 +212,7 @@ func validateMeasures(entity Entity, measures []Measure) error {
 		if _, known := knownAggregates[m.Fn]; !known {
 			return &RefusalError{
 				Kind:    RefusalUnsupported,
-				Message: fmt.Sprintf("no aggregate named %q", m.Fn),
+				Message: fmt.Sprintf("no aggregate named %s", httperr.QuoteCaller(string(m.Fn))),
 				Suggest: "use one of: " + strings.Join(AggregateNames(), ", "),
 			}
 		}
@@ -224,7 +224,7 @@ func validateMeasures(entity Entity, measures []Measure) error {
 				return &RefusalError{
 					Kind:    RefusalInvalid,
 					Message: "count takes no field; it counts rows",
-					Suggest: fmt.Sprintf("use count_distinct on %q to count values", m.Field),
+					Suggest: fmt.Sprintf("use count_distinct on %s to count values", httperr.QuoteCaller(m.Field)),
 				}
 			}
 			continue
@@ -236,7 +236,7 @@ func validateMeasures(entity Entity, measures []Measure) error {
 		if numericAggregates[m.Fn] && field.Kind != KindMeasure {
 			return &RefusalError{
 				Kind:    RefusalInvalid,
-				Message: fmt.Sprintf("%s over %q, which is a %s", m.Fn, m.Field, field.Kind),
+				Message: fmt.Sprintf("%s over %s, which is a %s", m.Fn, httperr.QuoteCaller(m.Field), field.Kind),
 				Suggest: fmt.Sprintf("%s one of: %s", m.Fn,
 					strings.Join(entity.FieldNames(KindMeasure), ", ")),
 			}
@@ -270,7 +270,7 @@ func validateAliases(q Query) error {
 			if name == reserved {
 				return &RefusalError{
 					Kind:    RefusalInvalid,
-					Message: fmt.Sprintf("%q is the engine's own column", name),
+					Message: fmt.Sprintf("%s is the engine's own column", httperr.QuoteCaller(name)),
 					Suggest: "name the result something else",
 				}
 			}
@@ -278,7 +278,7 @@ func validateAliases(q Query) error {
 		if seen[name] {
 			return &RefusalError{
 				Kind:    RefusalInvalid,
-				Message: fmt.Sprintf("two result columns would both be called %q", name),
+				Message: fmt.Sprintf("two result columns would both be called %s", httperr.QuoteCaller(name)),
 				Suggest: "give each measure its own name",
 			}
 		}
@@ -305,7 +305,7 @@ func validateFilters(entity Entity, filters []Filter) error {
 		if _, ok := filterSQL[f.Op]; !ok {
 			return &RefusalError{
 				Kind:    RefusalUnsupported,
-				Message: fmt.Sprintf("no comparison named %q", f.Op),
+				Message: fmt.Sprintf("no comparison named %s", httperr.QuoteCaller(string(f.Op))),
 				Suggest: "use one of: " + strings.Join(FilterOpNames(), ", "),
 			}
 		}
@@ -316,8 +316,8 @@ func validateFilters(entity Entity, filters []Filter) error {
 			return &RefusalError{
 				Kind: RefusalInvalid,
 				Message: fmt.Sprintf(
-					"%s on %q was given the wrong shape: %s takes %s",
-					f.Op, f.Field, f.Op, valueShape(f.Op)),
+					"%s on %s was given the wrong shape: %s takes %s",
+					f.Op, httperr.QuoteCaller(f.Field), f.Op, valueShape(f.Op)),
 				Suggest: "drop the value, or use a comparison that takes one",
 			}
 		}

--- a/backend/internal/compose/closedsetrefusalbudget_test.go
+++ b/backend/internal/compose/closedsetrefusalbudget_test.go
@@ -3,23 +3,34 @@
 
 package compose
 
-// A refusal that names a closed set must be able to DELIVER that set.
+// A refusal that names a closed set must be able to DELIVER that set, and a
+// caller must not be able to push it out.
 //
-// The tool surface bounds what a refusal may say (agents.MaxFaultDetail),
-// because the text lands in a transcript whose later prompts the same model
-// reads. Every vocabulary this file measures is refused against by naming the
-// whole set, and each grew independently of that bound — so the two agree only
-// while somebody checks, and this is the check.
+// The tool surface bounds what a refusal may say, because the text lands in a
+// transcript whose later prompts the same model reads. Every vocabulary below is
+// refused against by naming the whole set, and each grew independently of that
+// bound — so the two agree only while somebody checks.
 //
-// The defect it exists for: the bound was the figure sized for a bad-args echo,
-// and the sets were measured against it and lost. A report's block grammar never
-// reached a caller at all, and the analytics populations arrived cut mid-name —
-// which is worse than absent, because a truncated list reads as a complete one
-// and a caller stops looking for the entry that was removed.
+// TWO DEFECTS THIS HOLDS, both of which shipped:
 //
-// The corpus is DERIVED from the producers rather than listed here. A listed one
-// would pass while a fifteenth block kind or a thirteenth population went
-// unmeasured, which is the census that fails short.
+// The bound was the figure sized for a bad-args echo, and the sets were measured
+// against it and lost. A report's block grammar never reached a caller at all,
+// and the analytics populations arrived cut mid-name — worse than absent,
+// because a truncated list reads as a complete one and a caller stops looking
+// for the entry that was removed.
+//
+// And the first pass of this census was itself hand-listed while claiming to be
+// derived. It named four subjects and there were more, so it reported PASS over
+// the aggregates, the comparison operators and the report field vocabularies —
+// three of which were still echoing an unbounded caller token in front of their
+// set. A census that can fail short has already failed, so the subjects are
+// enumerated from the exported producers and each one asserts it is non-empty.
+//
+// IT ASSERTS ON THE CLASSIFIED FAULT, not on err.Error(). The renderer is not
+// the only ceiling: httperr bounds a module-declared fault at MaxFaultText
+// BEFORE the renderer is reached, so a MessageFault-bearing vocabulary is cut at
+// the smaller figure and a test measuring the raw error would never see it.
+// Asking httperr.Classify is asking the surface rather than a model of it.
 
 import (
 	"maps"
@@ -30,23 +41,26 @@ import (
 	"github.com/margince/margince/backend/internal/compose/analyticsquery"
 	"github.com/margince/margince/backend/internal/compose/reportdoc"
 	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/platform/httperr"
 )
 
-// floodedToken is what a caller sends when the refusal's budget is the thing
-// under attack: far past any bound, so a producer that does not bound its echo
-// leaves nothing for the set.
-var floodedToken = strings.Repeat("k", 4000)
+// floodedCallerToken is what a caller sends when the refusal's budget is the
+// thing under attack: far past any bound, so a producer that does not bound its
+// echo leaves nothing for the set.
+const floodedCallerTokenLen = 4000
 
-// setBearingRefusal is one vocabulary, the refusal that names it, and the way
-// to provoke that refusal with a token of the caller's choosing.
+func floodedCallerToken() string { return strings.Repeat("k", floodedCallerTokenLen) }
+
+// setBearingRefusal is one vocabulary, the refusal that names it, and the way to
+// provoke that refusal with a token of the caller's choosing.
 type setBearingRefusal struct {
 	what    string
 	members []string
 	refuse  func(token string) error
 }
 
-// closedSetRefusals derives every set-bearing refusal the tool surface can
-// answer with, by asking the producers themselves rather than restating them.
+// closedSetRefusals enumerates every set-bearing refusal this surface can answer
+// with, taking each vocabulary from the producer that owns it.
 func closedSetRefusals(t *testing.T) []setBearingRefusal {
 	t.Helper()
 
@@ -57,11 +71,12 @@ func closedSetRefusals(t *testing.T) []setBearingRefusal {
 	if len(schema.Entities) == 0 {
 		t.Fatal("the derived analytics schema is empty, so this census measures nothing")
 	}
-
-	pipeline, ok := schema.Entities["pipeline-current"]
+	const entity = "pipeline-current"
+	pipeline, ok := schema.Entities[entity]
 	if !ok {
-		t.Fatal("pipeline-current is absent from the widest schema; this census needs a real entity")
+		t.Fatalf("%s is absent from the widest schema; this census needs a real entity", entity)
 	}
+	measure := analyticsquery.Measure{Fn: analyticsquery.Sum, Field: "amount_base_minor"}
 
 	return []setBearingRefusal{
 		{
@@ -75,12 +90,26 @@ func closedSetRefusals(t *testing.T) []setBearingRefusal {
 			},
 		},
 		{
+			what:    "report block severities",
+			members: reportdoc.Severities(),
+			refuse: func(token string) error {
+				_, err := reportdoc.Validate(reportdoc.Document{
+					Blocks: []reportdoc.Block{{
+						Kind:     reportdoc.KindCallout,
+						Text:     "a callout states its severity",
+						Severity: reportdoc.Severity(token),
+					}},
+				})
+				return err
+			},
+		},
+		{
 			what:    "analytics populations",
 			members: schema.EntityNames(),
 			refuse: func(token string) error {
 				return analyticsquery.Query{
 					Entity:   token,
-					Measures: []analyticsquery.Measure{{Fn: analyticsquery.Sum, Field: "amount_base_minor"}},
+					Measures: []analyticsquery.Measure{measure},
 				}.Validate(schema)
 			},
 		},
@@ -89,9 +118,44 @@ func closedSetRefusals(t *testing.T) []setBearingRefusal {
 			members: pipeline.FieldNames(analyticsquery.KindDimension),
 			refuse: func(token string) error {
 				return analyticsquery.Query{
-					Entity:   "pipeline-current",
+					Entity:   entity,
 					GroupBy:  []string{token},
-					Measures: []analyticsquery.Measure{{Fn: analyticsquery.Sum, Field: "amount_base_minor"}},
+					Measures: []analyticsquery.Measure{measure},
+				}.Validate(schema)
+			},
+		},
+		{
+			what:    "the measures of one population",
+			members: pipeline.FieldNames(analyticsquery.KindMeasure),
+			refuse: func(token string) error {
+				return analyticsquery.Query{
+					Entity:   entity,
+					Measures: []analyticsquery.Measure{{Fn: analyticsquery.Sum, Field: token}},
+				}.Validate(schema)
+			},
+		},
+		{
+			what:    "analytics aggregates",
+			members: analyticsquery.AggregateNames(),
+			refuse: func(token string) error {
+				return analyticsquery.Query{
+					Entity: entity,
+					Measures: []analyticsquery.Measure{
+						{Fn: analyticsquery.AggFn(token), Field: "amount_base_minor"},
+					},
+				}.Validate(schema)
+			},
+		},
+		{
+			what:    "analytics comparison operators",
+			members: analyticsquery.FilterOpNames(),
+			refuse: func(token string) error {
+				return analyticsquery.Query{
+					Entity:   entity,
+					Measures: []analyticsquery.Measure{measure},
+					Filters: []analyticsquery.Filter{
+						{Field: "currency", Op: analyticsquery.FilterOp(token), Value: "EUR"},
+					},
 				}.Validate(schema)
 			},
 		},
@@ -105,6 +169,20 @@ func closedSetRefusals(t *testing.T) []setBearingRefusal {
 			refuse: func(token string) error {
 				_, err := (&reportEngine{}).Run(seatWith("deal"), token, reportRequest{})
 				return err
+			},
+		},
+		{
+			// A MessageFault, so httperr caps it at MaxFaultText before the
+			// renderer is reached. This is the subject the first census could not
+			// see, and the one whose set was being destroyed outright.
+			what:    "the dimensions of one prebuilt report",
+			members: allowedReportNames(prebuiltReports["deals-by-stage"].dimensions),
+			refuse: func(token string) error {
+				return &FieldNotAllowedError{
+					Field:   token,
+					Slot:    slotGroupBy,
+					Allowed: allowedReportNames(prebuiltReports["deals-by-stage"].dimensions),
+				}
 			},
 		},
 	}
@@ -121,15 +199,12 @@ func TestEveryClosedSetSurvivesTheToolSurface(t *testing.T) {
 				t.Fatalf("%s came back empty, so this case measures nothing", subject.what)
 			}
 
-			err := subject.refuse("a-name-nothing-serves")
-			if err == nil {
-				t.Fatalf("%s admitted a name it does not serve, so no refusal names the set", subject.what)
-			}
-			detail := err.Error()
+			detail := classifiedDetail(t, subject, "a-name-nothing-serves")
 
 			if len(detail) > agents.MaxFaultDetail {
-				t.Errorf("the %s refusal is %d bytes and the tool surface admits %d, so the set is cut "+
-					"before a caller reads it:\n%s", subject.what, len(detail), agents.MaxFaultDetail, detail)
+				t.Errorf("the %s refusal is %d bytes and the tool surface admits %d, so the set is "+
+					"cut before a caller reads it:\n%s",
+					subject.what, len(detail), agents.MaxFaultDetail, detail)
 			}
 			for _, member := range subject.members {
 				if !strings.Contains(detail, member) {
@@ -150,16 +225,16 @@ func TestACallersTokenCannotCrowdOutTheSet(t *testing.T) {
 	for _, subject := range closedSetRefusals(t) {
 		t.Run(subject.what, func(t *testing.T) {
 			t.Parallel()
-			err := subject.refuse(floodedToken)
-			if err == nil {
-				t.Fatalf("%s admitted a 4000-byte name", subject.what)
-			}
-			detail := err.Error()
+			detail := classifiedDetail(t, subject, floodedCallerToken())
 
 			if len(detail) > agents.MaxFaultDetail {
 				t.Errorf("a caller's oversized name pushed the %s refusal to %d bytes, past the %d "+
 					"the surface admits — so the token is not bounded where it enters",
 					subject.what, len(detail), agents.MaxFaultDetail)
+			}
+			if strings.Contains(detail, strings.Repeat("k", httperr.MaxCallerToken+1)) {
+				t.Errorf("the %s refusal echoed more of the caller's token than MaxCallerToken (%d) "+
+					"admits:\n%s", subject.what, httperr.MaxCallerToken, detail)
 			}
 			for _, member := range subject.members {
 				if !strings.Contains(detail, member) {
@@ -169,4 +244,40 @@ func TestACallersTokenCannotCrowdOutTheSet(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEveryClosedSetMemberFitsTheCallerTokenBound holds the sentence that
+// justifies MaxCallerToken's figure — "every name in every closed vocabulary is
+// comfortably inside it" — which was a claim with nothing behind it. A member
+// longer than the bound would be truncated when a caller named it back, so the
+// refusal would quote a name that matches nothing in the set beside it.
+func TestEveryClosedSetMemberFitsTheCallerTokenBound(t *testing.T) {
+	t.Parallel()
+	for _, subject := range closedSetRefusals(t) {
+		for _, member := range subject.members {
+			if rendered := httperr.QuoteCaller(member); strings.Contains(rendered, "…") {
+				t.Errorf("%s: %q is longer than MaxCallerToken (%d), so a caller naming it back "+
+					"is quoted a name that is in no set: %s",
+					subject.what, member, httperr.MaxCallerToken, rendered)
+			}
+		}
+	}
+}
+
+// classifiedDetail asks the ONE taxonomy what a caller is told, rather than
+// reading Error() and hoping the two agree. httperr bounds a module-declared
+// fault before any renderer sees it, so this is where a ceiling smaller than the
+// renderer's becomes visible.
+func classifiedDetail(t *testing.T, subject setBearingRefusal, token string) string {
+	t.Helper()
+	err := subject.refuse(token)
+	if err == nil {
+		t.Fatalf("%s admitted a name it does not serve, so no refusal names the set", subject.what)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("%s refused with an error the taxonomy does not classify, so an agent is told "+
+			"nothing actionable: %v", subject.what, err)
+	}
+	return fault.Detail
 }

--- a/backend/internal/compose/reportcatalog.go
+++ b/backend/internal/compose/reportcatalog.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
 
@@ -125,7 +126,7 @@ func (e *reportEngine) Run(ctx context.Context, report string, req reportRequest
 	if uuidShape.MatchString(report) {
 		// Saved reports are a later slice; an unknown id is absent, not
 		// half-supported.
-		return reportOutcome{}, fmt.Errorf("saved report %s: %w", report, apperrors.ErrNotFound)
+		return reportOutcome{}, fmt.Errorf("saved report %s: %w", httperr.QuoteCaller(report), apperrors.ErrNotFound)
 	}
 	spec, ok := prebuiltReports[report]
 	if !ok {
@@ -154,7 +155,12 @@ func unservedPlanArguments(planArgs json.RawMessage) []string {
 	var unserved []string
 	for key := range keys {
 		if !servedPlanArguments[key] {
-			unserved = append(unserved, "`"+key+"`")
+			// The key is the CALLER's, quoted and bounded where it enters. It
+			// reaches an agent spliced into a refusal that goes on to name the
+			// arguments this tool DOES take, and a raw one arrived able to both
+			// push that list out and carry a character the transcript reads as
+			// a line ending.
+			unserved = append(unserved, httperr.QuoteCaller(key))
 		}
 	}
 	slices.Sort(unserved)

--- a/backend/internal/compose/reportdoc/validate.go
+++ b/backend/internal/compose/reportdoc/validate.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -156,8 +157,9 @@ func checkSeverity(b Block, where string) error {
 	}
 	if !b.Severity.known() {
 		return &InvalidError{
-			Where:  where,
-			Reason: fmt.Sprintf("no such severity %q", b.Severity),
+			Where: where,
+			Reason: fmt.Sprintf("no such severity %s. The severities are: %s",
+				httperr.QuoteCaller(string(b.Severity)), strings.Join(Severities(), ", ")),
 		}
 	}
 	return nil

--- a/backend/internal/compose/reporterrors.go
+++ b/backend/internal/compose/reporterrors.go
@@ -56,9 +56,9 @@ type FieldNotAllowedError struct {
 
 func (e *FieldNotAllowedError) Error() string {
 	if e.Slot == "" {
-		return fmt.Sprintf("report: field %q is outside this report's vocabulary", e.Field)
+		return fmt.Sprintf("report: field %s is outside this report's vocabulary", httperr.QuoteCaller(e.Field))
 	}
-	return fmt.Sprintf("report: this report's `%s` does not accept %q", e.Slot, e.Field)
+	return fmt.Sprintf("report: this report's `%s` does not accept %s", e.Slot, httperr.QuoteCaller(e.Field))
 }
 
 // MessageFault carries the 422 verdict on the error itself, so the ONE taxonomy
@@ -142,8 +142,8 @@ type FilterValueNotAllowedError struct {
 }
 
 func (e *FilterValueNotAllowedError) Error() string {
-	return fmt.Sprintf("report: this report's `%s` cannot compare %s against %q",
-		slotFilters, e.Kind, e.Filter)
+	return fmt.Sprintf("report: this report's `%s` cannot compare %s against %s",
+		slotFilters, e.Kind, httperr.QuoteCaller(e.Filter))
 }
 
 // MessageFault reuses the contract's one declared 422 code, for the reason
@@ -240,7 +240,8 @@ func (e *EmptyReportPlanError) MessageFault() (code, message string) {
 type ReservedAliasError struct{ Alias string }
 
 func (e *ReservedAliasError) Error() string {
-	return fmt.Sprintf("report: %q is reserved for the drill-through handle this surface adds to every row", e.Alias)
+	return fmt.Sprintf("report: %s is reserved for the drill-through handle this surface adds to every row",
+		httperr.QuoteCaller(e.Alias))
 }
 
 // MessageFault reuses the contract's one declared 422 code, for the reason

--- a/backend/internal/modules/agents/badargs.go
+++ b/backend/internal/modules/agents/badargs.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/margince/margince/backend/internal/platform/httperr"
@@ -97,17 +98,16 @@ func decodeArgs[T any](in json.RawMessage, into *T) error {
 const maxBadArgsDetail = 200
 
 // MaxFaultDetail bounds a CLASSIFIED refusal's detail, which is a different
-// obligation from maxBadArgsDetail above and used to borrow its number.
+// obligation from maxBadArgsDetail above.
 //
 // The two differ in who wrote the text. A bad-args detail quotes the caller's
 // own argument names and is mostly their words, so 200 is generous. A
 // classified fault's detail is OURS: it names what was refused and then, for
 // every closed vocabulary on this surface, lists the whole set that would have
 // worked. Sharing one figure meant the set was measured against a budget sized
-// for something else, and it lost — a report's fourteen block kinds never
-// reached a caller at all, and the twelve analytics populations arrived cut
-// mid-name, which is worse than absent because a truncated list reads as a
-// complete one.
+// for something else, and it lost: a report's block grammar never reached a
+// caller at all, and the analytics populations arrived cut mid-name — worse than
+// absent, because a truncated list reads as a complete one.
 //
 // The caller's share of one of these is bounded at its SOURCE
 // (httperr.QuoteCaller), so this figure is spent on our own text rather than on
@@ -206,7 +206,7 @@ func boundDetail(s string, n int) string {
 }
 
 // echoSafe prepares caller-authored text for a tool result: bounded, and with
-// every control character rendered as a visible escape.
+// everything that does not PRINT rendered as a visible escape.
 //
 // Bounding alone is not enough. A tool result lands in a transcript that later
 // prompts of the same run read, and the author of these strings is the model
@@ -214,10 +214,23 @@ func boundDetail(s string, n int) string {
 // line of conversation, and an escape byte can move a terminal's cursor.
 // Rendering them keeps what the caller actually wrote while taking away its
 // ability to forge the frame around it.
+//
+// UNPRINTABLE, not "an ASCII control character", and the difference is a
+// reachable injection. This switch tested `r < 0x20 || r == 0x7f`, which admits
+// every character above ASCII that ends a line or reverses one: U+2028 LINE
+// SEPARATOR and U+2029 PARAGRAPH SEPARATOR are line terminators to a great many
+// tokenizers and renderers, U+0085 NEXT LINE is one to some, U+202E flips the
+// reading order of everything after it, and U+200B is invisible. A caller who
+// cannot write a newline into the frame could write U+2028 and get one.
+//
+// unicode.IsPrint is the same question `%q` asks — which matters, because
+// httperr.QuoteCaller bounds a caller's token with `%q` before it ever reaches
+// here, and two spellings of "safe to echo" that disagreed would mean the
+// protection depended on which door the text came through.
 func echoSafe(s string, n int) string {
 	var b strings.Builder
 	b.Grow(len(s))
-	for _, r := range s {
+	for i, r := range s {
 		switch {
 		case r == '\n':
 			b.WriteString(`\n`)
@@ -225,8 +238,14 @@ func echoSafe(s string, n int) string {
 			b.WriteString(`\r`)
 		case r == '\t':
 			b.WriteString(`\t`)
-		case r < 0x20 || r == 0x7f:
-			fmt.Fprintf(&b, `\x%02x`, r)
+		case r == utf8.RuneError && !utf8.ValidString(s[i:i+1]):
+			// A byte that is not UTF-8 at all. Ranging yields RuneError for it,
+			// which IS printable, so writing the rune back would silently
+			// replace the caller's byte with U+FFFD and report a name they did
+			// not send. The byte itself is what they sent.
+			fmt.Fprintf(&b, `\x%02x`, s[i])
+		case !unicode.IsPrint(r):
+			fmt.Fprintf(&b, `\u%04x`, r)
 		default:
 			b.WriteRune(r)
 		}

--- a/backend/internal/modules/agents/echosafe_test.go
+++ b/backend/internal/modules/agents/echosafe_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// A caller's text never keeps its ability to forge the frame around it.
+//
+// echoSafe escaped ASCII control characters only, which admits every character
+// ABOVE ascii that ends a line: U+2028 and U+2029 are line terminators to a
+// great many tokenizers, U+0085 to some, U+202E reverses the reading order of
+// everything after it, and U+200B is invisible. A caller who could not write a
+// newline into a tool result could write U+2028 and get one.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEchoSafeEscapesEverythingThatDoesNotPrint(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		what string
+		raw  string
+	}{
+		{"line separator", "\u2028"},
+		{"paragraph separator", "\u2029"},
+		{"next line", "\u0085"},
+		{"right-to-left override", "\u202e"},
+		{"zero width space", "\u200b"},
+		{"a bare escape byte", "\x1b"},
+		{"a byte that is not utf-8", "\xff"},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			t.Parallel()
+			got := echoSafe("before"+tc.raw+"after", maxBadArgsDetail)
+
+			if strings.Contains(got, tc.raw) {
+				t.Errorf("%s survived into the tool result verbatim: %q", tc.what, got)
+			}
+			if !strings.Contains(got, "before") || !strings.Contains(got, "after") {
+				t.Errorf("the caller's own text was lost around the escape: %q", got)
+			}
+		})
+	}
+}
+
+// Ordinary text is left alone. Escaping everything unprintable must not start
+// mangling a real name — a German or Vietnamese company name is what this
+// surface refuses against every day.
+func TestEchoSafeLeavesRealNamesAlone(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{
+		"K\u00f6rber Sensorik Rollout",
+		"C\u00f4ng ty X\u00e2y d\u1ef1ng",
+		"deals-by-stage",
+		"amount_base_minor",
+		"a name with spaces",
+	} {
+		if got := echoSafe(name, maxBadArgsDetail); got != name {
+			t.Errorf("echoSafe rewrote an ordinary name: %q became %q", name, got)
+		}
+	}
+}

--- a/backend/internal/modules/agents/explain.go
+++ b/backend/internal/modules/agents/explain.go
@@ -214,9 +214,16 @@ func (s *Dispatcher) explainClassified(tool string, err error) string {
 // message only on the module-declared path, so one from a direct Validation
 // call reaches this point unbounded. The message needs both outright — it
 // quotes the caller's own token back, since a refused plan names the target it
-// could not resolve, into a transcript later prompts of this run read — and it
-// borrows httperr.MaxFaultText as its figure so the two bounds are one number
-// rather than two that agree by coincidence.
+// could not resolve, into a transcript later prompts of this run read.
+//
+// THREE FIGURES, and each answers a different question about whose words are
+// being echoed. A classified fault's detail is OURS and names closed
+// vocabularies, so it gets MaxFaultDetail. The per-field remedy is also ours
+// and borrows httperr.MaxFaultText, the same number that package applies on
+// the module-declared path. The flattened field:code fallthrough is the
+// caller's own list, as long as they chose to make it, so it keeps
+// maxBadArgsDetail. They agreed on one number until a closed set was measured
+// against a budget sized for an argument-name echo and lost.
 //
 // The field and the code get the same treatment because nothing in the taxonomy
 // PROMISES they are ours either. A field slot fed from a caller-chosen key is
@@ -268,7 +275,14 @@ func faultExplanation(fault httperr.Fault) string {
 	if remedied {
 		return named
 	}
-	return named + ": " + echoSafe(fault.Detail, MaxFaultDetail)
+	// maxBadArgsDetail, not MaxFaultDetail, and the two branches of this
+	// function differ for a reason. Reaching HERE means the fault named fields
+	// and none of them carried guidance, and the doc above records what Detail
+	// then is: the flattened field:code list, whose length is the CALLER's
+	// choice of how many inputs to get wrong. That is the axis maxRemedyBudget
+	// exists to bound, so widening it here would undo that on the one branch
+	// where the text is not ours.
+	return named + ": " + echoSafe(fault.Detail, maxBadArgsDetail)
 }
 
 // maxRemedyBudget bounds the TOTAL guidance one refusal contributes, across

--- a/backend/internal/modules/agents/explainclosedset_test.go
+++ b/backend/internal/modules/agents/explainclosedset_test.go
@@ -5,11 +5,8 @@ package agents
 
 // A refusal that names a closed set must deliver the WHOLE set.
 //
-// The defect these hold against: this renderer bounded a classified fault's
-// detail with the figure sized for a bad-args echo, so the set — the half a
-// caller acts on — was what the truncation took. A report's block grammar never
-// reached a caller at all, and the analytics populations arrived cut mid-name,
-// which is worse than absent because a partial list reads as a complete one.
+// The set is the half a caller acts on, so it is the half that must survive a
+// truncation rather than the half that pays for it.
 //
 // The vocabularies themselves are NOT named here. They live in compose, which
 // is downstream of this package, so this file proves the MECHANISM against a
@@ -24,11 +21,6 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/httperr"
 )
-
-func newTestDispatcher() *Dispatcher {
-	return NewDispatcher(nil, nil, "t", "0").
-		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
-}
 
 // closedSetRefusal is the shape both real producers take: one detail carrying
 // prose that names what was refused and then the whole set that would have
@@ -46,7 +38,11 @@ func closedSetRefusal(detail string) error {
 	}
 }
 
-// blockKindRefusal is the report validator's message, as reportdoc spells it.
+// blockKindRefusal has the SHAPE the report validator's message has — prose
+// that names what was refused, then the set. Not a copy of it: reportdoc lives
+// in compose, which this package may not import, so the real vocabularies are
+// held where they are visible (compose's closed-set census) and this file proves
+// only the mechanism.
 func blockKindRefusal(members []string) string {
 	return `block 0 ("paragraph"): no such block kind. A renderer meeting one either draws ` +
 		`something nobody specified or drops it silently, and a report missing a block it ` +
@@ -61,7 +57,8 @@ func TestARefusalDeliversTheWholeClosedSet(t *testing.T) {
 		"record_table", "callout", "evidence_drawer",
 	}
 
-	got := newTestDispatcher().explain("compose_analytics_report", closedSetRefusal(blockKindRefusal(members)))
+	got := NewDispatcher(nil, nil, "t", "0").
+		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))).explain("compose_analytics_report", closedSetRefusal(blockKindRefusal(members)))
 
 	for _, member := range members {
 		if !strings.Contains(got, member) {
@@ -77,7 +74,8 @@ func TestARefusalDeliversTheWholeClosedSet(t *testing.T) {
 // ceiling at all: the detail lands in a transcript whose later prompts the same
 // model reads, so an unbounded one is an unbounded write into every one of them.
 func TestAnOverlongDetailIsStillCut(t *testing.T) {
-	got := newTestDispatcher().explain("compose_analytics_report",
+	got := NewDispatcher(nil, nil, "t", "0").
+		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))).explain("compose_analytics_report",
 		closedSetRefusal(strings.Repeat("x", MaxFaultDetail+64)))
 
 	if !strings.Contains(got, "…") {
@@ -98,7 +96,8 @@ func TestAnOverlongDetailIsStillCut(t *testing.T) {
 func TestARefusalUnderTheCeilingIsUntouched(t *testing.T) {
 	detail := blockKindRefusal([]string{"title", "summary", "callout"})
 
-	got := newTestDispatcher().explain("compose_analytics_report", closedSetRefusal(detail))
+	got := NewDispatcher(nil, nil, "t", "0").
+		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))).explain("compose_analytics_report", closedSetRefusal(detail))
 
 	if !strings.Contains(got, detail) {
 		t.Errorf("a refusal inside the ceiling did not travel verbatim:\nwant substring: %s\ngot: %s", detail, got)

--- a/backend/internal/platform/httperr/callertoken.go
+++ b/backend/internal/platform/httperr/callertoken.go
@@ -20,9 +20,12 @@ import (
 // surface downstream carry the set whole: the caller-influenced share of the
 // message is a known quantity rather than whatever was sent.
 //
-// Sized for a real identifier and nothing more. Every name in every closed
-// vocabulary this refuses against is comfortably inside it, so a token that
-// needs truncating is not a name anybody has.
+// Sized for a real identifier and nothing more, so a token that needs
+// truncating is not a name anybody has. That every member of every closed
+// vocabulary is inside it is not an assumption: compose's closed-set census
+// asserts it, because a member longer than this would be truncated when a caller
+// named it back and the refusal would quote a name matching nothing in the set
+// beside it.
 //
 // BYTES, like MaxFaultText beside it. A rune bound would let a multi-byte
 // token spend three times the budget for the same count, and what the figure
@@ -40,6 +43,15 @@ const MaxCallerToken = 80
 // prompts the same model reads, and where the name being quoted was written by
 // that model. A refusal is not the place to discover that a caller chose a
 // control character.
+//
+// TWO PLACES DECIDE WHAT IS SAFE TO ECHO, and the second is named here because
+// spellings that drifted would mean the protection depended on which door the
+// text came through. agents.echoSafe re-escapes whatever reaches the tool
+// surface, by the same test (unicode.IsPrint) `%q` applies here — so a token
+// quoted here passes through it unchanged, and one arriving by another route is
+// still escaped. Bounding is the half that must happen HERE: echoSafe bounds the
+// whole message, and by then a caller's token has already spent the budget the
+// vocabulary needs.
 //
 // The bound is applied AFTER quoting, not before, because quoting is what
 // decides the length: eighty bytes of newlines escape to a hundred and sixty,

--- a/backend/internal/platform/httperr/callertoken_test.go
+++ b/backend/internal/platform/httperr/callertoken_test.go
@@ -5,10 +5,9 @@ package httperr
 
 // The rendered token is bounded and escaped, whatever a caller sends.
 //
-// Both halves were reported: the bound was applied before quoting, so escaping
-// pushed the answer past it, and the doc claimed no escaping happened at all
-// while `%q` was doing it. A caller who can choose the size of a refusal can
-// choose how much of a transcript it fills.
+// The bound applies to the RENDERED form, because quoting is what decides the
+// length: a caller who can choose the size of a refusal can choose how much of a
+// transcript it fills.
 
 import (
 	"strings"

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -158,11 +158,18 @@ func clientInputValidation(err error) (error, bool) {
 // wrapped driver message through. Long enough for a real explanation, short
 // enough that nothing large rides out.
 //
-// Exported as a shared FIGURE, not a promise: the MCP renderer bounds the
-// message it echoes and borrows this number rather than inventing a second,
-// but this package applies it only on the module-declared path — a Message
-// from a direct Validation call arrives unbounded, and escaping can push one
-// that was inside it back over. The echoing surface does its own bounding.
+// Exported as a shared FIGURE, not a promise: this package applies it only on
+// the module-declared path — a Message from a direct Validation call arrives
+// unbounded, and escaping can push one that was inside it back over — so the
+// echoing surface does its own bounding, and the MCP renderer borrows this
+// number for the per-field remedy it writes.
+//
+// It is NOT the only figure on that surface any more, and pretending otherwise
+// hid a defect: a refusal naming a closed vocabulary needs more room than an
+// echo of a caller's argument names, and measuring the first against a budget
+// sized for the second silently truncated the vocabulary. agents.MaxFaultDetail
+// is that larger figure, and agents.faultExplanation records which position
+// gets which.
 const MaxFaultText = 300
 
 // boundFaultText caps one caller-facing value from a module-declared fault.


### PR DESCRIPTION
Follow-up to #5126, from its two end-of-work reviewers. Both found the same thing
independently, and one confirmed it by running the attack.

## #5126 fixed four call sites and claimed an invariant

Its `MaxFaultDetail` doc justified raising the classified-detail ceiling 200 → 512
with "the caller's share of one of these is bounded at its SOURCE". True of the
three producers it touched. False of the tree — and **sibling refusals in the same
files** were still echoing an unbounded caller token in front of a closed
vocabulary, so raising the ceiling made every one of them 2.5x worse.

Measured, on the surface:

```
  tools/call run_analytics_query {"measures":[{"fn":"<4000 k's>", ...}]}
    → all eight aggregate names pushed out of the budget
    → 4105 bytes of caller-chosen text into a transcript whose
      later prompts the same model reads     (was 200 before #5126)
```

Eleven more echoes are bounded at their source: the analytics aggregates,
comparison operators, measures, engine-column and alias collisions
(`analyticsquery/ir.go`); the report field vocabulary, filter value and reserved
alias (`reporterrors.go`); the saved report id and the raw plan-argument key
(`reportcatalog.go`); the block severity (`reportdoc/validate.go`).

## The one the ceiling could never have saved

`FieldNotAllowedError` is a `MessageFault`, so `httperr` clamps it with
`boundFaultText` at **`MaxFaultText` = 300** *upstream of the renderer*. A long
field name destroyed its whole allowed list at 300 bytes and 512 bought it
nothing. Confirmed: `run_report` with a 4000-byte `group_by` yields a 303-byte
detail naming **none** of `stage/owner/currency/partner_sourced`.

## The census was itself the defect it exists to catch

It said it derived "every set-bearing refusal the tool surface can answer with"
and returned four hand-written literals. The *members* were derived; the
*subjects* were not — so it reported PASS over the aggregates, the comparison
operators and the report vocabularies, three of which were the live holes above.
A census that can fail short has already failed.

Nine subjects now, each asserting it is non-empty. And it asks
`httperr.Classify(err).Detail` rather than `err.Error()` — the surface instead of
a model of it, which is what makes the 300-byte `MessageFault` ceiling visible at
all. The three formerly-invisible subjects were watched failing at 4105, 4098 and
4009 bytes with the new bounds reverted.

## echoSafe admitted line terminators above ASCII

Its switch was `r < 0x20 || r == 0x7f`. That admits every character above ASCII
that ends or reverses a line:

```
  U+2028 LINE SEPARATOR       → a line terminator to many tokenizers
  U+2029 PARAGRAPH SEPARATOR  → likewise
  U+0085 NEXT LINE            → likewise to some
  U+202E RTL OVERRIDE         → reverses everything after it
  U+200B ZERO WIDTH SPACE     → invisible
```

So a caller who could not write a newline into a tool result could write U+2028
and get one — and one reachable path delivered exactly that verbatim
(`reportcatalog`'s raw plan-argument key, spliced with no quoting and no bound).

It now escapes anything `unicode.IsPrint` refuses, which is the same question
`%q` asks — so the two places that decide "safe to echo" cannot disagree about
which door the text came through. A byte that is not UTF-8 renders as itself
rather than silently becoming U+FFFD and reporting a name the caller never sent.
All five characters were watched surviving the old switch.

## Narrowed back

`faultExplanation`'s `Fields`-present fallthrough returns to `maxBadArgsDetail`.
The case for the larger figure covers a detail that is **ours**; that branch's
detail is the flattened `field:code` list, whose length is the caller's choice of
how many inputs to get wrong — the axis `maxRemedyBudget` exists to bound. #5126
widened it with nothing arguing for it.

## Stale claims

Two comments said the surface had one bound "rather than two that agree by
coincidence". It has three — a classified detail (ours, 512), a per-field remedy
(ours, 300), a flattened field list (the caller's, 200) — and each now says which
question it answers. `MaxCallerToken`'s "every name in every closed vocabulary is
comfortably inside it" was a justification with nothing behind it; the census
holds it now.

## Recorded, not acted on

`QuoteCaller` lives in `httperr`, whose own package doc calls it the HTTP
problem+json choke point, while this helper is transport-agnostic and its
motivating surface is the MCP transcript. `shared/kernel` (beside `promptfence`,
same hazard) is arguably the more honest home. arch-lint permits the current
edge, so moving it is churn I am not doing reactively — noting it for whoever
touches this next.

Also noted and not changed: `UnknownReportError.Served` names every
`prebuiltReports` key before any RBAC check, while the analytics schema filters
per caller. Deliberate — the catalog is a compile-time installation table, not
tenant data — but the two seams answer "which populations exist" differently.

## Verification

- every new assertion watched failing first, against the real old behaviour
- `make lint` 0 issues, `make craft-static` 0 findings, full `./gates/` green
- the uniqueness-claim gate caught a phrase of mine that read as a uniqueness
  claim while asserting the opposite; reworded rather than registered


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds every caller-chosen token echoed in refusals at its source, and escapes all unprintable characters in tool results, so oversized or injection-shaped input can no longer crowd out the closed-set vocabulary a refusal names.

**Behavior**

- Caller-chosen tokens are now bounded and quoted with `httperr.QuoteCaller` at 11 more sites across `analyticsquery`, `reportcatalog`, `reportdoc`, and `reporterrors`.
- `FieldNotAllowedError` now bounds its field name; previously `httperr` clamped it at 300 bytes before the renderer, which destroyed the allowed list.
- `echoSafe` now escapes everything `unicode.IsPrint` refuses instead of only ASCII control characters, covering U+2028/U+2029 line separators, U+0085, U+202E RTL override, and U+200B zero-width space.
- Non-UTF-8 bytes render as themselves rather than silently becoming U+FFFD.
- `faultExplanation`'s Fields-present fallthrough returns to `maxBadArgsDetail` (200), since that branch echoes the caller's own field list.

**Census**

- The closed-set census now derives 9 subjects instead of 4 hand-written literals, each asserting it is non-empty.
- It now asks `httperr.Classify(err).Detail` rather than `err.Error()`, making both ceilings visible.
- Three previously invisible subjects (aggregates, comparison operators, report field vocabularies) were watched failing at 4105, 4098, and 4009 bytes with the new bounds reverted.

<sup>Written for commit 9ce2386d935d7bd63e50a41d388076acbf908769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

