### PR TITLE
The URI and method doors bound their echo, and Derive names the vocabulary it refuses against

### DIFF
--- a/backend/internal/compose/closedsetrefusalbudget_test.go
+++ b/backend/internal/compose/closedsetrefusalbudget_test.go
@@ -11,20 +11,22 @@ package compose
 // refused against by naming the whole set, and each grew independently of that
 // bound — so the two agree only while somebody checks.
 //
-// TWO DEFECTS THIS HOLDS, both of which shipped:
+// A truncated set is worse than an absent one: it reads as complete, so a caller
+// stops looking for the entry that was removed.
 //
-// The bound was the figure sized for a bad-args echo, and the sets were measured
-// against it and lost. A report's block grammar never reached a caller at all,
-// and the analytics populations arrived cut mid-name — worse than absent,
-// because a truncated list reads as a complete one and a caller stops looking
-// for the entry that was removed.
+// WHAT IS DERIVED AND WHAT IS NOT, said plainly, because the first pass of this
+// file claimed the whole of it and was wrong. Every set's MEMBERS come from the
+// producer that owns them, so a member added or removed moves this test. The
+// SUBJECT LIST is hand-built and cannot be otherwise: provoking a refusal means
+// composing a call that earns it, and no reflection writes that. What guards the
+// list instead is that every subject asserts its members are non-empty, so a
+// vocabulary that silently empties fails here rather than passing vacuously.
 //
-// And the first pass of this census was itself hand-listed while claiming to be
-// derived. It named four subjects and there were more, so it reported PASS over
-// the aggregates, the comparison operators and the report field vocabularies —
-// three of which were still echoing an unbounded caller token in front of their
-// set. A census that can fail short has already failed, so the subjects are
-// enumerated from the exported producers and each one asserts it is non-empty.
+// AND IT ONLY SEES compose's OWN vocabularies. It cannot reach the ones in
+// modules/agents, modules/search or shared/ports/datasource — compose is
+// downstream of all three, so importing them here is legal but provoking their
+// refusals from this package is not the same test. Those carry the same
+// obligation and are held where they live; this file does not speak for them.
 //
 // IT ASSERTS ON THE CLASSIFIED FAULT, not on err.Error(). The renderer is not
 // the only ceiling: httperr bounds a module-declared fault at MaxFaultText
@@ -59,8 +61,12 @@ type setBearingRefusal struct {
 	refuse  func(token string) error
 }
 
-// closedSetRefusals enumerates every set-bearing refusal this surface can answer
-// with, taking each vocabulary from the producer that owns it.
+// closedSetRefusals is compose's set-bearing refusals, each vocabulary taken
+// from the producer that owns it.
+//
+// It fatals on an empty or unresolvable subject rather than leaving that to the
+// callers: two of the three tests below loop over members and would be green
+// over an empty list, which is the vacuous pass this file exists to prevent.
 func closedSetRefusals(t *testing.T) []setBearingRefusal {
 	t.Helper()
 
@@ -78,7 +84,15 @@ func closedSetRefusals(t *testing.T) []setBearingRefusal {
 	}
 	measure := analyticsquery.Measure{Fn: analyticsquery.Sum, Field: "amount_base_minor"}
 
-	return []setBearingRefusal{
+	// A named report, resolved rather than indexed: a renamed key would
+	// otherwise hand two of the tests below an empty vocabulary and pass.
+	const namedReport = "deals-by-stage"
+	reportSpec, ok := prebuiltReports[namedReport]
+	if !ok {
+		t.Fatalf("%s is absent from the report catalog; this census needs a real report", namedReport)
+	}
+
+	subjects := []setBearingRefusal{
 		{
 			what:    "report block kinds",
 			members: reportdoc.KindNames(),
@@ -175,17 +189,26 @@ func closedSetRefusals(t *testing.T) []setBearingRefusal {
 			// A MessageFault, so httperr caps it at MaxFaultText before the
 			// renderer is reached. This is the subject the first census could not
 			// see, and the one whose set was being destroyed outright.
+			// The catalog read here, the refusal built by the ENGINE — so this
+			// asserts the engine hands over the right vocabulary rather than
+			// replaying one the test supplied. Hand-building the error would
+			// have tested the renderer and nothing else.
 			what:    "the dimensions of one prebuilt report",
-			members: allowedReportNames(prebuiltReports["deals-by-stage"].dimensions),
+			members: allowedReportNames(reportSpec.dimensions),
 			refuse: func(token string) error {
-				return &FieldNotAllowedError{
-					Field:   token,
-					Slot:    slotGroupBy,
-					Allowed: allowedReportNames(prebuiltReports["deals-by-stage"].dimensions),
-				}
+				_, err := (&reportEngine{}).Derive(seatWith("deal"), namedReport,
+					derivationQuery{GroupBy: []string{token}})
+				return err
 			},
 		},
 	}
+
+	for _, subject := range subjects {
+		if len(subject.members) == 0 {
+			t.Fatalf("%s came back empty, so every case over it would pass vacuously", subject.what)
+		}
+	}
+	return subjects
 }
 
 // TestEveryClosedSetSurvivesTheToolSurface is the census: each vocabulary,
@@ -195,10 +218,6 @@ func TestEveryClosedSetSurvivesTheToolSurface(t *testing.T) {
 	for _, subject := range closedSetRefusals(t) {
 		t.Run(subject.what, func(t *testing.T) {
 			t.Parallel()
-			if len(subject.members) == 0 {
-				t.Fatalf("%s came back empty, so this case measures nothing", subject.what)
-			}
-
 			detail := classifiedDetail(t, subject, "a-name-nothing-serves")
 
 			if len(detail) > agents.MaxFaultDetail {

--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -146,7 +146,13 @@ func (e *reportEngine) Derive(ctx context.Context, report string, q derivationQu
 	}
 	spec, ok := prebuiltReports[report]
 	if !ok {
-		return derivationOutcome{}, fmt.Errorf("report %q: %w", report, apperrors.ErrNotFound)
+		// UnknownReportError, the same answer Run gives: it bounds the caller's
+		// key and names the keys this installation does serve. A bare %q here
+		// echoed an unbounded key and named nothing that would have worked.
+		return derivationOutcome{}, &UnknownReportError{
+			Report: report,
+			Served: slices.Sorted(maps.Keys(prebuiltReports)),
+		}
 	}
 	if err := auth.Require(ctx, string(spec.entity), principal.ActionRead); err != nil {
 		return derivationOutcome{}, err
@@ -208,7 +214,15 @@ func compileDerivation(spec reportSpec, q derivationQuery) (derivationPlan, erro
 	grouped := map[string]bool{}
 	for _, dim := range q.GroupBy {
 		if _, ok := spec.dimensions[dim]; !ok {
-			return derivationPlan{}, &FieldNotAllowedError{Field: dim}
+			// Slot and Allowed, not the name alone. Without them the refusal
+			// says "use a name this report declares" and declares nothing, so
+			// a caller loops on guesses — the same refusal Run's own group_by
+			// path gives, which this one silently did not match.
+			return derivationPlan{}, &FieldNotAllowedError{
+				Field:   dim,
+				Slot:    slotGroupBy,
+				Allowed: allowedReportNames(spec.dimensions),
+			}
 		}
 		grouped[dim] = true
 		plan.groupBy = append(plan.groupBy, dim)
@@ -216,28 +230,18 @@ func compileDerivation(spec reportSpec, q derivationQuery) (derivationPlan, erro
 	// Predicates admit the union of the report's dimensions and filters:
 	// a group-key value pins the cell, a filter value replays the plan.
 	for key, value := range q.Predicates {
-		if threshold, ok := spec.thresholds[key]; ok {
-			plan.preds = append(plan.preds, boundExpr{field: key, value: value, threshold: &threshold})
-			continue
+		pred, err := resolvePredicate(spec, key, value, false)
+		if err != nil {
+			return derivationPlan{}, err
 		}
-		expr, ok := spec.dimensions[key]
-		if !ok {
-			expr, ok = spec.filters[key]
-		}
-		if !ok {
-			return derivationPlan{}, &FieldNotAllowedError{Field: key}
-		}
-		plan.preds = append(plan.preds, boundExpr{field: key, expr: expr, value: value})
+		plan.preds = append(plan.preds, pred)
 	}
 	for field := range q.Unset {
-		expr, ok := spec.dimensions[field]
-		if !ok {
-			expr, ok = spec.filters[field]
+		pred, err := resolvePredicate(spec, field, "", true)
+		if err != nil {
+			return derivationPlan{}, err
 		}
-		if !ok {
-			return derivationPlan{}, &FieldNotAllowedError{Field: field}
-		}
-		plan.preds = append(plan.preds, boundExpr{field: field, expr: expr, isNull: true})
+		plan.preds = append(plan.preds, pred)
 	}
 	sort.Slice(plan.preds, func(i, j int) bool { return plan.preds[i].field < plan.preds[j].field })
 
@@ -393,4 +397,52 @@ func sortedKeys(m map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// allowedPredicateNames is what a derivation predicate may name: the union a
+// predicate is actually resolved against above — the report's dimensions, its
+// filters and its thresholds.
+//
+// Derived from the spec rather than listed, and the UNION rather than either
+// half, because a refusal naming only the dimensions would refuse a caller a
+// filter name this engine accepts.
+func allowedPredicateNames(spec reportSpec) []string {
+	names := make([]string, 0, len(spec.dimensions)+len(spec.filters)+len(spec.thresholds))
+	names = append(names, allowedReportNames(spec.dimensions)...)
+	names = append(names, allowedReportNames(spec.filters)...)
+	for key := range spec.thresholds {
+		names = append(names, key)
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
+}
+
+// resolvePredicate resolves one predicate name against what this report admits: a
+// threshold, a dimension or a filter, in that order.
+//
+// The two callers differ only in whether the predicate pins a value or asserts
+// its absence, and they resolved the name identically — twice, which is how one
+// of them came to refuse without naming the vocabulary while the other did.
+func resolvePredicate(spec reportSpec, name, value string, isNull bool) (boundExpr, error) {
+	if threshold, ok := spec.thresholds[name]; ok {
+		if isNull {
+			return boundExpr{field: name, isNull: true, threshold: &threshold}, nil
+		}
+		return boundExpr{field: name, value: value, threshold: &threshold}, nil
+	}
+	expr, ok := spec.dimensions[name]
+	if !ok {
+		expr, ok = spec.filters[name]
+	}
+	if !ok {
+		return boundExpr{}, &FieldNotAllowedError{
+			Field:   name,
+			Slot:    slotFilters,
+			Allowed: allowedPredicateNames(spec),
+		}
+	}
+	if isNull {
+		return boundExpr{field: name, expr: expr, isNull: true}, nil
+	}
+	return boundExpr{field: name, expr: expr, value: value}, nil
 }

--- a/backend/internal/compose/reportcatalog.go
+++ b/backend/internal/compose/reportcatalog.go
@@ -126,7 +126,7 @@ func (e *reportEngine) Run(ctx context.Context, report string, req reportRequest
 	if uuidShape.MatchString(report) {
 		// Saved reports are a later slice; an unknown id is absent, not
 		// half-supported.
-		return reportOutcome{}, fmt.Errorf("saved report %s: %w", httperr.QuoteCaller(report), apperrors.ErrNotFound)
+		return reportOutcome{}, fmt.Errorf("saved report %s: %w", report, apperrors.ErrNotFound)
 	}
 	spec, ok := prebuiltReports[report]
 	if !ok {
@@ -155,17 +155,32 @@ func unservedPlanArguments(planArgs json.RawMessage) []string {
 	var unserved []string
 	for key := range keys {
 		if !servedPlanArguments[key] {
-			// The key is the CALLER's, quoted and bounded where it enters. It
-			// reaches an agent spliced into a refusal that goes on to name the
-			// arguments this tool DOES take, and a raw one arrived able to both
-			// push that list out and carry a character the transcript reads as
-			// a line ending.
+			// The key is the CALLER's, quoted and bounded where it enters: raw,
+			// it carried both an unbounded write and a character the transcript
+			// reads as a line ending.
 			unserved = append(unserved, httperr.QuoteCaller(key))
 		}
 	}
 	slices.Sort(unserved)
+
+	// AND THE LENGTH OF THE LIST IS ALSO THE CALLER'S. Bounding each key left
+	// the count unbounded, which crowds the served set out of the same refusal
+	// just as effectively: twenty unknown keys pushed `group_by` and
+	// `aggregates` off the end of a sentence that exists to name them. Naming a
+	// few and counting the rest keeps the answer's size ours — a caller with
+	// twenty wrong keys has the grammar wrong, not twenty separate mistakes.
+	if len(unserved) > maxUnservedNamed {
+		rest := len(unserved) - maxUnservedNamed
+		unserved = append(unserved[:maxUnservedNamed:maxUnservedNamed],
+			fmt.Sprintf("and %d more", rest))
+	}
 	return unserved
 }
+
+// maxUnservedNamed bounds how many of a caller's unknown plan-argument keys one
+// refusal names. Enough that a caller fixing a typo or two sees their own key
+// quoted back; few enough that the served vocabulary beside it always fits.
+const maxUnservedNamed = 4
 
 // reportPlanVocabulary is what the engine accepts from a plan beyond the
 // per-report names: the aggregate functions.

--- a/backend/internal/modules/agents/badargs.go
+++ b/backend/internal/modules/agents/badargs.go
@@ -104,10 +104,9 @@ const maxBadArgsDetail = 200
 // own argument names and is mostly their words, so 200 is generous. A
 // classified fault's detail is OURS: it names what was refused and then, for
 // every closed vocabulary on this surface, lists the whole set that would have
-// worked. Sharing one figure meant the set was measured against a budget sized
-// for something else, and it lost: a report's block grammar never reached a
-// caller at all, and the analytics populations arrived cut mid-name — worse than
-// absent, because a truncated list reads as a complete one.
+// worked. A set measured against a budget sized for an argument-name echo does
+// not fit, and a truncated set is worse than an absent one — it reads as
+// complete, so a caller stops looking for what was removed.
 //
 // The caller's share of one of these is bounded at its SOURCE
 // (httperr.QuoteCaller), so this figure is spent on our own text rather than on
@@ -205,6 +204,20 @@ func boundDetail(s string, n int) string {
 	return s[:cut] + "…"
 }
 
+// invalidByteAt says whether the byte at i is one UTF-8 cannot decode, as
+// opposed to the first byte of a legitimately encoded U+FFFD.
+//
+// The two are indistinguishable to a range loop — both yield RuneError — and
+// telling them apart by re-validating the single byte gets it WRONG for the
+// legitimate one: the lead byte of U+FFFD (0xEF) is not valid UTF-8 on its own,
+// so a caller who sent a replacement character had it reported back as a bare
+// \xef with its two continuation bytes dropped. The decode WIDTH is what
+// separates them: one byte means the decoder gave up, three means it succeeded.
+func invalidByteAt(s string, i int) bool {
+	_, size := utf8.DecodeRuneInString(s[i:])
+	return size == 1
+}
+
 // echoSafe prepares caller-authored text for a tool result: bounded, and with
 // everything that does not PRINT rendered as a visible escape.
 //
@@ -238,12 +251,17 @@ func echoSafe(s string, n int) string {
 			b.WriteString(`\r`)
 		case r == '\t':
 			b.WriteString(`\t`)
-		case r == utf8.RuneError && !utf8.ValidString(s[i:i+1]):
+		case r == utf8.RuneError && invalidByteAt(s, i):
 			// A byte that is not UTF-8 at all. Ranging yields RuneError for it,
-			// which IS printable, so writing the rune back would silently
-			// replace the caller's byte with U+FFFD and report a name they did
-			// not send. The byte itself is what they sent.
+			// which IS printable, so writing the rune back would replace the
+			// caller's byte with U+FFFD and report a name they did not send.
 			fmt.Fprintf(&b, `\x%02x`, s[i])
+		case r > 0xFFFF:
+			// Above the BMP, `\u` takes no more than four digits — `\ue0020`
+			// for U+E0020 is not a legal escape anywhere and reads as `\ue002`
+			// followed by a `0`. The tag block this covers (U+E0000..U+E007F)
+			// is the one used to smuggle invisible text.
+			fmt.Fprintf(&b, `\U%08x`, r)
 		case !unicode.IsPrint(r):
 			fmt.Fprintf(&b, `\u%04x`, r)
 		default:

--- a/backend/internal/modules/agents/dispatch.go
+++ b/backend/internal/modules/agents/dispatch.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"slices"
 
+	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 )
 
@@ -306,7 +307,10 @@ func (s *Dispatcher) eraOwned(req rpcRequest, fr framing) (rpcResponse, bool) {
 func methodNotFound(req rpcRequest) rpcResponse {
 	return rpcResponse{
 		JSONRPC: jsonRPCVersion, ID: req.ID,
-		Error: &rpcError{Code: codeMethodNotFound, Message: "method not found: " + req.Method},
+		// The method is the caller's own string off the JSON body, bounded and
+		// escaped for the reason UnknownToolError bounds a tool name: both are
+		// chosen freely and both land in a transcript the same run reads back.
+		Error: &rpcError{Code: codeMethodNotFound, Message: "method not found: " + httperr.QuoteCaller(req.Method)},
 	}
 }
 

--- a/backend/internal/modules/agents/echosafe_test.go
+++ b/backend/internal/modules/agents/echosafe_test.go
@@ -29,6 +29,7 @@ func TestEchoSafeEscapesEverythingThatDoesNotPrint(t *testing.T) {
 		{"zero width space", "\u200b"},
 		{"a bare escape byte", "\x1b"},
 		{"a byte that is not utf-8", "\xff"},
+		{"a tag character above the BMP", "\U000e0020"},
 	} {
 		t.Run(tc.what, func(t *testing.T) {
 			t.Parallel()
@@ -41,6 +42,34 @@ func TestEchoSafeEscapesEverythingThatDoesNotPrint(t *testing.T) {
 				t.Errorf("the caller's own text was lost around the escape: %q", got)
 			}
 		})
+	}
+}
+
+// A REPLACEMENT CHARACTER the caller actually sent is reported as itself.
+//
+// It is the one rune a range loop cannot tell from a broken byte — both arrive
+// as RuneError — and deciding between them by re-validating the single lead byte
+// gets this case wrong: U+FFFD came back as a bare \xef with its two
+// continuation bytes dropped, so the refusal named a byte nobody sent.
+func TestEchoSafeReportsARealReplacementCharacterAsItself(t *testing.T) {
+	t.Parallel()
+	const sent = "before\ufffdafter"
+
+	got := echoSafe(sent, maxBadArgsDetail)
+
+	if got != sent {
+		t.Errorf("a legitimately encoded U+FFFD was rewritten: %q became %q", sent, got)
+	}
+}
+
+// An astral escape must be one a reader can parse back. `\u` takes four digits,
+// so U+E0020 rendered as `\ue0020` reads as `\ue002` followed by a `0`.
+func TestEchoSafeRendersAnAstralRuneUnambiguously(t *testing.T) {
+	t.Parallel()
+	got := echoSafe("tag\U000e0020here", maxBadArgsDetail)
+
+	if !strings.Contains(got, `\U000e0020`) {
+		t.Errorf("an astral rune was not rendered as an eight-digit escape: %q", got)
 	}
 }
 

--- a/backend/internal/modules/agents/explain.go
+++ b/backend/internal/modules/agents/explain.go
@@ -222,8 +222,7 @@ func (s *Dispatcher) explainClassified(tool string, err error) string {
 // and borrows httperr.MaxFaultText, the same number that package applies on
 // the module-declared path. The flattened field:code fallthrough is the
 // caller's own list, as long as they chose to make it, so it keeps
-// maxBadArgsDetail. They agreed on one number until a closed set was measured
-// against a budget sized for an argument-name echo and lost.
+// maxBadArgsDetail.
 //
 // The field and the code get the same treatment because nothing in the taxonomy
 // PROMISES they are ours either. A field slot fed from a caller-chosen key is

--- a/backend/internal/modules/agents/explainclosedset_test.go
+++ b/backend/internal/modules/agents/explainclosedset_test.go
@@ -22,6 +22,13 @@ import (
 	"github.com/margince/margince/backend/internal/platform/httperr"
 )
 
+// newTestDispatcher is the wiring every case here needs and none of them is
+// about: a dispatcher with a logger that goes nowhere.
+func newTestDispatcher() *Dispatcher {
+	return NewDispatcher(nil, nil, "t", "0").
+		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+}
+
 // closedSetRefusal is the shape both real producers take: one detail carrying
 // prose that names what was refused and then the whole set that would have
 // worked, with NO per-field breakdown. The set is last because that is how a
@@ -57,8 +64,7 @@ func TestARefusalDeliversTheWholeClosedSet(t *testing.T) {
 		"record_table", "callout", "evidence_drawer",
 	}
 
-	got := NewDispatcher(nil, nil, "t", "0").
-		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))).explain("compose_analytics_report", closedSetRefusal(blockKindRefusal(members)))
+	got := newTestDispatcher().explain("compose_analytics_report", closedSetRefusal(blockKindRefusal(members)))
 
 	for _, member := range members {
 		if !strings.Contains(got, member) {
@@ -74,8 +80,7 @@ func TestARefusalDeliversTheWholeClosedSet(t *testing.T) {
 // ceiling at all: the detail lands in a transcript whose later prompts the same
 // model reads, so an unbounded one is an unbounded write into every one of them.
 func TestAnOverlongDetailIsStillCut(t *testing.T) {
-	got := NewDispatcher(nil, nil, "t", "0").
-		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))).explain("compose_analytics_report",
+	got := newTestDispatcher().explain("compose_analytics_report",
 		closedSetRefusal(strings.Repeat("x", MaxFaultDetail+64)))
 
 	if !strings.Contains(got, "…") {
@@ -96,8 +101,7 @@ func TestAnOverlongDetailIsStillCut(t *testing.T) {
 func TestARefusalUnderTheCeilingIsUntouched(t *testing.T) {
 	detail := blockKindRefusal([]string{"title", "summary", "callout"})
 
-	got := NewDispatcher(nil, nil, "t", "0").
-		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))).explain("compose_analytics_report", closedSetRefusal(detail))
+	got := newTestDispatcher().explain("compose_analytics_report", closedSetRefusal(detail))
 
 	if !strings.Contains(got, detail) {
 		t.Errorf("a refusal inside the ceiling did not travel verbatim:\nwant substring: %s\ngot: %s", detail, got)

--- a/backend/internal/modules/agents/resources.go
+++ b/backend/internal/modules/agents/resources.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
@@ -139,6 +140,23 @@ func (s *Dispatcher) resourceList(ctx context.Context, fr framing) []resourceDes
 // A host that renders views is unaffected: every route to a view's URI runs
 // through a tool's `_meta.ui`, which only an App-declaring request is served,
 // so a client that knows the URI at all is one that declared it can render it.
+// noResourceAt renders the not-found answer, so that no branch can quote the
+// caller's URI back raw by forgetting to.
+//
+// The URI arrives off the JSON body, where nothing bounds it but the transport's
+// megabyte cap, and the answer lands in a transcript whose later prompts the same
+// run reads. Raw, it carried both an unbounded write and a character the reader
+// treats as a line ending. Bounded and escaped, it still says which URI was
+// asked for — which is the whole value of naming it.
+//
+// Four branches answer with it, and they answer IDENTICALLY on purpose: an
+// unknown URI, one this caller's scopes do not reach, one the provider does not
+// serve, and an app document on a surface not offering apps. A caller must not
+// be able to tell "does not exist" from "not yours".
+func noResourceAt(uri string) string {
+	return "no resource at " + httperr.QuoteCaller(uri)
+}
+
 func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage, fr framing) (resourceContents, *rpcError) {
 	var p struct {
 		URI string `json:"uri"`
@@ -153,16 +171,16 @@ func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage, f
 		return resourceContents{}, &rpcError{Code: codeInvalidParams, Message: "invalid params: resources/read needs a non-empty \"uri\""}
 	}
 	if s.resources == nil {
-		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: "no resource at " + p.URI}
+		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: noResourceAt(p.URI)}
 	}
 	if !s.readableByThisCaller(ctx, p.URI) {
 		// The same answer an unknown URI gets: a caller whose scopes do not
 		// reach a document must not learn that it exists.
-		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: "no resource at " + p.URI}
+		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: noResourceAt(p.URI)}
 	}
 	contents, err := s.resources.ReadResource(ctx, p.URI)
 	if errors.Is(err, apperrors.ErrNotFound) {
-		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: "no resource at " + p.URI}
+		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: noResourceAt(p.URI)}
 	}
 	if err == nil && isAppDocument(contents.MIMEType) && !s.appsOffered(fr) {
 		// Judged on what the provider actually SERVED, not on what the
@@ -170,7 +188,7 @@ func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage, f
 		// catalogue names the first advertiser while this read takes the first
 		// that serves, and the bytes in hand are what the client would have to
 		// render.
-		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: "no resource at " + p.URI}
+		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: noResourceAt(p.URI)}
 	}
 	if err != nil {
 		// The cause is server-side knowledge (a pool fault, a wrapped SQL

--- a/backend/internal/modules/agents/tools_approvals.go
+++ b/backend/internal/modules/agents/tools_approvals.go
@@ -345,6 +345,12 @@ func verdict(decision string) (bool, error) {
 	case "reject":
 		return false, nil
 	default:
-		return false, &BadArgsError{Cause: fmt.Errorf("`decision` is %q; it is `approve` or `reject`", decision)}
+		// Same split as tools_enrich: the caller's word in Cause, the two words
+		// that would have worked in Guidance, so a long one cannot erase them.
+		return false, &BadArgsError{
+			Cause:    fmt.Errorf("`decision` is %q", decision),
+			Field:    "decision",
+			Guidance: "it is `approve` or `reject`",
+		}
 	}
 }

--- a/backend/internal/modules/agents/tools_enrich.go
+++ b/backend/internal/modules/agents/tools_enrich.go
@@ -166,8 +166,16 @@ func readEnrichArgs(in json.RawMessage) (enrichArgs, error) {
 		args.Depth = EnrichDepthPage
 	}
 	if args.Depth != EnrichDepthPage && args.Depth != EnrichDepthSite && args.Depth != EnrichDepthTechnical {
-		return enrichArgs{}, &BadArgsError{Cause: fmt.Errorf("depth %q is not %q, %q or %q",
-			args.Depth, EnrichDepthPage, EnrichDepthSite, EnrichDepthTechnical)}
+		// The depth rides in Cause, which is bounded and escaped, and the SET
+		// rides in Guidance, which is ours. Both in Cause meant a long depth
+		// erased the three names the caller needed — the shape BadArgsError's
+		// own doc prescribes, applied.
+		return enrichArgs{}, &BadArgsError{
+			Cause: fmt.Errorf("depth %q is not one this tool takes", args.Depth),
+			Field: "depth",
+			Guidance: fmt.Sprintf("use %s, %s or %s",
+				EnrichDepthPage, EnrichDepthSite, EnrichDepthTechnical),
+		}
 	}
 	if err := requireEnrichURL(args.URL); err != nil {
 		return enrichArgs{}, err

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -164,12 +164,9 @@ func clientInputValidation(err error) (error, bool) {
 // echoing surface does its own bounding, and the MCP renderer borrows this
 // number for the per-field remedy it writes.
 //
-// It is NOT the only figure on that surface any more, and pretending otherwise
-// hid a defect: a refusal naming a closed vocabulary needs more room than an
-// echo of a caller's argument names, and measuring the first against a budget
-// sized for the second silently truncated the vocabulary. agents.MaxFaultDetail
-// is that larger figure, and agents.faultExplanation records which position
-// gets which.
+// It is one of three figures the tool surface applies, each answering a
+// different question about whose words are being echoed.
+// agents.faultExplanation is where that table lives.
 const MaxFaultText = 300
 
 // boundFaultText caps one caller-facing value from a module-declared fault.


### PR DESCRIPTION
Round three on one invariant, from #5137's two reviewers. Both found siblings the
previous sweep missed — including a door neither earlier pass had looked at.

## The resources and dispatch doors echoed raw

`resources.go` in four branches and `dispatch.go` once took the caller's own
string straight off the JSON body:

```go
Message: "no resource at " + p.URI          // no bound, no quoting, no escaping
Message: "method not found: " + req.Method  // likewise
```

The transport's only limit on either is a megabyte. That is the same U+2028
primitive this line of work exists to close, on the two remaining caller-chosen
strings of that surface — while the tool **name** beside them has been bounded
and escaped for exactly this reason since `UnknownToolError`
(`maxToolNameEcho = 64`, whose doc states the rule outright).

The four not-found branches now share one rendering, so a fifth cannot quote it
raw by forgetting to, and they still answer **identically** — a caller must not
be able to tell "does not exist" from "not yours".

## Derive refused without naming anything

Found the moment the census's report subject was made to provoke the real engine
instead of hand-building the error — which is precisely what the reviewer said
hand-building would hide:

```
report: field "a-name-nothing-serves" is outside this report's vocabulary
        — use a name this report declares
                              ^ and declares none
```

Three `FieldNotAllowedError` sites carried a field name with no `Slot` and no
`Allowed`. Its sibling `Run` had named its vocabulary all along. The two callers
that resolve a predicate name did it twice, which is how one came to refuse
without the vocabulary while the other did not; they share `resolvePredicate`
now, and `compileDerivation` came back under the line ceiling as a result.

## Bounding each key left the count unbounded

`unservedPlanArguments` quoted every unknown plan-argument key, but the **list's
length is also the caller's**: twenty unknown keys pushed `group_by` and
`aggregates` off the end of the sentence that exists to name them. Four are named
and the rest counted.

## echoSafe was wrong in the case its own comment claimed to protect

It asked whether the byte at `i` re-validates alone — and the lead byte of a
legitimately encoded `U+FFFD` does not:

```
  caller sends "be�af"  →  reported as "be\xefaf"
                                 the two continuation bytes silently dropped,
                                 naming a byte nobody sent
```

Decode **width** is what separates a byte the decoder gave up on from one it
decoded. An astral rune now renders as `\U%08x`: `0` is no legal escape and
reads as `` then a `0`, which matters for the tag block (U+E0000..U+E007F)
used to smuggle invisible text. Both cases were missing from the table, which is
why both passed.

## Smaller confirmed findings

- The set in a `BadArgsError` belongs in `Guidance` (ours, unbounded), not
  `Cause` (bounded). `tools_enrich` and `tools_approvals` had both in `Cause`, so
  a long `depth` or `decision` erased the words that would have worked.
- `derivation.go`'s unknown-key path answers `UnknownReportError` like `Run`,
  rather than a bare `%q` that bounded nothing and named nothing.
- The `QuoteCaller` guard on `Run`'s saved report id is **dropped** — `uuidShape`
  has already pinned that token, so it could never fire.
- The census now says plainly what is derived (members, from their producers) and
  what is not (subjects, because provoking a refusal needs a written call), and
  that it speaks only for compose's vocabularies. Its non-empty guard moved into
  the constructor so all three tests inherit it rather than one, and a renamed
  report key fatals instead of handing two of them an empty list to pass over.

## Recorded as a follow-up, not attempted here

**The remaining sweep needs a gate, not a fourth partial pass.** Three rounds have
each found more writers of this one invariant, which is the signal that chasing
call sites is the wrong instrument. Still outstanding, all named by the reviewers:

- `search/querysql.go`, `queryvalidate.go`, `querybind.go` — several unbounded
  `quote(callerToken)` in front of closed sets; `queryrefusal.go`'s `quote`
  should simply become `QuoteCaller` (it escapes already, it just does not bound)
- `shared/ports/datasource/util.go` — agent-reachable via `read_record`, and
  **it cannot be fixed as-is**: `shared` sits below `platform` in the DAG, so it
  cannot import `httperr`. This is the concrete argument for moving
  `QuoteCaller` down into `shared/kernel`, which #5126's reviewer already
  suggested on placement grounds
- `compose/captureverdictask.go`'s `clampToken` (64 runes, no escaping) — a second
  spelling of this obligation whose own doc claims it tree-wide
- `tools_import_preview.go` — caller-authored CSV headers ride in `Guidance`
  unbounded (~220 KB flooding channel), with a comment that rationalises the gap
- `signals/store.go`, `csvfields.go` — set-bearing, not agent-reachable

The follow-up should move `QuoteCaller` to `shared/kernel`, fold `clampToken` and
`search`'s `quote` into it, and add the fitness function: a gate asserting every
exported vocabulary producer appears in a census subject.

## Verification

- both new echoSafe cases watched failing against the shipped implementation
- the Derive defect surfaced by the census itself once the subject provoked the
  engine — that is the census doing its job on its first outing
- `make lint` 0 issues, `craft-static` 0 findings, full `./gates/` green
- the uniqueness-claim gate caught a phrase of mine again ("the ONE spelling");
  reworded rather than registered as debt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the last raw echoes of caller-chosen strings in not-found and refusal messages, and makes `Derive`'s refusals name the vocabulary they reject against.

**Echoes are now bounded and escaped**
- The four resource not-found branches share one renderer that runs the caller's URI through `QuoteCaller`; the method-not-found message does the same.
- Unknown plan-argument keys are named at most four at a time and the rest counted, so a long list can no longer crowd the served vocabulary out of the same message.
- `echoSafe` now tells a legitimately encoded `U+FFFD` from an invalid byte using decode width, and renders astral runes as `\U%08x` so tag-block characters (`U+E0000`–`U+E007F`) can't be misread.
- `BadArgsError` sets moved from `Cause` to `Guidance` in `tools_enrich` and `tools_approvals`, so a long caller value can't erase the names that would have worked.

**`Derive` refusals name what they refuse against**
- `FieldNotAllowedError` now carries the slot and the allowed set, and `GroupBy`, `Predicates`, and `Unset` share one `resolvePredicate` path.
- Unknown reports answer `UnknownReportError` (bounded, names the served keys) instead of a bare `%q`, and the dead `QuoteCaller` guard on saved report IDs is dropped.
- The census test provokes the real engine for the report-block subject, derives members from their producers, and fatals on a renamed report key.
- A follow-up is recorded to move `QuoteCaller` into `shared/kernel` and gate the remaining unbounded echoes in `search` and `shared/ports/datasource`.

<sup>Written for commit 0448d9f9ab98d531bc8f82cc6d60dda03a336538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved report and field validation errors with clearer available-name guidance.
  - Refined handling of unknown reports, missing resources, invalid methods, and unsupported arguments.
  - Preserved valid replacement characters and rendered non-BMP characters unambiguously in error details.
  - Structured invalid tool-argument errors with separate field, cause, and guidance information.
  - Limited oversized error details while retaining the most useful context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->