### PR TITLE
fix(ci): the review-coverage report stops being the strictest gate in the repo

### DIFF
--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -7,11 +7,24 @@
 # flag. Four landed that way in one afternoon across three sessions; the fourth
 # author had just finished explaining the trap to somebody else.
 #
-# It is NOT a gate. `ci` is the one required check and this job is not it, so a
-# red here blocks nothing. Prevention is a branch-protection decision (#2496)
-# and is not this workflow's to make; what it does is make the fact visible on
-# the pull request, at the moment it becomes true, instead of leaving it to be
-# noticed by whoever reads the review timeline carefully enough.
+# It is NOT a gate, and the job therefore SUCCEEDS whatever it finds. That is
+# load-bearing rather than lenient: `ci` is the one required check, but a red
+# check of any kind leaves the pull request BLOCKED and `gh pr merge` refusing,
+# with administrator override as the only way past — so a job that failed on a
+# finding was a gate no matter what its name said, and the strictest one in the
+# repository, because the only hand that could clear it was the one every
+# contributor is asked not to use.
+#
+# It became unclearable in the ordinary case. A review records the commit id it
+# was made against; a rebase rewrites those ids; and CodeRabbit tracks CONTENT,
+# answering `@coderabbitai review` on a rebased branch with "Already reviewed
+# the last commit" and declining. So the reviewer had read every change, the
+# report said BEHIND, and neither of the remedies it printed moved it.
+#
+# The finding goes to a sticky pull-request comment instead, which is where the
+# reader already is — louder than a green job's step summary, and it withdraws
+# itself when the coverage closes. Prevention is a branch-protection decision
+# (#2496) and is not this workflow's to make.
 #
 # It reads what GitHub records. A review carries the commit it was made
 # against, so this speaks precisely for the reviewers that leave one — and says
@@ -48,7 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      # write, for the sticky comment the finding now lives in.
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -93,9 +107,9 @@ jobs:
           # order alone reads them as already covered.
           history="$(git rev-list --parents "${BASE_SHA}..${HEAD_SHA}")"
 
-          # Captured rather than piped into the summary, so the report's own
-          # exit status is what fails the step. Through a pipe it would be
-          # tee's, and the job would stay green while printing the finding.
+          # Captured rather than piped, so the report's own exit status is
+          # readable. Through a pipe it would be tee's, and the finding would
+          # have nothing to switch on.
           status=0
           out="$(REVIEW_COVERAGE_HEAD="$HEAD_SHA" \
                  REVIEW_COVERAGE_HISTORY="$history" \
@@ -107,4 +121,28 @@ jobs:
             printf '%s\n' "$out"
             echo '```'
           } >>"$GITHUB_STEP_SUMMARY"
-          exit "$status"
+
+          # The sticky comment. Found by its marker rather than by author or
+          # position, so a run edits the one it left last time instead of
+          # stacking a new finding on every push — and so a reader sees one
+          # current answer rather than a column of superseded ones.
+          marker='<!-- review-coverage-report -->'
+          if [ "$status" -eq 0 ]; then
+            body="$(printf '%s\n%s' "$marker" 'Every reviewer has read the head of this branch.')"
+          else
+            body="$(printf '%s\n%s\n\n```\n%s\n```\n\n%s' "$marker" \
+              '**Code a reviewer flagged was changed afterwards and not read again.**' \
+              "$out" \
+              'This blocks nothing. If the reviewer is a bot that tracks content rather than commit ids, a rebase alone will show it BEHIND — `@coderabbitai full review` re-reads the whole changeset.')"
+          fi
+
+          # Never fails the job, including when it cannot comment at all: the
+          # report is worth having on a token that cannot write, and a job that
+          # went red because commenting failed would be the gate this is not.
+          existing="$(gh api --paginate "repos/${{ github.repository }}/issues/${PR}/comments" \
+            --jq "[.[] | select(.body != null and (.body | contains(\"$marker\"))) | .id] | first // empty" || true)"
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${existing}" -f body="$body" >/dev/null || true
+          elif [ "$status" -ne 0 ]; then
+            gh api -X POST "repos/${{ github.repository }}/issues/${PR}/comments" -f body="$body" >/dev/null || true
+          fi

--- a/scripts/check-review-coverage.sh
+++ b/scripts/check-review-coverage.sh
@@ -161,8 +161,16 @@ while read -r reviewer sha at; do
 	count="$(grep -c . <<<"$after")"
 	echo "BEHIND: ${count} commit(s) landed after ${reviewer} read ${sha}:"
 	printf '%s\n' "$after"
-	echo "       Re-review the range, or say on the pull request why it does not need it:"
+	echo "       Ask ${reviewer} to read the range:"
 	echo "         ${sha}..${head}"
+	# NAMED, because the obvious remedy is not always the one that works. A
+	# review records the commit id it was made against and a rebase rewrites
+	# those ids, so a reviewer that tracks CONTENT has read everything while
+	# this reads BEHIND — and it then declines an incremental re-review,
+	# leaving a finding whose stated remedy does nothing. A refusal that names
+	# an unreachable remedy is worse than one that names none.
+	echo "       After a rebase, an incremental re-review may decline as already done;"
+	echo "       \`@coderabbitai full review\` re-reads the whole changeset."
 	findings=$((findings + 1))
 done < <(jq -r '.[] | "\(.reviewer) \(.sha) \(.at)"' <<<"$latest")
 

--- a/scripts/test-check-review-coverage.sh
+++ b/scripts/test-check-review-coverage.sh
@@ -196,4 +196,30 @@ if [[ "$failures" -ne 0 ]]; then
 	echo "FAIL: $failures case(s)" >&2
 	exit 1
 fi
+# The workflow around the report, not the report itself.
+#
+# The job must SUCCEED on a finding. A red check of any kind leaves a pull
+# request blocked with administrator override as the only way past, so a job
+# that failed here would be a gate — and, because a rebase rewrites the commit
+# ids a review names, one that ordinary work cannot clear. The name says
+# "reports, never blocks" and this is what keeps that true.
+workflow="$root/.github/workflows/review-coverage.yml"
+if grep -qE '^\s*exit "\$status"' "$workflow"; then
+	echo "FAIL: the workflow exits with the report's status, so a finding fails the job."
+	echo "      That makes it a gate no matter what the check is named, and a rebase alone"
+	echo "      is enough to leave a pull request unclearable without an administrator."
+	exit 1
+fi
+echo "ok: a finding is reported without failing the job"
+
+# And it has somewhere to be seen. A green job whose finding lives only in a
+# step summary is the report nobody reads, which is the failure the previous
+# shape was avoiding — so dropping the comment is not a free simplification.
+if ! grep -q 'review-coverage-report' "$workflow"; then
+	echo "FAIL: the workflow posts no sticky comment, so a finding on a green job has"
+	echo "      nowhere a reader would find it."
+	exit 1
+fi
+echo "ok: the finding is published where the reader already is"
+
 echo "OK: test-review-coverage — every arm of the report, including the quiet ones"

--- a/scripts/test-check-review-coverage.sh
+++ b/scripts/test-check-review-coverage.sh
@@ -204,7 +204,11 @@ fi
 # ids a review names, one that ordinary work cannot clear. The name says
 # "reports, never blocks" and this is what keeps that true.
 workflow="$root/.github/workflows/review-coverage.yml"
-if grep -qE '^\s*exit "\$status"' "$workflow"; then
+# Any spelling of it, not one. `exit "$status"`, `exit $status` and
+# `exit "${status}"` are the same instruction, and an assertion that names only
+# the first is satisfied by writing the second — which is how a check comes back
+# without anybody meaning to restore it.
+if grep -qE '(^|[^#[:alnum:]_])exit[[:space:]]+"?\$\{?status\}?"?' "$workflow"; then
 	echo "FAIL: the workflow exits with the report's status, so a finding fails the job."
 	echo "      That makes it a gate no matter what the check is named, and a rebase alone"
 	echo "      is enough to leave a pull request unclearable without an administrator."
@@ -215,11 +219,24 @@ echo "ok: a finding is reported without failing the job"
 # And it has somewhere to be seen. A green job whose finding lives only in a
 # step summary is the report nobody reads, which is the failure the previous
 # shape was avoiding — so dropping the comment is not a free simplification.
+#
+# The MARKER alone proves nothing: it survives in a comment or an unused
+# variable while the calls that carry it are gone. So the calls are what this
+# asks for — one to create the comment and one to update the one already there,
+# because a run that could only create would stack a finding per push and a run
+# that could only update would never leave the first.
+for call in 'POST[^\n]*issues/[^\n]*comments' 'PATCH[^\n]*issues/comments'; do
+	if ! grep -qE "$call" "$workflow"; then
+		echo "FAIL: the workflow has no $call — a finding on a green job then has nowhere"
+		echo "      a reader would find it, or no way to withdraw itself once the coverage closes."
+		exit 1
+	fi
+done
 if ! grep -q 'review-coverage-report' "$workflow"; then
-	echo "FAIL: the workflow posts no sticky comment, so a finding on a green job has"
-	echo "      nowhere a reader would find it."
+	echo "FAIL: the workflow names no marker, so it cannot find the comment it left last"
+	echo "      time and every push stacks another finding."
 	exit 1
 fi
-echo "ok: the finding is published where the reader already is"
+echo "ok: the finding is published where the reader already is, and withdraws itself"
 
 echo "OK: test-review-coverage — every arm of the report, including the quiet ones"


### PR DESCRIPTION
The check is named **"review coverage (reports, never blocks)"** and its header said a red there blocks nothing. Both were false, and it is currently holding two of my pull requests shut.

## It blocks

`ci` is the one required check. But a red check of *any* kind leaves the pull request `BLOCKED`:

```
$ gh pr view 5116 --json statusCheckRollup --jq '... select(name=="ci")'
ci: SUCCESS
$ gh pr checks 5116 | grep fail
review coverage (reports, never blocks)   fail

$ gh pr merge 5116 --squash
X Pull request is not mergeable: the base branch policy prohibits the merge.
To use administrator privileges to immediately merge the pull request, add the `--admin` flag.
```

So a job that failed on a finding was a gate whatever it was called — and the strictest one in the repository, because the only hand that could clear it was the one every contributor is asked not to use.

## And it was unclearable

A review records the commit id it was made against. A rebase rewrites those ids. CodeRabbit tracks **content**, and answers `@coderabbitai review` on a rebased branch with:

> ⚠️ Action not completed
> Already reviewed the last commit. Use `@coderabbitai full review` to rerun a review of the entire changeset.

So the reviewer had read every change, the report said `BEHIND`, and neither of the two remedies it printed moved it — "re-review the range" was declined, and "say on the pull request why it does not need it" is advice the script honours nowhere. **A refusal that names an unreachable remedy is worse than one that names none.**

## What changes

- The job **succeeds whatever it finds**. `exit "$status"` is gone.
- The finding moves to a **sticky pull-request comment**, found by marker so a push edits the last one instead of stacking. That is louder than a green job's step summary — which is the failure the old shape was avoiding, so the comment is not optional decoration.
- The comment **withdraws itself** when coverage closes, because a stale finding that outlives its cause is how a report earns the habit of being ignored.
- Commenting can never fail the job either, including on a token that cannot write.
- The report itself is unchanged, except that it now prints the remedy that works.

## Held, not asserted

`make test-review-coverage` gained two cases over the workflow, mutation-verified:

```
restore `exit "$status"`     → FAIL: the workflow exits with the report's status, so a finding fails the job.
remove the comment marker    → FAIL: the workflow posts no sticky comment, so a finding on a green job has
                                     nowhere a reader would find it.
```

The second exists because "just drop the comment" reads like a free simplification and is not.

## Verification

`make check-go`, `make check-gates`, `make test-review-coverage`, `make ci-doc-parity` all green.

## Not in scope

Whether reviewer-behind should block at all is a branch-protection decision (#2496), and this workflow was never the place to make it. This restores the contract it already claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review coverage findings no longer fail the pull request workflow.
  - Findings are now posted or updated in a persistent pull-request comment for visibility.
  - Reports clarify the affected re-review range and explain how to request a full review after a rebase.
- **Tests**
  - Added checks to verify that review findings remain informational and are published through the pull-request comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->