### PR TITLE
The decoders stop describing this program, and a threshold cannot be unset

### DIFF
--- a/backend/internal/compose/closedsetrefusalbudget_test.go
+++ b/backend/internal/compose/closedsetrefusalbudget_test.go
@@ -26,7 +26,9 @@ package compose
 // modules/agents, modules/search or shared/ports/datasource — compose is
 // downstream of all three, so importing them here is legal but provoking their
 // refusals from this package is not the same test. Those carry the same
-// obligation and are held where they live; this file does not speak for them.
+// obligation. Two of them are NOT held anywhere — the enrich depths and the
+// approval decision, both agents' own sets — and saying so is better than a
+// sentence implying somebody covers them.
 //
 // IT ASSERTS ON THE CLASSIFIED FAULT, not on err.Error(). The renderer is not
 // the only ceiling: httperr bounds a module-declared fault at MaxFaultText
@@ -35,6 +37,8 @@ package compose
 // Asking httperr.Classify is asking the surface rather than a model of it.
 
 import (
+	"encoding/json"
+	"fmt"
 	"maps"
 	"slices"
 	"strings"
@@ -51,7 +55,14 @@ import (
 // echo leaves nothing for the set.
 const floodedCallerTokenLen = 4000
 
-func floodedCallerToken() string { return strings.Repeat("k", floodedCallerTokenLen) }
+// It is not plain ASCII, and that is the point: a token bounded at 80 bytes by
+// QuoteCaller can still EXPAND downstream, because agents.echoSafe escapes what
+// does not print. An ASCII flood measured the bound and never the expansion, and
+// an astral-escaping regression that pushed a refusal from 358 to 466 bytes went
+// unseen here for exactly that reason.
+func floodedCallerToken() string {
+	return strings.Repeat("k\u2028\U000e0020", floodedCallerTokenLen/12)
+}
 
 // setBearingRefusal is one vocabulary, the refusal that names it, and the way to
 // provoke that refusal with a token of the caller's choosing.
@@ -171,6 +182,34 @@ func closedSetRefusals(t *testing.T) []setBearingRefusal {
 						{Field: "currency", Op: analyticsquery.FilterOp(token), Value: "EUR"},
 					},
 				}.Validate(schema)
+			},
+		},
+		{
+			// The refusal maxUnservedNamed exists for. Each unknown key is
+			// bounded, but the COUNT of them is the caller's too — twenty
+			// pushed the served vocabulary off the end of the sentence that
+			// names it, which is why the list is truncated and counted.
+			what:    "the plan arguments this tool takes",
+			members: []string{slotFilters, slotGroupBy, slotAggregates},
+			refuse: func(token string) error {
+				// TWENTY unknown keys, not one: each is bounded on its own and
+				// the count is what crowds the served set out.
+				args := map[string]string{}
+				for i := range 20 {
+					args[fmt.Sprintf("%s-%d", token, i)] = "x"
+				}
+				body, err := json.Marshal(args)
+				if err != nil {
+					t.Fatalf("could not build a plan with unknown keys: %v", err)
+				}
+				unserved := unservedPlanArguments(body)
+				if len(unserved) == 0 {
+					t.Fatal("twenty unknown plan keys were all served, so this case measures nothing")
+				}
+				// The sentence the tool surface builds, as registry.go builds it.
+				return httperr.Validation("arguments", "malformed_json",
+					"this tool does not take "+strings.Join(unserved, ", ")+
+						"; its plan arguments are `"+slotFilters+"`, `"+slotGroupBy+"` and `"+slotAggregates+"`")
 			},
 		},
 		{

--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -53,7 +53,12 @@ const asOfKey = "as_of"
 // reservedDerivationKeys are the query-string names a handle owns. Report
 // vocabularies may not squat on them, or a minted URL would be ambiguous.
 // Derived from here rather than restated, so adding a key updates the gate.
-var reservedDerivationKeys = []string{"by", "agg", nullPredicateKey, asOfKey, reservedDerivationColumn}
+var reservedDerivationKeys = []string{groupByKey, "agg", nullPredicateKey, asOfKey, reservedDerivationColumn}
+
+// groupByKey names the dimensions a handle groups by. Named because a refusal
+// quotes it back, and a refusal naming an argument the caller did not send is
+// the confusion FieldNotAllowedError.Slot exists to prevent.
+const groupByKey = "by"
 
 // derivationQuery is one parsed derivation handle: the equality
 // predicates that pin the explained cell (plan filters + the row's
@@ -214,13 +219,17 @@ func compileDerivation(spec reportSpec, q derivationQuery) (derivationPlan, erro
 	grouped := map[string]bool{}
 	for _, dim := range q.GroupBy {
 		if _, ok := spec.dimensions[dim]; !ok {
-			// Slot and Allowed, not the name alone. Without them the refusal
-			// says "use a name this report declares" and declares nothing, so
-			// a caller loops on guesses — the same refusal Run's own group_by
-			// path gives, which this one silently did not match.
+			// Slot and Allowed, not the name alone: without them the refusal
+			// says "use a name this report declares" and declares nothing, so a
+			// caller loops on guesses.
+			//
+			// Slot is the HANDLE's key rather than the plan's `group_by`. This
+			// path resolves a minted URL, whose arguments a caller can see and
+			// edit, and naming the plan's spelling would quote back an argument
+			// they never sent.
 			return derivationPlan{}, &FieldNotAllowedError{
 				Field:   dim,
-				Slot:    slotGroupBy,
+				Slot:    groupByKey,
 				Allowed: allowedReportNames(spec.dimensions),
 			}
 		}
@@ -230,14 +239,14 @@ func compileDerivation(spec reportSpec, q derivationQuery) (derivationPlan, erro
 	// Predicates admit the union of the report's dimensions and filters:
 	// a group-key value pins the cell, a filter value replays the plan.
 	for key, value := range q.Predicates {
-		pred, err := resolvePredicate(spec, key, value, false)
+		pred, err := resolveValuePredicate(spec, key, value)
 		if err != nil {
 			return derivationPlan{}, err
 		}
 		plan.preds = append(plan.preds, pred)
 	}
 	for field := range q.Unset {
-		pred, err := resolvePredicate(spec, field, "", true)
+		pred, err := resolveNullPredicate(spec, field)
 		if err != nil {
 			return derivationPlan{}, err
 		}
@@ -399,50 +408,93 @@ func sortedKeys(m map[string]string) []string {
 	return keys
 }
 
-// allowedPredicateNames is what a derivation predicate may name: the union a
-// predicate is actually resolved against above — the report's dimensions, its
-// filters and its thresholds.
-//
-// Derived from the spec rather than listed, and the UNION rather than either
-// half, because a refusal naming only the dimensions would refuse a caller a
-// filter name this engine accepts.
-func allowedPredicateNames(spec reportSpec) []string {
-	names := make([]string, 0, len(spec.dimensions)+len(spec.filters)+len(spec.thresholds))
-	names = append(names, allowedReportNames(spec.dimensions)...)
-	names = append(names, allowedReportNames(spec.filters)...)
-	for key := range spec.thresholds {
-		names = append(names, key)
+// resolveValuePredicate resolves a predicate that pins a VALUE, against what
+// this report admits one over: a threshold, a dimension or a filter.
+func resolveValuePredicate(spec reportSpec, name, value string) (boundExpr, error) {
+	if threshold, ok := spec.thresholds[name]; ok {
+		return boundExpr{field: name, value: value, threshold: &threshold}, nil
 	}
+	expr, ok := predicateExpr(spec, name)
+	if !ok {
+		// No Slot: a handle pins a value with a bare `field=value`, so there is
+		// no argument name to quote back — FieldNotAllowedError falls back to
+		// the unqualified wording and still names the vocabulary.
+		return boundExpr{}, &FieldNotAllowedError{
+			Field:   name,
+			Allowed: allowedPredicateNames(spec),
+		}
+	}
+	return boundExpr{field: name, expr: expr, value: value}, nil
+}
+
+// resolveNullPredicate resolves a predicate asserting a column is UNSET.
+//
+// A THRESHOLD IS REFUSED HERE, and that is the whole reason this is its own
+// function. A threshold is a comparison over a number, not a column that can be
+// null, and the fetch below switches on `threshold != nil` BEFORE `isNull` — so
+// a threshold carrying isNull took the threshold arm with an empty value and
+// died later telling the caller to "send it as a number", advice for a request
+// they did not make. Refusing it here says what is actually wrong, and names
+// the keys that can be unset.
+func resolveNullPredicate(spec reportSpec, name string) (boundExpr, error) {
+	if _, isThreshold := spec.thresholds[name]; isThreshold {
+		return boundExpr{}, &FieldNotAllowedError{
+			Field:   name,
+			Slot:    nullPredicateKey,
+			Allowed: allowedNullableNames(spec),
+		}
+	}
+	expr, ok := predicateExpr(spec, name)
+	if !ok {
+		return boundExpr{}, &FieldNotAllowedError{
+			Field:   name,
+			Slot:    nullPredicateKey,
+			Allowed: allowedNullableNames(spec),
+		}
+	}
+	return boundExpr{field: name, expr: expr, isNull: true}, nil
+}
+
+// predicateExpr is the column expression a predicate name resolves to: a
+// dimension's or a filter's. One lookup, so the two resolvers above cannot come
+// to disagree about what a predicate may name.
+func predicateExpr(spec reportSpec, name string) (string, bool) {
+	if expr, ok := spec.dimensions[name]; ok {
+		return expr, true
+	}
+	expr, ok := spec.filters[name]
+	return expr, ok
+}
+
+// allowedPredicateNames is what a VALUE predicate may name — the union
+// resolveValuePredicate resolves against.
+//
+// The filter half comes from catalogFilterNames, which the report catalog and
+// the plan's own `filters` refusal already use, rather than a second spelling of
+// "filters and thresholds as one list": that pairing has a reason
+// (reportcatalog.go) and two copies of it would drift.
+//
+// THE TWO HALVES ARE SCOPED DIFFERENTLY and this says so rather than reading as
+// though they were not: grantedSpec narrows a caller's dimensions and measures
+// and leaves filters and thresholds alone, so the dimension half is this seat's
+// and the filter half is the installation's. It discloses nothing either way —
+// the report catalog publishes every filter and threshold name to every caller —
+// but a reader comparing this list against the catalog will find the dimensions
+// shorter, and that is why.
+func allowedPredicateNames(spec reportSpec) []string {
+	names := append(allowedReportNames(spec.dimensions), catalogFilterNames(spec)...)
 	slices.Sort(names)
 	return slices.Compact(names)
 }
 
-// resolvePredicate resolves one predicate name against what this report admits: a
-// threshold, a dimension or a filter, in that order.
+// allowedNullableNames is what an UNSET predicate may name: the same union
+// WITHOUT the thresholds, which resolveNullPredicate refuses.
 //
-// The two callers differ only in whether the predicate pins a value or asserts
-// its absence, and they resolved the name identically — twice, which is how one
-// of them came to refuse without naming the vocabulary while the other did.
-func resolvePredicate(spec reportSpec, name, value string, isNull bool) (boundExpr, error) {
-	if threshold, ok := spec.thresholds[name]; ok {
-		if isNull {
-			return boundExpr{field: name, isNull: true, threshold: &threshold}, nil
-		}
-		return boundExpr{field: name, value: value, threshold: &threshold}, nil
-	}
-	expr, ok := spec.dimensions[name]
-	if !ok {
-		expr, ok = spec.filters[name]
-	}
-	if !ok {
-		return boundExpr{}, &FieldNotAllowedError{
-			Field:   name,
-			Slot:    slotFilters,
-			Allowed: allowedPredicateNames(spec),
-		}
-	}
-	if isNull {
-		return boundExpr{field: name, expr: expr, isNull: true}, nil
-	}
-	return boundExpr{field: name, expr: expr, value: value}, nil
+// Two sets rather than one, because naming a vocabulary the resolver goes on to
+// refuse is the same defect as naming none — the caller picks a name off the
+// list and is refused again.
+func allowedNullableNames(spec reportSpec) []string {
+	names := append(allowedReportNames(spec.dimensions), allowedReportNames(spec.filters)...)
+	slices.Sort(names)
+	return slices.Compact(names)
 }

--- a/backend/internal/modules/agents/badargs.go
+++ b/backend/internal/modules/agents/badargs.go
@@ -256,11 +256,14 @@ func echoSafe(s string, n int) string {
 			// which IS printable, so writing the rune back would replace the
 			// caller's byte with U+FFFD and report a name they did not send.
 			fmt.Fprintf(&b, `\x%02x`, s[i])
-		case r > 0xFFFF:
-			// Above the BMP, `\u` takes no more than four digits — `\ue0020`
-			// for U+E0020 is not a legal escape anywhere and reads as `\ue002`
-			// followed by a `0`. The tag block this covers (U+E0000..U+E007F)
-			// is the one used to smuggle invisible text.
+		case !unicode.IsPrint(r) && r > 0xFFFF:
+			// An UNPRINTABLE rune above the BMP, and the printability test comes
+			// first for a reason: an emoji and a CJK extension character are
+			// both astral AND printable, so escaping every astral rune would
+			// mangle a real name. `\u` takes no more than four digits, so
+			// `\ue0020` for U+E0020 is not a legal escape anywhere and reads as
+			// `\ue002` followed by a `0` — and U+E0000..U+E007F is the tag block
+			// used to smuggle invisible text.
 			fmt.Fprintf(&b, `\U%08x`, r)
 		case !unicode.IsPrint(r):
 			fmt.Fprintf(&b, `\u%04x`, r)

--- a/backend/internal/modules/agents/dispatch.go
+++ b/backend/internal/modules/agents/dispatch.go
@@ -378,7 +378,14 @@ func (s *Dispatcher) call(ctx context.Context, params json.RawMessage, fr framin
 		Arguments json.RawMessage `json:"arguments"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
-		return toolError("malformed tools/call params: " + err.Error())
+		// Same reason decodeArgs masks its decoder: encoding/json describes this
+		// program, not anything the caller can fix, and the withheld words go
+		// to the operator instead of into the model's transcript.
+		safe, withheld := httperr.SafeDecodeError(err)
+		if withheld {
+			s.log.Warn("mcp: unnamed tools/call params decode failure", "err", err)
+		}
+		return toolError("malformed tools/call params: " + safe.Error())
 	}
 	if p.Arguments == nil {
 		p.Arguments = json.RawMessage(`{}`)

--- a/backend/internal/modules/agents/echosafe_test.go
+++ b/backend/internal/modules/agents/echosafe_test.go
@@ -84,6 +84,10 @@ func TestEchoSafeLeavesRealNamesAlone(t *testing.T) {
 		"deals-by-stage",
 		"amount_base_minor",
 		"a name with spaces",
+		// Astral AND printable. Escaping every rune above the BMP to render the
+		// tag block safely would have mangled both of these.
+		"Ren\u00e9 \U0001f600",
+		"\U00020000 extension B",
 	} {
 		if got := echoSafe(name, maxBadArgsDetail); got != name {
 			t.Errorf("echoSafe rewrote an ordinary name: %q became %q", name, got)

--- a/backend/internal/modules/agents/resources.go
+++ b/backend/internal/modules/agents/resources.go
@@ -140,29 +140,24 @@ func (s *Dispatcher) resourceList(ctx context.Context, fr framing) []resourceDes
 // A host that renders views is unaffected: every route to a view's URI runs
 // through a tool's `_meta.ui`, which only an App-declaring request is served,
 // so a client that knows the URI at all is one that declared it can render it.
-// noResourceAt renders the not-found answer, so that no branch can quote the
-// caller's URI back raw by forgetting to.
-//
-// The URI arrives off the JSON body, where nothing bounds it but the transport's
-// megabyte cap, and the answer lands in a transcript whose later prompts the same
-// run reads. Raw, it carried both an unbounded write and a character the reader
-// treats as a line ending. Bounded and escaped, it still says which URI was
-// asked for — which is the whole value of naming it.
-//
-// Four branches answer with it, and they answer IDENTICALLY on purpose: an
-// unknown URI, one this caller's scopes do not reach, one the provider does not
-// serve, and an app document on a surface not offering apps. A caller must not
-// be able to tell "does not exist" from "not yours".
-func noResourceAt(uri string) string {
-	return "no resource at " + httperr.QuoteCaller(uri)
-}
-
 func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage, fr framing) (resourceContents, *rpcError) {
 	var p struct {
 		URI string `json:"uri"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
-		return resourceContents{}, &rpcError{Code: codeInvalidParams, Message: "invalid params: " + err.Error()}
+		// SafeDecodeError, not err.Error(): what encoding/json says here
+		// describes THIS program — a Go struct field, a Go type — which an agent
+		// can neither act on nor is entitled to read, and it lands in a
+		// transcript whose later prompts the same run reads. decodeArgs refuses
+		// it for exactly this reason; this decoder is the same door.
+		safe, withheld := httperr.SafeDecodeError(err)
+		if withheld {
+			s.log.Warn("mcp: unnamed resources/read params decode failure", "err", err)
+		}
+		return resourceContents{}, &rpcError{
+			Code:    codeInvalidParams,
+			Message: "invalid params: " + safe.Error(),
+		}
 	}
 	// An absent, null or empty uri is a request this server could not read,
 	// not a resource that is missing — a different thing for the caller to
@@ -193,7 +188,11 @@ func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage, f
 	if err != nil {
 		// The cause is server-side knowledge (a pool fault, a wrapped SQL
 		// error); the client learns only that the read did not happen.
-		s.log.Error("mcp: reading resource", "uri", p.URI, "err", err)
+		// The URI is bounded in the OPERATOR's log too. It is caller-controlled
+		// and limited only by the transport's cap, and a caller who can provoke
+		// a provider error can otherwise drive megabytes per call into it. What
+		// the line is worth is which URI, not all of it.
+		s.log.Error("mcp: reading resource", "uri", httperr.QuoteCaller(p.URI), "err", err)
 		return resourceContents{}, &rpcError{Code: codeInternalError, Message: "the resource could not be read; retry, and if it persists ask an administrator to check the server logs"}
 	}
 	return resourceContents{Contents: []resourceContentBlock{{
@@ -205,6 +204,23 @@ func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage, f
 		// bytes with the other provider's rules. See mcp.ResourceContents.UI.
 		Meta: resourceMetaFor(mcp.Resource{URI: contents.URI, UI: contents.UI}),
 	}}}, nil
+}
+
+// noResourceAt renders the not-found answer, so that no branch can quote the
+// caller's URI back raw by forgetting to.
+//
+// The URI arrives off the JSON body, where nothing bounds it but the transport's
+// megabyte cap, and the answer lands in a transcript whose later prompts the same
+// run reads. Raw, it carried both an unbounded write and a character the reader
+// treats as a line ending. Bounded and escaped, it still says which URI was
+// asked for — which is the whole value of naming it.
+//
+// Every branch that answers not-found answers IDENTICALLY on purpose: an unknown
+// URI, one this caller's scopes do not reach, one the provider does not serve,
+// and an app document on a surface not offering apps. A caller must not be able
+// to tell "does not exist" from "not yours".
+func noResourceAt(uri string) string {
+	return "no resource at " + httperr.QuoteCaller(uri)
 }
 
 // isAppDocument reports whether a document is an interactive view.


### PR DESCRIPTION
Round-three review findings on #5138, from both reviewers. **Three of these are
defects #5138 itself introduced**, which is the honest headline.

## An astral rune is not automatically unprintable

My new escape arm ran *before* the printability test:

```
  emoji U+1F600      IsPrint=true   → escaped   ✗
  CJK ext-B U+20000  IsPrint=true   → escaped   ✗
  tag char U+E0020   IsPrint=false  → escaped   ✓
```

So `"René 😀"` came back as `"René \U0001f600"`. It also broke the property the
file states out loud: `%q` passes printable astral through, so `echoSafe` and
`QuoteCaller` stopped asking the same question — meaning a token bounded at 80
bytes by `QuoteCaller` could expand tenfold downstream (measured: a refusal going
358 → 466 bytes inside a 512 budget).

**The census could not see it, because it floods with ASCII.** It floods with an
expanding token now — `k` + U+2028 + a tag character — so the next escaping change
that inflates a bounded token fails here.

## The unset-threshold arm was a reachable regression

`compileDerivation` gained an `isNull` predicate carrying a threshold, and
`derivationWhere` switches on `threshold != nil` **before** `isNull` — so the flag
was dead, the threshold arm ran with an empty value, and:

```
  ?isnull=days on projects-gone-quiet
    before: refused at compile time, naming the vocabulary
    after:  compiles, then dies with "takes a whole number of days"
            — advice for a request the caller did not make
```

A threshold is a comparison over a number and cannot be unset, so
`resolveNullPredicate` refuses it and names the keys that *can* be. That needed a
second derived set: naming a vocabulary the resolver goes on to refuse is the
same defect as naming none.

## The helper stole the doc comment above it

`noResourceAt` landed directly beneath `readResource`'s three-paragraph essay on
framing and not-found symmetry, so godoc rendered that essay over a two-line
string helper and left `readResource` undocumented.

## Two decoders on this surface still described this program

```go
Message: "invalid params: " + err.Error()            // resources/read
toolError("malformed tools/call params: " + err.Error())
```

`resources/read` with `{"uri": 5}` answered *"json: cannot unmarshal number into
Go struct field .uri of type string"* — unbounded, unescaped, describing this
program into a transcript whose later prompts the same run reads. `decodeArgs`
has masked exactly this through `httperr.SafeDecodeError` since it was written,
with the reason spelled out; these are the same door and never got the copy. The
withheld words go to the operator's log — and the URI in that log is bounded too,
since a caller who can provoke a provider error could otherwise drive megabytes
per call into it.

## Smaller confirmed findings

- `allowedPredicateNames` is built on the existing `catalogFilterNames` rather
  than spelling "filters and thresholds as one list" a second time — that pairing
  has a documented reason and two copies drift. Its two halves *are* scoped
  differently (`grantedSpec` narrows dimensions, not filters), and it now says so
  rather than reading as though they matched. Confirmed by the security reviewer
  as fails-closed and not a disclosure: the report catalog already publishes
  every filter and threshold name to every caller.
- The census enumerates the refusal `maxUnservedNamed` was added for, which
  nothing measured — watched failing at **1725 bytes** with the truncation
  removed.
- Its claim that agents' own sets are "held where they live" was **false**. It now
  names the two that are held nowhere (the enrich depths, the approval decision)
  rather than implying somebody covers them.
- `resolvePredicate`'s boolean became two named functions over one shared lookup,
  and a derivation refusal quotes the **handle's** argument keys (`by`, `isnull`)
  rather than the plan's, which named arguments a handle caller never sent.

## Verified

`compileDerivation` runs after `auth.Require`, `requireVocabularyGrants` and
`grantedSpec`, so the vocabularies these refusals name are post-authorization —
checked independently by the security reviewer, who also probed `echoSafe`
against 14 malformed and astral inputs (overlong encodings, truncated tails, lone
surrogates, a real U+FFFD, U+E0001/E0020, U+2028, U+202E) and found no raw
unprintable, bidi control or line terminator surviving.

`make lint` 0 issues, `craft-static` 0 findings, full `./gates/` green, every
touched package green. The regression and the new census subject were both
watched failing first.

## Still outstanding, and it wants a gate not a fourth pass

Unchanged from #5138's note: `search/query*.go`, `shared/ports/datasource`
(blocked on the DAG until `QuoteCaller` moves to `shared/kernel`),
`compose/captureverdictask.go`'s `clampToken`, `tools_import_preview.go`'s
unbounded `Guidance`, `signals/store.go`, `csvfields.go`. Four rounds have each
found more writers of this one invariant; the follow-up should move `QuoteCaller`
down, fold the duplicate spellings into it, and add the fitness function that
asserts every exported vocabulary producer appears in a census subject.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three regressions from the prior round — astral escaping no longer mangles printable names like emoji, `isnull` on a threshold is refused at compile time, and `readResource`'s doc comment is back — and masks two decoders that still leaked Go internals into tool results.

**Bug Fixes**
- `echoSafe` escapes only unprintable astral runes, so emoji and CJK extension text pass through intact.
- `isnull` on a threshold is refused at compile time and names only keys that can be unset; previously it compiled and then failed with advice for a request the caller never made.
- `resources/read` and `tools/call` route decode errors through `httperr.SafeDecodeError`, sending `encoding/json` details only to the operator log; the logged URI is bounded via `QuoteCaller`.
- `readResource`'s doc comment is restored; it had been rendered over the `noResourceAt` helper.

**Refactors**
- `resolvePredicate`'s boolean becomes two resolvers over one shared lookup.
- Derivation refusals quote the handle's argument keys (`by`, `isnull`) rather than plan spellings.
- `allowedPredicateNames` derives from `catalogFilterNames` instead of spelling the filter/threshold union twice.
- The census floods with a token that expands under escaping, so the astral regression would have failed it.

<sup>Written for commit d708ee23b4eeb101929e0c12d3ec114f28e44d21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

