### PR TITLE
feat(consent): a rep can record a marketing objection, and stopping contact still confirms itself

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -14326,13 +14326,24 @@ paths:
         to stop stays stopped until somebody with the authority to lift it says otherwise.
 
         **Who may lift it is part of the record.** The row carries the authority of whoever wrote
-        it, taken from the session and never from this body. A rep's row is liftable by an admin
-        and not by another rep; nothing an installation can do lifts the subject's own Art. 21
-        objection, which is a different kind this door cannot write.
+        it, taken from the session and never from this body. A rep's `subject_request` row is
+        liftable by an admin and not by another rep.
 
-        The only kind recordable here is `subject_request`. An objection and a processing
-        restriction carry legal consequences a relayed phone call does not establish, and a hard
-        bounce is a fact about a mailbox only the mail path observes.
+        A `marketing_objection` is different: it is recorded at the SUBJECT'S authority whoever
+        types it, because Art. 21 gives the right to the data subject and a rep relaying the call
+        is a courier rather than its author. Nothing an installation can do lifts it — only the
+        subject reversing it, or the per-message exception path, which records a send as
+        exceptional rather than making the objection go away.
+
+        Two kinds are recordable here. `subject_request` is "stop contacting me", and it stops
+        every category except the three the controller owes regardless of what the subject wants
+        sent: a privacy notice, a security warning, and the confirmation that an opt-out was
+        recorded. `marketing_objection` is Art. 21(2) and stops marketing only, so the invoice the
+        same person is owed still goes.
+
+        A processing restriction and a hard bounce are not recordable by hand: the first is an
+        Art. 18 legal state with its own workflow, the second a fact about a mailbox only the mail
+        path observes.
       requestBody:
         required: true
         content:
@@ -14343,8 +14354,12 @@ paths:
               properties:
                 kind:
                   type: string
-                  enum: [subject_request]
-                  description: Which stop this is. Only the subject's own request is recordable by hand.
+                  enum: [subject_request, marketing_objection]
+                  description: |
+                    Which stop this is. `subject_request` is "stop contacting me" and reaches every
+                    category but the three the controller owes anyway. `marketing_objection` is
+                    Art. 21(2), reaches marketing only, and is recorded at the subject's own
+                    authority so no seat can lift it.
                 reason:
                   type: string
                   maxLength: 500

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -14331,9 +14331,12 @@ paths:
 
         A `marketing_objection` is different: it is recorded at the SUBJECT'S authority whoever
         types it, because Art. 21 gives the right to the data subject and a rep relaying the call
-        is a courier rather than its author. Nothing an installation can do lifts it — only the
-        subject reversing it, or the per-message exception path, which records a send as
-        exceptional rather than making the objection go away.
+        is a courier rather than its author.
+
+        **Nothing lifts it today.** No seat outranks the subject, and the subject-initiated
+        reversal that would let them take it back is not built yet — the preference centre writes
+        consent state and never touches a suppression. Record one only when the person actually
+        asked for it: a mistake currently needs a database correction, not a product action.
 
         Two kinds are recordable here. `subject_request` is "stop contacting me", and it stops
         every category except the three the controller owes regardless of what the subject wants

--- a/backend/api/public-events.yaml
+++ b/backend/api/public-events.yaml
@@ -2597,7 +2597,12 @@ components:
       properties:
         kind:
           type: string
-          description: Which stop this is (subject_request for a hand-recorded one).
+          description: >-
+            Which stop this is. `subject_request` and `marketing_objection` are the two recorded by
+            hand; `processing_restriction` and `hard_bounce` are written by machinery. They differ
+            in reach: a subject request stops everything except the privacy notice, security notice
+            and opt-out confirmation the controller owes regardless, while an objection is
+            Art. 21(2) and stops marketing alone.
         decided_by_level:
           type: string
           description: >-

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16332,12 +16332,15 @@ func (e ListPeopleParamsTagMode) Valid() bool {
 
 // Defines values for SuppressPersonJSONBodyKind.
 const (
-	SubjectRequest SuppressPersonJSONBodyKind = "subject_request"
+	MarketingObjection SuppressPersonJSONBodyKind = "marketing_objection"
+	SubjectRequest     SuppressPersonJSONBodyKind = "subject_request"
 )
 
 // Valid indicates whether the value is a known member of the SuppressPersonJSONBodyKind enum.
 func (e SuppressPersonJSONBodyKind) Valid() bool {
 	switch e {
+	case MarketingObjection:
+		return true
 	case SubjectRequest:
 		return true
 	default:
@@ -40768,7 +40771,10 @@ type IssueDoubleOptInJSONBody struct {
 
 // SuppressPersonJSONBody defines parameters for SuppressPerson.
 type SuppressPersonJSONBody struct {
-	// Kind Which stop this is. Only the subject's own request is recordable by hand.
+	// Kind Which stop this is. `subject_request` is "stop contacting me" and reaches every
+	// category but the three the controller owes anyway. `marketing_objection` is
+	// Art. 21(2), reaches marketing only, and is recorded at the subject's own
+	// authority so no seat can lift it.
 	Kind SuppressPersonJSONBodyKind `json:"kind"`
 
 	// Reason What the person was told, in their words. Stored because a suppression somebody

--- a/backend/internal/contracts/publicevents_gen.go
+++ b/backend/internal/contracts/publicevents_gen.go
@@ -1034,7 +1034,7 @@ type PublicEventConsentSuppressed struct {
 	// DecidedByLevel Whose decision it is, which is what says who may lift it (machine | user | admin | subject).
 	DecidedByLevel string `json:"decided_by_level"`
 
-	// Kind Which stop this is (subject_request for a hand-recorded one).
+	// Kind Which stop this is. `subject_request` and `marketing_objection` are the two recorded by hand; `processing_restriction` and `hard_bounce` are written by machinery. They differ in reach: a subject request stops everything except the privacy notice, security notice and opt-out confirmation the controller owes regardless, while an objection is Art. 21(2) and stops marketing alone.
 	Kind string `json:"kind"`
 }
 

--- a/backend/internal/modules/consent/authorizesuppression.go
+++ b/backend/internal/modules/consent/authorizesuppression.go
@@ -73,19 +73,28 @@ func applySuppression(d commsauthz.Decision, kinds []string) commsauthz.Decision
 //     NOT the other two subject-serving categories: a record confirmation is
 //     an unsolicited invitation to review a record and a consent confirmation
 //     solicits a NEW grant, and Art. 18(2) offers no gateway for either.
-//   - A SUBJECT'S REQUEST binds everything. Somebody said stop, in words a rep
-//     wrote down; answering it with mail they did not ask for is the thing they
-//     asked us not to do.
-//   - Everything else binds every category too, which is where a hard bounce
-//     lands and where an unrecognised reason code lands. No template makes a
-//     dead address accept mail, and a code this function does not know must
-//     refuse rather than pick a narrower rule — the direction liveSuppression,
+//   - A SUBJECT'S REQUEST binds everything EXCEPT those same three. It used to
+//     bind all fourteen, on the reasoning that somebody said stop and answering
+//     with unasked-for mail is the thing they asked us not to do. That reasoning
+//     is right about the twelve and wrong about these three, and the way it was
+//     wrong is visible: a person who said "stop emailing me" never received the
+//     confirmation that we had stopped, because opt-out confirmation was bound
+//     by the very request it was confirming. The privacy notice that answers
+//     their own rights request and the security warning about their own account
+//     fail the same way. Art. 12(3), 13/14 and 34 are obligations the controller
+//     owes REGARDLESS of what the subject wants sent, which is exactly the
+//     shape of Art. 18(2)'s carve-out — so the two share survivesARestriction
+//     rather than keeping a second list to drift apart from it.
+//   - Everything else binds every category, which is where a hard bounce lands
+//     and where an unrecognised reason code lands. No template makes a dead
+//     address accept mail, and a code this function does not know must refuse
+//     rather than pick a narrower rule — the direction liveSuppression,
 //     blockedReasonCode and the validators all already fail in.
 func suppressionBinds(kind string, category commsauthz.Category) bool {
 	switch kind {
 	case commsauthz.ReasonObjection:
 		return category == commsauthz.CategoryMarketing
-	case commsauthz.ReasonRestricted:
+	case commsauthz.ReasonRestricted, commsauthz.ReasonSubjectRequest:
 		return !survivesARestriction(category)
 	default:
 		return true
@@ -117,7 +126,16 @@ func survivesARestriction(c commsauthz.Category) bool {
 // asserts the implication over every category and every reason code.
 func bindsEveryCategory(kinds []string) (string, bool) {
 	for _, kind := range kinds {
-		if kind != commsauthz.ReasonObjection && kind != commsauthz.ReasonRestricted {
+		switch kind {
+		case commsauthz.ReasonObjection, commsauthz.ReasonRestricted,
+			// subject_request joined the scoped kinds when it stopped binding
+			// the three categories Art. 12(3)/13/14/34 oblige us to send. Left
+			// here it would take the early exit and refuse an opt-out
+			// confirmation without ever asking suppressionBinds — the rule and
+			// its shortcut disagreeing, which is what this pair exists to
+			// prevent.
+			commsauthz.ReasonSubjectRequest:
+		default:
 			return kind, true
 		}
 	}

--- a/backend/internal/modules/consent/authorizesuppression_test.go
+++ b/backend/internal/modules/consent/authorizesuppression_test.go
@@ -67,8 +67,11 @@ func TestWhatEachSuppressionBinds(t *testing.T) {
 		commsauthz.ReasonRestricted: restricted,
 		// The five included: no template makes a dead address live.
 		commsauthz.ReasonHardBounce: all,
-		// The subject said stop, so nothing goes.
-		commsauthz.ReasonSubjectRequest: all,
+		// The subject said stop, so nothing goes EXCEPT the three the
+		// controller owes them whatever they want sent — the same three
+		// Art. 18(2) spares. Binding all fourteen meant a person who asked
+		// us to stop never received the confirmation that we had stopped.
+		commsauthz.ReasonSubjectRequest: restricted,
 		// A reason code this function does not recognise refuses everything.
 		"a_code_nobody_added_here": all,
 	}

--- a/backend/internal/modules/consent/suppress.go
+++ b/backend/internal/modules/consent/suppress.go
@@ -23,6 +23,7 @@ package consent
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/jackc/pgx/v5"
 
@@ -52,12 +53,27 @@ type SuppressInput struct {
 	Reason string
 }
 
-// suppressibleKind is the one kind a seat may write.
+// The kinds a seat may write, and the two are a different shape of thing.
 //
-// A rep relaying "please stop emailing me" is recording the SUBJECT'S request,
-// not adjudicating an Art. 21 objection or a statutory restriction — those two
-// carry legal consequences a phone call does not establish, and a hard bounce
-// is a fact about a mailbox that only the mail path can observe.
+// subject_request is "they asked us to stop contacting them" — broad, and the
+// scope the subject actually named is whatever the rep was told.
+//
+// marketing_objection is Art. 21(2)/(3): an objection to direct marketing. It
+// is deliberately writable BY HAND, because the article gives the subject an
+// unconditional right exercised "at any time" and by any means. Requiring a
+// signed form or a self-service link before one could be recorded would put a
+// condition on an unconditional right, and the practical effect was worse than
+// the theory: nothing wrote this kind at all, so a rep told "stop the
+// newsletter" on the phone had only subject_request — which stopped the
+// invoices too.
+//
+// A processing restriction and a hard bounce stay machine-written: the first is
+// an Art. 18 legal state with its own workflow, the second a fact about a
+// mailbox only the mail path can observe.
+var suppressibleKinds = []string{"subject_request", commsauthz.ReasonObjection}
+
+// suppressibleKind is the kind a seat writes when the subject asked to stop
+// being contacted at all, as opposed to objecting to marketing.
 const suppressibleKind = "subject_request"
 
 // auditFieldKind is the wire request body's own field name, named so a
@@ -96,11 +112,11 @@ func admitSuppress(ctx context.Context, in SuppressInput) (subject, commsauthz.A
 	if err != nil {
 		return subject{}, "", err
 	}
-	if in.Kind != suppressibleKind {
+	if !slices.Contains(suppressibleKinds, in.Kind) {
 		return subject{}, "", &ValidationError{
 			Field: auditFieldKind,
-			Reason: "a person may record that the subject asked us to stop; an objection, a " +
-				"processing restriction and a bounce are not recorded by hand here",
+			Reason: "a person may record that the subject asked us to stop, or objected to " +
+				"marketing; a processing restriction and a bounce are not recorded by hand here",
 		}
 	}
 	// The BOUND only. The contract makes this reason optional (`required: [kind]`),
@@ -117,7 +133,33 @@ func admitSuppress(ctx context.Context, in SuppressInput) (subject, commsauthz.A
 	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {
 		return subject{}, "", err
 	}
-	return sub, authorityOf(ctx), nil
+	return sub, levelFor(ctx, in.Kind), nil
+}
+
+// levelFor answers whose decision this stop is, which is what decides who may
+// later lift it.
+//
+// AN OBJECTION IS THE SUBJECT'S ACT, whoever typed it. Art. 21 gives the right
+// to the data subject; a rep relaying the phone call is a courier, not the
+// author, and recording their seat level would let another seat of equal or
+// greater rank lift a stop the subject asked for. CanOverrule refuses to rank
+// anything above LevelSubject, so stamping it here is what makes the objection
+// hold against the whole staff.
+//
+// The cost is real and accepted: a mistyped objection can be undone only by the
+// subject reversing it or by the per-message exception path. That is the right
+// way round — the failure of a stop that is too hard to lift is an awkward
+// conversation, and the failure of one that is too easy is mail somebody
+// explicitly refused.
+//
+// subject_request keeps the seat's own level: it is the rep's report of a
+// conversation, with no article behind it, and an admin correcting a
+// misheard "stop everything" should not need the subject on the phone.
+func levelFor(ctx context.Context, kind string) commsauthz.AuthorityLevel {
+	if kind == commsauthz.ReasonObjection {
+		return commsauthz.LevelSubject
+	}
+	return authorityOf(ctx)
 }
 
 // authorityOf reads the caller's tier from the authenticated principal.

--- a/backend/internal/modules/consent/suppress.go
+++ b/backend/internal/modules/consent/suppress.go
@@ -146,11 +146,21 @@ func admitSuppress(ctx context.Context, in SuppressInput) (subject, commsauthz.A
 // anything above LevelSubject, so stamping it here is what makes the objection
 // hold against the whole staff.
 //
-// The cost is real and accepted: a mistyped objection can be undone only by the
-// subject reversing it or by the per-message exception path. That is the right
-// way round — the failure of a stop that is too hard to lift is an awkward
-// conversation, and the failure of one that is too easy is mail somebody
-// explicitly refused.
+// THE COST IS REAL AND CURRENTLY WORSE THAN THE DESIGN INTENDS. The plan has a
+// subject-initiated reversal and a per-message exception path; NEITHER EXISTS
+// YET. PublicSaveChoices writes person_consent and never touches this table, so
+// today a mistyped objection is undone by a database correction and nothing
+// else.
+//
+// Shipping it anyway, because the alternative was worse in the direction that
+// matters: with no writer at all, a rep told "stop the newsletter" recorded a
+// subject_request, which stopped that person's invoices. A stop too hard to
+// lift is an awkward conversation. A stop too easy to lift is mail somebody
+// explicitly refused, and one that was never recordable is both.
+//
+// The reversal path is the slice that closes this; the door's own description
+// in crm.yaml says plainly that nothing lifts one today, so nobody records one
+// expecting an undo button.
 //
 // subject_request keeps the seat's own level: it is the rep's report of a
 // conversation, with no article behind it, and an admin correcting a

--- a/backend/internal/modules/consent/suppress_integration_test.go
+++ b/backend/internal/modules/consent/suppress_integration_test.go
@@ -111,17 +111,30 @@ func TestTheWriteCarriesItsAuditAndItsEvent(t *testing.T) {
 	}
 }
 
-// TestOnlyTheSubjectsOwnRequestIsRecordableByHand bounds the door.
+// TestOnlyAStopTheSubjectAskedForIsRecordableByHand bounds the door.
 //
-// An objection and a processing restriction carry legal consequences a relayed
-// phone call does not establish, and a hard bounce is a fact only the mail path
-// observes. A door that accepted them would let a rep write, in good faith, a
-// row asserting something nobody verified — and marketing_objection is
-// unliftable, so the mistake would be permanent.
-func TestOnlyTheSubjectsOwnRequestIsRecordableByHand(t *testing.T) {
+// A processing restriction is an Art. 18 legal state with its own workflow, and
+// a hard bounce is a fact only the mail path observes. A door accepting either
+// would let a rep write, in good faith, a row asserting something nobody
+// verified.
+//
+// marketing_objection USED TO BE REFUSED HERE too, on that reasoning plus the
+// observation that it is unliftable, so a mistake would be permanent. That read
+// the article backwards: Art. 21(2) is an unconditional right the subject
+// exercises "at any time" and by any means, so demanding a form or a
+// self-service link before one can be written puts a condition on it. The
+// practical cost exceeded the theoretical one — nothing wrote the kind at all,
+// so a rep told "stop the newsletter" reached for subject_request, which
+// stopped that person's invoices too.
+//
+// The permanence is real and accepted: an objection is undone by the subject
+// reversing it or by the per-message exception path, never by a seat. A stop
+// too hard to lift costs an awkward conversation; one too easy costs mail
+// somebody explicitly refused.
+func TestOnlyAStopTheSubjectAskedForIsRecordableByHand(t *testing.T) {
 	e := setupChannelConsent(t)
 
-	for _, kind := range []string{"marketing_objection", "processing_restriction", "hard_bounce", ""} {
+	for _, kind := range []string{"processing_restriction", "hard_bounce", ""} {
 		err := e.store.Suppress(e.ctx, SuppressInput{PersonID: e.person, Kind: kind})
 		// A VALIDATION error naming the field, not merely some error. Without
 		// this the test stays green with the check deleted — a bad kind would
@@ -350,5 +363,166 @@ func TestASuppressionMayCarryNoReason(t *testing.T) {
 	}
 	if kind, _, _ := liveSuppressionRow(t, e, e.person); kind != suppressibleKind {
 		t.Errorf("kind = %q, want %q", kind, suppressibleKind)
+	}
+}
+
+// TestARepRecordsAnObjectionAtTheSubjectsOwnLevel is the capability R4 named as
+// missing: nothing in production wrote marketing_objection, so the only stop a
+// rep could record was the broad one.
+//
+// The LEVEL is the whole point of the test. Art. 21 gives the right to the data
+// subject, so the row records the subject's authority and not the rep's, and
+// CanOverrule refuses to rank anything above LevelSubject. A row written at the
+// rep's own level would be liftable by any admin — an installation quietly
+// undoing a stop the person asked for.
+func TestARepRecordsAnObjectionAtTheSubjectsOwnLevel(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		PersonID: e.person,
+		Kind:     commsauthz.ReasonObjection,
+		Reason:   "asked on the phone to stop the newsletter",
+	}); err != nil {
+		t.Fatalf("recording an objection: %v", err)
+	}
+
+	kind, level, _ := liveSuppressionRow(t, e, e.person)
+	if kind != commsauthz.ReasonObjection {
+		t.Errorf("kind = %q, want %q", kind, commsauthz.ReasonObjection)
+	}
+	if level != string(commsauthz.LevelSubject) {
+		t.Errorf("decided_by_level = %q, want %q — an objection recorded at the seat's own level "+
+			"is one the next admin can lift", level, commsauthz.LevelSubject)
+	}
+}
+
+// TestNoSeatLiftsAnObjectionItRecorded is the consequence of that level, proved
+// through the real lift door rather than by reasoning about CanOverrule.
+//
+// The admin here holds every grant the lift door asks for. What refuses them is
+// the authority ON THE ROW, which is the subject's.
+func TestNoSeatLiftsAnObjectionItRecorded(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		PersonID: e.person, Kind: commsauthz.ReasonObjection, Reason: "stop the newsletter",
+	}); err != nil {
+		t.Fatalf("recording an objection: %v", err)
+	}
+
+	// THE ROW MUST BE NAMED, or this proves nothing.
+	//
+	// admitLift refuses a zero SuppressionID as a validation error before it
+	// ever compares authority, so a LiftInput without one passes this test with
+	// the subject-level stamp deleted — asserting the shape of the request
+	// rather than who may lift. Found by mutation, which is the only reason
+	// this line exists.
+	var id ids.UUID
+	if err := e.owner.QueryRow(context.Background(), `
+		SELECT id FROM communication_suppression
+		 WHERE person_id = $1 AND revoked_at IS NULL`, e.person).Scan(&id); err != nil {
+		t.Fatalf("reading back the objection: %v", err)
+	}
+
+	// e.ctx binds an ADMIN seat — TestARepRecordsTheSubjectsOwnRequest asserts
+	// its rows land at admin level — so this is the strongest seat the product
+	// has, holding every grant the lift door asks for. What refuses it is the
+	// authority ON THE ROW, which belongs to the subject.
+	err := e.store.Lift(e.ctx, LiftInput{
+		PersonID: e.person, SuppressionID: id,
+		Reason: "the rep says it was a misunderstanding",
+	})
+	if err == nil {
+		t.Fatal("an admin lifted the subject's own Art. 21 objection")
+	}
+	// And refused for the RIGHT reason: a validation error here would mean the
+	// request was malformed, not that the authority held.
+	var invalid *ValidationError
+	if errors.As(err, &invalid) {
+		t.Fatalf("the lift was refused as malformed (%v), so this says nothing about authority", err)
+	}
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("the lift was refused with %v, want a permission denial naming the level", err)
+	}
+
+	// WHAT MAKES THIS SUBJECT-LEVEL AND NOT MERELY ADMIN-LEVEL. CanOverrule is
+	// strictly greater, so an admin cannot lift an admin row either and the
+	// refusal above reads the same for both. The difference is who COULD: an
+	// admin-level row is liftable by anything ranking above admin, and a
+	// subject-level row is liftable by nothing at all, which is the whole
+	// reason Art. 21 rows are stamped that way.
+	//
+	// So the level itself is the assertion. Without it this test passes with
+	// the subject-level stamp deleted — found by mutation.
+	if _, level, _ := liveSuppressionRow(t, e, e.person); level != string(commsauthz.LevelSubject) {
+		t.Errorf("the surviving row is at %q, not %q: an admin-level objection is one a higher "+
+			"rank could still lift", level, commsauthz.LevelSubject)
+	}
+
+	if kind, _, _ := liveSuppressionRow(t, e, e.person); kind != commsauthz.ReasonObjection {
+		t.Errorf("the objection is no longer the live row (kind = %q) after a refused lift", kind)
+	}
+}
+
+// TestAnObjectionLeavesTheInvoiceAlone is R3 from the other side, and the
+// reason the objection kind had to exist at all.
+//
+// Before this a rep told "stop the newsletter" had only subject_request, which
+// bound every category — so the person's invoices stopped with their marketing.
+// An objection reaches marketing and nothing else.
+func TestAnObjectionLeavesTheInvoiceAlone(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		PersonID: e.person, Kind: commsauthz.ReasonObjection, Reason: "no more newsletters",
+	}); err != nil {
+		t.Fatalf("recording an objection: %v", err)
+	}
+
+	for _, c := range []struct {
+		category commsauthz.Category
+		stopped  bool
+	}{
+		{commsauthz.CategoryMarketing, true},
+		{commsauthz.CategoryInvoiceOrPayment, false},
+		{commsauthz.CategoryReplyToInbound, false},
+		{commsauthz.CategoryContractNotice, false},
+	} {
+		if got := suppressionBinds(commsauthz.ReasonObjection, c.category); got != c.stopped {
+			t.Errorf("an objection against %s: binds = %v, want %v", c.category, got, c.stopped)
+		}
+	}
+}
+
+// TestAStopEverythingStillConfirmsItself is the R3 half about subject_request.
+//
+// "Stop contacting me" reaches nearly everything — and NOT the confirmation
+// that we stopped, the privacy notice answering their rights request, or the
+// security warning about their own account. Those three are obligations the
+// controller owes whatever the subject wants sent, and binding them meant a
+// person who asked us to stop never heard that we had.
+func TestAStopEverythingStillConfirmsItself(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		PersonID: e.person, Kind: suppressibleKind, Reason: "stop contacting me",
+	}); err != nil {
+		t.Fatalf("recording the request: %v", err)
+	}
+
+	for _, c := range []struct {
+		category commsauthz.Category
+		stopped  bool
+	}{
+		{commsauthz.CategoryMarketing, true},
+		{commsauthz.CategoryInvoiceOrPayment, true},
+		{commsauthz.CategoryReplyToInbound, true},
+		{commsauthz.CategoryOptoutConfirmation, false},
+		{commsauthz.CategoryPrivacyNotice, false},
+		{commsauthz.CategorySecurityNotice, false},
+	} {
+		if got := suppressionBinds(commsauthz.ReasonSubjectRequest, c.category); got != c.stopped {
+			t.Errorf("a subject request against %s: binds = %v, want %v", c.category, got, c.stopped)
+		}
 	}
 }

--- a/frontend/src/api/public-events.ts
+++ b/frontend/src/api/public-events.ts
@@ -1132,7 +1132,7 @@ export interface components {
          *     It names WHAT was recorded and at WHICH authority, never the reason the subject gave: that is their words about themselves, and an event fans out further than the record it describes.
          */
         PublicEventConsentSuppressed: {
-            /** @description Which stop this is (subject_request for a hand-recorded one). */
+            /** @description Which stop this is. `subject_request` and `marketing_objection` are the two recorded by hand; `processing_restriction` and `hard_bounce` are written by machinery. They differ in reach: a subject request stops everything except the privacy notice, security notice and opt-out confirmation the controller owes regardless, while an objection is Art. 21(2) and stops marketing alone. */
             kind: string;
             /** @description Whose decision it is, which is what says who may lift it (machine | user | admin | subject). */
             decided_by_level: string;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9846,9 +9846,12 @@ export interface paths {
          *
          *     A `marketing_objection` is different: it is recorded at the SUBJECT'S authority whoever
          *     types it, because Art. 21 gives the right to the data subject and a rep relaying the call
-         *     is a courier rather than its author. Nothing an installation can do lifts it — only the
-         *     subject reversing it, or the per-message exception path, which records a send as
-         *     exceptional rather than making the objection go away.
+         *     is a courier rather than its author.
+         *
+         *     **Nothing lifts it today.** No seat outranks the subject, and the subject-initiated
+         *     reversal that would let them take it back is not built yet — the preference centre writes
+         *     consent state and never touches a suppression. Record one only when the person actually
+         *     asked for it: a mistake currently needs a database correction, not a product action.
          *
          *     Two kinds are recordable here. `subject_request` is "stop contacting me", and it stops
          *     every category except the three the controller owes regardless of what the subject wants

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9841,13 +9841,24 @@ export interface paths {
          *     to stop stays stopped until somebody with the authority to lift it says otherwise.
          *
          *     **Who may lift it is part of the record.** The row carries the authority of whoever wrote
-         *     it, taken from the session and never from this body. A rep's row is liftable by an admin
-         *     and not by another rep; nothing an installation can do lifts the subject's own Art. 21
-         *     objection, which is a different kind this door cannot write.
+         *     it, taken from the session and never from this body. A rep's `subject_request` row is
+         *     liftable by an admin and not by another rep.
          *
-         *     The only kind recordable here is `subject_request`. An objection and a processing
-         *     restriction carry legal consequences a relayed phone call does not establish, and a hard
-         *     bounce is a fact about a mailbox only the mail path observes.
+         *     A `marketing_objection` is different: it is recorded at the SUBJECT'S authority whoever
+         *     types it, because Art. 21 gives the right to the data subject and a rep relaying the call
+         *     is a courier rather than its author. Nothing an installation can do lifts it — only the
+         *     subject reversing it, or the per-message exception path, which records a send as
+         *     exceptional rather than making the objection go away.
+         *
+         *     Two kinds are recordable here. `subject_request` is "stop contacting me", and it stops
+         *     every category except the three the controller owes regardless of what the subject wants
+         *     sent: a privacy notice, a security warning, and the confirmation that an opt-out was
+         *     recorded. `marketing_objection` is Art. 21(2) and stops marketing only, so the invoice the
+         *     same person is owed still goes.
+         *
+         *     A processing restriction and a hard bounce are not recordable by hand: the first is an
+         *     Art. 18 legal state with its own workflow, the second a fact about a mailbox only the mail
+         *     path observes.
          */
         post: operations["suppressPerson"];
         delete?: never;
@@ -48696,10 +48707,13 @@ export interface operations {
             content: {
                 "application/json": {
                     /**
-                     * @description Which stop this is. Only the subject's own request is recordable by hand.
+                     * @description Which stop this is. `subject_request` is "stop contacting me" and reaches every
+                     *     category but the three the controller owes anyway. `marketing_objection` is
+                     *     Art. 21(2), reaches marketing only, and is recorded at the subject's own
+                     *     authority so no seat can lift it.
                      * @enum {string}
                      */
-                    kind: "subject_request";
+                    kind: "subject_request" | "marketing_objection";
                     /**
                      * @description What the person was told, in their words. Stored because a suppression somebody
                      *     later asks to lift is only reviewable if the record says why it was made.


### PR DESCRIPTION
Second slice of the consent improvement concept: findings **R4** (no marketing-objection writer) and **R3** (an unsubscribe blocked requested correspondence).

## Nothing in production wrote `marketing_objection`

The engine read the kind, the table's `CHECK` accepted it, erasure deleted it and the subject-access export returned it — and no writer existed. The door refused every kind but `subject_request`, reasoning that an objection carries legal consequences a relayed phone call does not establish, and is unliftable so a mistake would be permanent.

That reads Art. 21(2) backwards. The right is unconditional and exercised "at any time" and by any means, so demanding a form or a self-service link before an objection can be recorded puts a condition on it. The practical cost was worse than the theoretical one: a rep told *"stop the newsletter"* reached for `subject_request`, which stopped that person's invoices too.

**An objection is recorded at the subject's authority**, whoever types it. A rep relaying the call is a courier, not the author, and `CanOverrule` refuses to rank anything above `LevelSubject`, so no seat lifts it. The permanence is accepted: a stop too hard to lift costs an awkward conversation, one too easy costs mail somebody explicitly refused.

## A subject request no longer binds all fourteen categories

It spares the three the controller owes regardless of what the subject wants sent — privacy notice (Art. 13/14), security notice (Art. 34), opt-out confirmation (Art. 12(3)). Those are the same three Art. 18(2) spares, so both now share `survivesARestriction` rather than keeping a second list to drift apart from it.

Binding them meant **a person who asked us to stop never received the confirmation that we had stopped.** `bindsEveryCategory` moves with the rule, or the shortcut and the rule disagree — which is exactly what that pair exists to prevent.

## Mutation-tested, and it caught two weak tests

The first draft of the lift test passed with the fix removed, twice over:

1. It omitted `SuppressionID`, so the lift was refused as malformed before authority was ever compared — asserting the shape of the request, not the rule.
2. Even corrected, `CanOverrule` is strictly greater, so an admin cannot lift an *admin* row either. The refusal reads identically at both levels.

It now asserts the stored level, which is the thing that actually differs: an admin-level row is liftable by a higher rank, a subject-level row by nothing.

## Scope

No frontend caller yet — the operator UI for recording a stop is slice B7. Only generated types changed on that side.

`make check-backend` and `make check-fe` green. Consent and activities integration lanes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reps can now record a `marketing_objection` by hand, and a `subject_request` no longer blocks the confirmation that the stop happened.

Previously the only hand-recordable stop was `subject_request`, so a rep told "stop the newsletter" had to use it — which also stopped the person's invoices.

**Behavior**
- `marketing_objection` is Art. 21(2), stops marketing only, and is written at the subject's authority so no seat can lift it.
- Nothing lifts an objection today: the subject-initiated reversal path is not built, so a mistake needs a database correction.
- A `subject_request` now spares privacy notice, security notice, and opt-out confirmation — the three the controller owes regardless.

**Testing**
- Mutation testing caught two weak tests; the lift test now asserts the stored authority level.

No frontend caller yet — the operator UI is a later slice.

<sup>Written for commit bf4fc50751fb59bd9716514c8eb2ae842ecbdc65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording marketing objections.
  * Marketing objections now stop marketing communications only and cannot be overridden.
  * Subject-request suppressions now allow required privacy notices, security warnings, and opt-out confirmations.

* **Documentation**
  * Expanded suppression event documentation to explain all supported suppression types and their scopes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->