### PR TITLE
test(format): a compact money figure's suffix case is the ICU build's call

### DIFF
--- a/frontend/src/format/format.test.ts
+++ b/frontend/src/format/format.test.ts
@@ -97,16 +97,28 @@ describe("money formatting (B-EP09.17)", () => {
 // EXACT strings, because the assertion shape is what let it run unnoticed:
 // `toContain("420")` is satisfied by "€420k", by "€420.0k" AND by the
 // uncompacted "€420,000.00", so it could not tell the three apart.
+//
+// The one thing NOT pinned is the suffix's letter case: ICU 76 renders the
+// thousands marker "k", ICU 77 "K", and which a reader sees is the ICU build's
+// call, not this module's. So the compact figure is folded to lower case before
+// comparison — the digit, the decimal and the symbol stay exact, which is what
+// tells the three figures apart; only the case floats.
 describe("a money figure abbreviated for a KPI slot", () => {
   it("drops a decimal a round figure does not need", () => {
-    expect(formatMoneyCompact(42_000_000, "EUR", "en")).toBe("€420k");
+    expect(formatMoneyCompact(42_000_000, "EUR", "en").toLowerCase()).toBe(
+      "€420k",
+    );
   });
 
   // The maximum earns its keep here: rounded to whole thousands these two
   // figures are the same number on the page.
   it("keeps the decimal that tells two figures apart", () => {
-    expect(formatMoneyCompact(18_640_000, "EUR", "en")).toBe("€186.4k");
-    expect(formatMoneyCompact(18_690_000, "EUR", "en")).toBe("€186.9k");
+    expect(formatMoneyCompact(18_640_000, "EUR", "en").toLowerCase()).toBe(
+      "€186.4k",
+    );
+    expect(formatMoneyCompact(18_690_000, "EUR", "en").toLowerCase()).toBe(
+      "€186.9k",
+    );
   });
 
   // Below the threshold the long form is no wider and carries every digit, so
@@ -120,7 +132,9 @@ describe("a money figure abbreviated for a KPI slot", () => {
   // minor unit, so 420,000 minor units is ₫420k; dividing by Intl's count
   // instead would draw ₫4.2k, a figure the record does not hold.
   it("abbreviates on the stored scale, not Intl's own count", () => {
-    expect(formatMoneyCompact(420_000, "VND", "en")).toBe("₫420k");
+    expect(formatMoneyCompact(420_000, "VND", "en").toLowerCase()).toBe(
+      "₫420k",
+    );
   });
 });
 

--- a/frontend/src/screens/brief.readings.test.tsx
+++ b/frontend/src/screens/brief.readings.test.tsx
@@ -153,7 +153,7 @@ describe("the brief readings strip", () => {
     );
     draw();
 
-    await screen.findByText(/420k|420,000/);
+    await screen.findByText(/420k|420,000/i);
     expect(screen.queryAllByText("—")).toHaveLength(0);
   });
 
@@ -284,7 +284,7 @@ describe("the brief readings strip", () => {
     // COMPACT for the headline figure — the slot is ~110px and a full euro
     // amount wraps mid-number. The weighted figure keeps its exact form on the
     // detail line, where there is room for it.
-    expect(await screen.findByText(/420k/)).toBeTruthy();
+    expect(await screen.findByText(/420k/i)).toBeTruthy();
     // The weighted figure and the priced-of-eligible completeness ride the same
     // line: a weighted number over a partly priced population is a floor, and a
     // reader who cannot see the second cannot judge the first.

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -2108,7 +2108,7 @@ describe("the money slot says WHY it has no figure", () => {
     });
     renderCompany();
     await strip();
-    expect((await screen.findAllByText(/186\.4k/)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/186\.4k/i)).length).toBeGreaterThan(0);
     expect(
       (await screen.findAllByText(/Last synced a while ago/)).length,
     ).toBeGreaterThan(0);
@@ -2125,7 +2125,7 @@ describe("the money slot says WHY it has no figure", () => {
     });
     renderCompany();
     await strip();
-    expect((await screen.findAllByText(/186\.4k/)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/186\.4k/i)).length).toBeGreaterThan(0);
     expect(
       (await screen.findAllByText(/Last sync failed/)).length,
     ).toBeGreaterThan(0);
@@ -2155,7 +2155,7 @@ describe("the money slot says WHY it has no figure", () => {
     });
     renderCompany();
     await strip();
-    expect((await screen.findAllByText(/186\.4k/)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/186\.4k/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("datev")).length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/screens/personreadings.test.tsx
+++ b/frontend/src/screens/personreadings.test.tsx
@@ -320,8 +320,10 @@ describe("what they decide and when we next meet", () => {
     const deal = card(grid, "Deals they decide");
     // en-GB compact notation, one decimal: the reader's own spelling. The
     // sample carries a real tenth, because whether a whole thousand shows a
-    // trailing ".0" is the ICU build's decision, not this reading's.
-    expect(within(deal).getByText("€185.5k")).toBeTruthy();
+    // trailing ".0" is the ICU build's decision, not this reading's — and the
+    // suffix's letter case (k vs K) is the ICU build's call too, so it is
+    // matched case-insensitively.
+    expect(within(deal).getByText(/€185\.5k/i)).toBeTruthy();
     expect(within(deal).getByText(/Negotiation/)).toBeTruthy();
     const meeting = card(grid, "Next meeting");
     expect(within(meeting).getByText("Demo, Product Cloud")).toBeTruthy();


### PR DESCRIPTION
## What

Makes every compact-money test assertion tolerant of the compact-notation **suffix casing** (`k` vs `K`), so the suite gives the same verdict under ICU 76 and ICU 77.

## Why

`formatMoneyCompact` renders through `Intl.NumberFormat(..., { notation: "compact" })`. The English "thousands" suffix casing is CLDR data, and it **flipped between ICU versions**:

- **ICU 76** → lowercase `€420k`
- **ICU 77** (CLDR 47) → uppercase `€420K`

The KPI-slot assertions pinned the exact string `€420k`, so on any toolchain carrying ICU 77 all nine compact-money assertions fail on a character the product never decides:

```
Expected: "€420k"
Received: "€420K"
```

CI is still on a Node 24 build with ICU 76, so this is **green today** — but it's latent: `node-version: 24` is unpinned at the minor level, and CI goes red on these exact assertions the moment a runner resolves a 24.x that bundles ICU 77, with no product change. This closes that gap before it bites. (`format.ts` itself is unchanged and correct; this is purely test brittleness.)

`M`/`B` suffixes were always uppercase and de-DE uses `Mio.`, so only the thousands `k`/`K` is affected — but the fix is generally case-insensitive to cover any future drift.

## How

- **Exact-string `.toBe` / `getByText`** — fold the rendered figure to lower case (`format.test.ts`) or match with a case-insensitive regex `/…/i` (`personreadings`).
- **Regex `findByText` / `findAllByText`** — add the `/i` flag (`company360`, `brief.readings`).

The digit, the decimal and the currency symbol stay **exactly** pinned — that's what tells `€420k`, `€420.0k` and `€420,000.00` apart, which is the distinction the original exact-string assertions exist to catch. Only the letter case floats.

## Test

`make check-fe` green locally on Node 25 / **ICU 77.1** (where these previously failed): `8545 passed, 0 failed`. Also correct under ICU 76 — `.toLowerCase()` and `/i` match either case.

Files: `format.test.ts` (KPI slot), `personreadings`, `brief.readings`, `company360`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes compact-money test assertions tolerant of the suffix casing (`k` vs `K`) that `Intl.NumberFormat` renders differently across ICU versions, so the suite passes under both ICU 76 and ICU 77.

- Exact-string assertions now lower-case the rendered figure before comparing; regex assertions use the `/i` flag.
- Digits, decimals, and currency symbols stay exactly pinned, so the assertions still distinguish `€420k` from `€420.0k` and `€420,000.00`.
- No product code changes; this is test-only.

<sup>Written for commit de1cbe16078527804cd9db6c0d1452a6d6109885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated money-formatting tests to accept locale-dependent capitalization of compact number suffixes.
  - Improved coverage for compact currency and pipeline figures across reading, company, and person views.
  - Preserved exact checks for numeric values, decimal precision, and currency symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->