### PR TITLE
A refused promotion trigger names the four that count

### DIFF
--- a/backend/internal/modules/agents/commandlifecycle.go
+++ b/backend/internal/modules/agents/commandlifecycle.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -90,7 +92,24 @@ func requireGenuineTrigger(trigger string) error {
 	if validTriggers[trigger] {
 		return nil
 	}
-	return &BadArgsError{Cause: fmt.Errorf("trigger %q is not genuine engagement", trigger)}
+	// The four that count ride in Guidance, which is ours, and the caller's word
+	// in Cause, which is bounded. Naming none of them left an agent guessing at
+	// a closed set of four, while the REST twin (people.handlers_lead) spelled
+	// it out — one door taught the vocabulary and the other refused without it.
+	return &BadArgsError{
+		Cause:    fmt.Errorf("trigger %q is not genuine engagement", trigger),
+		Field:    "trigger",
+		Guidance: "promotion rests on one of: " + strings.Join(genuineTriggerNames(), ", "),
+	}
+}
+
+// genuineTriggerNames is the closed set, derived from the predicate that admits
+// it rather than restated beside it: a second list is how the sentence and the
+// check come to disagree about what promotes a lead.
+func genuineTriggerNames() []string {
+	names := slices.Collect(maps.Keys(validTriggers))
+	slices.Sort(names)
+	return names
 }
 
 // DisqualifyLeadCommand is one lead retirement, whichever door asked for it.


### PR DESCRIPTION
Found while auditing the still-failing use cases **before** paying for another
sweep, using the method that found case 20's two blockers: drive each failing
case's required tools by hand and see which are unsatisfiable. No model tokens
spent.

## The one real defect

`promote_lead` refused an ungenuine trigger by quoting the caller's word and
naming nothing:

```
  MCP:   trigger "the buyer asked for a proposal" is not genuine engagement
  REST:  promotion needs genuine engagement: inbound_reply, meeting_booked,
         meeting_held or human_qualify
```

One door teaches the vocabulary, the other refuses without it — an agent left
guessing at a closed set of four. Same shape as #5126/#5137/#5138, one more
surface.

The set rides in `Guidance` (ours) and the caller's word stays in `Cause`
(bounded), the split `BadArgsError` documents. The names are derived from
`validTriggers`, the predicate that admits them, rather than restated beside it.

Verified live after rebuild:

```
  trigger "..." is not genuine engagement; promotion rests on one of:
  human_qualify, inbound_reply, meeting_booked, meeting_held
```

`case40_sort_the_queue` requires `promote_lead` and scores 1/3 on opus, 0/3 on
sonnet. This is one refusal it could not recover from.

## What the audit CLEARED — so a re-run measures the models, not the fixture

- **case41_close_the_project** (0/3 haiku and sonnet) — fully satisfiable as an
  agent. `advance_project_phase` to `closed` is not approval-gated, and its
  refusal is actionable: *"reason is required when to_phase is closed"*. Supplying
  a reason succeeds. Genuine model capability.
- **case32_two_words_for_one_thing** (0/3 haiku and sonnet) — fixture correct:
  `Strategic Account` has 3 companies, `Strategic Accts` has 1, so the survivor
  is unambiguous and the `must_mention` count of 3 is satisfiable. `merge_tags`
  is confirm-first and can only be staged by an agent — and criterion 2 *expects*
  exactly that, so the 🟡 gate is the point of the case, not a blocker. A
  well-formed case.
- **case40's other two verbs** — `qualify_lead` and `disqualify_lead` both
  succeed for an agent.

## Reported, not changed

**`qualify_lead` takes `record_id` while `promote_lead` and `disqualify_lead`
take `lead_id`.** Three sibling verbs over one record type, two spellings of the
same argument — a model that learns one from two of them is refused by the third:

```
  qualify_lead     required=['record_id']
  promote_lead     required=['lead_id', 'trigger']
  disqualify_lead  required=['lead_id']
```

`qualify_lead` is absent from `crm.yaml`'s `x-mcp-tool` list (it is a generic
record verb, which is probably why it is `record_id`), so aligning the names is a
public-contract question rather than a bug fix, and not mine to make unilaterally.
Worth a decision: the inconsistency costs a tool call every time an agent meets
this trio.

**`scripts/dev.sh:247` has a `set -u` bug** — `[[ -f "$state" ]]` with `state`
unbound, from #4543. It fires as *"dev.sh: line 247: state: unbound variable"*
before the port check's own message, so `make dev` on an already-running slug
reports a shell error above the actionable one. Pre-existing and unrelated to
this diff; not fixed here to keep this PR to one thing.

## Verification

`make lint` 0 issues, `craft-static` 0 findings, `./gates/` green, agents and
compose packages green, and the new refusal confirmed on a live rebuilt stack.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`promote_lead` now names the four valid engagement triggers when it refuses one, so agents aren't left guessing at a closed set. Previously the error only quoted the caller's trigger word.

The valid names are derived from the `validTriggers` map, not restated, so the message can't drift from the check. The caller's word stays in `Cause`; the valid set lives in `Guidance`.

<sup>Written for commit dfbadeca0b1ed98c7e7430f857c6b6818856f742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

