### PR TITLE
fix(gates): regenerate the gate-inventory doc

### DIFF
--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -123,7 +123,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (138)
+## Census (139)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
## Claim

Red on origin/main: `TestTheGateInventoryPageIsCurrent` (backend/gates) — `docs/reference/gate-inventory.md` no longer matches the `//gate:kind` declarations in the tree.

## Fix

Regenerate via `go test ./gates -run GateInventory -update-gate-inventory` and commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRuXiSKkD1X1D1U5yRF4Qn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates `docs/reference/gate-inventory.md` so `TestTheGateInventoryPageIsCurrent` passes again; the doc's census had drifted from the `//gate:kind` declarations in the tree (138 vs 139).

<sup>Written for commit 93f619b4e053a40004ad3cc9a39887112bdfb209. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

