### PR TITLE
fix(contracts): the account's contract list is ordered by term

### DIFF
--- a/backend/internal/compose/integration/contracttermorder_integration_test.go
+++ b/backend/internal/compose/integration/contracttermorder_integration_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// An account's contract list is ordered by TERM, and pages across the boundary
+// between dated and undated agreements without repeating or skipping one.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedTermFixture writes four agreements on one account, created in an order
+// deliberately opposite to their terms so creation order cannot pass for term
+// order: the newest term is written FIRST and the oldest LAST.
+//
+// Two carry no start date, which is the ordinary shape of an imported
+// agreement and the case the null placement is about.
+func seedTermFixture(t *testing.T, e *Env) (org ids.OrganizationID, byTerm []string) {
+	t.Helper()
+	orgID := orgIDOf(e.SeedOrg(t, "Terms GmbH", nil))
+	day := func(y int, m time.Month, d int) *time.Time {
+		when := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+		return &when
+	}
+	for _, c := range []struct {
+		title    string
+		startsOn *time.Time
+	}{
+		{"2026 term", day(2026, time.January, 1)},
+		{"2024 term", day(2024, time.January, 1)},
+		{"undated, written third", nil},
+		{"undated, written fourth", nil},
+	} {
+		seedContract(t, e, contracts.CreateContractInput{
+			OrganizationID: orgID, Title: c.title, StartsOn: c.startsOn, ValueBasis: "total",
+		})
+	}
+	// Dated terms newest first, then the undated tail newest-written first —
+	// created_at DESC is the only ordering left among agreements that name no
+	// term, and it is the tiebreak the ORDER BY falls through to.
+	return orgID, []string{"2026 term", "2024 term", "undated, written fourth", "undated, written third"}
+}
+
+// The list answers "which agreement is current" — by term, not by write time.
+//
+// The fixture writes the newest term FIRST, so a list ordered by creation puts
+// it last and this fails. That inversion is the whole point: with the two
+// orderings agreeing, a test cannot tell which one produced the page.
+func TestTheContractListIsOrderedByTermNotByWriteTime(t *testing.T) {
+	e := Setup(t)
+	org, wantOrder := seedTermFixture(t, e)
+
+	page, err := e.Contracts.ListOrganizationContracts(e.Admin(), contracts.ListContractsInput{
+		OrganizationID: org,
+	})
+	if err != nil {
+		t.Fatalf("listing the account's contracts: %v", err)
+	}
+
+	got := make([]string, 0, len(page.Data))
+	for _, c := range page.Data {
+		got = append(got, c.Title)
+	}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("the list answered %d agreement(s), want %d — %v", len(got), len(wantOrder), got)
+	}
+	for i := range wantOrder {
+		if got[i] != wantOrder[i] {
+			t.Fatalf("the list reads %v, want %v — an agreement is presented as current on the strength "+
+				"of when its row was written rather than when its term begins", got, wantOrder)
+		}
+	}
+}
+
+// Paging across the dated/undated boundary serves every agreement exactly once.
+//
+// THIS IS THE CASE THE NULL HANDLING IS FOR. Under `starts_on DESC NULLS LAST`
+// every dated term precedes every undated one, so the continuation predicate
+// asks a different question on each side of that boundary. A single tuple
+// comparison cannot express it — `(starts_on, …) < (…)` is NULL-valued the
+// moment either side is NULL, so the list would end early with rows remaining,
+// and the reader would never learn that agreements exist below the fold.
+//
+// A limit of 1 walks the boundary a row at a time, so the page that crosses it
+// is exercised rather than hoped for.
+func TestPagingContractsCrossesTheUndatedBoundaryExactlyOnce(t *testing.T) {
+	e := Setup(t)
+	org, wantOrder := seedTermFixture(t, e)
+
+	var seen []string
+	var cursor *string
+	for range len(wantOrder) + 2 {
+		limit := 1
+		page, err := e.Contracts.ListOrganizationContracts(e.Admin(), contracts.ListContractsInput{
+			OrganizationID: org, Limit: &limit, Cursor: cursor,
+		})
+		if err != nil {
+			t.Fatalf("listing page after %v: %v", seen, err)
+		}
+		for _, c := range page.Data {
+			seen = append(seen, c.Title)
+		}
+		if !page.Page.HasMore {
+			break
+		}
+		if page.Page.NextCursor == nil {
+			t.Fatalf("the page after %v says there is more and hands back no cursor to fetch it with", seen)
+		}
+		cursor = page.Page.NextCursor
+	}
+
+	if len(seen) != len(wantOrder) {
+		t.Fatalf("paging one at a time saw %d agreement(s), want %d — %v. A page that ends early leaves "+
+			"agreements the reader can never reach, and one that repeats serves the same term twice",
+			len(seen), len(wantOrder), seen)
+	}
+	for i := range wantOrder {
+		if seen[i] != wantOrder[i] {
+			t.Fatalf("paging saw %v, want %v — the continuation predicate does not place undated terms "+
+				"where the ORDER BY puts them", seen, wantOrder)
+		}
+	}
+}

--- a/backend/internal/modules/contracts/contract_list.go
+++ b/backend/internal/modules/contracts/contract_list.go
@@ -80,13 +80,12 @@ func listContractsTx(ctx context.Context, tx pgx.Tx, in ListContractsInput, asOf
 		if err != nil {
 			return crmcontracts.ContractListResponse{}, err
 		}
-		where = append(where, storekit.SQLf("(created_at, id) < ($%d, $%d)",
-			arg(cursor.CreatedAt), arg(cursor.ID)))
+		where = append(where, continueAfterTerm(cursor, arg))
 	}
 
 	limit := storekit.ClampLimit(in.Limit)
 	rows, err := tx.Query(ctx, storekit.SQLf(
-		`SELECT %s, %s FROM contract WHERE %s ORDER BY created_at DESC, id DESC LIMIT $%d`,
+		`SELECT %s, %s FROM contract WHERE %s ORDER BY `+termOrder+` LIMIT $%d`,
 		contractColumns, underContractSQL(asOfPos), strings.Join(where, " AND "), arg(limit+1)), args...)
 	if err != nil {
 		return crmcontracts.ContractListResponse{}, fmt.Errorf("list contracts: %w", err)
@@ -114,7 +113,7 @@ func listContractsTx(ctx context.Context, tx pgx.Tx, in ListContractsInput, asOf
 	if len(contracts) > limit {
 		contracts = contracts[:limit]
 		last := contracts[len(contracts)-1]
-		next, err := storekit.EncodeCursor(cursorTime(last.CreatedAt), ids.UUID(last.Id))
+		next, err := termCursor(last)
 		if err != nil {
 			return crmcontracts.ContractListResponse{}, err
 		}
@@ -158,7 +157,7 @@ func (s *Store) ListProjectContractsTx(ctx context.Context, tx pgx.Tx, projectID
 	}
 	lim := storekit.ClampLimit(limit)
 	rows, err := tx.Query(ctx, storekit.SQLf(
-		`SELECT %s, %s FROM contract WHERE %s ORDER BY created_at DESC, id DESC LIMIT $%d`,
+		`SELECT %s, %s FROM contract WHERE %s ORDER BY `+termOrder+` LIMIT $%d`,
 		contractColumns, underContractSQL(asOfPos), strings.Join(where, " AND "), arg(lim+1)), args...)
 	if err != nil {
 		return crmcontracts.ContractListResponse{}, fmt.Errorf("list project contracts: %w", err)
@@ -184,4 +183,86 @@ func (s *Store) ListProjectContractsTx(ctx context.Context, tx pgx.Tx, projectID
 		page.HasMore = true
 	}
 	return crmcontracts.ContractListResponse{Data: contracts, Page: page}, nil
+}
+
+// termOrder is how an account's agreements are ordered, in both list queries.
+//
+// BY TERM, not by when the row was written. A reader looking at a contract list
+// is asking which agreement is CURRENT, and ordering by creation answered a
+// different question: an older agreement imported today sorted ahead of a newer
+// one created last week, so the page presented the wrong agreement as current.
+//
+// NULLS LAST because an imported agreement often carries no start date, and a
+// term we know no start for is not the newest one — it is the one we know least
+// about. Floating it to the top would misinform exactly the reader this
+// ordering is for, and on an account whose contracts were all imported, an
+// arbitrary undated row would present itself as current.
+//
+// created_at is the tiebreak among terms beginning on the same day, and the
+// only ordering left among undated ones. id breaks the remaining tie so the
+// order is total — a keyset cursor over a non-total order repeats or skips rows
+// at a page boundary.
+//
+// A constant both queries reference, rather than the clause written out twice:
+// they are one order, and the index (contract_account_ix) is built to serve
+// this exact clause, null placement included. Two copies could drift from each
+// other and from the index, and a page that no longer matches its index is
+// served by a sort node over the whole account without saying so.
+const termOrder = "starts_on DESC NULLS LAST, created_at DESC, id DESC"
+
+// continueAfterTerm renders the keyset predicate that resumes a page after the
+// row a cursor names, matching termOrder including where it puts NULLs.
+//
+// THE NULL HANDLING IS THE PART THAT GOES WRONG. Under `DESC NULLS LAST` every
+// dated term precedes every undated one, so the continuation asks a different
+// question on each side of that boundary:
+//
+//   - after a DATED row, the rest of the page is the terms ordering below it
+//     AND every undated term, because all of those come later;
+//   - after an UNDATED row, only undated terms remain — admitting a dated one
+//     would serve a row the reader already passed.
+//
+// A single tuple comparison cannot say that: `(starts_on, created_at, id) <
+// (…)` is NULL-valued whenever either side is NULL, so it admits nothing at all
+// once the page crosses into the undated tail, and the list ends early while
+// rows remain.
+func continueAfterTerm(cursor storekit.Cursor, arg func(any) int) string {
+	if cursor.SortKey == nil {
+		// The cursor names an undated term: the tail is undated terms only.
+		return storekit.SQLf("starts_on IS NULL AND (created_at, id) < ($%d, $%d)",
+			arg(cursor.CreatedAt), arg(cursor.ID))
+	}
+	// Each branch registers ONLY the arguments its own clause names. An
+	// argument passed and never referenced has no type Postgres can infer from
+	// anywhere, and it answers 42P18 for a parameter that is simply unused —
+	// a confusing failure to meet at a page boundary, and one that reads as a
+	// cast problem rather than an arity one.
+	//
+	// ::date because the token carries the start date as TEXT, and a row
+	// comparison gives Postgres nothing to infer it from.
+	return storekit.SQLf(
+		"((starts_on IS NOT NULL AND (starts_on, created_at, id) < ($%d::date, $%d, $%d)) OR starts_on IS NULL)",
+		arg(*cursor.SortKey), arg(cursor.CreatedAt), arg(cursor.ID))
+}
+
+// termCursor mints the token that continues a page after one contract,
+// carrying the term the ordering is by.
+//
+// SortKey holds the start date, and nil is not "unset" here — it is the row's
+// own NULL, which continueAfterTerm reads as "the page is into the undated
+// tail". SortField and SortDesc record which ordering the token was minted
+// under, so a cursor from a differently ordered list is legible rather than
+// silently applied to this one.
+func termCursor(c crmcontracts.Contract) (string, error) {
+	cur := storekit.Cursor{
+		CreatedAt: cursorTime(c.CreatedAt),
+		ID:        ids.UUID(c.Id),
+		SortField: "starts_on",
+		SortDesc:  true,
+	}
+	if c.StartsOn != nil {
+		key := c.StartsOn.String()
+		cur.SortKey = &key
+	}
+	return storekit.EncodeOpaque(cur)
 }

--- a/backend/migrations/core/1788945717_the_contract_list_is_ordered_by_term.down.sql
+++ b/backend/migrations/core/1788945717_the_contract_list_is_ordered_by_term.down.sql
@@ -1,0 +1,7 @@
+SET LOCAL lock_timeout = '3s';
+
+DROP INDEX IF EXISTS contract_account_ix;
+
+CREATE INDEX contract_account_ix ON contract
+    USING btree (organization_id, created_at DESC, id DESC)
+    WHERE (archived_at IS NULL);

--- a/backend/migrations/core/1788945717_the_contract_list_is_ordered_by_term.up.sql
+++ b/backend/migrations/core/1788945717_the_contract_list_is_ordered_by_term.up.sql
@@ -1,0 +1,24 @@
+-- The account's contract list answers "which agreement is current", so it is
+-- ordered by TERM, not by when the row was written.
+--
+-- The index followed the query rather than the promise: it was moved to
+-- created_at when the query was, so the page was internally consistent and
+-- wrong. An older agreement imported today sorted ahead of a newer one created
+-- last week, and the account page read as though the wrong agreement was
+-- current.
+--
+-- NULLS LAST is spelled out because Postgres defaults a DESC index to NULLS
+-- FIRST, and the query orders `starts_on DESC NULLS LAST` — an index whose null
+-- placement disagrees with the ORDER BY cannot serve the sort, so the page
+-- would silently fall back to a sort node over the whole account.
+--
+-- created_at stays in the key, after starts_on: it is the tiebreak among terms
+-- that begin on the same day, and among imported agreements that carry no start
+-- date at all — where it is the only ordering left.
+SET LOCAL lock_timeout = '3s';
+
+DROP INDEX IF EXISTS contract_account_ix;
+
+CREATE INDEX contract_account_ix ON contract
+    USING btree (organization_id, starts_on DESC NULLS LAST, created_at DESC, id DESC)
+    WHERE (archived_at IS NULL);

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1953,7 +1953,7 @@ public.contract.updated_at timestamp with time zone NOT NULL gen=- def=now()
 public.contract.value_basis text NOT NULL gen=- def='total'::text
 public.contract.value_minor bigint gen=- def=-
 public.contract.version bigint NOT NULL gen=- def=1
-public.contract_account_ix CREATE INDEX contract_account_ix ON public.contract USING btree (organization_id, created_at DESC, id DESC) WHERE (archived_at IS NULL)
+public.contract_account_ix CREATE INDEX contract_account_ix ON public.contract USING btree (organization_id, starts_on DESC NULLS LAST, created_at DESC, id DESC) WHERE (archived_at IS NULL)
 public.contract_deal_ix CREATE INDEX contract_deal_ix ON public.contract USING btree (deal_id) WHERE ((deal_id IS NOT NULL) AND (archived_at IS NULL))
 public.contract_pkey CREATE UNIQUE INDEX contract_pkey ON public.contract USING btree (id)
 public.contract_renewal_due_ix CREATE INDEX contract_renewal_due_ix ON public.contract USING btree (renewal_on) WHERE ((renewal_on IS NOT NULL) AND (archived_at IS NULL))


### PR DESCRIPTION
Closes #1394.

## The defect

`listOrganizationContracts` is documented as *"newest term first"* and ordered by `created_at DESC, id DESC`. An older agreement imported today sorted ahead of a newer one created last week, and the account page presented the wrong agreement as current.

That is a reader acting on a false answer, not a documentation mismatch — which is why the description stays and the order moves to match it. Correcting the sentence to "newest created first" was the cheap option and would have made it true while leaving the page wrong.

## NULLS LAST

An imported agreement often carries no start date. A term we know no start for is not the newest one — it is the one we know least about, and on an account whose contracts were all imported, floating an arbitrary undated row to the top would present it as current.

`created_at` is the tiebreak among terms beginning on the same day, and the only ordering left among undated ones.

## The cursor is the part that goes subtly wrong

Under `starts_on DESC NULLS LAST` every dated term precedes every undated one, so the continuation predicate asks a **different question on each side of that boundary**:

- after a **dated** row, the tail is the terms ordering below it *and every undated term*, because all of those come later;
- after an **undated** row, only undated terms remain — admitting a dated one would re-serve a row the reader already passed.

A single tuple comparison cannot express that. `(starts_on, created_at, id) < (…)` is NULL-valued the moment either side is NULL, so once a page crossed into the undated tail it would admit nothing at all: the list ends early with rows still to serve, and the reader never learns they exist.

The cursor carries the start date in `storekit.Cursor`'s existing `SortKey`, with `nil` meaning the row's own NULL rather than "unset". `SortField`/`SortDesc` record which ordering minted the token.

**Each branch registers only the arguments its own clause names.** My first version computed the shared `(created_at, id)` fragment up front and left it unused on the dated path — Postgres then has no way to infer that parameter's type and answers `42P18` for a parameter that is simply *unused*, which reads as a cast problem rather than an arity one, and does so at a page boundary.

## The index

Moves with the query, to `(organization_id, starts_on DESC NULLS LAST, created_at DESC, id DESC)`. **NULLS LAST is spelled out** because Postgres defaults a DESC index to NULLS FIRST: an index whose null placement disagrees with the `ORDER BY` cannot serve the sort, so the page would fall back to a sort node over the whole account without saying so.

Head catalog regenerated in the same commit.

## What was already built

My earlier ruling on this issue called for generalising `storekit.Cursor` so it could carry a non-creation ordering key. That landed in the meantime — `Cursor` already carries `SortField`, `SortDesc` and `SortKey`, and `storekit`'s own `OrderBy` already renders `NULLS LAST`. So the shared-pagination work the issue was deferred for is done, and this is the contract list adopting it.

## Tests

- `TestTheContractListIsOrderedByTermNotByWriteTime` — the fixture writes the **newest term first**, so a list ordered by creation puts it last and fails. With the two orderings agreeing, a test cannot tell which one produced the page.
- `TestPagingContractsCrossesTheUndatedBoundaryExactlyOnce` — pages one row at a time so the crossing page is exercised rather than hoped for, and asserts every agreement is served exactly once in term order.

| mutation | result |
|---|---|
| order back to `created_at DESC` | the ordering test fails, printing both sequences |
| `NULLS FIRST` instead of `LAST` | the ordering test fails |
| the undated branch admits dated rows | the paging test fails |

## Checks

`make check-backend` green; `make craft-static` 0/0/0; `go test -count=1 ./gates` green; the contracts and compose/integration lanes green.

**Note on CI:** main is currently red on 25 integration tests from #5103 (the `transactional` purpose key no longer authorising a send on its own). Another session is fixing it. If this PR shows send/schedule/capture 409s, that is the cause and not this change.