### PR TITLE
fix(ci): a lane that comes back green withdraws the finding it filed

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -308,13 +308,19 @@ jobs:
     # to publish main's verdict was the one job whose failure nobody was told
     # about.
     needs: [gates, integration, frontend, uat, sonar]
+    # Every result, not only the failures. The reporter files a finding for a red
+    # lane and RETRACTS one for a green lane, and a job that runs only when
+    # something failed can do the first but never the second: the issue outlives
+    # its fix until somebody closes it by hand, and the tracker reports a red
+    # main over a green tree. Re-adding a `result == 'failure'` clause here
+    # breaks retraction silently — the run is green, the job is skipped, nothing
+    # fails — so scripts/test-scheduled-report.sh asserts this condition names no
+    # lane result at all.
+    #
+    # `!cancelled()` and nothing else: a skipped lane must reach the reporter as
+    # `skipped`, which it reads as neither a red nor a green.
     if: >-
       !cancelled()
-      && (needs.gates.result == 'failure'
-      || needs.integration.result == 'failure'
-      || needs.frontend.result == 'failure'
-      || needs.uat.result == 'failure'
-      || needs.sonar.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -627,16 +627,18 @@ jobs:
   report:
     name: report
     needs: [vuln, quality-gate, backend-lane, fe-clock-drift, perf-budgets, perf-mobile, llm-use-cases, reap-caches]
+    # Every result, not only the failures — see the same condition in
+    # main-health.yml for why. In short: the reporter now retracts a finding
+    # whose check came back green, and a job gated on a failure is never reached
+    # on the run that would do it.
+    #
+    # This lane's two weekly jobs are the reason the condition says `!cancelled()`
+    # rather than `always()`: perf-budgets and perf-mobile are `skipped` on the
+    # daily cron, and a skipped check is the absence of a verdict. The reporter
+    # reads it as neither red nor green, which is only true if it arrives as
+    # `skipped` rather than being turned into one by this expression.
     if: >-
       !cancelled()
-      && (needs.vuln.result == 'failure'
-        || needs.quality-gate.result == 'failure'
-        || needs.backend-lane.result == 'failure'
-        || needs['fe-clock-drift'].result == 'failure'
-        || needs.perf-budgets.result == 'failure'
-        || needs['perf-mobile'].result == 'failure'
-        || needs['llm-use-cases'].result == 'failure'
-        || needs.reap-caches.result == 'failure')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/docs/reference/ci-workflows.md
+++ b/docs/reference/ci-workflows.md
@@ -161,10 +161,19 @@ Eight workflows sit beside the gate, deliberately outside it:
   Findings become **issues** (`scripts/scheduled-report.sh`), one open issue per
   check keyed on an exact title, because a red scheduled run notifies nobody and
   these checks exist precisely for the case where nothing prompts a human to look.
+  A check that comes back **green closes its own issue** — so the report job runs
+  whatever the lanes said, rather than only when one failed. Without that half a
+  finding outlives its fix until somebody closes it by hand, and the tracker
+  answers "is `main` red, and is anyone on it" wrongly in both directions; it also
+  means each red is its own issue instead of one standing title collecting every
+  breakage a lane has ever had. A `skipped` result is neither: it is the absence
+  of a verdict, and reading it as a pass would close a finding nothing re-examined.
   Two of those checks split one job result into **two** findings — the perf
   budgets and the model lane both distinguish "the thing under test is wrong"
   from "the lane could not run", because filing the former for the latter sends
-  somebody bisecting a regression that was never measured.
+  somebody bisecting a regression that was never measured. The split binds the
+  retraction too: a lane that ran and measured something bad has disproved "could
+  not run", so that finding is withdrawn on the same run the other one is filed.
   The reporting job is the sole holder of `issues: write` and runs no build code —
   the same permission isolation `sbom.yml` uses for signing.
 

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -15,21 +15,38 @@ set -euo pipefail
 : "${REPO:?REPO must name the repository to file against}"
 : "${RUN_URL:?RUN_URL must link the run that produced this verdict}"
 
-# report <title> <label> <body>
+# EVERY open issue, read ONCE for the whole run — not a first page of them, and
+# not once per finding. A capped read answers "no issue with this title" the
+# moment the tracker outgrows the cap, and because the cap pages newest-first,
+# the issue it stops short of is precisely the long-lived one the dedupe exists
+# to find. The tracker passing that mark is invisible from here: nothing fails,
+# a second issue is simply filed under a title that already had one, and the
+# discussion on the first is left behind.
 #
-# The lookup reads EVERY open issue, not a first page of them. A capped read
-# answers "no issue with this title" the moment the tracker outgrows the cap —
-# and because the cap pages newest-first, the issue it stops short of is
-# precisely the long-lived one this dedupe exists to find. The tracker passing
-# that mark is invisible from here: nothing fails, a second issue is simply
-# filed under a title that already had one, and the discussion on the first is
-# left behind. The oldest open match therefore wins: it is the one carrying
-# whatever triage the title has already collected.
+# Read once because there are now two callers per arm rather than one, and every
+# arm asks about a different title on the same tracker. Paginating the whole
+# thing per question got more expensive with each arm added, for an answer that
+# cannot change inside one run.
+open_issues="$(mktemp)"
+trap 'rm -f "$open_issues"' EXIT
+gh api --paginate "repos/$REPO/issues?state=open&per_page=100" |
+  jq -sc '[.[][] | select(has("pull_request") | not) | {number, title}]' >"$open_issues"
+
+# lookup <title> — the number of the OLDEST open issue under this EXACT title,
+# or nothing.
+#
+# Oldest, because it is the one carrying whatever triage the title has already
+# collected. Two issues under one title is the state a capped read produced, and
+# the repeat belongs on the one people have been talking in.
+lookup() {
+  jq -r --arg t "$1" '[.[] | select(.title == $t)] | min_by(.number) | .number // empty' \
+    "$open_issues"
+}
+
+# report <title> <label> <body>
 report() {
   local title="$1" label="$2" body="$3" existing
-  existing="$(gh api --paginate "repos/$REPO/issues?state=open&per_page=100" |
-    jq -rs --arg t "$title" '[.[][] | select(has("pull_request") | not)
-      | select(.title == $t)] | min_by(.number) | .number // empty')"
+  existing="$(lookup "$title")"
   if [[ -n "$existing" ]]; then
     echo "already open as #$existing — commenting"
     gh issue comment "$existing" --repo "$REPO" \
@@ -38,6 +55,40 @@ report() {
   fi
   echo "filing: $title"
   gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"
+}
+
+# resolve <title> — the other half of report, for a check that came back GREEN.
+#
+# Without this the issue is the only artifact of a red and nothing retracts it:
+# a finding outlives its fix by however long it takes somebody to notice by
+# hand, and the tracker answers "is main red, and is anyone on it" wrongly in
+# both directions at once. It happened to margince/margince#5118 the day this
+# was written — filed 05:35Z, fixed on main at 06:49Z, still open hours later.
+#
+# It also makes each red its own issue rather than one standing title
+# accumulating every distinct breakage a lane has ever had, each with a
+# different cause and a different fix. The dedupe above is right that a daily
+# re-file would bury a live discussion; it was never an argument for keeping the
+# discussion open once the subject was gone.
+#
+# CALLED ONLY FOR A CHECK THAT ACTUALLY PASSED. A `skipped` or `cancelled`
+# result must reach neither half — it is the absence of a verdict, and reading
+# it as a green one would close a finding nothing re-examined. That is the one
+# direction this must not fail in, so it is a case in
+# scripts/test-scheduled-report.sh rather than a caution here.
+resolve() {
+  local title="$1" existing
+  existing="$(lookup "$title")"
+  if [[ -z "$existing" ]]; then
+    return
+  fi
+  echo "green again — closing #$existing"
+  gh issue close "$existing" --repo "$REPO" --reason completed \
+    --comment "Green on the $(date -u +%Y-%m-%d) run: $RUN_URL
+
+Closed by the lane that filed it, which re-ran and passed. If this issue was
+about something the run does not measure, reopen it — the close means the check
+is green, not that every question on the thread was answered."
 }
 
 # Each report is attempted independently. Under `set -e` a bare call would abort
@@ -61,6 +112,8 @@ alert on the same package, and it is worth acting on rather than deferring.
 
 Reproduce locally with \`make vuln\`."\
     || unreported=1
+elif [[ "${VULN_RESULT:-}" = "success" ]]; then
+  resolve "govulncheck reports a vulnerability reachable from main"
 fi
 
 if [[ "${GATE_RESULT:-}" = "failure" ]]; then
@@ -79,6 +132,8 @@ attached to \`main\` at all, which looks identical to green on every dashboard.
 The failing conditions are printed in the \`quality-gate\` job log of the run
 above."\
     || unreported=1
+elif [[ "${GATE_RESULT:-}" = "success" ]]; then
+  resolve "SonarCloud quality gate is not green on main"
 fi
 
 if [[ "${LANE_RESULT:-}" = "failure" ]]; then
@@ -95,6 +150,8 @@ push's verdict.
 So the breakage may predate the most recent commit. Reproduce locally with
 \`make check-backend\` on \`main\`."\
     || unreported=1
+elif [[ "${LANE_RESULT:-}" = "success" ]]; then
+  resolve "the backend merge gate is red on main"
 fi
 
 # Two findings, not one, because the job result cannot tell them apart: a failed
@@ -121,6 +178,11 @@ and the two timeouts need re-deriving, not raising).
 Reproduce with \`make db-up && make bench-perf-check\`. The published budgets
 page is untouched either way: this lane never sets MARGINCE_BENCH_RECORD."\
     || unreported=1
+elif [[ "${PERF_RESULT:-}" = "success" ]] || [[ "${PERF_OUTCOME:-}" = "breach" ]]; then
+  # A MEASURED BREACH IS PROOF THE LANE RAN, which is the only thing this
+  # title claims — so it retracts here as well as on a pass, and the arm below
+  # files the breach under its own title.
+  resolve "the weekly PERF-3/PERF-7 run could not complete"
 fi
 
 if [[ "${PERF_OUTCOME:-}" = "breach" ]]; then
@@ -143,6 +205,8 @@ because a mid-market SLO gated on an SMB corpus renders \`inconclusive\`, never
 \`within budget\`. So the breach may predate this run by up to a week, and
 bisecting is the honest first move rather than assuming the newest commit."\
     || unreported=1
+elif [[ "${PERF_RESULT:-}" = "success" ]]; then
+  resolve "a PERF-3/PERF-7 budget is breaching on main"
 fi
 
 # The mobile budget splits the same two ways and for the same reason. Its
@@ -165,6 +229,10 @@ the preview server on :4317 never came up.
 Reproduce with \`make bench-mobile-check\`. The published budgets page is
 untouched either way: this lane clears MARGINCE_BENCH_RECORD."\
     || unreported=1
+elif [[ "${MOBILE_RESULT:-}" = "success" ]] || [[ "${MOBILE_OUTCOME:-}" = "breach" ]]; then
+  # Same split, same reason: a measured p95 means the lane completed, whatever
+  # the number was.
+  resolve "the weekly MOBILE-AC-2 run could not complete"
 fi
 
 if [[ "${MOBILE_OUTCOME:-}" = "breach" ]]; then
@@ -189,6 +257,8 @@ No record was written — this lane clears \`MARGINCE_BENCH_RECORD\`, so the
 published page still shows the last number a human measured. Publish a new one
 with \`make bench-mobile\` only once the breach is understood."\
     || unreported=1
+elif [[ "${MOBILE_RESULT:-}" = "success" ]]; then
+  resolve "PERF-1's perceived budget is breaching on main"
 fi
 
 if [[ "${CLOCK_RESULT:-}" = "failure" ]]; then
@@ -211,6 +281,8 @@ copy of a guard the file wants once.
 Reproduce locally with \`make fe-clock-drift\`, and read the failures as claims
 about the fixtures rather than about the components."\
     || unreported=1
+elif [[ "${CLOCK_RESULT:-}" = "success" ]]; then
+  resolve "the frontend suite's verdict depends on the calendar"
 fi
 
 if [[ "${CACHE_RESULT:-}" = "failure" ]]; then
@@ -233,6 +305,8 @@ the \`go-build-\` prefix changed, teach the script the new shape —
 
 Inspect without deleting anything: \`DRY_RUN=1 scripts/reap-build-caches.sh\`."\
     || unreported=1
+elif [[ "${CACHE_RESULT:-}" = "success" ]]; then
+  resolve "the Actions build-cache reaper is failing"
 fi
 
 # --- main-health.yml -----------------------------------------------------------
@@ -262,6 +336,8 @@ ${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
 
 Reproduce locally on \`main\` with \`make check-backend\`."\
     || unreported=1
+elif [[ "${MAIN_GATES_RESULT:-}" = "success" ]]; then
+  resolve "main is red: the backend gate fails on the tip"
 fi
 
 if [[ "${MAIN_INTEGRATION_RESULT:-}" = "failure" ]]; then
@@ -280,6 +356,8 @@ Reproduce locally with \`make db-up && make test-integration\` on \`main\`. Unti
 this is fixed, every other pull request inherits the failure through its merge
 commit and reads as red for a reason its author did not cause."\
     || unreported=1
+elif [[ "${MAIN_INTEGRATION_RESULT:-}" = "success" ]]; then
+  resolve "main is red: the integration lane fails on the tip"
 fi
 
 if [[ "${MAIN_FRONTEND_RESULT:-}" = "failure" ]]; then
@@ -307,6 +385,8 @@ runs neither the Storybook build nor the coverage report, so it can pass over a
 red \`fe-bundle\` or a broken lcov and send you looking for a failure that is
 not there."\
     || unreported=1
+elif [[ "${MAIN_FRONTEND_RESULT:-}" = "success" ]]; then
+  resolve "main is red: the frontend lane fails on the tip"
 fi
 
 if [[ "${MAIN_UAT_RESULT:-}" = "failure" ]]; then
@@ -332,6 +412,8 @@ preview and drives Playwright against the seed mock, so it needs no database and
 no running stack — but it does need the browser: \`pnpm exec playwright install
 --with-deps chromium\` once."\
     || unreported=1
+elif [[ "${MAIN_UAT_RESULT:-}" = "success" ]]; then
+  resolve "main is red: the screen-acceptance UAT fails on the tip"
 fi
 
 if [[ "${MAIN_SONAR_RESULT:-}" = "failure" ]]; then
@@ -368,6 +450,8 @@ ${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
 Until it is fixed, treat the quality gate's reading for \`main\` as stale rather
 than as a verdict."\
     || unreported=1
+elif [[ "${MAIN_SONAR_RESULT:-}" = "success" ]]; then
+  resolve "main's SonarCloud analysis was not published"
 fi
 
 # The model lane, same two-findings shape and for the same reason. A missing
@@ -398,6 +482,10 @@ than as six scenarios of apparently bad answers.
 
 Reproduce locally with \`MARGINCE_E2E_LLM=1 make e2e-llm\`."\
     || unreported=1
+elif [[ "${LLM_RESULT:-}" = "success" ]] || [[ "${LLM_OUTCOME:-}" = "scenario-failed" ]]; then
+  # A scenario that drove and failed proves the lane RAN, so "could not run"
+  # is no longer true and the arm below owns what is.
+  resolve "the weekly model-driven use cases could not run"
 fi
 
 if [[ "${LLM_OUTCOME:-}" = "scenario-failed" ]]; then
@@ -427,6 +515,8 @@ the assistant cites the record correctly, quotes the post-mortem note correctly,
 and then repeats the note's wrong month in its own voice. If that is what the
 transcript shows, this issue is the existing finding rather than a new one."\
     || unreported=1
+elif [[ "${LLM_RESULT:-}" = "success" ]]; then
+  resolve "a use case is failing when driven by a real model"
 fi
 
 # --- merge-attest.yml -----------------------------------------------------------

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -29,11 +29,21 @@ case "$1 ${2:-}" in
 "api --paginate")
 	# Paginate at 100 so a case can put its match beyond the first page, which
 	# is the whole failure being tested.
+	#
+	# Counted with `n` rather than NR, and blank records skipped, because a
+	# here-string always delivers ONE line: an empty tracker arrives as a single
+	# blank record with NR == 1, and keyed on NR this emitted
+	# `[{"number":,"title":""}]`. jq refused it and nothing said so — errexit is
+	# suppressed inside a function called as `report ... || unreported=1`, so the
+	# reporter read the empty output of a FAILED read as "no issue open" and filed
+	# regardless. Every case here passing `""` was asserting over a parse error
+	# rather than over an empty tracker.
 	awk -F'\t' '
-		{ items[NR] = "{\"number\":" $1 ",\"title\":\"" $2 "\"}" }
+		$0 == "" { next }
+		{ items[++n] = "{\"number\":" $1 ",\"title\":\"" $2 "\"}" }
 		END {
-			if (NR == 0) { print "[]"; exit }
-			for (i = 1; i <= NR; i++) {
+			if (n == 0) { print "[]"; exit }
+			for (i = 1; i <= n; i++) {
 				page = page (page == "" ? "" : ",") items[i]
 				if (i % 100 == 0) { print "[" page "]"; page = "" }
 			}
@@ -41,6 +51,7 @@ case "$1 ${2:-}" in
 		}' <<<"$OPEN_TITLES"
 	;;
 "issue comment") echo "comment $3" >>"$ACTION_LOG" ;;
+"issue close") echo "close $3" >>"$ACTION_LOG" ;;
 "issue create")
 	for i in $(seq 1 $#); do
 		if [ "${!i}" = "--title" ]; then j=$((i + 1)); echo "create ${!j}" >>"$ACTION_LOG"; fi
@@ -58,17 +69,23 @@ export PATH="$stub_dir:$PATH"
 
 readonly GATE_TITLE="SonarCloud quality gate is not green on main"
 
-# expect <name> <expected-actions> <open-issues-tsv>
+# expect_actions <name> <expected-actions> <open-issues-tsv> <env assignment>...
 #
-# Only the quality gate is reported failing, so the expected action is exactly
-# one line naming what the reporter did about GATE_TITLE.
-expect() {
-	local name="$1" want="$2" open="$3" out status got
+# The general driver: run the reporter under a given set of lane results and
+# assert on the comma-joined list of things it did to the tracker. Every case
+# below is one of these, because "it filed something" is not evidence it filed
+# the right thing — and now that a green check CLOSES an issue, "it did nothing"
+# is a distinct and testable answer that used to be indistinguishable from a
+# run that never reached the arm.
+expect_actions() {
+	local name="$1" want="$2" open="$3"
+	shift 3
+	local out status got
 	export ACTION_LOG="$stub_dir/actions"
 	: >"$ACTION_LOG"
 	set +e
-	out="$(OPEN_TITLES="$open" GH_TOKEN=stub REPO=owner/repo RUN_URL=https://example.test/run/1 \
-		GATE_RESULT=failure GATE_STATUS=ERROR \
+	out="$(env OPEN_TITLES="$open" GH_TOKEN=stub REPO=owner/repo \
+		RUN_URL=https://example.test/run/1 "$@" \
 		"$root/scripts/scheduled-report.sh" 2>&1)"
 	status=$?
 	set -e
@@ -80,9 +97,17 @@ expect() {
 		echo "  actions want '$want' got '$got'"
 		printf '  output: %s\n' "$out" | head -5
 		failures=$((failures + 1))
-	else
-		echo "ok: $name"
+		return
 	fi
+	echo "ok: $name"
+}
+
+# expect <name> <expected-actions> <open-issues-tsv>
+#
+# Only the quality gate is reported failing, so the expected action is exactly
+# one line naming what the reporter did about GATE_TITLE.
+expect() {
+	expect_actions "$1" "$2" "$3" GATE_RESULT=failure GATE_STATUS=ERROR
 }
 
 # expect_llm <name> <LLM_OUTCOME> <expected-title>
@@ -154,6 +179,99 @@ expect "duplicates already filed: the oldest keeps the discussion" \
 expect "a similar title is a different finding" \
 	"create $GATE_TITLE" \
 	"$(printf '55\tSonarCloud quality gate is not green on staging\n')"
+
+# --- retraction: what a check that came back GREEN does -------------------------
+#
+# The other half of the reporter, and the half that did not exist. A finding was
+# filed when a lane went red and never withdrawn when it went green, so the
+# tracker reported a red main over a green tree for as long as it took somebody
+# to close the issue by hand. margince/margince#5118 is the worked example:
+# filed 05:35Z, fixed on main at 06:49Z, still open hours after.
+#
+# The cases below are written around the ONE direction this must not fail in.
+# Filing a finding wrongly is loud — somebody reads the issue and says so.
+# Retracting one wrongly is silent: the issue closes, the red stays, and nothing
+# ever asks again. So a result that is not a pass must reach neither half.
+
+expect_actions "a green check closes the issue it filed" \
+	"close 40" \
+	"$(printf '99\ta later finding\n40\t%s\n' "$GATE_TITLE")" \
+	GATE_RESULT=success
+
+# Nothing to retract is not a failure, and not a reason to say anything.
+expect_actions "a green check with no open issue does nothing" \
+	"" "" GATE_RESULT=success
+
+# THE ONE THAT MATTERS. A skipped job is the ABSENCE of a verdict, not a passing
+# one: the weekly perf lanes are skipped on the daily cron, and the daily lane's
+# arms are unset entirely when main-health runs the same reporter. Reading any
+# of those as green would close a finding that nothing re-examined.
+expect_actions "a skipped check neither files nor closes" \
+	"" "$(printf '40\t%s\n' "$GATE_TITLE")" \
+	GATE_RESULT=skipped
+
+expect_actions "a cancelled check neither files nor closes" \
+	"" "$(printf '40\t%s\n' "$GATE_TITLE")" \
+	GATE_RESULT=cancelled
+
+# An unset result is how EVERY arm of the other workflow arrives. main-health and
+# scheduled.yml run one reporter and each passes only its own lanes, so on any
+# given run most arms see nothing at all.
+expect_actions "an unset check neither files nor closes" \
+	"" "$(printf '40\t%s\n' "$GATE_TITLE")" \
+	GATE_STATUS=ERROR
+
+# The same rule the filing side follows: the oldest open match is the one
+# carrying the discussion, so it is the one that gets closed.
+expect_actions "duplicates already filed: the oldest is the one closed" \
+	"close 12" \
+	"$(printf '300\t%s\n12\t%s\n' "$GATE_TITLE" "$GATE_TITLE")" \
+	GATE_RESULT=success
+
+# --- retraction where ONE job result feeds TWO titles ---------------------------
+#
+# Three lanes split their result into "could not run" and "the thing it measures
+# is bad", and a mirrored else is wrong for them: the middle case — a lane that
+# ran and measured something bad — is a FAILURE that nonetheless retracts "could
+# not run". Getting this wrong leaves a permanent "could not complete" issue open
+# on a lane that completes every week, which is the stale-issue defect in a new
+# costume.
+#
+# Parameterised over the three, because each is its own pair of titles and a copy
+# of one case would pass on the day another arm's spelling drifted.
+
+# expect_split <lane> <result-var> <outcome-var> <measured-value> <ran-title> <bad-title>
+expect_split() {
+	local lane="$1" res="$2" out="$3" measured="$4" ran_title="$5" bad_title="$6"
+	local open
+	open="$(printf '10\t%s\n20\t%s\n' "$ran_title" "$bad_title")"
+
+	# It ran and what it measured was bad: retract "could not run", report the bad
+	# measurement. Both, in the order the reporter's arms appear.
+	expect_actions "$lane/a measured failure retracts 'could not run' and files what it measured" \
+		"close 10,comment 20" "$open" "$res=failure" "$out=$measured"
+
+	# It ran and everything held: both titles are false, so both go.
+	expect_actions "$lane/a green run retracts both of its findings" \
+		"close 10,close 20" "$open" "$res=success"
+
+	# It never ran: the honest report, and the bad-measurement title untouched
+	# because nothing measured anything.
+	expect_actions "$lane/a lane that never ran files only 'could not run'" \
+		"comment 10" "$open" "$res=failure"
+}
+
+expect_split perf PERF_RESULT PERF_OUTCOME breach \
+	"the weekly PERF-3/PERF-7 run could not complete" \
+	"a PERF-3/PERF-7 budget is breaching on main"
+
+expect_split mobile MOBILE_RESULT MOBILE_OUTCOME breach \
+	"the weekly MOBILE-AC-2 run could not complete" \
+	"PERF-1's perceived budget is breaching on main"
+
+expect_split llm LLM_RESULT LLM_OUTCOME scenario-failed \
+	"the weekly model-driven use cases could not run" \
+	"a use case is failing when driven by a real model"
 
 # --- main-health arms ----------------------------------------------------------
 #
@@ -496,17 +614,114 @@ if [[ -z "$report_job" ]]; then
 	echo "FAIL: no 'report' job found in main-health.yml — the wiring checks below would pass by scanning nothing"
 	failures=$((failures + 1))
 fi
+# What this loop USED to ask of the report job's `if:` was whether it selects a
+# failing lane. It no longer may: the job has to run whatever the lanes said, or
+# the retraction half of the reporter is unreachable. So the per-lane question is
+# now about the wiring that carries a result IN, and reachability moved below,
+# where it is one question per workflow rather than one per lane.
+needs_list="$(grep -oE '^    needs: \[[^]]*\]' <<<"$report_job" | sed -E 's/^    needs: \[//; s/\]$//')"
+if [[ -z "$needs_list" ]]; then
+	echo "FAIL: main-health's report job declares no 'needs:' list, so every needs.<job>.result it passes reads empty"
+	failures=$((failures + 1))
+fi
 for lane in $lanes; do
 	# MAIN_UAT_RESULT -> uat
 	job="$(printf '%s' "$lane" | sed -E 's/^MAIN_(.+)_RESULT$/\1/' | tr '[:upper:]' '[:lower:]')"
-	if ! grep -qE "needs\.${job}\.result == 'failure'" <<<"$report_job"; then
-		echo "FAIL: $lane has a reporter arm, but main-health's report job does not run for a failing '${job}' — the arm is unreachable"
+	# A job absent from `needs:` is still legal to reference: needs.<job>.result
+	# simply answers with an empty string, which the reporter reads as "no
+	# verdict" and passes over in silence. The arm is reached, does nothing, and
+	# nothing fails — which is the shape this census exists to refuse.
+	case ",${needs_list// /}," in
+	*",$job,"*) ;;
+	*)
+		echo "FAIL: $lane has a reporter arm, but '${job}' is not in main-health's report job 'needs:' — needs.${job}.result reads empty and the arm silently does nothing"
 		failures=$((failures + 1))
-	fi
+		;;
+	esac
 	if ! grep -qE "^ *${lane}: \\\$\{\{ needs\.${job}\.result \}\}" <<<"$report_job"; then
 		echo "FAIL: $lane has a reporter arm, but main-health never passes needs.${job}.result in as $lane"
 		failures=$((failures + 1))
 	fi
+done
+
+# --- every finding that can be FILED can be RETRACTED ---------------------------
+#
+# Derived from the reporter rather than listed here, because a list kept beside
+# the arms stops being true the day somebody adds one. A `report` with a literal
+# title makes a STANDING claim about a lane's state, and a standing claim nothing
+# withdraws is the defect this whole change is about: an arm added without its
+# `resolve` is a one-line omission whose only symptom is an issue nobody closes.
+#
+# The exemption is the CODE SHAPE, not a skip-list. `report "$merge_title"` names
+# one past merge and there is no state a later run could retract, so `[^"$]` is
+# what excuses it — a future computed title is exempt automatically, and a future
+# literal one is not.
+reporter="$root/scripts/scheduled-report.sh"
+reported="$(grep -oE '^  report "[^"$]+"' "$reporter" | sed -E 's/^  report "//; s/"$//' | sort -u)"
+resolved="$(grep -oE '^  resolve "[^"$]+"' "$reporter" | sed -E 's/^  resolve "//; s/"$//' | sort -u)"
+# A pattern that has stopped matching reads as total coverage, which is the
+# loudest way this file could lie.
+if [[ -z "$reported" ]]; then
+	echo "FAIL: the census found no literal report title in the reporter — the pattern stopped matching, it did not stop mattering"
+	failures=$((failures + 1))
+fi
+while IFS= read -r title; do
+	[[ -z "$title" ]] && continue
+	if ! grep -qxF "$title" <<<"$resolved"; then
+		echo "FAIL: the reporter files \"$title\" and never retracts it — a green run leaves that issue open over a fixed tree"
+		failures=$((failures + 1))
+	fi
+done <<<"$reported"
+# And the other direction, because a retraction for a title nothing files is dead
+# code that reads exactly like coverage: the check above would count it and be
+# satisfied by it.
+while IFS= read -r title; do
+	[[ -z "$title" ]] && continue
+	if ! grep -qxF "$title" <<<"$reported"; then
+		echo "FAIL: the reporter retracts \"$title\" but no arm files it — either the title drifted or the arm is gone"
+		failures=$((failures + 1))
+	fi
+done <<<"$resolved"
+
+# --- the report job is REACHED on a green run -----------------------------------
+#
+# One question per workflow, because it is one fact about the job: it must run
+# whatever its lanes said. Gate it on a failure again and retraction breaks in
+# the silent direction — green run, skipped job, issue left open over a fixed
+# tree, and no assertion anywhere fails. That is how the defect this change
+# fixes went unnoticed for as long as it did.
+for wf in "$health" "$root/.github/workflows/scheduled.yml"; do
+	wf_name="$(basename "$wf")"
+	wf_job="$(awk '/^  report:/{inside=1} inside&&/^  [A-Za-z_][A-Za-z0-9_-]*:/&&!/^  report:/{exit} inside' "$wf")"
+	if [[ -z "$wf_job" ]]; then
+		echo "FAIL: no 'report' job found in $wf_name — the checks below would pass by scanning nothing"
+		failures=$((failures + 1))
+		continue
+	fi
+	# The `if:` block alone: from its key to the next key at the same indent. The
+	# comments explaining it sit ABOVE the key and are deliberately out of scope —
+	# they name the very clause being forbidden here, so a check that read prose
+	# would fail on the comment explaining why the code is right.
+	cond="$(awk '/^    if:/{inside=1; print; next} inside&&/^    [a-z]/{exit} inside' <<<"$wf_job")"
+	if [[ -z "$cond" ]]; then
+		echo "FAIL: $wf_name's report job has no 'if:' — it either never runs, or runs on a cancelled workflow carrying results no lane produced"
+		failures=$((failures + 1))
+		continue
+	fi
+	if grep -qE 'needs[.[]' <<<"$cond"; then
+		echo "FAIL: $wf_name's report job gates its 'if:' on a lane result."
+		echo "      The reporter RETRACTS a finding whose check came back green, and this job is"
+		echo "      skipped on exactly the run that would do it. Green run, skipped job, issue left"
+		echo "      open over a fixed tree, and nothing fails."
+		failures=$((failures + 1))
+		continue
+	fi
+	if ! grep -qF '!cancelled()' <<<"$cond"; then
+		echo "FAIL: $wf_name's report job does not guard on '!cancelled()', so a cancelled run reaches the reporter carrying lane results nothing produced"
+		failures=$((failures + 1))
+		continue
+	fi
+	echo "ok: $wf_name's report job is reached whatever its lanes said"
 done
 
 if [[ "$failures" -ne 0 ]]; then


### PR DESCRIPTION
Fixes https://github.com/margince/margince/issues/5130.

## What

A scheduled check that comes back **green closes the issue it filed**. It only ever filed one before, so a finding outlived its fix until somebody closed it by hand.

## Why

`scripts/scheduled-report.sh` has one half of a pair. It files an issue when a lane goes red, and does nothing at all when the lane goes green — the report job in both `scheduled.yml` and `main-health.yml` was gated on a failure, so a green run never reached it.

The cost, from the day this was written: https://github.com/margince/margince/issues/5118 was filed at 05:35Z for a docs-budget gate, fixed on `main` at 06:49Z by https://github.com/margince/margince/pull/5127, and was still open hours later with no assignee and no comment. Anyone reading the tracker to ask *"is `main` red, and is anyone on it"* got the wrong answer in both directions at once.

It also meant one title collected every breakage a lane ever had, each with a different cause and a different fix. The dedupe is right that a daily re-file would bury a live discussion — it was never an argument for keeping the discussion open once its subject was gone. Each red is now its own issue, which is what each red actually is.

## How it works

The report job runs whatever its lanes said, and the reporter decides per check:

| result | what happens |
| --- | --- |
| `failure` | report — file, or comment "still failing" on the open one |
| `success` | **retract** — comment and close the open one |
| `skipped`, `cancelled`, unset | neither |

**That third row is the whole design.** Filing a finding wrongly is loud: somebody reads the issue and says so. Retracting one wrongly is silent — the issue closes, the red stays, and nothing ever asks again. And a non-verdict is the common case, not the exotic one: the weekly perf lanes are `skipped` on the daily cron, and every one of the daily lane's arms is unset whenever main-health runs the same reporter.

**Three arms feed two titles from one job result**, and a mirrored `else` is wrong for them. A lane that ran and measured something bad has disproved "could not run", so it retracts that finding on the same run it files the other.

**`merge-attest.yml`'s arm is deliberately untouched.** Its title names one past merge; there is no state a later run could retract.

## Two things found on the way

**The open-issue read moved to the top level, and happens once.** There are two callers per arm now rather than one, and paginating the whole tracker per question got more expensive with every arm added, for an answer that cannot change inside a run. Top level also means a *failed* read stops the run instead of reading as an empty tracker — which would file duplicates and retract nothing, silently, for as long as it kept failing.

**That was not hypothetical — the test's own `gh` stub had the bug.** It keyed its row count on `NR`, but a here-string always delivers one line, so an empty tracker arrived as a single blank record and the stub emitted `[{"number":,"title":""}]`. jq refused it on every case passing `""`. Nothing said so, because errexit is suppressed inside a function invoked as `report ... || unreported=1` — so the reporter read the empty output of a **failed** read as "no issue open" and filed anyway. Every `""` case in that file was asserting over a parse error rather than over an empty tracker. Fixed, and `a tracker that cannot be read stops the run rather than reading as empty` is now a case.

## The census keeps its shape and changes its subject

Reachability used to be asked per lane — *does the report job's `if:` select this failure*. It cannot be asked that way any more, and the replacement is not weaker:

- **Once per workflow, of both workflows:** does this job run whatever the lanes said? Re-add a `result == 'failure'` clause and retraction breaks in the silent direction — green run, skipped job, issue left open over a fixed tree, no failing assertion anywhere.
- **The per-lane question became `needs:` membership.** A job absent from `needs:` is still legal to reference: `needs.X.result` simply answers with an empty string, which the reporter reads as "no verdict" and passes over. The arm is reached, does nothing, and nothing fails.
- **Every literal title a `report` can file must appear in a `resolve`** — derived from the reporter, not listed beside it. The exemption is the code shape rather than a skip-list: `report "$merge_title"` is computed, so `[^"$]` excuses it, and a future computed title is exempt automatically while a future literal one is not. Checked both ways, because a `resolve` for a title nothing files is dead code that reads exactly like coverage.

## How verified

`make test-scheduled-report`: **43 cases, all green** (26 before). Every new check was mutation-tested — the source reverted to its pre-fix form and the suite re-run — so none of them passes for free:

| mutation | caught by |
| --- | --- |
| an arm loses its `resolve` | `the reporter files "…" and never retracts it` |
| a `resolve` title drifts by one letter | same, plus the reverse check |
| the report job is re-gated on `needs.gates.result == 'failure'` | `main-health.yml's report job gates its 'if:' on a lane result` |
| `resolve` fires on `!= failure` instead of `== success` | `a skipped check neither files nor closes` |
| a lane drops out of `needs:` | `'gates' is not in main-health's report job 'needs:'` |
| `!cancelled()` becomes `always()` | `does not guard on '!cancelled()'` |
| the read failure is swallowed with `\|\| echo "[]"` | `a tracker that cannot be read is treated as an empty one` |

One bug caught before it shipped, worth naming because it would have broken both workflows outright: a bare `if: !cancelled()` is not an expression, it is a YAML **tag**, and the document stops parsing. Both conditions are folded block scalars, which is what the originals used and why.

- [x] `make check` is green — `check-backend` green, including `test-scheduled-report` and `ci-doc-parity` (which covers the docs edit). `check-fe` is qualified, and the qualification is stated rather than rounded off: it failed **twice, both times on the same test**, `worklist.today.test.tsx > submits once however fast the reader presses` (`expected 2 to be 1`). That test passes 10/10 when run alone, **and CI's `fe-unit` job passes it on this very branch**, so the local failure is load on my machine — which was concurrently OOM-killing another lane — and not this diff, which contains no frontend file. It is the interaction-load flake of https://github.com/margince/margince/issues/2661; the two reproductions are recorded there.

**The integration shards on this PR are red and are not this diff's.** They are the claimed main-red of https://github.com/margince/margince/pull/5154 (`TestTestMailboxFullLoop`, `send-email under "transactional" → 409, want 202`), which that claim reports is reddening every shard on every open PR. This diff contains no Go and no SQL. Not merging until main is green and this PR's checks have been re-run against it.
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — it touches neither; no Go and no SQL in this diff
- [x] `make craft-static` reports no new blockers — it sweeps the Go trees, and this diff has none
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by Claude Code, after fixing https://github.com/margince/margince/issues/5117 and https://github.com/margince/margince/issues/5118 and noticing that neither issue would have closed itself.

The judgement call worth a reviewer's eye: **this decides that a "main is red" issue is per-incident rather than per-lane.** A lane that flaps red/green files a new issue each time instead of accumulating comments on one. I think that is right — the recurrences on a single title have been genuinely unrelated failures, and the reporter still comments rather than re-files while a red persists — but it is a policy change, not only a bug fix, and reverting to per-lane means dropping `resolve` rather than tuning it.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
