### PR TITLE
fix(people): an in-contract offer summary always reaches the company header

### DIFF
--- a/backend/internal/compose/company_integration_test.go
+++ b/backend/internal/compose/company_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 
@@ -374,7 +375,19 @@ func TestAcceptedOfferSummaryWritesTheDescriptionColumn(t *testing.T) {
 	}
 }
 
-func TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence(t *testing.T) {
+// What an overlong summary does to the header line it renders into.
+//
+// `offer_summary` is what an installation says about what it sells and the
+// contract takes 2000 characters of it; `organization_description_length` caps
+// the header at 500. The header is one RENDERING of the summary, so a value too
+// long for the line is a value to shorten — not a write to drop, which is what
+// used to happen: the summary saved, the header stayed blank, and nothing said
+// why to the caller, the audit trail or the operator.
+//
+// Both shapes, because the cut is a rule and not just a length. Spelled in
+// multibyte characters so a byte-counting cut fails this test: the CHECK counts
+// characters, and a byte cut would refuse text the column accepts.
+func TestAnOverlongOfferSummaryFillsTheHeaderWithItsFirstLine(t *testing.T) {
 	e := integration.Setup(t)
 	store := people.NewStore(e.DB())
 	base := principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), e.WS), ids.NewV7())
@@ -383,23 +396,18 @@ func TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence(t *testing.T) {
 		UserID: e.Rep1, OnBehalfOf: e.Rep1, Permissions: integration.AdminPerms,
 	})
 
-	// organization_description_length caps the column at 500 CHARACTERS (0203).
-	// The pair below is the exact boundary: 501 must skip the fill (not abort
-	// the apply), and 500 must land — spelled in multibyte characters so a
-	// future byte-counting guard (octet_length) fails this test.
-	long := strings.Repeat("ü", 501)
-	orgID, err := store.ApplyColdStartProfile(agent, people.ApplyColdStartProfileInput{
-		SourceURL: "https://longwinded.example",
-		Fields: []people.ColdStartFieldInput{{
-			Field: "offer_summary", Value: long,
-			EvidenceSnippet: "We build RevOps software", SourceURL: "https://longwinded.example", Confidence: 0.9,
-		}},
-	})
-	if err != nil {
-		t.Fatalf("ApplyColdStartProfile with an overlong summary: %v", err)
-	}
-
-	readState := func() (*string, string) {
+	apply := func(t *testing.T, source, summary string) (*string, string) {
+		t.Helper()
+		orgID, err := store.ApplyColdStartProfile(agent, people.ApplyColdStartProfileInput{
+			SourceURL: source,
+			Fields: []people.ColdStartFieldInput{{
+				Field: "offer_summary", Value: summary,
+				EvidenceSnippet: "We build RevOps software", SourceURL: source, Confidence: 0.9,
+			}},
+		})
+		if err != nil {
+			t.Fatalf("ApplyColdStartProfile: %v", err)
+		}
 		var description *string
 		var evidenceValue string
 		if err := database.WithWorkspaceTx(e.As(e.Rep1, nil, integration.AdminPerms), e.Pool, func(tx pgx.Tx) error {
@@ -415,28 +423,49 @@ func TestOverlongOfferSummarySkipsTheColumnButKeepsTheEvidence(t *testing.T) {
 		}
 		return description, evidenceValue
 	}
-	description, evidenceValue := readState()
-	if description != nil {
-		t.Fatalf("a 501-character summary filled description = %q, want NULL", *description)
+
+	// One 501-character word: there is no boundary to cut at, and a bounded
+	// value still beats an empty one.
+	unbroken := strings.Repeat("ü", 501)
+	description, evidenceValue := apply(t, "https://unbroken.example", unbroken)
+	if description == nil {
+		t.Fatal("a 501-character summary left the header NULL — the fill it is too long for is the one a reader sees, and dropping it is the silence this replaced")
 	}
-	if evidenceValue != long {
-		t.Fatal("the evidence row should still carry the full accepted summary")
+	if got := utf8.RuneCountInString(*description); got != 500 {
+		t.Errorf("the header line is %d characters; want the 500 the column admits", got)
+	}
+	if evidenceValue != unbroken {
+		t.Error("the evidence row lost the accepted summary — the header is a rendering of it, and shortening the rendering may not shorten the record")
 	}
 
-	// The skipped fill left the column NULL, so a later in-bounds read still
-	// fills it: exactly 500 characters (1000 bytes) passes the guard.
-	atCap := strings.Repeat("ü", 500)
-	if _, err := store.ApplyColdStartProfile(agent, people.ApplyColdStartProfileInput{
-		SourceURL: "https://longwinded.example",
-		Fields: []people.ColdStartFieldInput{{
-			Field: "offer_summary", Value: atCap,
-			EvidenceSnippet: "We build RevOps software", SourceURL: "https://longwinded.example", Confidence: 0.9,
-		}},
-	}); err != nil {
-		t.Fatalf("ApplyColdStartProfile at the cap: %v", err)
+	// The same length in words, chosen so the hard 500-rune cut lands INSIDE a
+	// word — a phrase whose repeat happens to end on 500 would pass whether the
+	// boundary rule ran or not. The assertion is then the RULE rather than a
+	// second copy of the arithmetic: the line stops on a boundary the summary
+	// itself has, so no word is cut in half.
+	spoken := strings.Repeat("Wörter ", 100)
+	description, _ = apply(t, "https://spoken.example", spoken)
+	if description == nil {
+		t.Fatal("a long spoken summary left the header NULL")
 	}
-	if description, _ := readState(); description == nil || *description != atCap {
-		t.Fatal("a summary of exactly 500 characters should fill description")
+	line := *description
+	if count := utf8.RuneCountInString(line); count > 500 || count == 0 {
+		t.Errorf("the header line is %d characters; want a non-empty line within the 500 the column admits", count)
+	}
+	rest, isPrefix := strings.CutPrefix(spoken, line)
+	if !isPrefix {
+		t.Fatalf("the header line %q is not the start of the summary it renders", line)
+	}
+	if next, _ := utf8.DecodeRuneInString(rest); next != ' ' {
+		t.Errorf("the line stops mid-word, before %q — a word cut in half reads as a bug where a clean stop reads as a summary", rest[:min(20, len(rest))])
+	}
+
+	// At the cap the value passes through untouched: the shortening is for what
+	// does not fit, and a summary that fits is not a summary to edit.
+	atCap := strings.Repeat("ü", 500)
+	description, _ = apply(t, "https://atcap.example", atCap)
+	if description == nil || *description != atCap {
+		t.Error("a summary of exactly 500 characters should reach the header unchanged")
 	}
 }
 

--- a/backend/internal/compose/companyheaderline_integration_test.go
+++ b/backend/internal/compose/companyheaderline_integration_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// An in-contract offer summary always reaches the company header.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
+)
+
+// anchorDescription reads the header line the company view renders, straight
+// off the column — what was WRITTEN is the question, not what an assembler
+// hands back.
+func anchorDescription(t *testing.T, e *integration.Env) string {
+	t.Helper()
+	var description *string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT description FROM organization WHERE is_anchor AND archived_at IS NULL`).Scan(&description)
+	}); err != nil {
+		t.Fatalf("reading the anchor's header line: %v", err)
+	}
+	if description == nil {
+		return ""
+	}
+	return *description
+}
+
+// A summary longer than the header column still fills the header.
+//
+// THE DEFECT. The contract accepts 2000 characters of `offer_summary`; the
+// column behind the header holds 500. The write used to carry a length test, so
+// an in-contract summary over 500 saved as a profile field and wrote NOTHING to
+// the header — no error, no audit entry, no signal. The company header stayed
+// blank and there was no way to learn why.
+//
+// 1500 characters is the case the issue names, and it is fully in contract.
+func TestALongOfferSummaryStillFillsTheCompanyHeader(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, nil, integration.AdminPerms)
+	summary := strings.TrimSpace(strings.Repeat("We build warehouse robotics for mid-market logistics. ", 29))
+	if len([]rune(summary)) < 1400 {
+		t.Fatalf("the fixture summary is %d characters — too short to be over the column's bound, so "+
+			"this would pass without exercising anything", len([]rune(summary)))
+	}
+
+	if _, err := e.People.SaveCompany(ctx, people.SaveCompanyInput{
+		DisplayName: "Acme Robotics",
+		Fields:      map[string]*string{"offer_summary": &summary},
+	}); err != nil {
+		t.Fatalf("saving the company profile: %v", err)
+	}
+
+	header := anchorDescription(t, e)
+	if header == "" {
+		t.Fatal("the header is blank after an in-contract summary was saved — the write was skipped and " +
+			"nothing said so, which is the whole defect: a reader sees an empty header and cannot find out why")
+	}
+	if n := len([]rune(header)); n > 500 {
+		t.Errorf("the header holds %d characters, over the column's 500 — the CHECK would have refused it", n)
+	}
+	if !strings.HasPrefix(summary, header) {
+		t.Errorf("the header is not a prefix of the summary, so it says something the profile does not: %q", header)
+	}
+}
+
+// The boundary: exactly 500 writes whole, 501 writes a prefix. 501 is the case
+// that was silently broken.
+func TestTheHeaderBoundaryWritesAtFiveHundredAndAtFiveHundredAndOne(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		length int
+	}{
+		{"exactly the column's bound", 500},
+		{"one character over", 501},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := integration.Setup(t)
+			ctx := e.As(e.Rep1, nil, integration.AdminPerms)
+			// Words, so the 501 case has a boundary to cut at — a single long
+			// token would exercise the hard-cut arm instead, which
+			// headerline_test.go covers on its own.
+			summary := strings.TrimSpace(strings.Repeat("robotics ", tc.length/9+1))[:tc.length]
+
+			if _, err := e.People.SaveCompany(ctx, people.SaveCompanyInput{
+				DisplayName: "Acme Robotics",
+				Fields:      map[string]*string{"offer_summary": &summary},
+			}); err != nil {
+				t.Fatalf("saving a %d-character summary: %v", tc.length, err)
+			}
+
+			header := anchorDescription(t, e)
+			if header == "" {
+				t.Fatalf("a %d-character summary left the header blank", tc.length)
+			}
+			if !strings.HasPrefix(summary, header) {
+				t.Errorf("the header is not a prefix of the summary: %q", header)
+			}
+			if tc.length <= 500 && header != summary {
+				t.Errorf("a summary the column accepts whole was shortened to %d characters", len([]rune(header)))
+			}
+		})
+	}
+}

--- a/backend/internal/modules/people/coldstartcolumn.go
+++ b/backend/internal/modules/people/coldstartcolumn.go
@@ -60,6 +60,12 @@ func applyUnclaimedOrgColumn(ctx context.Context, tx pgx.Tx, orgID ids.Organizat
 			return false, nil
 		}
 		authority = replaceStanding
+		// The same bound the form applies, for the same reason: the header is
+		// one rendering of a longer field, and a value too long for the line is
+		// a value to shorten rather than a write to drop. A read-back that
+		// skipped it left the header blank on exactly the companies whose site
+		// said the most.
+		value = headerLine(value)
 	}
 	// Nothing to fill. Writing "" here would satisfy the fill arm's own
 	// WHERE legal_name IS NULL once and never again: the column would read as

--- a/backend/internal/modules/people/companyform.go
+++ b/backend/internal/modules/people/companyform.go
@@ -121,6 +121,19 @@ func writeCompanyFields(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 // it. Said here because the form carries no version to pin, so nothing else in
 // this file records what stops the second save silently losing the first.
 func setCompanyColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, spec companyField, value string) (bool, error) {
+	// Bounded HERE, at the one edge both writers pass through, so the header
+	// line is derived once rather than guarded twice. The column it feeds is a
+	// display line with a CHECK behind it; the profile field it comes from is
+	// what an installation says about itself, and the contract accepts far more
+	// of that than the line can show.
+	//
+	// This used to be a length test inside the statement, and an overlong value
+	// simply did not write: the summary saved, the header stayed blank, and
+	// nothing told the caller. A prefix cannot fail that way — every value the
+	// contract accepts now reaches the header as much of itself as fits.
+	if spec.column == columnDescription {
+		value = headerLine(value)
+	}
 	var stored *string
 	if value != "" {
 		stored = &value

--- a/backend/internal/modules/people/headerline_test.go
+++ b/backend/internal/modules/people/headerline_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// A header line is a bounded prefix of the field it renders — never a write
+// that silently did not happen.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAHeaderLineIsABoundedPrefixOfWhatItRenders(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  string
+		why   string
+	}{
+		{
+			name: "a value that fits is untouched",
+			// The common case, and the one a prefix must not disturb: no cut,
+			// no trim, byte-for-byte what the caller wrote.
+			value: "We sell warehouse robotics.",
+			want:  "We sell warehouse robotics.",
+			why:   "a value inside the bound is not a rendering decision at all",
+		},
+		{
+			name:  "exactly at the bound is untouched",
+			value: strings.Repeat("a", orgDescriptionMax),
+			want:  strings.Repeat("a", orgDescriptionMax),
+			why:   "the CHECK admits this length, so cutting it would shorten a value the column holds",
+		},
+		{
+			name: "one past the bound cuts at a word boundary",
+			// THE CASE THAT WAS SILENTLY BROKEN. 501 characters: in contract,
+			// refused by the column, and before this the write simply did not
+			// happen and the header stayed blank.
+			value: strings.Repeat("ab ", 166) + "xyz",
+			why:   "a value one character over used to write nothing at all",
+		},
+		{
+			name: "a single unbroken word is cut hard",
+			// No boundary to cut at. A bounded value beats an empty one, and
+			// this is the case a word-boundary rule has to answer rather than
+			// fall through.
+			value: strings.Repeat("z", orgDescriptionMax+50),
+			want:  strings.Repeat("z", orgDescriptionMax),
+			why:   "with no boundary to find, the hard cut is the only bounded answer",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := headerLine(tc.value)
+			if len([]rune(got)) > orgDescriptionMax {
+				t.Fatalf("the line is %d characters, over the column's %d — the write the column would "+
+					"refuse is exactly what this exists to prevent", len([]rune(got)), orgDescriptionMax)
+			}
+			if got == "" && tc.value != "" {
+				t.Fatalf("a non-empty value rendered to nothing (%s)", tc.why)
+			}
+			if tc.want != "" && got != tc.want {
+				t.Fatalf("got %q, want %q — %s", got, tc.want, tc.why)
+			}
+			if !strings.HasPrefix(tc.value, got) {
+				t.Errorf("the line is not a prefix of the value it renders, so it says something the "+
+					"field does not: %q", got)
+			}
+		})
+	}
+}
+
+// A multi-byte value is bounded by CHARACTERS, because that is what the column
+// counts.
+//
+// Postgres length() counts characters, so a byte-based cut would both refuse
+// text the column accepts and split a character in half — a header rendering
+// as a replacement glyph, from a field a human wrote correctly.
+func TestAHeaderLineCountsCharactersNotBytes(t *testing.T) {
+	value := strings.Repeat("ü", orgDescriptionMax)
+
+	got := headerLine(value)
+
+	if got != value {
+		t.Errorf("a value of %d characters (%d bytes) was cut to %d characters — the column counts "+
+			"characters, so this shortens text it would have accepted",
+			len([]rune(value)), len(value), len([]rune(got)))
+	}
+}

--- a/backend/internal/modules/people/orgcolumnwrites.go
+++ b/backend/internal/modules/people/orgcolumnwrites.go
@@ -34,6 +34,8 @@ package people
 
 // orgWriteAuthority says what a writer may do to a column somebody has already
 // answered. It has no zero value on purpose — a writer states which it holds.
+import "strings"
+
 type orgWriteAuthority uint8
 
 const (
@@ -85,16 +87,66 @@ var orgColumnWrites = map[string]orgColumnWrite{
 		replace: `UPDATE organization SET address_line1 = $2 WHERE id = $1 AND archived_at IS NULL
 		          AND address_line1 IS DISTINCT FROM $2`,
 	},
-	// The length guard mirrors organization_description_length (0203): a summary
-	// the CHECK would reject skips the write instead of aborting the whole save
-	// — the profile-field row still lands, and the column stays writable by a
-	// shorter later one. The replace arm tolerates a NULL because clearing the
-	// column is one of the things it does; the fill arm refuses one, because
-	// filling a column with nothing would answer it forever.
+	// No length guard: the value arrives already bounded by headerLine, so a
+	// statement that skipped an overlong one could only skip a value nothing
+	// produces. The guard used to be here and it SILENTLY dropped the write —
+	// a 501-character summary the contract accepts left the header blank with
+	// nothing said to the caller, no audit entry, and no way to find out why.
+	//
+	// The replace arm tolerates a NULL because clearing the column is one of the
+	// things it does; the fill arm refuses one, because filling a column with
+	// nothing would answer it forever.
 	columnDescription: {
 		fill: `UPDATE organization SET description = $2 WHERE id = $1 AND archived_at IS NULL
-		       AND description IS NULL AND $2::text IS NOT NULL AND length($2) <= 500`,
+		       AND description IS NULL AND $2::text IS NOT NULL`,
 		replace: `UPDATE organization SET description = $2 WHERE id = $1 AND archived_at IS NULL
-		          AND description IS DISTINCT FROM $2 AND ($2::text IS NULL OR length($2) <= 500)`,
+		          AND description IS DISTINCT FROM $2`,
 	},
+}
+
+// orgDescriptionMax is what organization_description_length admits — the CHECK
+// bounding the header line the company view renders. Held by the schema itself:
+// a write over this length is refused by the column, which is why the value is
+// bounded before it gets there rather than tested once it arrives.
+
+const orgDescriptionMax = 500
+
+// headerLine renders a profile value as the display line the description
+// column can hold.
+//
+// The bound is baked in rather than taken as a parameter, because description
+// is the only capped column among the four this file writes — a parameter would
+// take one value at every call site and read as though it took several.
+//
+// WHY A PREFIX AND NOT A GUARD. `offer_summary` is what an installation says
+// about what it sells, and the contract accepts far more of it than the column
+// holds. The header is ONE RENDERING of that — the column's own comment frames
+// description as a display line — so a value too long for the line is a value
+// to shorten, not a write to drop. Dropping it is what happened before: the summary saved, the
+// header stayed blank, and nothing anywhere said why.
+//
+// Capping the source to fit the rendering was the other option and it is the
+// wrong direction: it shortens what a company may say about itself so that one
+// of its displays fits.
+//
+// CUT AT A WORD BOUNDARY, and add nothing. An ellipsis would be this function
+// inventing punctuation into a field a human wrote, and the header is a line
+// the reader sees rather than a string another system parses — a word cut in
+// half reads as a bug in the product, where a clean stop reads as a summary.
+// If there is no boundary to cut at (one very long word), the hard cut stands:
+// a bounded value beats an empty one.
+//
+// Runes, not bytes: the CHECK counts characters (Postgres length() does), so a
+// byte cut would both refuse text the column accepts and split a multi-byte
+// character.
+func headerLine(value string) string {
+	runes := []rune(value)
+	if len(runes) <= orgDescriptionMax {
+		return value
+	}
+	cut := string(runes[:orgDescriptionMax])
+	if at := strings.LastIndexAny(cut, " \t\n"); at > 0 {
+		return strings.TrimRight(cut[:at], " \t\n")
+	}
+	return cut
 }


### PR DESCRIPTION
Closes #870.

## The defect

The contract accepts 2000 characters of `offer_summary`; the column behind the company header holds 500. The write carried a length test, so an in-contract summary over 500 **saved as a profile field and wrote nothing to the header** — no error, no audit entry, no signal to caller or operator. The header stayed blank and there was no way to learn why.

## The header is one rendering of the summary

So a value too long for the line is a value to **shorten**, not a write to drop. `headerLine` takes a bounded prefix:

- **cut at a word boundary**, because a word split in half reads as a bug in the product where a clean stop reads as a summary;
- **adding nothing** — an ellipsis would be this code inventing punctuation into a field a human wrote, and the header is a line a reader sees rather than a string another system parses;
- **hard cut when there is no boundary** (one very long word): a bounded value beats an empty one;
- **runes, not bytes** — the CHECK counts characters, so a byte cut would both refuse text the column accepts and split a character in half.

The issue's other two options are worse. Recording the skip in the audit evidence is truthful and leaves the header blank — that diagnoses the defect rather than fixing it. Tightening the contract to 500 solves a display problem by shortening what an installation may say about what it sells.

## Both write paths

They are two edges, not one: the human company form (`setCompanyColumn`) and the read-back's overwrite arm (`applyUnclaimedOrgColumn`) each reach the column separately. Fixing one would have left the other silently dropping — and the read-back is the path that matters most, because it drops on exactly the companies whose site said the most.

The statement's length guard is gone with it. A statement that skipped an overlong value could now only skip a value nothing produces, and leaving it would keep the failure mode alive behind a condition that never fires.

## The census the ruling asked for

`description` is the **only** length-capped column on `organization`, so `offer_summary` is the only field whose destination is tighter than its contract. No second instance of this shape exists today — worth knowing, since this was found by reviewing one PR and the same shape elsewhere would have been found the same way.

## Tests

- `headerline_test.go` — fits / exactly at the bound / one over with a boundary / one unbroken word, plus a multi-byte case asserting characters rather than bytes. Every case also asserts the result is a **prefix of the value**, so the line cannot say something the field does not.
- `TestALongOfferSummaryStillFillsTheCompanyHeader` — a 1500-character summary end to end, reading the column directly rather than an assembler's answer.
- `TestTheHeaderBoundaryWritesAtFiveHundredAndAtFiveHundredAndOne` — 501 is the case that was silently broken; 500 asserts a value the column accepts whole is not shortened.

| mutation | result |
|---|---|
| the old silent guard restored | the end-to-end test fails: header blank after an in-contract save |
| the prefix stops respecting the bound | six cases fail |

## Checks

`make check-backend` green; `make craft-static` 0/0/0; `go test -count=1 ./gates` green; the people and compose integration lanes green.

**Note on CI:** main is currently red from #5103. Send/schedule 409s on this PR are that, not this change.