### PR TITLE
fix(contract-api): a declared page dial is read, or it is not declared

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -13965,9 +13965,14 @@ paths:
       tags: [Compliance]
       operationId: listConsentPurposes
       summary: List the workspace's consent purposes (e.g. transactional, marketing_email, profiling).
-      parameters:
-        - $ref: '#/components/parameters/Cursor'
-        - $ref: '#/components/parameters/Limit'
+      description: |
+        UNPAGED, deliberately. A workspace's consent purposes are configuration — a handful of
+        them, set up once — so the answer is the whole set and `page` reports `has_more: false`.
+
+        It used to declare `cursor` and `limit` and honour neither: `?limit=5` returned the
+        catalog, and a caller who sized a page got everything. Nothing was hidden, and nothing
+        was kept either. Removing the dial makes the surface true rather than adding paging
+        machinery with no user.
       responses:
         '200':
           description: A page of consent purposes.
@@ -15505,9 +15510,13 @@ paths:
       security: [ { cookieAuth: [] } ]
       x-agent-access: human-only
       summary: List the owner's corpus manifest and live meter; source text is never returned.
-      parameters:
-        - $ref: '#/components/parameters/Cursor'
-        - $ref: '#/components/parameters/Limit'
+      description: |
+        UNPAGED, deliberately, and for the same reason listConsentPurposes is: one voice
+        profile's corpus sources are configuration rather than accumulated data, so the answer
+        is the whole manifest.
+
+        It declared `cursor` and `limit` and honoured neither. Removing the dial is free now
+        and stops being free once a client depends on the parameter being accepted.
       responses:
         '200':
           description: Manifest and meter.

--- a/backend/gates/declaredfilters_test.go
+++ b/backend/gates/declaredfilters_test.go
@@ -92,12 +92,32 @@ const (
 	wantMinimumOverlayShadows = 4
 )
 
-// pagingParameterTypes are the generated types the contract spells its shared
-// paging and ordering parameters with. Recognising them by TYPE rather than by
-// name is what keeps the exclusion honest: it is the contract's own component
-// reuse that says these three are a page's shape, and a filter that happened to
-// be called `sort` on some operation would still be judged.
-var pagingParameterTypes = map[string]bool{"Cursor": true, "Limit": true, "Sort": true}
+// unjudgedParameterTypes are the generated types this gate does not judge.
+//
+// Recognising them by TYPE rather than by name is what keeps the exclusion
+// honest: it is the contract's own component reuse that says a parameter is a
+// page's shape, and a filter that happened to be called `sort` on some
+// operation would still be judged.
+//
+// `Cursor` and `Limit` are NOT here any more. They were scoped out with `Sort`
+// as "a page's shape rather than its membership", and the distinction is real —
+// a dropped filter answers a wider question than the one asked, where a dropped
+// page dial answers the right question in the wrong shape. But the second is
+// still a claim the surface does not keep: `?limit=5` returning the whole set
+// means the caller sized a page and got a catalog, and `?cursor=` accepted and
+// inert is the shape that walks page one forever.
+//
+// There is deliberately NO waiver list beside this. An operation that will not
+// honour a dial removes the declaration from the contract instead — the honest
+// state after a retirement is that the parameter is gone, not that it is
+// declared and excused.
+//
+// `Sort` stays scoped out for now, and only because honouring it is a per-store
+// change rather than a contract edit: three operations declare it unread, and
+// each needs its store to take a sort vocabulary and a keyset cursor that
+// carries the sort key. Issue #827 holds that half; this line is what will be
+// deleted when it lands.
+var unjudgedParameterTypes = map[string]bool{"Sort": true}
 
 // declaredFilter is one narrowing query parameter of one operation: the Go
 // field a handler reads, and the name a caller types.
@@ -282,9 +302,11 @@ func TestTheDeclaredFilterCensusReadsTheGeneratedShape(t *testing.T) {
 	for _, filter := range people {
 		wire = append(wire, filter.wire)
 	}
-	// The person list declares exactly these, and the three paging components
-	// it also declares are not among them.
-	want := "ai_written,captured_by_kind,include_archived,organization_id,owner_id,owner_team_id,q,tag_id,tag_mode,unassigned"
+	// The person list declares exactly these. cursor and limit ARE among them —
+	// the gate judges a page dial the same way it judges a filter — and `sort`
+	// is not, because it is the one type still scoped out.
+	want := "ai_written,captured_by_kind,cursor,include_archived,limit,organization_id,owner_id," +
+		"owner_team_id,q,tag_id,tag_mode,unassigned"
 	if got := strings.Join(wire, ","); got != want {
 		t.Errorf("listPeople's narrowing parameters = %q, want %q", got, want)
 	}
@@ -477,8 +499,8 @@ func narrowingParametersByType(t *testing.T) map[string][]declaredFilter {
 }
 
 // narrowingFields reads one params struct's query fields: the `form` tag names
-// the wire parameter, and a field typed by one of the shared paging components
-// is not one of them.
+// the wire parameter, and a field typed by one this gate does not judge
+// (unjudgedParameterTypes) is not one of them.
 func narrowingFields(structType *ast.StructType) []declaredFilter {
 	var out []declaredFilter
 	for _, field := range structType.Fields.List {
@@ -486,7 +508,7 @@ func narrowingFields(structType *ast.StructType) []declaredFilter {
 			continue
 		}
 		wire := formTagName(field.Tag.Value)
-		if wire == "" || pagingParameterTypes[pointedToTypeName(field.Type)] {
+		if wire == "" || unjudgedParameterTypes[pointedToTypeName(field.Type)] {
 			continue
 		}
 		out = append(out, declaredFilter{field: field.Names[0].Name, wire: wire})

--- a/backend/internal/compose/integration/recordgrantpaging_integration_test.go
+++ b/backend/internal/compose/integration/recordgrantpaging_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -86,11 +87,17 @@ func TestTheRecordGrantListServesThePageItWasAskedFor(t *testing.T) {
 // The default limit applies when the caller names none, which is what stops the
 // old behaviour — read the whole table, then one visibility query per row —
 // coming back for a caller who simply did not pass a dial.
+//
+// The corpus is one grant OVER that default, and the default is read from the
+// clamp rather than written here: a test seeding three rows passes whatever the
+// limit is, including no limit at all, and a hard-coded 50 stops testing the
+// bound the day the contract moves it.
 func TestTheRecordGrantListIsBoundedWithoutADial(t *testing.T) {
 	e := Setup(t)
 	ctx := e.As(e.AdminUser, nil, AdminPerms)
 	shares := identity.NewServiceFor(e.DB())
-	for range 3 {
+	bound := storekit.ClampLimit(nil)
+	for range bound + 1 {
 		org := e.SeedOrg(t, "Shared Holding", &e.Rep1)
 		if _, err := shares.CreateRecordGrant(ctx, identity.CreateGrantInput{
 			RecordType: "organization", RecordID: org,
@@ -100,11 +107,21 @@ func TestTheRecordGrantListIsBoundedWithoutADial(t *testing.T) {
 		}
 	}
 
-	grants, _, err := shares.ListRecordGrants(ctx, identity.ListGrantsInput{})
+	grants, page, err := shares.ListRecordGrants(ctx, identity.ListGrantsInput{})
 	if err != nil {
 		t.Fatalf("listing without a dial: %v", err)
 	}
-	if len(grants) == 0 {
-		t.Fatal("a caller passing no dial got nothing — the default limit must serve a page, not refuse one")
+	if len(grants) != bound {
+		t.Fatalf("a caller passing no dial got %d grant(s) over a corpus of %d; want the default page of %d — "+
+			"an unbounded read is what this list used to do, and it reads exactly like a short table",
+			len(grants), bound+1, bound)
+	}
+	// The page has to SAY it is short, or a caller who reads the whole list as
+	// the whole table is told nothing about the rest.
+	if !page.HasMore {
+		t.Fatal("the default page served every row it was going to and said there was no more")
+	}
+	if page.NextCursor == "" {
+		t.Fatal("the page says there is more and hands back no cursor to fetch it with")
 	}
 }

--- a/backend/internal/compose/integration/recordgrantpaging_integration_test.go
+++ b/backend/internal/compose/integration/recordgrantpaging_integration_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The record-grant list honours the page it was asked for.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The list serves the page it was asked for, and walks the rest exactly once.
+//
+// WHY THIS ONE IS PAGED AND THE OTHER TWO ARE NOT. Consent purposes and voice
+// corpus sources are configuration — a workspace sets up a handful once. A
+// grant row is created every time somebody shares a record, so its count is
+// driven by usage, and the unfiltered read returned the WHOLE table and then
+// ran one visibility query per row it had read.
+//
+// The subtlety is that the visibility filter runs AFTER the page: a page of
+// `limit` rows can serve fewer once the invisible ones are dropped. So the
+// walk is asserted by what it SEES across pages, and the pages are sized
+// smaller than the fixture so a boundary is actually crossed.
+func TestTheRecordGrantListServesThePageItWasAskedFor(t *testing.T) {
+	e := Setup(t)
+	ctx := e.As(e.AdminUser, nil, AdminPerms)
+	shares := identity.NewServiceFor(e.DB())
+
+	const total = 5
+	for i := range total {
+		org := e.SeedOrg(t, "Shared Holding", &e.Rep1)
+		if _, err := shares.CreateRecordGrant(ctx, identity.CreateGrantInput{
+			RecordType: "organization", RecordID: org,
+			SubjectType: "user", SubjectID: e.Rep3, Access: "read",
+		}); err != nil {
+			t.Fatalf("sharing record %d: %v", i, err)
+		}
+	}
+
+	limit := 2
+	var seen []ids.UUID
+	var cursor *string
+	for range total + 2 {
+		grants, page, err := shares.ListRecordGrants(ctx, identity.ListGrantsInput{
+			Limit: &limit, Cursor: cursor,
+		})
+		if err != nil {
+			t.Fatalf("listing after %d grant(s): %v", len(seen), err)
+		}
+		if len(grants) > limit {
+			t.Fatalf("a page of %d came back for limit=%d — the caller sized a page and got more of "+
+				"the catalog than they asked for", len(grants), limit)
+		}
+		for _, g := range grants {
+			seen = append(seen, g.ID)
+		}
+		if !page.HasMore {
+			break
+		}
+		if page.NextCursor == "" {
+			t.Fatalf("the page says there is more and hands back no cursor to fetch it with")
+		}
+		cursor = &page.NextCursor
+	}
+
+	if len(seen) != total {
+		t.Fatalf("the walk saw %d grant(s), want %d — a page that ends early leaves grants nobody can "+
+			"reach, and one that repeats serves the same share twice", len(seen), total)
+	}
+	unique := map[ids.UUID]bool{}
+	for _, id := range seen {
+		if unique[id] {
+			t.Fatalf("grant %s was served twice — the keyset repeats at a page boundary", id)
+		}
+		unique[id] = true
+	}
+}
+
+// An unpaged call is still bounded.
+//
+// The default limit applies when the caller names none, which is what stops the
+// old behaviour — read the whole table, then one visibility query per row —
+// coming back for a caller who simply did not pass a dial.
+func TestTheRecordGrantListIsBoundedWithoutADial(t *testing.T) {
+	e := Setup(t)
+	ctx := e.As(e.AdminUser, nil, AdminPerms)
+	shares := identity.NewServiceFor(e.DB())
+	for range 3 {
+		org := e.SeedOrg(t, "Shared Holding", &e.Rep1)
+		if _, err := shares.CreateRecordGrant(ctx, identity.CreateGrantInput{
+			RecordType: "organization", RecordID: org,
+			SubjectType: "user", SubjectID: e.Rep3, Access: "read",
+		}); err != nil {
+			t.Fatalf("sharing a record: %v", err)
+		}
+	}
+
+	grants, _, err := shares.ListRecordGrants(ctx, identity.ListGrantsInput{})
+	if err != nil {
+		t.Fatalf("listing without a dial: %v", err)
+	}
+	if len(grants) == 0 {
+		t.Fatal("a caller passing no dial got nothing — the default limit must serve a page, not refuse one")
+	}
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -667,7 +667,7 @@ func (stubs) SetConnectorSignatureEnrichment(w nethttp.ResponseWriter, r *nethtt
 	httperr.NotImplemented(w, r, "SetConnectorSignatureEnrichment")
 }
 
-func (stubs) ListConsentPurposes(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.ListConsentPurposesParams) {
+func (stubs) ListConsentPurposes(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "ListConsentPurposes")
 }
 
@@ -2355,7 +2355,7 @@ func (stubs) GetVoiceLearningSummary(w nethttp.ResponseWriter, r *nethttp.Reques
 	httperr.NotImplemented(w, r, "GetVoiceLearningSummary")
 }
 
-func (stubs) ListVoiceCorpusSources(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.ListVoiceCorpusSourcesParams) {
+func (stubs) ListVoiceCorpusSources(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
 	httperr.NotImplemented(w, r, "ListVoiceCorpusSources")
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -38371,22 +38371,6 @@ type ConnectorOAuthCallbackParams struct {
 	Error *string `form:"error,omitempty" json:"error,omitempty"`
 }
 
-// ListConsentPurposesParams defines parameters for ListConsentPurposes.
-type ListConsentPurposesParams struct {
-	// Cursor Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
-	// effective `sort` of the originating request (field + direction) plus the last row's keyset
-	// (sort-key tuple + the `created_at`/`id` tie-breaker). **Stability:** results are stable
-	// under concurrent inserts/updates (keyset pagination, not offset). Supplying `cursor`
-	// together with a `sort` that differs from the one the cursor was minted under returns
-	// `422 code: cursor_param_mismatch` — re-issue the query without the cursor. Filters are
-	// **not** fingerprinted by the cursor: changing a filter mid-walk changes which rows the
-	// remaining pages see, so re-issue the query without the cursor when changing filters.
-	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
-
-	// Limit Max items in the page.
-	Limit *Limit `form:"limit,omitempty" json:"limit,omitempty"`
-}
-
 // CreateContractParams defines parameters for CreateContract.
 type CreateContractParams struct {
 	// IdempotencyKey Client-supplied key making a mutation safe to retry — an update exactly as much as a
@@ -42075,22 +42059,6 @@ type RejectVoiceDraftParams struct {
 	// than half-honouring it, so read this contract, not the client, to know which calls are safe
 	// to retry blind.
 	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
-}
-
-// ListVoiceCorpusSourcesParams defines parameters for ListVoiceCorpusSources.
-type ListVoiceCorpusSourcesParams struct {
-	// Cursor Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
-	// effective `sort` of the originating request (field + direction) plus the last row's keyset
-	// (sort-key tuple + the `created_at`/`id` tie-breaker). **Stability:** results are stable
-	// under concurrent inserts/updates (keyset pagination, not offset). Supplying `cursor`
-	// together with a `sort` that differs from the one the cursor was minted under returns
-	// `422 code: cursor_param_mismatch` — re-issue the query without the cursor. Filters are
-	// **not** fingerprinted by the cursor: changing a filter mid-walk changes which rows the
-	// remaining pages see, so re-issue the query without the cursor when changing filters.
-	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
-
-	// Limit Max items in the page.
-	Limit *Limit `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
 // IngestVoiceCorpusSourceParams defines parameters for IngestVoiceCorpusSource.
@@ -51520,7 +51488,7 @@ type ServerInterface interface {
 	SetConnectorSignatureEnrichment(w http.ResponseWriter, r *http.Request, provider CaptureProvider)
 	// List the workspace's consent purposes (e.g. transactional, marketing_email, profiling).
 	// (GET /consent-purposes)
-	ListConsentPurposes(w http.ResponseWriter, r *http.Request, params ListConsentPurposesParams)
+	ListConsentPurposes(w http.ResponseWriter, r *http.Request)
 	// Define a consent purpose. 🟢 admin write.
 	// (POST /consent-purposes)
 	CreateConsentPurpose(w http.ResponseWriter, r *http.Request)
@@ -52786,7 +52754,7 @@ type ServerInterface interface {
 	GetVoiceLearningSummary(w http.ResponseWriter, r *http.Request, id Id)
 	// List the owner's corpus manifest and live meter; source text is never returned.
 	// (GET /voice-profiles/{id}/sources)
-	ListVoiceCorpusSources(w http.ResponseWriter, r *http.Request, id Id, params ListVoiceCorpusSourcesParams)
+	ListVoiceCorpusSources(w http.ResponseWriter, r *http.Request, id Id)
 	// Ingest or replace one manual own-authored text source.
 	// (POST /voice-profiles/{id}/sources)
 	IngestVoiceCorpusSource(w http.ResponseWriter, r *http.Request, id Id, params IngestVoiceCorpusSourceParams)
@@ -53869,7 +53837,7 @@ func (_ Unimplemented) SetConnectorSignatureEnrichment(w http.ResponseWriter, r 
 
 // List the workspace's consent purposes (e.g. transactional, marketing_email, profiling).
 // (GET /consent-purposes)
-func (_ Unimplemented) ListConsentPurposes(w http.ResponseWriter, r *http.Request, params ListConsentPurposesParams) {
+func (_ Unimplemented) ListConsentPurposes(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -56401,7 +56369,7 @@ func (_ Unimplemented) GetVoiceLearningSummary(w http.ResponseWriter, r *http.Re
 
 // List the owner's corpus manifest and live meter; source text is never returned.
 // (GET /voice-profiles/{id}/sources)
-func (_ Unimplemented) ListVoiceCorpusSources(w http.ResponseWriter, r *http.Request, id Id, params ListVoiceCorpusSourcesParams) {
+func (_ Unimplemented) ListVoiceCorpusSources(w http.ResponseWriter, r *http.Request, id Id) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -62365,9 +62333,6 @@ func (siw *ServerInterfaceWrapper) SetConnectorSignatureEnrichment(w http.Respon
 // ListConsentPurposes operation middleware
 func (siw *ServerInterfaceWrapper) ListConsentPurposes(w http.ResponseWriter, r *http.Request) {
 
-	var err error
-	_ = err
-
 	ctx := r.Context()
 
 	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
@@ -62376,37 +62341,8 @@ func (siw *ServerInterfaceWrapper) ListConsentPurposes(w http.ResponseWriter, r 
 
 	r = r.WithContext(ctx)
 
-	// Parameter object where we will unmarshal all parameters from the context
-	var params ListConsentPurposesParams
-
-	// ------------- Optional query parameter "cursor" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		var requiredError *runtime.RequiredParameterError
-		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
-		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
-		}
-		return
-	}
-
-	// ------------- Optional query parameter "limit" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
-	if err != nil {
-		var requiredError *runtime.RequiredParameterError
-		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
-		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
-		}
-		return
-	}
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ListConsentPurposes(w, r, params)
+		siw.Handler.ListConsentPurposes(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -81471,37 +81407,8 @@ func (siw *ServerInterfaceWrapper) ListVoiceCorpusSources(w http.ResponseWriter,
 
 	r = r.WithContext(ctx)
 
-	// Parameter object where we will unmarshal all parameters from the context
-	var params ListVoiceCorpusSourcesParams
-
-	// ------------- Optional query parameter "cursor" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		var requiredError *runtime.RequiredParameterError
-		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
-		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
-		}
-		return
-	}
-
-	// ------------- Optional query parameter "limit" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
-	if err != nil {
-		var requiredError *runtime.RequiredParameterError
-		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
-		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
-		}
-		return
-	}
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ListVoiceCorpusSources(w, r, id, params)
+		siw.Handler.ListVoiceCorpusSources(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {

--- a/backend/internal/modules/ai/handlers_voice.go
+++ b/backend/internal/modules/ai/handlers_voice.go
@@ -149,7 +149,7 @@ func (h Handlers) DeleteVoiceProfile(w http.ResponseWriter, r *http.Request, id 
 
 // ListVoiceCorpusSources implements (GET /voice-profiles/{id}/sources):
 // the manifest + the live word/register meter.
-func (h Handlers) ListVoiceCorpusSources(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, _ crmcontracts.ListVoiceCorpusSourcesParams) {
+func (h Handlers) ListVoiceCorpusSources(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	sources, summary, err := h.voice.ListSources(r.Context(), ids.UUID(id))
 	if err != nil {
 		writeVoiceErr(w, r, err)

--- a/backend/internal/modules/consent/handlers.go
+++ b/backend/internal/modules/consent/handlers.go
@@ -74,7 +74,12 @@ func (h Handlers) WithSubjectAccessAssembler(a SubjectAccessAssembler) Handlers 
 	return h
 }
 
-func (h Handlers) ListConsentPurposes(w http.ResponseWriter, r *http.Request, _ crmcontracts.ListConsentPurposesParams) {
+// ListConsentPurposes answers the workspace's configured purposes, unpaged.
+//
+// It takes no params value because the operation declares no query parameter:
+// purposes are configuration a workspace sets up once, so the answer is the
+// whole set. It used to declare cursor and limit and honour neither.
+func (h Handlers) ListConsentPurposes(w http.ResponseWriter, r *http.Request) {
 	purposes, err := h.store.ListPurposes(r.Context())
 	if err != nil {
 		writeConsentErr(w, r, err)

--- a/backend/internal/modules/identity/grants.go
+++ b/backend/internal/modules/identity/grants.go
@@ -58,64 +58,8 @@ type ListGrantsInput struct {
 	RecordID    *ids.UUID
 	SubjectType *string
 	SubjectID   *ids.UUID
-}
-
-func (s *Service) ListRecordGrants(ctx context.Context, in ListGrantsInput) ([]grantRow, error) {
-	var out []grantRow
-	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		var args []any
-		arg := func(v any) int { args = append(args, v); return len(args) }
-		where := "(expires_at IS NULL OR expires_at > now())"
-		if in.RecordType != nil {
-			where += storekit.SQLf(" AND record_type = $%d", arg(*in.RecordType))
-		}
-		if in.RecordID != nil {
-			where += storekit.SQLf(" AND record_id = $%d", arg(*in.RecordID))
-		}
-		if in.SubjectType != nil {
-			where += storekit.SQLf(" AND subject_type = $%d", arg(*in.SubjectType))
-		}
-		if in.SubjectID != nil {
-			where += storekit.SQLf(" AND subject_id = $%d", arg(*in.SubjectID))
-		}
-		rows, err := tx.Query(ctx,
-			"SELECT "+grantColumns+" FROM record_grant WHERE "+where+" ORDER BY created_at DESC", args...)
-		if err != nil {
-			return err
-		}
-		var candidates []grantRow
-		for rows.Next() {
-			g, err := scanGrant(rows)
-			if err != nil {
-				rows.Close()
-				return err
-			}
-			candidates = append(candidates, g)
-		}
-		rows.Close()
-		if err := rows.Err(); err != nil {
-			return err
-		}
-		// The visibility probe runs AFTER the cursor is drained and closed,
-		// never inside the scan loop: it issues its own query on this same
-		// transaction, and pgx refuses a second query while rows are open
-		// ("conn busy"). The probe used to be a no-op for an unbounded
-		// caller, which hid the collision until a caller whose row scope
-		// renders a real clause came along.
-		for _, g := range candidates {
-			// A grant row names a row-scoped record: only grants whose
-			// target the caller could read are disclosed.
-			visible, err := auth.VisibleTo(ctx, tx, g.RecordType, g.RecordID)
-			if err != nil {
-				return err
-			}
-			if visible {
-				out = append(out, g)
-			}
-		}
-		return nil
-	})
-	return out, err
+	Cursor      *string
+	Limit       *int
 }
 
 type CreateGrantInput struct {

--- a/backend/internal/modules/identity/grantsread.go
+++ b/backend/internal/modules/identity/grantsread.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// Reading a page of the manual per-record grants.
+//
+// Split from grants.go because the read answers a different question from the
+// writes beside it: those decide whether one share may exist, this one decides
+// what a caller may SEE of the shares that do — a page bounded by a keyset, and
+// then narrowed again by whether the caller could read each grant's target.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// ListRecordGrants answers one page of the active manual grants.
+//
+// PAGED, and this is the one of the three unpaged lists that had to be rather
+// than have its dial retired: consent purposes and voice corpus sources are
+// configuration a workspace sets up once, but a grant row is created every time
+// somebody shares a record. Its count is driven by usage, and the unfiltered
+// call read the WHOLE table — then ran one visibility query per row it had read.
+//
+// THE VISIBILITY FILTER RUNS AFTER THE PAGE, which is what makes the paging
+// less obvious than it looks. A page of `limit` rows can serve fewer once the
+// invisible ones are dropped, so:
+//
+//   - `HasMore` comes from the QUERY reading one row beyond the page, never
+//     from how many survived the filter — a page that filtered everything out
+//     still has more behind it, and reporting otherwise ends the walk early;
+//   - the cursor names the last row READ, not the last row served. A cursor
+//     minted from the last visible row would re-read every invisible row after
+//     it on the next page, forever, without ever serving one.
+func (s *Service) ListRecordGrants(ctx context.Context, in ListGrantsInput) ([]grantRow, storekit.Page, error) {
+	var out []grantRow
+	var page storekit.Page
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		limit := storekit.ClampLimit(in.Limit)
+		candidates, err := s.grantPage(ctx, tx, in, limit)
+		if err != nil {
+			return err
+		}
+		if len(candidates) > limit {
+			candidates = candidates[:limit]
+			last := candidates[len(candidates)-1]
+			next, err := storekit.EncodeCursor(last.CreatedAt, last.ID)
+			if err != nil {
+				return err
+			}
+			page.NextCursor, page.HasMore = next, true
+		}
+		out, err = visibleGrants(ctx, tx, candidates)
+		return err
+	})
+	return out, page, err
+}
+
+// grantPage reads one page of candidate rows, one beyond the limit so the
+// caller can tell a full page from the last one.
+func (s *Service) grantPage(ctx context.Context, tx pgx.Tx, in ListGrantsInput, limit int) ([]grantRow, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	where := "(expires_at IS NULL OR expires_at > now())"
+	for _, f := range []struct {
+		column string
+		value  any
+		set    bool
+	}{
+		{"record_type", derefOr(in.RecordType), in.RecordType != nil},
+		{"record_id", derefOr(in.RecordID), in.RecordID != nil},
+		{"subject_type", derefOr(in.SubjectType), in.SubjectType != nil},
+		{"subject_id", derefOr(in.SubjectID), in.SubjectID != nil},
+	} {
+		if f.set {
+			where += storekit.SQLf(" AND "+f.column+" = $%d", arg(f.value))
+		}
+	}
+	if in.Cursor != nil && *in.Cursor != "" {
+		cursor, err := storekit.DecodeCursor(*in.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		where += storekit.SQLf(" AND (created_at, id) < ($%d, $%d)", arg(cursor.CreatedAt), arg(cursor.ID))
+	}
+	// id joins the ORDER BY so the keyset is TOTAL: two grants created in the
+	// same instant would otherwise order arbitrarily, and a cursor over a
+	// non-total order repeats or skips at a page boundary.
+	//
+	// The LIMIT bounds the READ, not just the answer. Truncating in Go after an
+	// unbounded query would serve exactly the same page while still pulling the
+	// whole table across — and no test through this API can tell the two apart,
+	// because the difference is invisible in the result. That is why it is said
+	// here rather than left to a test.
+	rows, err := tx.Query(ctx,
+		"SELECT "+grantColumns+" FROM record_grant WHERE "+where+
+			storekit.SQLf(" ORDER BY created_at DESC, id DESC LIMIT $%d", arg(limit+1)), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var candidates []grantRow
+	for rows.Next() {
+		g, err := scanGrant(rows)
+		if err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, g)
+	}
+	return candidates, rows.Err()
+}
+
+// visibleGrants drops the grants whose target the caller cannot read.
+//
+// It runs AFTER the page's cursor is drained and closed, never inside the scan
+// loop: it issues its own query on this same transaction, and pgx refuses a
+// second query while rows are open ("conn busy"). The probe used to be a no-op
+// for an unbounded caller, which hid the collision until a caller whose row
+// scope renders a real clause came along.
+func visibleGrants(ctx context.Context, tx pgx.Tx, candidates []grantRow) ([]grantRow, error) {
+	out := make([]grantRow, 0, len(candidates))
+	for _, g := range candidates {
+		// A grant row names a row-scoped record: only grants whose target the
+		// caller could read are disclosed.
+		visible, err := auth.VisibleTo(ctx, tx, g.RecordType, g.RecordID)
+		if err != nil {
+			return nil, err
+		}
+		if visible {
+			out = append(out, g)
+		}
+	}
+	return out, nil
+}
+
+// derefOr reads a filter's value for binding, or nil when it is unset — the
+// caller has already decided whether the clause is rendered at all.
+//
+//craft:ignore naked-any the four filters bind different types through one argument registrar; the any is the registrar's own
+func derefOr[T any](p *T) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/backend/internal/modules/identity/handlers_grants.go
+++ b/backend/internal/modules/identity/handlers_grants.go
@@ -30,7 +30,8 @@ func (h Handlers) ListRecordGrants(w http.ResponseWriter, r *http.Request, param
 		id := ids.UUID(*params.SubjectId)
 		in.SubjectID = &id
 	}
-	grants, err := h.svc.ListRecordGrants(r.Context(), in)
+	in.Cursor, in.Limit = params.Cursor, params.Limit
+	grants, page, err := h.svc.ListRecordGrants(r.Context(), in)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
@@ -39,7 +40,11 @@ func (h Handlers) ListRecordGrants(w http.ResponseWriter, r *http.Request, param
 	for _, g := range grants {
 		data = append(data, wireGrant(g))
 	}
-	httperr.WriteJSON(w, http.StatusOK, map[string]any{"data": data, "page": crmcontracts.PageInfo{}})
+	wire := crmcontracts.PageInfo{HasMore: page.HasMore}
+	if page.NextCursor != "" {
+		wire.NextCursor = &page.NextCursor
+	}
+	httperr.WriteJSON(w, http.StatusOK, map[string]any{"data": data, "page": wire})
 }
 
 func (h Handlers) CreateRecordGrant(w http.ResponseWriter, r *http.Request, _ crmcontracts.CreateRecordGrantParams) {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9606,7 +9606,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List the workspace's consent purposes (e.g. transactional, marketing_email, profiling). */
+        /**
+         * List the workspace's consent purposes (e.g. transactional, marketing_email, profiling).
+         * @description UNPAGED, deliberately. A workspace's consent purposes are configuration — a handful of
+         *     them, set up once — so the answer is the whole set and `page` reports `has_more: false`.
+         *
+         *     It used to declare `cursor` and `limit` and honour neither: `?limit=5` returned the
+         *     catalog, and a caller who sized a page got everything. Nothing was hidden, and nothing
+         *     was kept either. Removing the dial makes the surface true rather than adding paging
+         *     machinery with no user.
+         */
         get: operations["listConsentPurposes"];
         put?: never;
         /** Define a consent purpose. 🟢 admin write. */
@@ -10647,7 +10656,15 @@ export interface paths {
             };
             cookie?: never;
         };
-        /** List the owner's corpus manifest and live meter; source text is never returned. */
+        /**
+         * List the owner's corpus manifest and live meter; source text is never returned.
+         * @description UNPAGED, deliberately, and for the same reason listConsentPurposes is: one voice
+         *     profile's corpus sources are configuration rather than accumulated data, so the answer
+         *     is the whole manifest.
+         *
+         *     It declared `cursor` and `limit` and honoured neither. Removing the dial is free now
+         *     and stops being free once a client depends on the parameter being accepted.
+         */
         get: operations["listVoiceCorpusSources"];
         put?: never;
         /**
@@ -48260,21 +48277,7 @@ export interface operations {
     };
     listConsentPurposes: {
         parameters: {
-            query?: {
-                /**
-                 * @description Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
-                 *     effective `sort` of the originating request (field + direction) plus the last row's keyset
-                 *     (sort-key tuple + the `created_at`/`id` tie-breaker). **Stability:** results are stable
-                 *     under concurrent inserts/updates (keyset pagination, not offset). Supplying `cursor`
-                 *     together with a `sort` that differs from the one the cursor was minted under returns
-                 *     `422 code: cursor_param_mismatch` — re-issue the query without the cursor. Filters are
-                 *     **not** fingerprinted by the cursor: changing a filter mid-walk changes which rows the
-                 *     remaining pages see, so re-issue the query without the cursor when changing filters.
-                 */
-                cursor?: components["parameters"]["Cursor"];
-                /** @description Max items in the page. */
-                limit?: components["parameters"]["Limit"];
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -49828,21 +49831,7 @@ export interface operations {
     };
     listVoiceCorpusSources: {
         parameters: {
-            query?: {
-                /**
-                 * @description Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
-                 *     effective `sort` of the originating request (field + direction) plus the last row's keyset
-                 *     (sort-key tuple + the `created_at`/`id` tie-breaker). **Stability:** results are stable
-                 *     under concurrent inserts/updates (keyset pagination, not offset). Supplying `cursor`
-                 *     together with a `sort` that differs from the one the cursor was minted under returns
-                 *     `422 code: cursor_param_mismatch` — re-issue the query without the cursor. Filters are
-                 *     **not** fingerprinted by the cursor: changing a filter mid-walk changes which rows the
-                 *     remaining pages see, so re-issue the query without the cursor when changing filters.
-                 */
-                cursor?: components["parameters"]["Cursor"];
-                /** @description Max items in the page. */
-                limit?: components["parameters"]["Limit"];
-            };
+            query?: never;
             header?: never;
             path: {
                 /** @description Opaque resource id (UUID; ordering semantics are not exposed). */


### PR DESCRIPTION
Refs #827. The issue stays open on the `sort` half — see below.

## What was scoped out

The declared-parameter gate from #826 judges the parameters that decide a page's **membership** and deliberately excluded the three that decide its **shape**. The distinction is real: a dropped filter answers a wider question than the one asked, where a dropped page dial answers the right question in the wrong shape.

But the second is still a claim the surface does not keep. `?limit=5` returning the whole set means the caller sized a page and got a catalog. `?cursor=` accepted and inert is the shape that can walk page one forever.

`Cursor` and `Limit` are judged now. **`Sort` stays scoped out**, with the reason in the code and the line that will be deleted when it lands: honouring it is a per-store change rather than a contract edit — each of `listActivities`, `listCustomFields` and `listPartners` needs its store to take a sort vocabulary and a keyset that carries the sort key.

**No waiver list beside the gate, deliberately.** The honest state after a retirement is that the parameter is *gone from the contract*, not that it is declared and excused — so an operation that will not honour a dial removes the declaration.

## Two retirements and one implementation

The ruling on the issue said to check `listRecordGrants`' shape rather than file it under "catalog" with the other two. Checking changed the answer:

- **`listConsentPurposes`** and **`listVoiceCorpusSources`** are configuration a workspace sets up once. The dial goes, and each description now says the list is unpaged and why. Free to remove today; a breaking change once a client depends on the parameter being accepted.
- **`listRecordGrants`** is not configuration. A grant row is written every time somebody shares a record, so its count is driven by usage — and the unfiltered read returned the **whole table**, then ran one visibility query per row it had read. It gets paging.

## The visibility filter runs after the page

Which is what makes that paging less obvious than it looks. A page of `limit` rows can serve fewer once the invisible ones are dropped, so:

- **`HasMore` comes from the query** reading one row beyond the page, never from how many survived the filter. A page that filtered everything out still has more behind it, and reporting otherwise ends the walk early.
- **The cursor names the last row read**, not the last served. A cursor minted from the last *visible* row would re-read every invisible row after it on the next page, forever, without ever serving one.

## Mutation checks, including one that survived

| mutation | result |
|---|---|
| `HasMore` taken from the filtered result | the walk test fails |
| the SQL `LIMIT` dropped | **passes** |

The second is recorded in the code rather than papered over. The page stays correct because the truncation happens in Go; what changes is that the read pulls the whole table across — and no test through this API can see the difference, because it is invisible in the result. That is why the `LIMIT`'s purpose is stated where it is written.

## One process note

I first ran the gate with `-run DeclaredFilter`, saw green, and started investigating why the widening had caught nothing. The filter did not match `TestEveryDeclaredNarrowingParameterIsReadByItsHandler` — the assertion I had just widened. It had been failing correctly the whole time. Same shape as reading a passing test as evidence: the selector, not the subject, decided the answer.

## Checks

`make check-backend` green; `make craft-static` 0/0/0; `go test -count=1 ./gates` green; the compose/integration lane green. Contract, generated Go types and frontend types regenerated together. `grants.go` crossed the 500-line ceiling, so the read moves to `grantsread.go` — the writes decide whether a share may exist, the read decides what a caller may see of the shares that do.

**Note on CI:** main is currently red from #5103. Send/schedule 409s here are that, not this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination and limit support to the record grants listing.
  * Record grants responses now include accurate pagination details, including whether more results are available and the next cursor.

* **API Changes**
  * Removed unsupported `cursor` and `limit` parameters from consent purposes and corpus manifest listings.
  * These listings are now explicitly documented as unpaged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->