### PR TITLE
fix(deps): the js-yaml floor moves to 4.3.2, where a merge budget counts its empty sources

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: ^4.3.1
+  js-yaml: ^4.3.2
 
 importers:
 
@@ -1644,8 +1644,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -2882,7 +2882,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -3609,7 +3609,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,13 +31,13 @@ overrides:
   # source, so `<<: *arr` over N empty mappings K times is O(N*K) work under the
   # limit), fixed in 4.3.2. Reached only through openapi-typescript ->
   # @redocly/openapi-core, which depends on an EXACT js-yaml version — 4.3.1
-  # today, 4.3.0 when this override was written — so no update can lift it and
-  # an override is the only route. The exposure here is small — the tool parses
-  # our own backend/api/*.yaml at build time, never anything a user supplies —
-  # but the fix is a patch bump, and a high advisory sitting open on a public
-  # repository costs more than it saves. Drop this once @redocly/openapi-core
-  # depends on a RANGE rather than a pin; lifting its pin, as it did once
-  # already, only moves the floor this line has to hold.
+  # today — so no update can lift it and an override is the only route. The
+  # exposure here is small — the tool parses our own backend/api/*.yaml at build
+  # time, never anything a user supplies — but the fix is a patch bump, and a
+  # high advisory sitting open on a public repository costs more than it saves.
+  # Drop this once @redocly/openapi-core depends on a RANGE rather than a pin:
+  # a lifted pin only moves the floor this line has to hold, so which version
+  # it names is never the test for retiring the override.
   #
   # Pinned to the 4.x line on purpose: an open `>=4.3.2` resolves to 5.x, whose
   # API the consumer was never written against, and swapping a DoS advisory for

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,16 +25,21 @@ allowBuilds:
 # pins below them. Each one is a patch-level lift with a reason to exist and a
 # condition for going away — never a blanket "newest wins".
 overrides:
-  # GHSA-5p4m-2wfm-xmqj: quadratic CPU consumption resolving `!!omap`, fixed in
-  # 4.3.1. Reached only through openapi-typescript -> @redocly/openapi-core,
-  # which depends on the EXACT version 4.3.0, so no update can lift it and an
-  # override is the only route. The exposure here is small — the tool parses our
-  # own backend/api/*.yaml at build time, never anything a user supplies — but
-  # the fix is a patch bump, and a high advisory sitting open on a public
+  # Two high DoS advisories, one CPU-exhaustion family: GHSA-5p4m-2wfm-xmqj
+  # (quadratic cost resolving `!!omap`), fixed in 4.3.1, and
+  # GHSA-2883-xcg3-v3hh (the merge-key budget does not count an empty merge
+  # source, so `<<: *arr` over N empty mappings K times is O(N*K) work under the
+  # limit), fixed in 4.3.2. Reached only through openapi-typescript ->
+  # @redocly/openapi-core, which depends on an EXACT js-yaml version — 4.3.1
+  # today, 4.3.0 when this override was written — so no update can lift it and
+  # an override is the only route. The exposure here is small — the tool parses
+  # our own backend/api/*.yaml at build time, never anything a user supplies —
+  # but the fix is a patch bump, and a high advisory sitting open on a public
   # repository costs more than it saves. Drop this once @redocly/openapi-core
-  # ships a range that admits 4.3.1.
+  # depends on a RANGE rather than a pin; lifting its pin, as it did once
+  # already, only moves the floor this line has to hold.
   #
-  # Pinned to the 4.x line on purpose: an open `>=4.3.1` resolves to 5.x, whose
+  # Pinned to the 4.x line on purpose: an open `>=4.3.2` resolves to 5.x, whose
   # API the consumer was never written against, and swapping a DoS advisory for
   # a broken type generator is not a trade.
-  js-yaml: '^4.3.1'
+  js-yaml: '^4.3.2'

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
   },
   "packageRules": [
     {
-      "description": "js-yaml stays on the 4.x line, and this is the only place that can say so. The override in pnpm-workspace.yaml exists solely to lift @redocly/openapi-core's EXACT 4.3.0 pin to 4.3.1 for GHSA-5p4m-2wfm-xmqj; Renovate reads that override as an ordinary range and offers the major like any other range it manages. Taking the major breaks the build instead of the advisory: openapi-typescript 7.x — latest — depends on @redocly/openapi-core ^1.34.6, which reads `js-yaml`'s `types.merge`, removed in 5.x, so `openapi-typescript` dies on require and fe-typecheck-composed fails with no schema to check against. @redocly/openapi-core 2.x is written against js-yaml ^5.2.2, so this rule and the override both go away together, once openapi-typescript adopts that line.",
+      "description": "js-yaml stays on the 4.x line, and this is the only place that can say so. The override in pnpm-workspace.yaml exists solely to lift @redocly/openapi-core's EXACT js-yaml pin — 4.3.1 today — to 4.3.2, for GHSA-5p4m-2wfm-xmqj and GHSA-2883-xcg3-v3hh; Renovate reads that override as an ordinary range and offers the major like any other range it manages. Taking the major breaks the build instead of the advisory: openapi-typescript 7.x — latest — depends on @redocly/openapi-core ^1.34.6, which reads `js-yaml`'s `types.merge`, removed in 5.x, so `openapi-typescript` dies on require and fe-typecheck-composed fails with no schema to check against. @redocly/openapi-core 2.x is written against js-yaml ^5.2.2, so this rule and the override both go away together, once openapi-typescript adopts that line.",
       "matchPackageNames": ["js-yaml"],
       "allowedVersions": "<5"
     },


### PR DESCRIPTION
Closes the one open Dependabot alert on this repository: https://github.com/margince/margince/security/dependabot/23

## The advisory

GHSA-2883-xcg3-v3hh (high, CVE-2026-84375, CVSS 7.5 A:H). `maxTotalMergeKeys` counts merge *keys*, and an empty mapping contributes none — so `<<: *arr` against a sequence of N empty mappings, repeated K times, costs O(N*K) while the configured budget never moves. Upstream measured ~500 KB of YAML for ~13 s of CPU. 4.3.2 charges one budget unit per merge source in addition to its keys.

## Why an override, again

Identical route to GHSA-5p4m-2wfm-xmqj, which the same override already holds: js-yaml is reached only through `openapi-typescript` -> `@redocly/openapi-core`, and openapi-core depends on an **exact** js-yaml version. Nothing downstream can lift it, so `overrides:` in `pnpm-workspace.yaml` is the only lever, and the floor moves `^4.3.1` -> `^4.3.2`.

The 4.x ceiling stays. `openapi-typescript@7.13.0` — latest — ranges on `@redocly/openapi-core@^1.34.6`, whose line tops out at 1.34.19; openapi-core 2.x is the first release written against js-yaml `^5.2.2`. An open `>=4.3.2` resolves to 5.x, which removed `types.merge` that openapi-core reads, and trading a DoS advisory for a dead type generator is not a trade.

## Two things the comments claimed that are no longer true

Both files describing this override named a pin that has since moved, so a reader would have gone looking for the wrong thing:

- **Upstream's pin is 4.3.1, not 4.3.0.** `@redocly/openapi-core@1.34.19` pins js-yaml `4.3.1` exactly. That changes the override's retirement condition: "a range that admits 4.3.1" was never the test, because lifting a pin only moves the floor this line has to hold. It goes away when openapi-core depends on a **range** rather than a pin.
- `renovate.json`'s js-yaml rule repeated the same stale 4.3.0 detail. It is the only place that can hold `<5`, so it is worth keeping accurate.

## Verification

- `pnpm install --frozen-lockfile` accepts the lockfile; the lockfile diff is js-yaml and nothing else.
- `pnpm gen:api` regenerates `src/api/schema.d.ts` and `src/api/public-events.ts` **byte-identically** under 4.3.2 — the generator's `types.merge` read is the one thing this bump could plausibly have broken, and it did not.
- `make check`: 186 backend packages ok, and `make check-fe` green at 651 files / 8595 tests. (In a combined run four screen tests timed out under machine contention; each passes alone and `fe-unit` is green on main's tip.)

## Adopted by hand, and why that is a finding

`lockFileMaintenance` is documented in `renovate.json` as *the* mechanism for a lockfile-only transitive advisory, on a daily cadence chosen for exactly this case. It did not adopt this one. js-yaml 4.3.2 published 2026-08-26 and the existing `^4.3.1` override already admitted it, so the nightly refresh should have taken it within a day.

Renovate appears to have stopped running on 2026-08-21: last PR of any kind is #2231 (https://github.com/margince/margince/pull/2231), and the Dependency Dashboard (https://github.com/margince/margince/issues/52) has not been rewritten since 2026-08-21T23:31Z — it still links the Mend portal at the pre-transfer `gradionhq/margince-poc-v1` path and still lists `infra/docker-compose.dev.yml`, retired in #4988 (https://github.com/margince/margince/pull/4988). The fix is on the app installation rather than in this tree, so it is filed separately rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)