### PR TITLE
fix(comms): main goes green — every send fixture names a purpose that can send

### DIFF
--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -230,7 +230,11 @@ func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, cap
 		// The registry that resolves a staged delivery's mailbox: the SAME
 		// sweep registry the capture polls use, so the connector set that
 		// syncs a mailbox is the one that transmits from it.
-		SendRegistry:      captureReg,
+		SendRegistry: captureReg,
+		// The origin a fired message builds its unsubscribe link on — the same
+		// pair sendPath hands the api's immediate send, so a message scheduled
+		// for later carries the link a message sent now would.
+		SendOrigin:        compose.SendOrigin{PublicBaseURL: cfg.publicBaseURL, Environment: cfg.posture},
 		SendPacing:        compose.SendPacing{Limit: cfg.sendRateLimit, Window: cfg.sendRateWindow, MaxAge: cfg.sendMaxAge},
 		CloseDateInterval: cfg.closeDateInterval,
 		ReconcileInterval: cfg.reconcileInterval,

--- a/backend/internal/compose/commsscheduled.go
+++ b/backend/internal/compose/commsscheduled.go
@@ -112,10 +112,15 @@ type scheduledSendWorker struct {
 // immediate one is: the signature, the sender name, the unsubscribe linker and
 // the draft-outcome recorder all present, all identical. A hand-built store
 // here would be a second send path wearing the first one's name.
-func newScheduledSendWorker(pool *pgxpool.Pool, delivery DeliveryMachinery, blob blobstore.Store, pacing SendPacing) *scheduledSendWorker {
+func newScheduledSendWorker(pool *pgxpool.Pool, delivery DeliveryMachinery, blob blobstore.Store, pacing SendPacing, origin SendOrigin) *scheduledSendWorker {
 	return &scheduledSendWorker{
-		pool:      pool,
-		store:     sendStore(pool, SendPath{}).WithBlobstore(blob),
+		pool: pool,
+		// The ORIGIN travels, because a fired message builds its unsubscribe
+		// link from it. An empty send path here refuses every scheduled
+		// correspondence and marketing send at fire time while the
+		// transactional ones beside it go out — which is what it did, and what
+		// nothing noticed, because every fixture scheduled a transactional one.
+		store:     sendStore(pool, origin.sendPath()).WithBlobstore(blob),
 		authority: identity.NewService(pool),
 		consent:   consentGateFor(pool),
 		// The SAME machinery every other send stages with, handed in rather

--- a/backend/internal/compose/commsscheduled_integration.go
+++ b/backend/internal/compose/commsscheduled_integration.go
@@ -38,12 +38,15 @@ import (
 //
 // A snooze is not an error: a message whose moment has moved reports one, and
 // the lane reads the ROW to see what happened rather than the return.
-func DriveScheduledSendForTest(ctx context.Context, pool *pgxpool.Pool, workspace, id ids.UUID) error {
+func DriveScheduledSendForTest(ctx context.Context, pool *pgxpool.Pool, workspace, id ids.UUID, origin SendOrigin) error {
 	inserter, err := jobs.NewInserter(pool, slog.New(slog.DiscardHandler))
 	if err != nil {
 		return err
 	}
-	worker := newScheduledSendWorker(pool, NewDeliveryStager(pool, inserter), nil, SendPacing{})
+	// The origin the worker role composes. Without it this harness assembles a
+	// worker production does not have, and a message carrying an unsubscribe
+	// link refuses here for a reason no deployment would hit.
+	worker := newScheduledSendWorker(pool, NewDeliveryStager(pool, inserter), nil, SendPacing{}, origin)
 	err = worker.Work(ctx, &river.Job[ScheduledSendArgs]{
 		JobRow: &rivertype.JobRow{Attempt: 1, MaxAttempts: scheduledSendMaxAttempts},
 		Args:   ScheduledSendArgs{Workspace: workspace, ScheduledSendID: id.String()},

--- a/backend/internal/compose/commsscheduled_integration.go
+++ b/backend/internal/compose/commsscheduled_integration.go
@@ -84,12 +84,13 @@ func ScheduleAsAgentForTest(
 	anchor ids.ActivityID,
 	in activities.SendEmailInput,
 	at time.Time,
+	origin SendOrigin,
 ) (activities.SendOutcome, error) {
 	inserter, err := jobs.NewInserter(pool, slog.New(slog.DiscardHandler))
 	if err != nil {
 		return activities.SendOutcome{}, err
 	}
-	store := sendStore(pool, SendPath{})
+	store := sendStore(pool, origin.sendPath())
 	agentCtx := principal.WithCorrelationID(
 		principal.WithActor(principal.WithWorkspaceID(ctx, workspace), actor), ids.NewV7())
 	return store.SendOrSchedule(agentCtx, activities.FromActivity(anchor), in,

--- a/backend/internal/compose/integration/accountsend_agent_integration_test.go
+++ b/backend/internal/compose/integration/accountsend_agent_integration_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 )
 
@@ -55,7 +56,7 @@ import (
 func accountSendBody(org, subject string) AnyMap {
 	return AnyMap{
 		"subject": subject, "body": "Good morning — introducing ourselves.",
-		"to": []string{"buyer@preflight.test"}, "consent_purpose": sendPurpose,
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": sendPurpose, "communication_context": agentSendContext,
 		"links": []AnyMap{{"entity_type": "organization", "entity_id": org}},
 	}
 }
@@ -66,6 +67,21 @@ type accountSendEnv struct {
 	*preflightEnv
 	org string
 }
+
+// agentSendContext is what every send in this suite claims.
+//
+// CLAIMED rather than left to the legacy arm, and the reason is not style. An
+// unclaimed correspondence send derives a one-click unsubscribe link, and the
+// link is built from the installation's public origin — which the APPROVED
+// RETRY path cannot reach: an accepted held message is re-armed through
+// heldSendActors, which composes sendStore(pool, SendPath{}) with no origin at
+// all. That is a real defect in the product and is tracked as #5153; it is not
+// this suite's subject, which is who authorized an agent's send and when.
+//
+// Answering an account that wrote to us carries no link, so these sends do not
+// depend on the origin either way — and when #5153 lands, nothing here has to
+// change.
+const agentSendContext = string(commsauthz.CategoryReplyToInbound)
 
 func setupAccountSend(t *testing.T) *accountSendEnv {
 	t.Helper()
@@ -158,7 +174,7 @@ func TestTheMCPDoorStagesTheSameShapeAsTheRESTDoor(t *testing.T) {
 
 	args, err := json.Marshal(map[string]any{
 		"to": []string{"buyer@preflight.test"}, "subject": "Hello over MCP",
-		"body": "Good morning.", "consent_purpose": sendPurpose,
+		"body": "Good morning.", "consent_purpose": sendPurpose, "communication_context": agentSendContext,
 		"links": []map[string]string{{"entity_type": "organization", "entity_id": a.org}},
 	})
 	if err != nil {
@@ -214,7 +230,7 @@ func TestAFlooredAccountSendStagesAndOnlyLeavesOnceApproved(t *testing.T) {
 	token := a.mintAccountSendPassport(t)
 	args, err := json.Marshal(map[string]any{
 		"to": []string{"buyer@preflight.test"}, "subject": "Hello from an agent",
-		"body": "Good morning.", "consent_purpose": sendPurpose,
+		"body": "Good morning.", "consent_purpose": sendPurpose, "communication_context": agentSendContext,
 		"links": []map[string]string{{"entity_type": "organization", "entity_id": a.org}},
 	})
 	if err != nil {
@@ -263,7 +279,7 @@ func TestAFlooredAccountSendStagesAndOnlyLeavesOnceApproved(t *testing.T) {
 	// exact message.
 	retry, err := json.Marshal(map[string]any{
 		"to": []string{"buyer@preflight.test"}, "subject": "Hello from an agent",
-		"body": "Good morning.", "consent_purpose": sendPurpose,
+		"body": "Good morning.", "consent_purpose": sendPurpose, "communication_context": agentSendContext,
 		"links":       []map[string]string{{"entity_type": "organization", "entity_id": a.org}},
 		"approval_id": approvalID,
 	})

--- a/backend/internal/compose/integration/accountsend_agent_integration_test.go
+++ b/backend/internal/compose/integration/accountsend_agent_integration_test.go
@@ -55,7 +55,7 @@ import (
 func accountSendBody(org, subject string) AnyMap {
 	return AnyMap{
 		"subject": subject, "body": "Good morning — introducing ourselves.",
-		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": sendPurpose,
 		"links": []AnyMap{{"entity_type": "organization", "entity_id": org}},
 	}
 }
@@ -158,7 +158,7 @@ func TestTheMCPDoorStagesTheSameShapeAsTheRESTDoor(t *testing.T) {
 
 	args, err := json.Marshal(map[string]any{
 		"to": []string{"buyer@preflight.test"}, "subject": "Hello over MCP",
-		"body": "Good morning.", "consent_purpose": "transactional",
+		"body": "Good morning.", "consent_purpose": sendPurpose,
 		"links": []map[string]string{{"entity_type": "organization", "entity_id": a.org}},
 	})
 	if err != nil {
@@ -214,7 +214,7 @@ func TestAFlooredAccountSendStagesAndOnlyLeavesOnceApproved(t *testing.T) {
 	token := a.mintAccountSendPassport(t)
 	args, err := json.Marshal(map[string]any{
 		"to": []string{"buyer@preflight.test"}, "subject": "Hello from an agent",
-		"body": "Good morning.", "consent_purpose": "transactional",
+		"body": "Good morning.", "consent_purpose": sendPurpose,
 		"links": []map[string]string{{"entity_type": "organization", "entity_id": a.org}},
 	})
 	if err != nil {
@@ -263,7 +263,7 @@ func TestAFlooredAccountSendStagesAndOnlyLeavesOnceApproved(t *testing.T) {
 	// exact message.
 	retry, err := json.Marshal(map[string]any{
 		"to": []string{"buyer@preflight.test"}, "subject": "Hello from an agent",
-		"body": "Good morning.", "consent_purpose": "transactional",
+		"body": "Good morning.", "consent_purpose": sendPurpose,
 		"links":       []map[string]string{{"entity_type": "organization", "entity_id": a.org}},
 		"approval_id": approvalID,
 	})

--- a/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
@@ -87,6 +87,18 @@ func (c *telegramEnv) grantConsent(t *testing.T, personID, purposeKey string) {
 
 // TestInboundThenReplyRoundTrip is the whole loop, in the order a customer and
 // a rep actually live it.
+// What every reply in this file claims, and what the fixture grants.
+//
+// These are answers to a message the customer sent, which is what makes them
+// lawful: the inbound IS the qualifying event, and the purpose key names the
+// claim rather than evidencing it. The context is claimed too, because only a
+// marketing category carries a one-click unsubscribe link and a chat reply that
+// grew a footer would be a different message from the one the rep wrote.
+const (
+	replyPurpose = "business_correspondence"
+	replyContext = "reply_to_inbound"
+)
+
 func TestInboundThenReplyRoundTrip(t *testing.T) {
 	c := setupTelegramConnected(t)
 	inbound := telegramUpdate{
@@ -111,7 +123,7 @@ func TestInboundThenReplyRoundTrip(t *testing.T) {
 	}
 
 	// 3. The workspace records the lawful basis for answering.
-	c.grantConsent(t, personID, "transactional")
+	c.grantConsent(t, personID, replyPurpose)
 
 	// 4. The rep answers from that conversation. Their own action IS the
 	//    approval, so no token and no idempotency key ride the request.
@@ -123,7 +135,8 @@ func TestInboundThenReplyRoundTrip(t *testing.T) {
 		Body            string `json:"body"`
 	}
 	status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", integration.AnyMap{
-		"body": reply, "consent_purpose": "transactional",
+		"body": reply, "consent_purpose": replyPurpose,
+		"communication_context": replyContext,
 	}, nil, &sent)
 	if status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)
@@ -188,9 +201,10 @@ func TestCustomerReplyNamesTheChannelItArrivedOn(t *testing.T) {
 
 	// The rep answers, which is what puts an outbound activity in this chat's
 	// thread for the customer's next message to match against.
-	c.grantConsent(t, personID, "transactional")
+	c.grantConsent(t, personID, replyPurpose)
 	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", integration.AnyMap{
-		"body": repReply, "consent_purpose": "transactional",
+		"body": repReply, "consent_purpose": replyPurpose,
+		"communication_context": replyContext,
 	}, nil, nil); status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)
 	}
@@ -254,12 +268,13 @@ func TestAnArchivedOutboundIsNotAConversationToReplyInto(t *testing.T) {
 	awaitJobKind(t, sub, compose.TelegramIngestArgs{}.Kind())
 	activityID, personID := c.capturedMessage(t, opening)
 
-	c.grantConsent(t, personID, "transactional")
+	c.grantConsent(t, personID, replyPurpose)
 	var sent struct {
 		ID string `json:"id"`
 	}
 	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", integration.AnyMap{
-		"body": "We are — hall 4.", "consent_purpose": "transactional",
+		"body": "We are — hall 4.", "consent_purpose": replyPurpose,
+		"communication_context": replyContext,
 	}, nil, &sent); status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)
 	}
@@ -328,9 +343,10 @@ func TestAForgedThreadKeyCannotReplyIntoAnotherMediumsConversation(t *testing.T)
 	activityID, personID := c.capturedMessage(t, opening)
 
 	// A real outbound goes into the Telegram conversation.
-	c.grantConsent(t, personID, "transactional")
+	c.grantConsent(t, personID, replyPurpose)
 	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", integration.AnyMap{
-		"body": "Sending it over today.", "consent_purpose": "transactional",
+		"body": "Sending it over today.", "consent_purpose": replyPurpose,
+		"communication_context": replyContext,
 	}, nil, nil); status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)
 	}

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -89,7 +89,7 @@ func setupChannelSend(t *testing.T) *channelSendEnv {
 	}
 	c.bindIdentity(t)
 	c.seedInboundMessage(t)
-	c.grantConsent(t, "transactional")
+	c.grantConsent(t, sendPurpose)
 	c.connectBot(t)
 	return c
 }
@@ -284,7 +284,7 @@ func (c *channelSendEnv) assertNoOutboundEffect(t *testing.T, refusal string) {
 func TestSendMessageRefusesAWriteOnlyPassport(t *testing.T) {
 	c := setupChannelSend(t)
 
-	status, code, _ := c.sendReplyAs(t, []string{"read", "write"}, "transactional")
+	status, code, _ := c.sendReplyAs(t, []string{"read", "write"}, sendPurpose)
 
 	if status != http.StatusForbidden || code != "scope_exceeds_grantor" {
 		t.Fatalf("write-only passport reply → %d %q, want 403 scope_exceeds_grantor", status, code)
@@ -307,7 +307,7 @@ func TestSendMessageRefusesAWriteOnlyPassport(t *testing.T) {
 func TestSendMessageAcceptsASendScopedPassportWithoutAToken(t *testing.T) {
 	c := setupChannelSend(t)
 
-	status, code, detail := c.sendReplyAs(t, []string{"read", "send"}, "transactional")
+	status, code, detail := c.sendReplyAs(t, []string{"read", "send"}, sendPurpose)
 
 	if status != http.StatusAccepted {
 		t.Fatalf("agent reply on a send-scoped passport → %d %q (%s), want 202", status, code, detail)
@@ -323,7 +323,7 @@ func TestSendMessageAcceptsASendScopedPassportWithoutAToken(t *testing.T) {
 func TestSendMessageRefusesAPassportWithoutTheSendCap(t *testing.T) {
 	c := setupChannelSend(t)
 
-	status, code, _ := c.sendReplyAs(t, []string{"read"}, "transactional")
+	status, code, _ := c.sendReplyAs(t, []string{"read"}, sendPurpose)
 
 	if status == http.StatusAccepted {
 		t.Fatalf("a read-only passport sent a channel reply → %d %q", status, code)
@@ -338,7 +338,7 @@ func TestSendMessageRefusesAPassportWithoutTheSendCap(t *testing.T) {
 func TestSendMessageAcceptsAHumanCallerWithoutAToken(t *testing.T) {
 	c := setupChannelSend(t)
 
-	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
+	status, code, detail := c.sendReply(t, sendPurpose, "Yes — shipping Monday.", nil)
 
 	if status != http.StatusAccepted {
 		t.Fatalf("human reply → %d %q (%s), want 202", status, code, detail)
@@ -383,7 +383,7 @@ func TestSendMessageRefusesWhenNoBotIsBoundForTheChannel(t *testing.T) {
 		t.Fatalf("disconnecting the bot: %v", err)
 	}
 
-	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
+	status, code, detail := c.sendReply(t, sendPurpose, "Yes — shipping Monday.", nil)
 
 	if status != http.StatusUnprocessableEntity || code != "channel_not_send_capable" {
 		t.Fatalf("reply with no bot bound → %d %q, want 422 channel_not_send_capable", status, code)
@@ -406,7 +406,7 @@ func TestSendMessageRefusesAnEmptyBody(t *testing.T) {
 	c := setupChannelSend(t)
 
 	for _, body := range []string{"", "   \n\t "} {
-		status, code, message := c.sendReply(t, "transactional", body, nil)
+		status, code, message := c.sendReply(t, sendPurpose, body, nil)
 
 		if status != http.StatusUnprocessableEntity {
 			t.Fatalf("reply with body %q → %d, want 422", body, status)
@@ -449,7 +449,7 @@ func TestSendMessageRefusesAnUnreachablePerson(t *testing.T) {
 		t.Fatalf("blocking the identity: %v", err)
 	}
 
-	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
+	status, code, detail := c.sendReply(t, sendPurpose, "Yes — shipping Monday.", nil)
 
 	if status != http.StatusUnprocessableEntity || code != "person_unreachable" {
 		t.Fatalf("reply to a blocked person → %d %q, want 422 person_unreachable", status, code)
@@ -473,7 +473,7 @@ func TestSentMessageLandsAsAnOutboundActivity(t *testing.T) {
 		Body      string `json:"body"`
 	}
 	if status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", AnyMap{
-		"body": "On its way.", "consent_purpose": "transactional",
+		"body": "On its way.", "consent_purpose": sendPurpose,
 	}, nil, &sent); status != http.StatusAccepted {
 		t.Fatalf("human reply → %d", status)
 	}

--- a/backend/internal/compose/integration/channelsend_mcp_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_mcp_integration_test.go
@@ -138,7 +138,7 @@ func TestSendMessageMCPLoopSendsOnASendScopedPassportAgainstRealPostgres(t *test
 	token := c.mintPassport(t, []string{"read", "send"})
 	invoke := c.sendMessageInvoker(t, token)
 
-	args := fmt.Sprintf(`{"activity_id":%q,"body":"Yes — shipping Monday.","consent_purpose":sendPurpose}`, c.activityID)
+	args := fmt.Sprintf(`{"activity_id":%q,"body":"Yes — shipping Monday.","consent_purpose":%q}`, c.activityID, sendPurpose)
 
 	out, err := invoke(args)
 	if err != nil {

--- a/backend/internal/compose/integration/channelsend_mcp_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_mcp_integration_test.go
@@ -138,7 +138,7 @@ func TestSendMessageMCPLoopSendsOnASendScopedPassportAgainstRealPostgres(t *test
 	token := c.mintPassport(t, []string{"read", "send"})
 	invoke := c.sendMessageInvoker(t, token)
 
-	args := fmt.Sprintf(`{"activity_id":%q,"body":"Yes — shipping Monday.","consent_purpose":"transactional"}`, c.activityID)
+	args := fmt.Sprintf(`{"activity_id":%q,"body":"Yes — shipping Monday.","consent_purpose":sendPurpose}`, c.activityID)
 
 	out, err := invoke(args)
 	if err != nil {

--- a/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
@@ -71,7 +71,7 @@ func setupChannelSendNoGmail(t *testing.T) *channelSendEnv {
 	}
 	c.bindIdentity(t)
 	c.seedInboundMessage(t)
-	c.grantConsent(t, "transactional")
+	c.grantConsent(t, sendPurpose)
 	return c
 }
 
@@ -84,7 +84,7 @@ func TestSendMessageRefusesWithNoGoogleAppConfiguredAndNoBotBound(t *testing.T) 
 	c := setupChannelSendNoGmail(t)
 	// No connectBot call: this workspace has bound no bot for telegram.
 
-	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
+	status, code, detail := c.sendReply(t, sendPurpose, "Yes — shipping Monday.", nil)
 
 	if status != http.StatusUnprocessableEntity || code != "channel_not_send_capable" {
 		t.Fatalf("reply with no Google app configured and no bot bound → %d %q, want 422 channel_not_send_capable", status, code)
@@ -105,7 +105,7 @@ func TestSendMessageAcceptsWithNoGoogleAppConfiguredButABotBound(t *testing.T) {
 	c := setupChannelSendNoGmail(t)
 	c.connectBot(t)
 
-	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
+	status, code, detail := c.sendReply(t, sendPurpose, "Yes — shipping Monday.", nil)
 
 	if status != http.StatusAccepted {
 		t.Fatalf("reply with a bot bound and no Google app configured → %d %q (%s), want 202", status, code, detail)

--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -235,7 +235,7 @@ func TestCapturedCopyOfASentEmailCollapsesOntoTheSameActivity(t *testing.T) {
 	p := setupPreflight(t)
 	p.connect(t, gmailReadonlyScope, gmailSendScope)
 
-	sentActivity := p.sendExpectingAcceptance(t, "transactional", "Re: Inbound question", "As discussed.")
+	sentActivity := p.sendExpectingAcceptance(t, sendPurpose, "Re: Inbound question", "As discussed.")
 	deliveryID, messageID := p.deliveryFor(t, sentActivity)
 	rfc822, capturingConnector := p.transmit(t, deliveryID, "")
 
@@ -379,7 +379,7 @@ func TestDeactivatingTheSenderParksAStagedDelivery(t *testing.T) {
 	p := setupPreflight(t)
 	p.connect(t, gmailReadonlyScope, gmailSendScope)
 
-	sentActivity := p.sendExpectingAcceptance(t, "transactional", "Re: Inbound question", "As discussed.")
+	sentActivity := p.sendExpectingAcceptance(t, sendPurpose, "Re: Inbound question", "As discussed.")
 	deliveryID, _ := p.deliveryFor(t, sentActivity)
 	p.deactivateSender(t)
 
@@ -407,7 +407,7 @@ func TestASenderDowngradedToAReadSeatParksAStagedDelivery(t *testing.T) {
 	p := setupPreflight(t)
 	p.connect(t, gmailReadonlyScope, gmailSendScope)
 
-	sentActivity := p.sendExpectingAcceptance(t, "transactional", "Re: Inbound question", "As discussed.")
+	sentActivity := p.sendExpectingAcceptance(t, sendPurpose, "Re: Inbound question", "As discussed.")
 	deliveryID, _ := p.deliveryFor(t, sentActivity)
 	p.downgradeSenderToReadSeat(t)
 

--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -143,16 +143,22 @@ func TestConsentDefaultDenySuppressesSends(t *testing.T) {
 // correctly ignored. Correspondence is allowed on a recorded qualifying event
 // and needs no consent object at all — while transactional mail, whose basis is
 // the contract itself, needs neither.
-func TestCorrespondenceAndTransactionalAreNotConsentGated(t *testing.T) {
+func TestCorrespondenceIsNotConsentGatedAndATransactionalClaimIsNotEvidence(t *testing.T) {
 	c := setupConsent(t)
 
 	// The fixture's person wrote to us: setupConsent captures an INBOUND
 	// activity from them, which is the qualifying event correspondence needs.
-	if status, code := c.send(t, "transactional"); status != http.StatusAccepted {
-		t.Fatalf("transactional send → %d %q, want 202 — the contract is the basis, not consent", status, code)
-	}
+	// No consent record anywhere, and the send is allowed — a derived basis is
+	// a basis.
 	if status, code := c.send(t, "business_correspondence"); status != http.StatusAccepted {
 		t.Fatalf("correspondence send → %d %q, want 202 — they wrote to us first", status, code)
+	}
+	// The transactional key NAMES a claim; it is not evidence for one. A
+	// contract basis belongs to a person with an invoice or an agreement behind
+	// them, and this fixture's person has neither — so the key alone buys
+	// nothing, which is the whole of what it used to buy.
+	if status, code := c.send(t, "transactional"); status != http.StatusConflict {
+		t.Fatalf("transactional send → %d %q, want 409 — the purpose key is a claim, and nothing here evidences it", status, code)
 	}
 }
 

--- a/backend/internal/compose/integration/messageidentity_integration_test.go
+++ b/backend/internal/compose/integration/messageidentity_integration_test.go
@@ -139,7 +139,7 @@ func TestAnEchoCapturedBeforeTransmitIsAbsorbedByTheReceiptItself(t *testing.T) 
 	p.connect(t, gmailReadonlyScope, gmailSendScope)
 
 	const subject = "Re: Inbound question"
-	sentActivity := p.sendExpectingAcceptance(t, "transactional", subject, "As discussed.")
+	sentActivity := p.sendExpectingAcceptance(t, sendPurpose, subject, "As discussed.")
 	deliveryID, mintedIdentity := p.deliveryFor(t, sentActivity)
 	// Captured BEFORE the transmission is recorded, which is the whole race:
 	// the row the re-key is about to claim the identity of already exists.
@@ -197,7 +197,7 @@ func TestAGmailRewrittenIdentityStillYieldsOneActivityAndOneReplyTarget(t *testi
 	p := setupPreflight(t)
 	p.connect(t, gmailReadonlyScope, gmailSendScope)
 
-	sentActivity := p.sendExpectingAcceptance(t, "transactional", "Re: Inbound question", "As discussed.")
+	sentActivity := p.sendExpectingAcceptance(t, sendPurpose, "Re: Inbound question", "As discussed.")
 	deliveryID, mintedIdentity := p.deliveryFor(t, sentActivity)
 	if mintedIdentity == gmailStamped {
 		t.Fatalf("the send staged under %q, which is the identity the provider is meant to REPLACE — this case would prove nothing", mintedIdentity)

--- a/backend/internal/compose/integration/preference_center_integration_test.go
+++ b/backend/internal/compose/integration/preference_center_integration_test.go
@@ -193,7 +193,7 @@ func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) string {
 
 	// A transactional (locked) send has nothing to unsubscribe from, so
 	// nothing is appended to what the sender wrote.
-	if _, tbody := sendMarketing(t, c.AppEnv, c.activityID, "transactional", "", ""); strings.Contains(tbody, "/unsubscribe") {
+	if _, tbody := sendMarketing(t, c.AppEnv, c.activityID, sendPurpose, "", ""); strings.Contains(tbody, "/unsubscribe") {
 		t.Fatalf("transactional send carried an unsubscribe link:\n%s", tbody)
 	}
 	return token
@@ -284,7 +284,7 @@ func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	c := setupConsent(t)
 
 	// A live deal's transactional lane stays open throughout.
-	grantPurpose(t, c, c.purposes["transactional"])
+	grantPurpose(t, c, c.purposes[sendPurpose])
 
 	newsletterID := createNewsletterPurpose(t, c)
 	grantPurpose(t, c, newsletterID)
@@ -296,7 +296,7 @@ func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	if s, _ := purposeStateOf(t, view, "newsletter"); s != "granted" {
 		t.Fatalf("newsletter shows %q before opt-out, want granted", s)
 	}
-	if s, locked := purposeStateOf(t, view, "transactional"); s != "granted" || !locked {
+	if s, locked := purposeStateOf(t, view, sendPurpose); s != "granted" || !locked {
 		t.Fatalf("transactional shows state=%q locked=%v, want granted+locked", s, locked)
 	}
 
@@ -329,7 +329,7 @@ func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	if s, code := c.send(t, "newsletter"); s != http.StatusConflict || code != "consent_not_granted" {
 		t.Fatalf("marketing send after opt-out → %d %q, want 409 consent_not_granted", s, code)
 	}
-	if s, code := c.send(t, "transactional"); s != http.StatusAccepted {
+	if s, code := c.send(t, sendPurpose); s != http.StatusAccepted {
 		t.Fatalf("transactional send after marketing opt-out → %d %q, want 202", s, code)
 	}
 

--- a/backend/internal/compose/integration/preference_center_integration_test.go
+++ b/backend/internal/compose/integration/preference_center_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // sendMarketing issues an authenticated send-email and returns the status
@@ -35,11 +36,26 @@ import (
 // (transmittedBody), not this response: the API caller is not the recipient
 // and has nothing to unsubscribe from. host/xfProto let a test forge the
 // request origin to prove the emitted link ignores them.
+// lockedPurpose is the one purpose the preference center refuses to change.
+// Named apart from sendPurpose because the two stopped being the same word:
+// `transactional` is still the locked lane and no longer authorizes a send, so
+// a case about locking and a case about sending now need different purposes.
+const lockedPurpose = "transactional"
+
 func sendMarketing(t *testing.T, e *apptest.AppEnv, activityID, purpose, host, xfProto string) (int, string) {
 	t.Helper()
-	raw, err := json.Marshal(AnyMap{
-		"subject": "Newsletter", "body": "hello", "to": []string{"subject@consent.test"}, "consent_purpose": purpose,
-	})
+	return postSend(t, e, activityID, AnyMap{
+		"subject": "Newsletter", "body": "hello", "to": []string{"subject@consent.test"},
+		"consent_purpose": purpose,
+	}, host, xfProto)
+}
+
+// postSend is the poster both send helpers call. The forged-origin headers it
+// sets are the subject of a case in this file, so a second copy of them would
+// be a second place for them to stop being sent.
+func postSend(t *testing.T, e *apptest.AppEnv, activityID string, body AnyMap, host, xfProto string) (int, string) {
+	t.Helper()
+	raw, err := json.Marshal(body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,12 +207,31 @@ func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) string {
 		t.Fatalf("hostile Host reshaped the unsubscribe link: %q", hostileLink)
 	}
 
-	// A transactional (locked) send has nothing to unsubscribe from, so
-	// nothing is appended to what the sender wrote.
-	if _, tbody := sendMarketing(t, c.AppEnv, c.activityID, sendPurpose, "", ""); strings.Contains(tbody, "/unsubscribe") {
-		t.Fatalf("transactional send carried an unsubscribe link:\n%s", tbody)
+	// A send with nothing to unsubscribe FROM appends nothing to what the
+	// sender wrote. The claim is what decides it: only the marketing category
+	// carries a link, so a reply to somebody's own message carries none.
+	//
+	// Claimed rather than left blank. An unclaimed send falls to the legacy
+	// arm, where the purpose KEY decides — and the one key that suppressed a
+	// link there was `transactional`, which no longer authorizes a send at all.
+	// Leaving it blank would test the vestigial half of that rule through a
+	// send the engine now refuses.
+	if _, tbody := sendReplyToInbound(t, c.AppEnv, c.activityID); strings.Contains(tbody, "/unsubscribe") {
+		t.Fatalf("a reply to an inbound message carried an unsubscribe link:\n%s", tbody)
 	}
 	return token
+}
+
+// sendReplyToInbound sends under a claimed non-marketing category — the shape
+// that has nothing to unsubscribe from because it is answering a message the
+// recipient sent.
+func sendReplyToInbound(t *testing.T, e *apptest.AppEnv, activityID string) (int, string) {
+	t.Helper()
+	return postSend(t, e, activityID, AnyMap{
+		"subject": "Re: your question", "body": "hello",
+		"to":                    []string{"subject@consent.test"},
+		"communication_context": string(commsauthz.CategoryReplyToInbound),
+	}, "", "")
 }
 
 // prefView is the no-login preference center's response shape.
@@ -283,8 +318,10 @@ func assertWithdrawalProvenanceAndWriteShape(t *testing.T, c *consentEnv, token,
 func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	c := setupConsent(t)
 
-	// A live deal's transactional lane stays open throughout.
-	grantPurpose(t, c, c.purposes[sendPurpose])
+	// The locked lane stays granted throughout — it is what the assertion
+	// below is about, and it is `transactional` by name: locking is a property
+	// of THAT purpose, unrelated to which purpose a send may claim.
+	grantPurpose(t, c, c.purposes[lockedPurpose])
 
 	newsletterID := createNewsletterPurpose(t, c)
 	grantPurpose(t, c, newsletterID)
@@ -296,8 +333,8 @@ func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	if s, _ := purposeStateOf(t, view, "newsletter"); s != "granted" {
 		t.Fatalf("newsletter shows %q before opt-out, want granted", s)
 	}
-	if s, locked := purposeStateOf(t, view, sendPurpose); s != "granted" || !locked {
-		t.Fatalf("transactional shows state=%q locked=%v, want granted+locked", s, locked)
+	if s, locked := purposeStateOf(t, view, lockedPurpose); s != "granted" || !locked {
+		t.Fatalf("%s shows state=%q locked=%v, want granted+locked", lockedPurpose, s, locked)
 	}
 
 	// A GET/prefetch on the unsubscribe path must NOT withdraw (RFC 8058

--- a/backend/internal/compose/integration/scheduledsend_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsend_integration_test.go
@@ -50,9 +50,20 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// seedConsentedRecipient creates a person with one address and a granted
-// transactional purpose — the minimum a send's consent gate demands of an
-// addressee, spelled once because a multi-recipient fixture needs it per head.
+// sendPurpose is what every scheduled send in this file claims. Named once so
+// the grant the fixture writes and the purpose the send names cannot drift into
+// disagreeing — a send whose purpose has no grant is held, and the failure
+// reads as the scheduler's rather than the fixture's.
+const sendPurpose = "business_correspondence"
+
+// seedConsentedRecipient creates a person a send may lawfully reach: one
+// address, an inbound message from them, and a granted correspondence purpose.
+// Spelled once because a multi-recipient fixture needs it per head.
+//
+// The INBOUND is the load-bearing half. A purpose key is a claim, not evidence
+// for one — the send path asks what supports THIS message, and a person who
+// wrote to us is the qualifying event correspondence derives its basis from.
+// Without it the grant alone buys nothing and every send here is held.
 func (p *preflightEnv) seedConsentedRecipient(t *testing.T, name, email string) {
 	t.Helper()
 	var person struct {
@@ -64,6 +75,12 @@ func (p *preflightEnv) seedConsentedRecipient(t *testing.T, name, email string) 
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create %s → %d", email, status)
 	}
+	if status := p.Call(t, "POST", "/v1/activities", AnyMap{
+		"kind": "email", "subject": "Inbound question", "direction": "inbound",
+		"links": []AnyMap{{"entity_type": "person", "entity_id": person.ID}},
+	}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("log the inbound %s replies to → %d", email, status)
+	}
 	var purposes struct {
 		Data []struct {
 			ID  string `json:"id"`
@@ -73,17 +90,8 @@ func (p *preflightEnv) seedConsentedRecipient(t *testing.T, name, email string) 
 	if status := p.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
 		t.Fatalf("list purposes → %d", status)
 	}
-	var transactional string
-	for _, purpose := range purposes.Data {
-		if purpose.Key == "transactional" {
-			transactional = purpose.ID
-		}
-	}
-	if transactional == "" {
-		t.Fatalf("bootstrap seeded no transactional purpose: %+v", purposes.Data)
-	}
 	if status := p.Call(t, "POST", "/v1/people/"+person.ID+"/consent", AnyMap{
-		"purpose_id": transactional, "new_state": "granted", "lawful_basis": "contract",
+		"purpose_id": purposeID(t, purposes.Data), "new_state": "granted", "lawful_basis": "consent",
 		"wording": "Yes, you may contact me about this.",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("grant consent for %s → %d", email, status)
@@ -136,7 +144,7 @@ func (p *preflightEnv) scheduleFor(t *testing.T, at time.Time) ids.UUID {
 	}
 	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
 		"subject": "Monday morning", "body": "Written the night before.",
-		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": sendPurpose,
 		"scheduled_at": at.UTC().Format(time.RFC3339),
 		"scheduled_tz": "Europe/Berlin",
 	}, nil, &scheduled)
@@ -194,7 +202,8 @@ func (p *preflightEnv) countDeliveries(t *testing.T) int {
 func (p *preflightEnv) fire(t *testing.T, id ids.UUID) {
 	t.Helper()
 	ws := p.workspaceID(t)
-	if err := compose.DriveScheduledSendForTest(context.Background(), p.Pool, ws, id); err != nil {
+	if err := compose.DriveScheduledSendForTest(context.Background(), p.Pool, ws, id,
+		compose.SendOrigin{PublicBaseURL: preflightBaseURL}); err != nil {
 		t.Fatalf("driving the scheduled-send timer: %v", err)
 	}
 }
@@ -229,12 +238,15 @@ func (p *preflightEnv) setDueAt(t *testing.T, id ids.UUID, at time.Time) {
 // message was written under, through the real consent surface.
 func (p *preflightEnv) withdrawConsent(t *testing.T) {
 	t.Helper()
-	p.setTransactionalConsent(t, "withdrawn")
+	p.setSendConsent(t, "withdrawn")
 }
 
-// setTransactionalConsent moves the recipient's transactional grant either way,
-// through the real consent surface.
-func (p *preflightEnv) setTransactionalConsent(t *testing.T, state string) {
+// setSendConsent moves the recipient's grant for the purpose these sends claim,
+// either way, through the real consent surface. It follows sendPurpose rather
+// than naming a purpose of its own: a withdrawal aimed at a purpose the send
+// does not claim withdraws nothing, and the send goes out while the case reads
+// as proving it was stopped.
+func (p *preflightEnv) setSendConsent(t *testing.T, state string) {
 	t.Helper()
 	var purposes struct {
 		Data []struct {
@@ -245,16 +257,7 @@ func (p *preflightEnv) setTransactionalConsent(t *testing.T, state string) {
 	if status := p.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
 		t.Fatalf("list purposes → %d", status)
 	}
-	var transactional string
-	for _, purpose := range purposes.Data {
-		if purpose.Key == "transactional" {
-			transactional = purpose.ID
-		}
-	}
-	if transactional == "" {
-		t.Fatalf("bootstrap seeded no transactional purpose: %+v", purposes.Data)
-	}
-	body := AnyMap{"purpose_id": transactional, "new_state": state, "lawful_basis": "consent"}
+	body := AnyMap{"purpose_id": purposeID(t, purposes.Data), "new_state": state, "lawful_basis": "consent"}
 	// Only a grant carries it: a grant that cannot say what the subject agreed
 	// to is refused, and a withdrawal demonstrates nothing, so sending it for
 	// one would describe a request this helper never makes.
@@ -409,7 +412,7 @@ func (p *preflightEnv) forceStatus(t *testing.T, id ids.UUID, status string) {
 // accepting a held card has actually fixed what stopped it.
 func (p *preflightEnv) grantTransactionalConsent(t *testing.T) {
 	t.Helper()
-	p.setTransactionalConsent(t, "granted")
+	p.setSendConsent(t, "granted")
 }
 
 // rescheduleTo moves a message through the endpoint a rep uses, version header
@@ -847,7 +850,7 @@ func TestAScheduledReplyFilesItselfUnderWhatTheComposerNamed(t *testing.T) {
 	}
 	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
 		"subject": "Monday morning", "body": "Written the night before.",
-		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": sendPurpose,
 		"scheduled_at": time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
 		"scheduled_tz": "Europe/Berlin",
 		"also_links":   []AnyMap{{"entity_type": "organization", "entity_id": org.String()}},
@@ -907,4 +910,23 @@ func (p *preflightEnv) countLinks(t *testing.T, scheduledID ids.UUID, entityType
 		t.Fatalf("counting the fired reply's links: %v", err)
 	}
 	return count
+}
+
+// purposeID resolves sendPurpose in the bootstrap catalog, failing loudly when
+// it is absent: a send naming a purpose the installation does not have is
+// refused for that reason, and the case would read as proving something about
+// consent.
+func purposeID(t *testing.T, catalog []struct {
+	ID  string `json:"id"`
+	Key string `json:"key"`
+},
+) string {
+	t.Helper()
+	for _, purpose := range catalog {
+		if purpose.Key == sendPurpose {
+			return purpose.ID
+		}
+	}
+	t.Fatalf("bootstrap seeded no %s purpose: %+v", sendPurpose, catalog)
+	return ""
 }

--- a/backend/internal/compose/integration/scheduledsend_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsend_integration_test.go
@@ -50,10 +50,12 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// sendPurpose is what every scheduled send in this file claims. Named once so
-// the grant the fixture writes and the purpose the send names cannot drift into
-// disagreeing — a send whose purpose has no grant is held, and the failure
-// reads as the scheduler's rather than the fixture's.
+// sendPurpose is what every scheduled send in this file claims, and what the
+// fixture's grant and a case's withdrawal are both written against.
+//
+// All three read it from here rather than repeating the word, so they answer
+// about one purpose. A send whose purpose has no grant is held, and the failure
+// then reads as the scheduler's rather than the fixture's.
 const sendPurpose = "business_correspondence"
 
 // seedConsentedRecipient creates a person a send may lawfully reach: one

--- a/backend/internal/compose/integration/scheduledsendagent_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendagent_integration_test.go
@@ -50,7 +50,7 @@ func (p *preflightEnv) scheduleAsAgent(t *testing.T, actor principal.Principal, 
 			Subject:        "Monday morning",
 			Body:           "Written the night before, by a tool.",
 			ConsentPurpose: sendPurpose,
-		}, at)
+		}, at, compose.SendOrigin{PublicBaseURL: preflightBaseURL})
 	if err != nil {
 		t.Fatalf("scheduling as an agent: %v", err)
 	}

--- a/backend/internal/compose/integration/scheduledsendagent_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendagent_integration_test.go
@@ -49,7 +49,7 @@ func (p *preflightEnv) scheduleAsAgent(t *testing.T, actor principal.Principal, 
 			Recipients:     []string{"buyer@preflight.test"},
 			Subject:        "Monday morning",
 			Body:           "Written the night before, by a tool.",
-			ConsentPurpose: "transactional",
+			ConsentPurpose: sendPurpose,
 		}, at)
 	if err != nil {
 		t.Fatalf("scheduling as an agent: %v", err)

--- a/backend/internal/compose/integration/scheduledsendpreview_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendpreview_integration_test.go
@@ -53,7 +53,7 @@ func TestAScheduledAccountSendReadsBackWhatItWillAskTheEngine(t *testing.T) {
 	status := p.Call(t, "POST", "/v1/emails", AnyMap{
 		"subject": "Your quote", "body": "As discussed.",
 		"to":              []string{"buyer@preflight.test"},
-		"consent_purpose": "transactional",
+		"consent_purpose": sendPurpose,
 		"links": []AnyMap{
 			{"entity_type": "person", "entity_id": p.personID},
 		},
@@ -75,7 +75,7 @@ func TestAScheduledAccountSendReadsBackWhatItWillAskTheEngine(t *testing.T) {
 			"the account-send preview refuses a message naming no records, so a row without them "+
 			"cannot be asked about", got.Links)
 	}
-	if got.ConsentPurpose != "transactional" {
+	if got.ConsentPurpose != sendPurpose {
 		t.Errorf("consent purpose came back %q, want transactional: the fire consults it where the record "+
 			"supports no category, so a preview without it asks a different question", got.ConsentPurpose)
 	}
@@ -104,7 +104,10 @@ func TestAScheduledReplyNamesItsAnchorAndNoRecords(t *testing.T) {
 	if len(got.Links) != 0 {
 		t.Errorf("a reply came back naming records of its own: %+v", got.Links)
 	}
-	if got.ConsentPurpose != "transactional" {
-		t.Errorf("consent purpose came back %q, want transactional", got.ConsentPurpose)
+	// The purpose the scheduler was GIVEN, read back unchanged. It is
+	// sendPurpose rather than a literal so the preview and the send it previews
+	// cannot claim different things.
+	if got.ConsentPurpose != sendPurpose {
+		t.Errorf("consent purpose came back %q, want %q", got.ConsentPurpose, sendPurpose)
 	}
 }

--- a/backend/internal/compose/integration/scheduledsendprivacy_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendprivacy_integration_test.go
@@ -152,7 +152,7 @@ func TestABlindCopiedSubjectSeesTheirOwnMailAndNobodyElsesAddress(t *testing.T) 
 		"subject": "Quiet copy", "body": "You were blind-copied on this.",
 		"to":              []string{"visible@preflight.test"},
 		"bcc":             []string{"buyer@preflight.test", otherBlind},
-		"consent_purpose": "transactional",
+		"consent_purpose": sendPurpose,
 		"links": []AnyMap{
 			{"entity_type": "person", "entity_id": p.personID},
 		},

--- a/backend/internal/compose/integration/scheduledsendprivacy_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendprivacy_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/privacy"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 func TestErasingARecipientEmptiesAndStopsTheirScheduledMail(t *testing.T) {
@@ -153,6 +154,12 @@ func TestABlindCopiedSubjectSeesTheirOwnMailAndNobodyElsesAddress(t *testing.T) 
 		"to":              []string{"visible@preflight.test"},
 		"bcc":             []string{"buyer@preflight.test", otherBlind},
 		"consent_purpose": sendPurpose,
+		// CLAIMED, because this message goes to several people at once. A send
+		// that carries a one-click unsubscribe link reaches one addressee at a
+		// time — the link is personal to whoever it opts out — so a blind-copied
+		// message can only exist under a category that carries none. Answering
+		// people who wrote to us is such a category; marketing is not.
+		"communication_context": string(commsauthz.CategoryReplyToInbound),
 		"links": []AnyMap{
 			{"entity_type": "person", "entity_id": p.personID},
 		},

--- a/backend/internal/compose/integration/send_preflight_integration_test.go
+++ b/backend/internal/compose/integration/send_preflight_integration_test.go
@@ -134,7 +134,7 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	}
 	var transactional string
 	for _, p := range purposes.Data {
-		if p.Key == "transactional" {
+		if p.Key == sendPurpose {
 			transactional = p.ID
 		}
 	}
@@ -181,7 +181,7 @@ func (p *preflightEnv) send(t *testing.T) (status int, code, message string) {
 	}
 	status = p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
 		"subject": "Re: Inbound question", "body": "answer",
-		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": sendPurpose,
 	}, nil, &problem)
 	if errs := problem.Details.Errors; len(errs) > 0 {
 		return status, errs[0].Code, errs[0].Message

--- a/backend/internal/compose/integration/stagingrefusal_integration_test.go
+++ b/backend/internal/compose/integration/stagingrefusal_integration_test.go
@@ -105,10 +105,10 @@ func TestAMailSendToASuppressedRecipientStagesNothing(t *testing.T) {
 // asserted separately.
 func TestAChannelSendToASuppressedRecipientStagesNothing(t *testing.T) {
 	c := setupChannelSend(t)
-	c.grantConsent(t, "transactional")
+	c.grantConsent(t, sendPurpose)
 	suppressPerson(t, c.AppEnv, c.personID)
 
-	status, code, _ := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
+	status, code, _ := c.sendReply(t, sendPurpose, "Yes — shipping Monday.", nil)
 
 	if status != http.StatusConflict || code != "consent_not_granted" {
 		t.Fatalf("channel reply to a recipient who asked us to stop → %d %q, want 409 consent_not_granted", status, code)
@@ -160,7 +160,7 @@ func TestAnAllowedSendRecordsItsStagingDecision(t *testing.T) {
 	p := setupPreflight(t)
 	p.connect(t, gmailReadonlyScope, gmailSendScope)
 
-	sent := p.sendExpectingAcceptance(t, "transactional", "Re: Inbound question", "As discussed.")
+	sent := p.sendExpectingAcceptance(t, sendPurpose, "Re: Inbound question", "As discussed.")
 	deliveryID, _ := p.deliveryFor(t, sent)
 
 	rows := p.stagingDecisions(t, deliveryID)
@@ -196,7 +196,7 @@ func (p *preflightEnv) sendExpectingAcceptanceClaiming(t *testing.T, context str
 	}
 	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
 		"subject": "Re: Inbound question", "body": "As discussed.",
-		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": sendPurpose,
 		"communication_context": context,
 	}, nil, &sent)
 	if status != http.StatusAccepted {
@@ -224,7 +224,7 @@ func (p *preflightEnv) sendClaiming(t *testing.T, context string) (status int, c
 	}
 	status = p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
 		"subject": "Re: Inbound question", "body": "answer",
-		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": sendPurpose,
 		"communication_context": context,
 	}, nil, &problem)
 	if errs := problem.Details.Errors; len(errs) > 0 {
@@ -286,9 +286,9 @@ func TestASendCannotClaimAControllerCategory(t *testing.T) {
 // no test anywhere posted a communication_context to this route.
 func TestAChannelSendCannotClaimAControllerCategory(t *testing.T) {
 	c := setupChannelSend(t)
-	c.grantConsent(t, "transactional")
+	c.grantConsent(t, sendPurpose)
 
-	status, code, _ := c.sendReplyClaiming(t, "transactional", "Yes — shipping Monday.", "security_notice", nil)
+	status, code, _ := c.sendReplyClaiming(t, sendPurpose, "Yes — shipping Monday.", "security_notice", nil)
 
 	if status != http.StatusUnprocessableEntity {
 		t.Fatalf("a channel reply claiming security_notice → %d, want 422", status)
@@ -303,9 +303,9 @@ func TestAChannelSendCannotClaimAControllerCategory(t *testing.T) {
 // is a category check rather than the channel door rejecting the field itself.
 func TestAChannelSendMayClaimAnOrdinaryCategory(t *testing.T) {
 	c := setupChannelSend(t)
-	c.grantConsent(t, "transactional")
+	c.grantConsent(t, sendPurpose)
 
-	status, _, detail := c.sendReplyClaiming(t, "transactional", "Yes — shipping Monday.", "reply_to_inbound", nil)
+	status, _, detail := c.sendReplyClaiming(t, sendPurpose, "Yes — shipping Monday.", "reply_to_inbound", nil)
 
 	if status != http.StatusAccepted {
 		t.Fatalf("a channel reply claiming reply_to_inbound → %d (%s), want 202", status, detail)

--- a/backend/internal/compose/integration/testmailbox_integration_test.go
+++ b/backend/internal/compose/integration/testmailbox_integration_test.go
@@ -102,7 +102,7 @@ func setupTestMailboxEnv(t *testing.T) *preflightEnv {
 	}
 	var transactional string
 	for _, p := range purposes.Data {
-		if p.Key == "transactional" {
+		if p.Key == sendPurpose {
 			transactional = p.ID
 		}
 	}
@@ -226,7 +226,7 @@ func TestTestMailboxFullLoop(t *testing.T) {
 		t.Fatal("connect returned no connection id")
 	}
 
-	sentActivity := p.sendExpectingAcceptance(t, "transactional", "Re: Inbound question", "As discussed.")
+	sentActivity := p.sendExpectingAcceptance(t, sendPurpose, "Re: Inbound question", "As discussed.")
 	deliveryID, messageID := p.deliveryFor(t, sentActivity)
 
 	outcome := p.dispatchTestMailboxOnce(t, deliveryID)

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -118,6 +118,16 @@ type JobRunnerConfig struct {
 	// delivery and its dispatch job, and a role that cannot do that would only
 	// wake a message to fail it.
 	SendDelivery DeliveryMachinery
+	// SendOrigin is the installation's public base URL and the posture it is
+	// judged under — the same pair the api's send path carries.
+	//
+	// A fired message that carries a one-click unsubscribe link builds it from
+	// this. Empty refuses that send rather than emitting a forgeable link,
+	// which means an unset origin does not disable a feature: it makes every
+	// scheduled correspondence and marketing message fail at fire time, while
+	// the transactional ones beside them go out. No worker is gated on it,
+	// because a role that can fire a link-less message should still fire it.
+	SendOrigin SendOrigin
 
 	// CloseDateInterval is the deals close-date hygiene sweep's cadence — the
 	// operator-facing --close-date-interval. No worker is gated on it: the

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -100,7 +100,7 @@ func addCapturePipelineJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerC
 		// machinery exists — a role that cannot send cannot fire either.
 		if cfg.SendDelivery != nil {
 			addDeclaredWorker[ScheduledSendArgs](reg,
-				newScheduledSendWorker(pool, cfg.SendDelivery, cfg.SendBlob, cfg.SendPacing))
+				newScheduledSendWorker(pool, cfg.SendDelivery, cfg.SendBlob, cfg.SendPacing, cfg.SendOrigin))
 		}
 	}
 

--- a/backend/internal/compose/sendorigin.go
+++ b/backend/internal/compose/sendorigin.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The public origin a send builds its links on, carried to the roles that fire
+// one.
+//
+// SendPath already holds this pair for the api's immediate send. The scheduled
+// worker is composed from JobsConfig rather than from a SendPath, so the pair
+// travels on its own rather than by handing the whole send path to a role that
+// needs two fields of it — and it stays a PAIR, because a base URL judged under
+// the wrong posture is the failure netguard exists to catch: a loopback origin
+// is a working dev stack or a link the recipient cannot open, and only the
+// environment says which.
+
+import "github.com/margince/margince/backend/internal/shared/runtimeenv"
+
+// SendOrigin is the installation's public base URL and the posture it is judged
+// under. The zero value is an unconfigured origin in production posture, which
+// is the direction that fails safe.
+type SendOrigin struct {
+	PublicBaseURL string
+	Environment   runtimeenv.Environment
+}
+
+// sendPath renders the origin as the send path a store is built from. Spelled
+// here so the two fields cannot be copied across one at a time.
+func (o SendOrigin) sendPath() SendPath {
+	return SendPath{PublicBaseURL: o.PublicBaseURL, Environment: o.Environment}
+}


### PR DESCRIPTION
**`main` is red and has been for hours.** `main-health` confirms it on `0f73b5db0`:

```
--- FAIL: TestTestMailboxFullLoop
    send-email under "transactional" → 409 "consent_not_granted", want 202
```

25 integration tests, across the send, schedule, capture, preference-centre and MCP paths. This turns them green.

## Why they broke

#5103 made the transactional purpose permanently unsupported on the send path. That is deliberate and its rollout note said so. What did not travel with it were the 25 tests that named that key because it was the cheapest one to type.

## Three parts

### 1. The wiring — a real product bug (#5153)

`newScheduledSendWorker` composed `sendStore(pool, SendPath{})` — an **empty** send path, so `PublicBaseURL` was `""` and any fired message carrying a one-click unsubscribe link refused at fire time:

```
comms_scheduled_send: firing …: send: public base URL is not configured
```

That is the **production** worker — `jobs_capture.go` composes it the same way. It was invisible because every scheduled-send fixture named the one purpose class that needs no link: a lane exercised only in the shape that cannot fail.

`JobsConfig` gains a `SendOrigin`, carrying the base URL and the posture as a **pair** — netguard needs both to tell a working dev stack from a link the recipient cannot open. Two test seams take it too; both claimed in their own docs to assemble the worker "the way the worker role assembles it", and that was true in the wrong direction.

### 2. The fixtures

Sends move to `business_correspondence` with an inbound activity seeded as the qualifying event — what a derived basis is actually derived from. Where a message reaches several people at once it also **claims a category**, because a send carrying an unsubscribe link reaches one addressee at a time; the link is personal to whoever it opts out.

`sendPurpose` and `lockedPurpose` are named apart, because the two stopped being the same word: `transactional` is still the locked lane the preference centre refuses to change, and no longer authorizes a send.

### 3. The two that looked like a contradiction

I reported these as needing a ruling, and I was wrong — there is a route that keeps both rules.

`TestPreferenceCenterOneClickUnsubscribe` and `TestEveryPreferenceAnswerIsUncacheable` assert a send with nothing to unsubscribe from carries no link. That fact used to be spelled `transactional`, the one locked key the **legacy** arm suppresses a link for. Since that key can no longer send, the same fact is now spelled as a claimed non-marketing category — which is where the rule already lived:

```go
func (u unsubscribeSurface) carries() bool {
    if u.category != "" { return u.category.CarriesUnsubscribe() }   // marketing only
    return u.purposeKey != "" && !lockedPurposeKey(u.purposeKey)     // legacy arm
}
```

The category is a caller's **claim**, not something the engine derives, so a fixture can state it. Nothing about the product rule moves.

## Not fixed here

One production path stays open on #5153: an approved held message is re-armed through `heldSendActors`, which composes an empty `SendPath` too. Threading an origin there crosses the approvals composition — server, signals, LinkedIn and attention wiring — which is a change of its own and not a main restoration. The one suite that reaches it says so where it claims its category, so nothing there has to move when #5153 lands.

## Verification

- `internal/compose/integration` — **all green** (178s), from 25 failures
- `make check-go`, `make craft-static` green

@margince/margince — this unblocks every open pull request in the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC