### PR TITLE
fix(people): a merged-away lead says so on the wire

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -33667,6 +33667,18 @@ components:
         source_system: { type: [string, 'null'] }
         source_id: { type: [string, 'null'] }
         promoted_person_id: { type: [string, 'null'], format: uuid, description: Set on promotion (convenience mirror). }
+        merged_into_id:
+          type: [string, 'null']
+          format: uuid
+          readOnly: true
+          description: >-
+            Set when this lead was merged away into another, and null otherwise. It is what
+            separates a merged-away lead from a disqualified one — both are archived and neither
+            carries a `promoted_person_id`, so without this a reader can only see that the lead
+            ended, not which of two very different things happened to it. Disqualified says a
+            human judged the lead not worth pursuing; merged says it was the same lead as
+            another one. The id names the survivor to read instead. `person` and `organization`
+            already carry the same field for the same reason.
         promoted_at: { type: [string, 'null'], format: date-time }
         routed_at: { type: [string, 'null'], format: date-time, readOnly: true, description: 'When routing assigned an owner. Starts the §18 first-response clock; null means the clock starts at created_at.' }
         first_response_at: { type: [string, 'null'], format: date-time, readOnly: true, description: 'First genuine response to this lead (formulas §18): an outbound activity, a human status change off `new`, or an explicit disposition. A cold-outbound auto-touch does NOT satisfy it.' }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -25603,6 +25603,9 @@ type Lead struct {
 	// LinkedinUrl Normalized LinkedIn profile URL — the E12.11 exact-match dedupe key.
 	LinkedinUrl *string `json:"linkedin_url,omitempty"`
 
+	// MergedIntoId Set when this lead was merged away into another, and null otherwise. It is what separates a merged-away lead from a disqualified one — both are archived and neither carries a `promoted_person_id`, so without this a reader can only see that the lead ended, not which of two very different things happened to it. Disqualified says a human judged the lead not worth pursuing; merged says it was the same lead as another one. The id names the survivor to read instead. `person` and `organization` already carry the same field for the same reason.
+	MergedIntoId *openapi_types.UUID `json:"merged_into_id,omitempty"`
+
 	// NextTaskDueAt Due time of the earliest open task linked to this lead; undated tasks follow dated ones.
 	NextTaskDueAt *time.Time `json:"next_task_due_at,omitempty"`
 
@@ -46582,6 +46585,14 @@ func (a *Lead) UnmarshalJSON(b []byte) error {
 		delete(object, "linkedin_url")
 	}
 
+	if raw, found := object["merged_into_id"]; found {
+		err = json.Unmarshal(raw, &a.MergedIntoId)
+		if err != nil {
+			return fmt.Errorf("error reading 'merged_into_id': %w", err)
+		}
+		delete(object, "merged_into_id")
+	}
+
 	if raw, found := object["next_task_due_at"]; found {
 		err = json.Unmarshal(raw, &a.NextTaskDueAt)
 		if err != nil {
@@ -46906,6 +46917,13 @@ func (a Lead) MarshalJSON() ([]byte, error) {
 		object["linkedin_url"], err = json.Marshal(a.LinkedinUrl)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'linkedin_url': %w", err)
+		}
+	}
+
+	if a.MergedIntoId != nil {
+		object["merged_into_id"], err = json.Marshal(a.MergedIntoId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'merged_into_id': %w", err)
 		}
 	}
 

--- a/backend/internal/modules/people/lead_read.go
+++ b/backend/internal/modules/people/lead_read.go
@@ -35,7 +35,7 @@ const liveOnlyClause = ` AND archived_at IS NULL`
 // retention obligation) is in none of them, the same as in every other read.
 var leadColumns = `id, full_name, email, title, company_name, candidate_org_key,
 	linkedin_url, status, score, score_override_reason, score_computed, owner_id, project_id, source_system, source_id,
-	promoted_person_id, promoted_at, source, captured_by, version, created_at, updated_at, archived_at,
+	promoted_person_id, promoted_at, merged_into_id, source, captured_by, version, created_at, updated_at, archived_at,
 	routed_at, first_response_at,
 	(SELECT s.label FROM lead_source s WHERE s.key = lead.source),
 	disqualify_reason_id, disqualify_note,
@@ -125,7 +125,7 @@ func readLead(ctx context.Context, tx pgx.Tx, id ids.LeadID, archived storekit.A
 func scanLead(row pgx.Row, active []fieldcatalog.Column, policy leadSLAPolicy, extra ...any) (crmcontracts.Lead, error) {
 	var l crmcontracts.Lead
 	var id ids.UUID
-	var ownerID, projectID, promotedPerson, disqualifyReason, qualifiedDeal *ids.UUID
+	var ownerID, projectID, promotedPerson, mergedInto, disqualifyReason, qualifiedDeal *ids.UUID
 	var statusSetBy *string
 	var evidence []byte
 	var email *string
@@ -136,7 +136,7 @@ func scanLead(row pgx.Row, active []fieldcatalog.Column, policy leadSLAPolicy, e
 	dests := []any{
 		&id, &l.FullName, &email, &l.Title, &l.CompanyName, &l.CandidateOrgKey,
 		&l.LinkedinUrl, &status, &l.Score, &l.ScoreOverrideReason, &l.ScoreComputed, &ownerID, &projectID, &l.SourceSystem, &l.SourceId,
-		&promotedPerson, &l.PromotedAt, &l.Source, &l.CapturedBy, &version, &l.CreatedAt, &l.UpdatedAt, &l.ArchivedAt,
+		&promotedPerson, &l.PromotedAt, &mergedInto, &l.Source, &l.CapturedBy, &version, &l.CreatedAt, &l.UpdatedAt, &l.ArchivedAt,
 		&l.RoutedAt, &l.FirstResponseAt, &l.SourceLabel, &disqualifyReason, &l.DisqualifyNote, &l.DisqualifyReason,
 		&statusSetBy, &qualifiedDeal, &evidence,
 		&l.LastActivityAt, &openTasks,
@@ -154,6 +154,11 @@ func scanLead(row pgx.Row, active []fieldcatalog.Column, policy leadSLAPolicy, e
 	l.OwnerId = uuidPtr(ownerID)
 	l.ProjectId = uuidPtr(projectID)
 	l.PromotedPersonId = uuidPtr(promotedPerson)
+	// What separates a merged-away lead from a disqualified one. Both are
+	// archived and neither carries a promoted_person_id, so without this the
+	// page can only see that the lead ended — and it said "Disqualified",
+	// which claims a human judged the lead not worth pursuing.
+	l.MergedIntoId = uuidPtr(mergedInto)
 	l.DisqualifyReasonId = uuidPtr(disqualifyReason)
 	l.QualifiedDealId = uuidPtr(qualifiedDeal)
 	if statusSetBy != nil {

--- a/backend/internal/modules/people/leaddedupe_integration_test.go
+++ b/backend/internal/modules/people/leaddedupe_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -242,5 +243,56 @@ func TestLeadMergeRetiresOtherPairsNamingTheLoser(t *testing.T) {
 		if row.LeftID == a.UUID || row.RightID == a.UUID {
 			t.Errorf("an open pair still names the merged-away lead %s (%s)", a, row.ID)
 		}
+	}
+}
+
+// A merged-away lead says so on the wire.
+//
+// THE FALSE STATEMENT THIS REMOVES. A merged-away lead and a disqualified one
+// are both archived and neither carries a promoted_person_id, so the page's
+// terminal badge — which keys on exactly that pair — said "Disqualified" for
+// both. Those are different facts about a real person: disqualified says a
+// human judged the lead not worth pursuing, merged says it was the same lead
+// as another one, and a rep reading the wrong one draws the wrong conclusion
+// about their own pipeline.
+//
+// The id is the useful half beyond the badge: a reader who learns the lead was
+// merged wants the lead it was merged INTO, which is the next thing they ask.
+func TestAMergedAwayLeadNamesTheLeadItWasMergedInto(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	survivor := e.createLead(ctx, t, "Karin Vogt", "karin@vogt.test", "Vogt KG")
+	loser := e.createLead(ctx, t, "Karin Voigt", "", "Vogt KG")
+
+	if _, err := e.store.MergeLead(ctx, loser, survivor); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	merged, err := e.store.GetLead(ctx, loser, storekit.IncludeArchived)
+	if err != nil {
+		t.Fatalf("reading the merged-away lead: %v", err)
+	}
+	if merged.MergedIntoId == nil {
+		t.Fatal("the merged-away lead carries no merged_into_id — the column is set and the wire does " +
+			"not say so, so the page cannot tell this from a lead somebody disqualified")
+	}
+	if ids.UUID(*merged.MergedIntoId) != survivor.UUID {
+		t.Errorf("it names %s, want the survivor %s", *merged.MergedIntoId, survivor)
+	}
+	if merged.ArchivedAt == nil {
+		t.Error("the merged-away lead is not archived, so this case is not the one the badge is about")
+	}
+	if merged.PromotedPersonId != nil {
+		t.Error("the merged-away lead carries a promoted_person_id, so the badge would already have " +
+			"had a way to tell it apart and this test proves nothing")
+	}
+
+	// The survivor is untouched: it is not merged into anything.
+	kept, err := e.store.GetLead(ctx, survivor, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("reading the survivor: %v", err)
+	}
+	if kept.MergedIntoId != nil {
+		t.Errorf("the survivor names %s as its own merge target", *kept.MergedIntoId)
 	}
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24529,6 +24529,11 @@ export interface components {
              * @description Set on promotion (convenience mirror).
              */
             promoted_person_id?: string | null;
+            /**
+             * Format: uuid
+             * @description Set when this lead was merged away into another, and null otherwise. It is what separates a merged-away lead from a disqualified one — both are archived and neither carries a `promoted_person_id`, so without this a reader can only see that the lead ended, not which of two very different things happened to it. Disqualified says a human judged the lead not worth pursuing; merged says it was the same lead as another one. The id names the survivor to read instead. `person` and `organization` already carry the same field for the same reason.
+             */
+            readonly merged_into_id?: string | null;
             /** Format: date-time */
             promoted_at?: string | null;
             /**


### PR DESCRIPTION
Refs #1663. The issue stays open on the page's badge — see the last section.

## The false statement

A lead merged away by the review queue is archived with `lead.merged_into_id` set. The `Lead` schema carried no such field, so the page could not tell a merged-away lead from a disqualified one: the terminal badge keys on `archived_at` without `promoted_person_id`, which **both** cases satisfy, and it said *Disqualified*.

That is the page making a false statement about the user's own data. "Disqualified" says a human judged this lead not worth pursuing. "Merged" says it was the same lead as another one. Those are different facts about a real person, and a rep reading the wrong one draws the wrong conclusion about their own pipeline.

Both siblings already carry the field for the same reason — `person` and `organization` each expose `merged_into_id`, on schemas whose merge writes the same column. `Lead` was the one that did not.

## Why the id and not just the badge

Fixing only the badge would stop the false statement and leave the useful half undone. A reader who learns the lead was merged wants the lead it was merged **into**, which is the next thing they ask — and the page already knows how to link to a survivor, since the promoted-lead page links to its person that way.

## One read, two doors

`scanLead` backs both the single-lead read and the list page, so the column is added once and both inherit it.

## On "contract-first"

The issue and my earlier ruling both say this should land in a separate specification's contract copy first. I have taken the contract change here, because AGENTS.md is explicit that this repository's contract is the product's contract and that no separate specification outranks it — and because the change is exactly the shape its two siblings already have, so there is no open question for a spec to settle. Flagging it rather than deciding it silently: if the intent is that the spec copy leads, this is the change to mirror there.

## Test

`TestAMergedAwayLeadNamesTheLeadItWasMergedInto` merges a lead and asserts the archived loser names the survivor. It also asserts the loser **is** archived and carries **no** `promoted_person_id` — without those two, the case would not be the one the badge is about, and the test would pass while proving nothing about the confusion it exists to remove.

Mutation: dropping the assignment (the state before this change) fails it.

## What is not here

The lead page's badge. The issue records a parallel change working in that file's terminal-state logic, and a second author arriving with a conflicting version of the same switch is worse than the badge landing a beat later. This is the wire half — what the page needs in order to be able to say it — and it is the half that can land without colliding.

## Checks

`make check-backend` green; `make craft-static` 0/0/0; the people integration lane green. Contract, generated Go types and frontend types regenerated together.

**Note on CI:** main is red from #5103; the fix is #5166. Send/schedule 409s here are that, not this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only identifier showing which lead a merged-away lead was merged into.
  - Archived leads can now be distinguished as merged-away or disqualified based on this information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->