### PR TITLE
feat(relstrength): a channel message is an interaction, counted by the day it ran on

### DIFF
--- a/backend/gates/activitykindsets_test.go
+++ b/backend/gates/activitykindsets_test.go
@@ -56,9 +56,8 @@ func publishedActivityKinds(t *testing.T) []string {
 			if !isNamed || named.Name != "ActivityKind" {
 				continue
 			}
-			literal, isLiteral := value.Values[0].(*ast.BasicLit)
-			if isLiteral && literal.Kind == token.STRING {
-				kinds = append(kinds, strings.Trim(literal.Value, `"`))
+			if kind, isString := gatekit.LiteralText(value.Values[0]); isString {
+				kinds = append(kinds, kind)
 			}
 		}
 	}
@@ -107,18 +106,24 @@ func TestEveryScoredKindHasParticipants(t *testing.T) {
 	}
 }
 
-// A message has a room and no settled warmth. Both halves are asserted because
-// each is a decision somebody could undo without noticing the other: adding it
-// to the scoring set moves every installation's deal-health and person-strength
-// numbers, and removing it from the participant set puts a group chat back to
-// naming nobody who was in it.
-func TestAMessageHasParticipantsAndIsNotScored(t *testing.T) {
+// A message has a room AND counts as warmth, and it is the unit that makes the
+// second half safe. All three are asserted because each is a decision somebody
+// could undo without noticing the others: dropping it from the scoring set puts
+// a chat-only account back to reading as never having spoken, dropping it from
+// the participant set puts a group chat back to naming nobody who was in it,
+// and counting its rows instead of its conversation-days lets an afternoon of
+// one-line replies outweigh a quarter of meetings.
+func TestAMessageHasParticipantsAndIsScoredByTheConversationDay(t *testing.T) {
 	t.Parallel()
 	if !relstrength.IsParticipantKind("message") {
 		t.Error("a message records no participants — a group chat names everyone who was in it, and this is where that is kept")
 	}
-	if scoredKind(t, "message") {
-		t.Error("a message scores as an interaction — whether chat traffic is warmth is an open product question, and answering it here moves every deal-health and person-strength number")
+	if !scoredKind(t, "message") {
+		t.Error("a message does not score as an interaction — two people spoke, which is the membership test the scoring set applies, and an account whose whole relationship runs over a channel reads as having none")
+	}
+	unit := relstrength.InteractionUnitSQL("a")
+	if !strings.Contains(unit, "'message'") || !strings.Contains(unit, "a.thread_key") {
+		t.Errorf("the counting unit is %q, which does not separate a message from the kinds counted per row — the scoring set holds a kind that arrives dozens of rows to a conversation", unit)
 	}
 }
 

--- a/backend/gates/interactionunit_test.go
+++ b/backend/gates/interactionunit_test.go
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H3
+
+package gates
+
+// Every count that becomes a relationship-strength number counts the shared
+// UNIT, not rows.
+//
+// A channel message arrives as one row per line, so an afternoon of chat is
+// dozens of rows and one conversation. relstrength.InteractionUnitSQL is what
+// collapses those to the day they happened on, and a fold that counts rows
+// instead reports a chat-only account as the warmest relationship in the
+// workspace — a number nothing else on the screen contradicts, so nobody
+// notices it is wrong.
+//
+// It is a gate rather than a test beside relstrength because the package holds
+// no query: the folds that must obey live in three other modules, and one of
+// them counts from a different table than the rest. A test inside relstrength
+// could only assert that the renderer renders.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
+)
+
+// unitSentinel stands where a statement interpolates the shared unit. Reading
+// the folded text for it, rather than reading the identifier's name, is what
+// makes a hand-written second copy of the expression fail: only a var assigned
+// from relstrength.InteractionUnitSQL resolves to this, so a local re-spelling
+// folds to gatekit.ComputedFragment and is reported.
+const unitSentinel = "<relstrength-interaction-unit>"
+
+// countsTheSharedUnit is the shape a compliant count has once folded.
+var countsTheSharedUnit = "count(DISTINCT " + unitSentinel + ")"
+
+// deliberateOtherCounts are the counts inside a qualifying statement that are
+// not counting interactions at all. Each says what it counts instead, because
+// "it is not an interaction count" is the only reason that can be right here.
+var deliberateOtherCounts = gatekit.Waive(map[string]string{
+	"internal/compose/org360/graphourside.go :: count(*) FROM colleagues)": "counts the colleagues an account has, not the interactions with any of them — it is the total the capped list is a page of",
+})
+
+// TestEveryInteractionCountReadsTheSharedUnit is the census.
+func TestEveryInteractionCountReadsTheSharedUnit(t *testing.T) {
+	t.Parallel()
+	defer deliberateOtherCounts.AssertAllMatched(t)
+
+	group := relstrength.InteractionKindSQLGroup()
+	if !strings.HasPrefix(group, "('") {
+		t.Fatalf("the scoring kind group renders as %q, which no statement can contain — this census would qualify nothing", group)
+	}
+	projections := interactionProjectionTables(t)
+
+	var viaGroup, viaProjection int
+	for _, pkg := range goPackagesUnder(t, ".") {
+		consts := relstrengthConsts(t, pkg, group)
+		for _, file := range pkg.files {
+			for _, stmt := range sqlStatementsWith(t, file, consts) {
+				if !strings.Contains(strings.ToLower(stmt), "count(") {
+					continue
+				}
+				byGroup := strings.Contains(stmt, group)
+				byProjection := namesAny(stmt, projections)
+				if !byGroup && !byProjection {
+					continue
+				}
+				if byGroup {
+					viaGroup++
+				}
+				if byProjection {
+					viaProjection++
+				}
+				judgeCounts(t, file.relPath, stmt)
+			}
+		}
+	}
+
+	// BOTH arms live, or the census is judging half the tree and reporting a
+	// clean one over the other half. The workspace score is reached through the
+	// kind group and the colleague edge through the projection table, and
+	// neither arm can see the other's statements.
+	if viaGroup == 0 {
+		t.Error("no statement counts under the scoring kind group — the arm that reaches the workspace score sees nothing")
+	}
+	if viaProjection == 0 {
+		t.Error("no statement counts over an interaction projection — the arm that reaches the colleague and contact edges sees nothing")
+	}
+}
+
+// judgeCounts reports each count in one qualifying statement that reads
+// something other than the shared unit.
+func judgeCounts(t *testing.T, relPath, stmt string) {
+	t.Helper()
+	for _, found := range countsIn(stmt) {
+		if strings.HasPrefix(found, countsTheSharedUnit) {
+			continue
+		}
+		key := relPath + " :: " + found
+		if deliberateOtherCounts.Waived(t, key) {
+			continue
+		}
+		t.Errorf("%s counts %s — a relationship count reads relstrength.InteractionUnitSQL, or a day of chat outscores a quarter of meetings. If this counts something other than interactions, say what in deliberateOtherCounts under the key %q", relPath, found, key)
+	}
+}
+
+// countsIn returns each count in the statement as its expression plus enough of
+// what follows to tell two counts in one statement apart — the form a waiver is
+// keyed on, whitespace collapsed so re-wrapping a long line does not move it.
+func countsIn(stmt string) []string {
+	var out []string
+	lower := strings.ToLower(stmt)
+	for at := 0; ; {
+		found := strings.Index(lower[at:], "count(")
+		if found < 0 {
+			return out
+		}
+		start := at + found
+		end := start + len(countTail(stmt[start:]))
+		out = append(out, collapse(stmt[start:end]))
+		at = start + len("count(")
+	}
+}
+
+// countTail is the count call plus the following twenty characters: the call
+// alone does not separate two `count(*)`s in one statement, and the whole
+// statement as a key would move every time a line beside it changed.
+func countTail(from string) string {
+	depth := 0
+	for i, r := range from {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				end := i + 21
+				if end > len(from) {
+					end = len(from)
+				}
+				return from[:end]
+			}
+		}
+	}
+	return from
+}
+
+var whitespace = regexp.MustCompile(`\s+`)
+
+func collapse(text string) string { return whitespace.ReplaceAllString(strings.TrimSpace(text), " ") }
+
+func namesAny(stmt string, tables []string) bool {
+	for _, table := range tables {
+		if strings.Contains(stmt, table) {
+			return true
+		}
+	}
+	return false
+}
+
+// interactionProjectionTables reads the tables that STORE an interaction count
+// out of the schema, rather than naming them here. A third projection added
+// beside the colleague and contact edges is then judged without anybody
+// remembering to add it, which is the whole reason this is derived: a census
+// carrying its own list of subjects grows only when somebody grows it, and a
+// missed subject reports PASS.
+//
+// It reads the head CATALOG and not the migrations, because the catalog is the
+// schema as of head in one file. A reader pointed at the baseline sees only the
+// tables that shipped in it, and a projection introduced by a later migration
+// is then invisible to a census that says nothing about it.
+func interactionProjectionTables(t *testing.T) []string {
+	t.Helper()
+	const catalog = "migrations/testdata/head_catalog.txt"
+	schema, err := os.ReadFile(catalog)
+	if err != nil {
+		t.Fatalf("reading the schema head: %v", err)
+	}
+	var tables []string
+	for _, line := range strings.Split(string(schema), "\n") {
+		qualified, _, isColumn := strings.Cut(line, " ")
+		if !isColumn || !strings.HasSuffix(qualified, ".count_90d") {
+			continue
+		}
+		parts := strings.Split(strings.TrimSuffix(qualified, ".count_90d"), ".")
+		tables = append(tables, parts[len(parts)-1])
+	}
+	if len(tables) == 0 {
+		t.Fatal("no table at schema head stores a count_90d — either the projections moved or this reader stopped seeing them, and either way the census below judges nothing")
+	}
+	return tables
+}
+
+// relstrengthConsts resolves the package's own names for relstrength's
+// renderers, so a statement that interpolates them folds to text this census
+// can read.
+//
+// Resolved per PACKAGE and not per file: `graphInteractionUnit` is declared in
+// one file of `search` and read by both, and a per-file reading would see the
+// second file's counts as interpolating something it cannot name — which reads
+// exactly like the violation it would then report.
+func relstrengthConsts(t *testing.T, pkg goPackage, group string) map[string]string {
+	t.Helper()
+	consts := map[string]string{}
+	for _, file := range pkg.files {
+		if !gatekit.References(file.ast, relstrengthImport, "InteractionUnitSQL") &&
+			!gatekit.References(file.ast, relstrengthImport, "InteractionKindSQLGroup") {
+			continue
+		}
+		ast.Inspect(file.ast, func(node ast.Node) bool {
+			spec, isSpec := node.(*ast.ValueSpec)
+			if !isSpec || len(spec.Names) != 1 || len(spec.Values) != 1 {
+				return true
+			}
+			call, isCall := spec.Values[0].(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+			selector, isSelector := call.Fun.(*ast.SelectorExpr)
+			if !isSelector {
+				return true
+			}
+			switch selector.Sel.Name {
+			case "InteractionUnitSQL":
+				consts[spec.Names[0].Name] = unitSentinel
+			case "InteractionKindSQLGroup":
+				consts[spec.Names[0].Name] = group
+			}
+			return true
+		})
+	}
+	return consts
+}
+
+const relstrengthImport = "github.com/margince/margince/backend/internal/shared/kernel/relstrength"
+
+// sqlStatementsWith is gatekit.SQLStatementsOf with the package's relstrength
+// names resolved — one entry per statement, flattened across the `+` chains the
+// folds are written as.
+func sqlStatementsWith(t *testing.T, file goFile, consts map[string]string) []string {
+	t.Helper()
+	var out []string
+	ast.Inspect(file.ast, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.BinaryExpr:
+			if typed.Op != token.ADD {
+				return true
+			}
+			if text, isString := gatekit.StringExpr(typed, consts, gatekit.FoldTotal); isString {
+				out = append(out, text)
+				return false
+			}
+		case *ast.BasicLit:
+			if text, isString := gatekit.LiteralText(typed); isString {
+				out = append(out, text)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+type goFile struct {
+	relPath string
+	ast     *ast.File
+}
+
+type goPackage struct {
+	files []goFile
+}
+
+// goPackagesUnder parses every non-test Go file in the module, grouped by
+// directory. The generated contract is skipped: it holds no statement, and
+// parsing it costs more than every other file together.
+func goPackagesUnder(t *testing.T, root string) []goPackage {
+	t.Helper()
+	byDir := map[string][]goFile{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || !strings.HasSuffix(path, ".go") ||
+			strings.HasSuffix(path, "_test.go") || strings.Contains(path, "/internal/contracts/") {
+			return err
+		}
+		parsed, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		dir := filepath.Dir(path)
+		byDir[dir] = append(byDir[dir], goFile{relPath: filepath.ToSlash(path), ast: parsed})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reading the tree: %v", err)
+	}
+	if len(byDir) == 0 {
+		t.Fatal("no Go package under the module — this census would judge nothing")
+	}
+	out := make([]goPackage, 0, len(byDir))
+	for _, files := range byDir {
+		out = append(out, goPackage{files: files})
+	}
+	return out
+}

--- a/backend/internal/modules/people/messageunit_integration_test.go
+++ b/backend/internal/modules/people/messageunit_integration_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// What ONE interaction is, over a real Postgres, when the interaction is a
+// channel message.
+//
+// A chat conversation arrives one row per line, so the §4 fold has to collapse
+// them or an afternoon of replies fills a ninety-day quota of contact:
+// FreqSaturation is 20, and twenty lines is five minutes of typing. The unit is
+// the conversation-day — relstrength.InteractionUnitSQL — and these are the
+// cases that separate it from counting rows and from counting a whole
+// conversation once however long it runs.
+//
+// Seeded as rows rather than through capture: the subject here is the READ,
+// and the shape a row may take is held by the activity table's own checks
+// (a message carries a channel_provider) which these seeds satisfy. Each test
+// asserts the raw row count first, so a fold that returned a small number
+// because the rows were never written cannot pass as a fold that collapsed
+// them.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedMessage writes one channel message linked to a person, on a named
+// conversation, at a chosen instant.
+func (e *dedupeEnv) seedMessage(t *testing.T, personID ids.PersonID, thread string, at time.Time, direction string) {
+	t.Helper()
+	id := ids.New[ids.ActivityKind]()
+	ctx := e.as()
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO activity (id, kind, body, direction, occurred_at, thread_key,
+			                      channel_provider, source_system, source_id, source, captured_by)
+			VALUES ($1, 'message', 'Hallo', $2, $3, $4, 'telegram', 'telegram', $5, 'telegram:seed', 'connector:telegram')`,
+			id, direction, at, thread, id.String()); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ($1, 'person', $2)`, id, personID)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a channel message: %v", err)
+	}
+}
+
+// rawActivityRows is what the fold is collapsing — read separately so a test
+// whose seeds never landed fails as a seeding problem rather than passing as a
+// collapse.
+func (e *dedupeEnv) rawActivityRows(t *testing.T, personID ids.PersonID) int {
+	t.Helper()
+	var rows int
+	ctx := e.as()
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM activity a
+			  JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
+			 WHERE a.archived_at IS NULL`, personID).Scan(&rows)
+	}); err != nil {
+		t.Fatalf("counting the seeded rows: %v", err)
+	}
+	return rows
+}
+
+// An afternoon of chat is one day of talking, and the email beside it still
+// counts as itself: the collapse is the message kind's, not every kind's.
+func TestAChannelConversationCountsOnceForTheDayItRanOn(t *testing.T) {
+	env := setupDedupe(t)
+	person := env.seedContact(t, "Ines Chatterjee")
+	now := time.Date(2026, 4, 20, 18, 0, 0, 0, time.UTC)
+	day := now.Add(-2 * time.Hour)
+
+	for minute, direction := range []string{"inbound", "outbound", "inbound", "inbound", "outbound"} {
+		env.seedMessage(t, person, "telegram:bot:900", day.Add(time.Duration(minute)*time.Minute), direction)
+	}
+	env.seedInteraction(t, person, day.Add(-time.Hour), "outbound")
+
+	if rows := env.rawActivityRows(t, person); rows != 6 {
+		t.Fatalf("seeded %d rows, expected 6 — the case below is about collapsing them, not about their absence", rows)
+	}
+
+	got, err := env.store.PersonStrength(env.as(), person, now)
+	if err != nil {
+		t.Fatalf("reading the score: %v", err)
+	}
+	if got.InteractionCount90d != 2 {
+		t.Errorf("counted %d interactions over five messages on one conversation plus one email; want 2 — a conversation-day and the email. Counting the rows lets five minutes of typing weigh five times a meeting", got.InteractionCount90d)
+	}
+	// Both directions ran inside the one conversation-day, so the day is
+	// itself in each: a two-way exchange reads as balanced rather than as
+	// three-to-two.
+	if got.Inbound90d != 1 {
+		t.Errorf("counted %d inbound; want 1 — the conversation-day the contact wrote on", got.Inbound90d)
+	}
+	if got.Outbound90d != 2 {
+		t.Errorf("counted %d outbound; want 2 — the conversation-day we wrote on, and the email", got.Outbound90d)
+	}
+}
+
+// The other side of the same unit: a conversation is not counted once however
+// long it runs, or a chat relationship of months would score as a single touch.
+// Two days on one conversation are two, and two conversations in one day are
+// two as well — the unit is the pair, not either half.
+func TestAConversationCountsOncePerDayItRanOn(t *testing.T) {
+	env := setupDedupe(t)
+	acrossDays := env.seedContact(t, "Ola Vermeer")
+	sameDay := env.seedContact(t, "Pia Lindqvist")
+	now := time.Date(2026, 4, 20, 18, 0, 0, 0, time.UTC)
+
+	for _, at := range []time.Time{
+		now.AddDate(0, 0, -3),
+		now.AddDate(0, 0, -3).Add(time.Minute),
+		now.AddDate(0, 0, -1),
+		now.AddDate(0, 0, -1).Add(time.Minute),
+	} {
+		env.seedMessage(t, acrossDays, "telegram:bot:901", at, "inbound")
+	}
+	for _, thread := range []string{"telegram:bot:902", "telegram:bot:903"} {
+		env.seedMessage(t, sameDay, thread, now.AddDate(0, 0, -1), "inbound")
+		env.seedMessage(t, sameDay, thread, now.AddDate(0, 0, -1).Add(time.Minute), "inbound")
+	}
+
+	if rows := env.rawActivityRows(t, acrossDays); rows != 4 {
+		t.Fatalf("seeded %d rows on the two-day conversation, expected 4", rows)
+	}
+	if rows := env.rawActivityRows(t, sameDay); rows != 4 {
+		t.Fatalf("seeded %d rows across the two conversations, expected 4", rows)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		person ids.PersonID
+		want   int
+	}{
+		{"one conversation over two days", acrossDays, 2},
+		{"two conversations on one day", sameDay, 2},
+	} {
+		got, err := env.store.PersonStrength(env.as(), tc.person, now)
+		if err != nil {
+			t.Fatalf("reading the score for %s: %v", tc.name, err)
+		}
+		if got.InteractionCount90d != tc.want {
+			t.Errorf("%s counted %d interactions; want %d", tc.name, got.InteractionCount90d, tc.want)
+		}
+	}
+}

--- a/backend/internal/modules/people/relationshipchange.go
+++ b/backend/internal/modules/people/relationshipchange.go
@@ -190,13 +190,13 @@ func changeInputs(
 	// unchanged and the whole derivation silent.
 	if err := tx.QueryRow(ctx, `
 		SELECT max(a.occurred_at),
-		       count(*) FILTER (WHERE a.occurred_at >= $2),
-		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'inbound'),
-		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $2),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'inbound'),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
 		       max(a.occurred_at) FILTER (WHERE a.occurred_at < $3),
-		       count(*) FILTER (WHERE a.occurred_at >= $4 AND a.occurred_at < $3),
-		       count(*) FILTER (WHERE a.occurred_at >= $4 AND a.occurred_at < $3 AND a.direction = 'inbound'),
-		       count(*) FILTER (WHERE a.occurred_at >= $4 AND a.occurred_at < $3 AND a.direction = 'outbound'),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $4 AND a.occurred_at < $3),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $4 AND a.occurred_at < $3 AND a.direction = 'inbound'),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $4 AND a.occurred_at < $3 AND a.direction = 'outbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound')
 		  FROM activity a
 		  JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1

--- a/backend/internal/modules/people/strength.go
+++ b/backend/internal/modules/people/strength.go
@@ -88,6 +88,11 @@ type RelationshipStrength struct {
 // shared definition — see relstrength.InteractionKindSQLGroup.
 var strengthKinds = relstrength.InteractionKindSQLGroup()
 
+// strengthInteractionUnit is what ONE interaction is when these folds count
+// them, from the same shared definition — see relstrength.InteractionUnitSQL.
+// Every fold below aliases activity as `a`, so one rendering serves them all.
+var strengthInteractionUnit = relstrength.InteractionUnitSQL("a")
+
 // PersonStrength computes the §4 baseline for one person. The person
 // read is row-scoped exactly like GetPerson: a person the caller cannot
 // see has no strength to disclose.
@@ -354,9 +359,9 @@ func contactStrengths(
 	rows, err := tx.Query(ctx, `
 		SELECT l.person_id,
 		       max(a.occurred_at),
-		       count(*) FILTER (WHERE a.occurred_at >= $2),
-		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'inbound'),
-		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $2),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'inbound'),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound'),
 		       (SELECT i.id FROM activity i
@@ -427,9 +432,9 @@ func strengthInputs(
 	// touch, the 90-day direction counts, and the contributing ids.
 	if err := tx.QueryRow(ctx, `
 		SELECT max(a.occurred_at),
-		       count(*) FILTER (WHERE a.occurred_at >= $2),
-		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'inbound'),
-		       count(*) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $2),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'inbound'),
+		       count(DISTINCT `+strengthInteractionUnit+`) FILTER (WHERE a.occurred_at >= $2 AND a.direction = 'outbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound'),
 		       (SELECT i.id FROM activity i

--- a/backend/internal/modules/search/contactedge.go
+++ b/backend/internal/modules/search/contactedge.go
@@ -115,8 +115,8 @@ func recomputeContactPairs(ctx context.Context, tx pgx.Tx, pairs []contactPair) 
 		folded AS (
 		    SELECT t.person_a, t.person_b,
 		           max(a.occurred_at) AS last_at,
-		           count(DISTINCT a.id) FILTER (WHERE a.occurred_at >= `+window+`) AS count_90d,
-		           count(DISTINCT a.id) AS count_total
+		           count(DISTINCT `+graphInteractionUnit+`) FILTER (WHERE a.occurred_at >= `+window+`) AS count_90d,
+		           count(DISTINCT `+graphInteractionUnit+`) AS count_total
 		      FROM target t
 		      JOIN activity_participant pa
 		        ON pa.person_id = t.person_a AND pa.role IN `+interactionRoles+`

--- a/backend/internal/modules/search/graphedge.go
+++ b/backend/internal/modules/search/graphedge.go
@@ -204,10 +204,10 @@ func recomputePairs(ctx context.Context, tx pgx.Tx, pairs []pair) error {
 		           max(a.occurred_at) AS last_at,
 		           max(a.occurred_at) FILTER (WHERE a.direction = 'inbound')  AS last_inbound_at,
 		           max(a.occurred_at) FILTER (WHERE a.direction = 'outbound') AS last_outbound_at,
-		           count(DISTINCT a.id) FILTER (WHERE a.occurred_at >= `+window+`) AS count_90d,
-		           count(DISTINCT a.id) FILTER (WHERE a.occurred_at >= `+window+` AND a.direction = 'inbound')  AS in_90d,
-		           count(DISTINCT a.id) FILTER (WHERE a.occurred_at >= `+window+` AND a.direction = 'outbound') AS out_90d,
-		           count(DISTINCT a.id) AS count_total
+		           count(DISTINCT `+graphInteractionUnit+`) FILTER (WHERE a.occurred_at >= `+window+`) AS count_90d,
+		           count(DISTINCT `+graphInteractionUnit+`) FILTER (WHERE a.occurred_at >= `+window+` AND a.direction = 'inbound')  AS in_90d,
+		           count(DISTINCT `+graphInteractionUnit+`) FILTER (WHERE a.occurred_at >= `+window+` AND a.direction = 'outbound') AS out_90d,
+		           count(DISTINCT `+graphInteractionUnit+`) AS count_total
 		      FROM target t
 		      JOIN activity_participant up
 		        ON up.user_id = t.user_id AND up.role IN `+interactionRoles+`
@@ -402,6 +402,16 @@ func scanEdges(rows pgx.Rows) ([]InteractionEdge, error) {
 // It is also the determinism fixture: a rebuild and a stream of incremental
 // recomputes over the same history must agree, and a test that says so is
 // what keeps the two paths from drifting apart.
+// graphInteractionUnit is what ONE interaction is when these projections count
+// them, from the same shared definition the workspace score reads — see
+// relstrength.InteractionUnitSQL. Every fold in this file and its contact half
+// aliases activity as `a`, so one rendering serves them all.
+//
+// It matters most here: these folds carry no kind filter, so a channel message
+// reaches them through activity_participant, and per-row counting would let a
+// day of chat outweigh a quarter of meetings on the colleague edge alone.
+var graphInteractionUnit = relstrength.InteractionUnitSQL("a")
+
 func RebuildEdges(ctx context.Context, tx pgx.Tx) error {
 	window := fmt.Sprintf("now() - interval '%d days'", relstrength.WindowDays)
 	// Replace wholesale rather than diff: the table is derived, the workspace
@@ -418,10 +428,10 @@ func RebuildEdges(ctx context.Context, tx pgx.Tx) error {
 		       max(a.occurred_at),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound'),
-		       count(DISTINCT a.id) FILTER (WHERE a.occurred_at >= `+window+`),
-		       count(DISTINCT a.id) FILTER (WHERE a.occurred_at >= `+window+` AND a.direction = 'inbound'),
-		       count(DISTINCT a.id) FILTER (WHERE a.occurred_at >= `+window+` AND a.direction = 'outbound'),
-		       count(DISTINCT a.id),
+		       count(DISTINCT `+graphInteractionUnit+`) FILTER (WHERE a.occurred_at >= `+window+`),
+		       count(DISTINCT `+graphInteractionUnit+`) FILTER (WHERE a.occurred_at >= `+window+` AND a.direction = 'inbound'),
+		       count(DISTINCT `+graphInteractionUnit+`) FILTER (WHERE a.occurred_at >= `+window+` AND a.direction = 'outbound'),
+		       count(DISTINCT `+graphInteractionUnit+`),
 		       now()
 		  FROM activity_participant up
 		  JOIN activity_participant pp ON pp.activity_id = up.activity_id
@@ -447,8 +457,8 @@ func rebuildContactEdges(ctx context.Context, tx pgx.Tx, window string) error {
 		    (person_a, person_b, last_at, count_90d, count_total, computed_at)
 		SELECT pa.person_id, pb.person_id,
 		       max(a.occurred_at),
-		       count(DISTINCT a.id) FILTER (WHERE a.occurred_at >= `+window+`),
-		       count(DISTINCT a.id),
+		       count(DISTINCT `+graphInteractionUnit+`) FILTER (WHERE a.occurred_at >= `+window+`),
+		       count(DISTINCT `+graphInteractionUnit+`),
 		       now()
 		  FROM activity_participant pa
 		  JOIN activity_participant pb

--- a/backend/internal/shared/kernel/relstrength/interactionkind.go
+++ b/backend/internal/shared/kernel/relstrength/interactionkind.go
@@ -9,31 +9,34 @@ import "strings"
 // exchange worth SCORING: the deal-health window, person strength, and the
 // organization signal scan.
 //
-// A task is intent and a note is a record of thinking; neither means two people
-// spoke, and counting them would let a rep's own to-do list score as a
-// relationship.
+// The membership test is whether two people spoke. A task is intent and a note
+// is a record of thinking; neither means two people spoke, and counting them
+// would let a rep's own to-do list score as a relationship. A chat message
+// passes that test the same way an email does, and an account whose whole
+// relationship runs over a channel read as having no interactions at all while
+// it was excluded.
+//
+// What a message does NOT share with the others is its unit: one row is one
+// exchange for an email, a call and a meeting, and one line of a conversation
+// for a message. InteractionUnitSQL below is where that difference is answered,
+// and it is answered there rather than by keeping the kind out, because the
+// membership question and the counting question have different answers.
 //
 // It is unexported and reached only through the SQL renderers below, because
 // every reader of it is a query.
-var interactionKinds = []string{"email", "call", "meeting"}
+var interactionKinds = []string{"email", "call", "meeting", "message"}
 
 // participantKinds is the closed set of kinds that HAVE participants — an
 // activity where it is meaningful to ask who was there.
 //
-// TWO QUESTIONS, TWO SETS, AND THE DIFFERENCE IS ONE KIND. "Who was in the
-// room" and "does this count as warmth" were one set until a group chat
-// arrived, because until then the answers never differed: a task and a note
-// have no room AND no warmth. A chat message has a room full of people and an
-// unsettled claim to warmth — nobody has decided whether a hundred one-line
-// replies mean a relationship the way a meeting does — so folding it into one
-// set would have answered that unasked question by moving every installation's
-// deal-health and person-strength numbers.
-//
-// This set is therefore the WIDER one, and only ever that way round: a kind may
-// be worth recording the people on without being worth scoring, while a kind
-// scored with nobody recorded on it would be a relationship with no one in it.
-// backend/gates/activitykindsets_test.go holds that direction, and holds both
-// sets against the contract's own kind vocabulary.
+// TWO QUESTIONS, TWO SETS. "Who was in the room" and "does this count as
+// warmth" hold the same four kinds today, and they are still two sets because
+// they are still two questions: a kind may be worth recording the people on
+// without being worth scoring, while a kind scored with nobody recorded on it
+// would be a relationship with no one in it. That direction is the one a diff
+// may move them apart in, and only that one.
+// Held by: TestEveryScoredKindHasParticipants (backend/gates/activitykindsets_test.go),
+// which also holds both sets against the contract's own kind vocabulary.
 //
 // Unexported for the same reason: a caller that could append to it would change
 // what four different writers stamp, and those four must agree or a captured
@@ -65,6 +68,46 @@ func InteractionKindSQLList() string {
 // `kind IN %s` shape the deal-health and person-strength queries use.
 func InteractionKindSQLGroup() string {
 	return "(" + InteractionKindSQLList() + ")"
+}
+
+// InteractionUnitSQL renders what ONE interaction is, for a query that counts
+// them: `count(DISTINCT <unit>)` in place of `count(*)`.
+//
+// An email, a call and a meeting are one interaction per row, because each row
+// is one exchange somebody decided to have. A channel message is not: a
+// conversation arrives as dozens of one-line replies, and counting rows makes an
+// afternoon of chat outweigh a quarter of meetings. FreqSaturation is 20, so
+// twenty lines typed in five minutes would fill a ninety-day quota of contact.
+//
+// So a message counts once per conversation per day. That is the unit a person
+// uses out loud — "we talked on Tuesday" — and unlike a per-message weight it
+// introduces no constant, so there is no number that has to be tuned against a
+// real channel before the count is honest. Twenty days of talking across the
+// quarter saturates frequency, which is a relationship; twenty lines in an
+// afternoon is one day of one.
+//
+// The directed counts read the same unit, so a conversation-day with traffic
+// both ways yields the unit under both filters and reads as balanced. That is
+// why Inputs does not require the two directions to sum to the total.
+//
+// UTC decides the day. The boundary only changes whether a conversation running
+// past midnight counts once or twice, every fixed zone is arbitrary for a
+// workspace spanning several, and UTC is the one a reader can reproduce from the
+// stored value alone.
+//
+// A message with no thread_key falls back to its own id, so it counts as one
+// rather than dropping out of the count: a unit that renders NULL is skipped by
+// count(DISTINCT), and a count that can silently shrink is the wrong way for
+// this to fail. The two prefixes keep the spaces apart, because a thread_key is
+// free text from a provider and could otherwise equal a uuid rendered as text.
+//
+// alias is the statement's alias for `activity`, always a compile-time literal
+// at the call site as the other renderers here require.
+func InteractionUnitSQL(alias string) string {
+	return "CASE WHEN " + alias + ".kind = 'message'" +
+		" THEN 'conversation-day:' || coalesce(" + alias + ".thread_key, " + alias + ".id::text)" +
+		" || ':' || (" + alias + ".occurred_at AT TIME ZONE 'UTC')::date" +
+		" ELSE 'activity:' || " + alias + ".id::text END"
 }
 
 // ParticipantKindSQLList renders the participant set for the backfill, which

--- a/backend/internal/shared/kernel/relstrength/relstrength.go
+++ b/backend/internal/shared/kernel/relstrength/relstrength.go
@@ -9,10 +9,16 @@
 // questions. PO-F-3 asks how warm a contact is to the WORKSPACE, folding
 // every activity linked to them. PO-F-3b asks how warm they are to ONE
 // COLLEAGUE, folding only the interactions that colleague was actually in
-// (ADR-0078). Same half-life, same saturation point, same reciprocity floor —
-// two scores a user will see side by side on the same screen, so a constant
-// tuned in one copy and not the other is a visible contradiction, not a
-// rounding difference.
+// (ADR-0078). Same half-life, same saturation point, same reciprocity floor,
+// and the same counting unit — two scores a user will see side by side on the
+// same screen, so a constant tuned in one copy and not the other is a visible
+// contradiction, not a rounding difference. The unit is on that list because
+// the two gather from different tables — the workspace score from
+// activity_link, the colleague score from activity_participant — and one unit
+// across both is what keeps a chat-only relationship from reading as warm on
+// the one and as never having spoken on the other.
+// Held by: TestEveryInteractionCountReadsTheSharedUnit
+// (backend/gates/interactionunit_test.go).
 //
 // The package holds no query and no storage. Callers gather counts however
 // their question requires and hand them here; that separation is what lets

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -123,7 +123,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (139)
+## Census (140)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -189,6 +189,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `gateinventory_test.go` | H3 | The gate inventory: every gate in this package declares its own shape, and the reference page listing them is rendered from those declarations. |
 | `governedkindseams_test.go` | H2 | The two halves of automatic apply agree about which kinds it covers. |
 | `insertattemptcaps_test.go` | H2 | An insert that names no MaxAttempts does not run without a retry ladder — it runs on River's default of 25, on attempt-to-the-fourth backoff, which reaches days. |
+| `interactionunit_test.go` | H3 | Every count that becomes a relationship-strength number counts the shared UNIT, not rows. |
 | `jobbinding_test.go` | H2 | workspaceBindFloor guards against a vacuous pass. |
 | `jobcensus_test.go` | H3 | The census as a fitness function, in both directions. |
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |


### PR DESCRIPTION
Closes #1564.

## What was wrong

`interactionKinds` held `email`, `call`, `meeting`. The comment above it states
the membership test — a task is intent and a note is thinking, and neither means
two people spoke — and a chat message passes that test. So excluding it was an
unstated exception to the file's own rule, and an account whose whole
relationship runs over a channel read as having **no interactions at all**.

Sizing the ticket turned up something that changes its shape: **the two scores in
this package already disagreed about `message`, in the direction with no volume
protection.** The per-colleague score (PO-F-3b) is folded from
`graph_interaction_edge`, whose counts come from `search/graphedge.go`. That
query joins through `activity_participant` and carries **no kind filter at all**,
and `message` is in `participantKinds` — so a channel message already moved the
colleague score, one row per message, at full weight, while moving the workspace
score not at all. One chat-only relationship rendered as warm on the colleague
edge and as never having spoken beside it, on the same screen the package doc
says must agree.

## The unit, rather than a weight

The ticket asked for a ruling because the weighting looked like a number to tune
and measure. It is not a weight question: it is a **unit** question, and the unit
needs no constant.

An email, a call and a meeting are one interaction per row — each row is one
exchange somebody decided to have. A message is not: a conversation arrives as
dozens of one-line replies. `FreqSaturation` is 20, so counting rows lets twenty
lines typed in five minutes fill a ninety-day quota of contact. Counted **once
per conversation per day**, twenty days of talking across the quarter saturates
frequency — which is a relationship — and an afternoon of replies is one day of
one. It is also the unit a person uses out loud: "we talked on Tuesday."

`relstrength.InteractionUnitSQL` renders it, and every fold that counts
interactions now reads it: the workspace fold, the relationship-change fold, and
**both graph projections, which were counting rows**. Landing both sides in one
change rather than making the workspace score correct on its own — half of this
would leave the two disagreeing by more than they do today.

The directed counts read the same unit, so a conversation-day with traffic both
ways yields the unit under both filters and reads as balanced. `Inputs` already
documents that the two directions need not sum to the total.

UTC decides the day. The boundary only changes whether a conversation running
past midnight counts once or twice; every fixed zone is arbitrary for a workspace
spanning several, and UTC is reproducible from the stored value alone.

## What else moves

- **Deal health / engaged stakeholders** (`engagedAmong`, `EngagedStakeholders`)
  ask `EXISTS` over the kind set, not a count. A stakeholder whose two-way
  exchange happened on a channel now reads as engaged, which is the point.
- **The ghosted-thread scan** takes the newest interaction and fires when it is
  outbound. An inbound channel reply now suppresses a signal an older outbound
  email would have raised — they answered us, so the thread is not ghosted.
- `TestAMessageHasParticipantsAndIsNotScored` asserted the decision this reverses.
  It is now `TestAMessageHasParticipantsAndIsScoredByTheConversationDay`, holding
  all three halves: the room, the warmth, and the unit that makes the second safe.

## The census

`TestEveryInteractionCountReadsTheSharedUnit` (`gates/interactionunit_test.go`).
A count in a qualifying statement must fold to `count(DISTINCT <unit>)`; a
`count(*)`, a `count(DISTINCT a.id)`, or a locally re-spelled unit is reported.
Only a var assigned from `relstrength.InteractionUnitSQL` resolves to the
sentinel the census reads, so a second copy of the expression fails.

The corpus is derived from both sides, because neither arm can see the other's
statements: the tables that store a `count_90d` **at schema head**, and the
rendered scoring kind group. The gate asserts both arms matched something — a
first draft read `0001_baseline.up.sql` for the table names, could not see
`graph_contact_edge` (added by a later migration), and reported PASS over a
counter that was counting rows.

One waiver: `org360/graphourside.go`'s `count(*) FROM colleagues`, which counts
colleagues rather than interactions.

## Checks

- `make check-backend` green.
- `craft static --strict` over the diff: 0 blocker, 0 major, 0 minor.
- `go test -count=1 ./gates` green.
- Integration lanes: `people`, `search`, `deals`, `compose`, `compose/org360`,
  `compose/network`.
- New integration tests seed real rows and assert the raw row count first, so a
  fold returning a small number because nothing was written cannot pass as a
  fold that collapsed. Mutation-checked twice: `count(*)` in place of the unit
  fails every assertion (6/3/3 and 4/4 instead of 2/1/2 and 2/2), and removing
  `message` from the kind set fails them the other way (1/0/1 and 0/0).