### PR TITLE
fix(compose): a mailed card's staging fault no longer costs its siblings their own review

### DIFF
--- a/backend/internal/compose/vcardingest.go
+++ b/backend/internal/compose/vcardingest.go
@@ -169,7 +169,7 @@ func (w *vcardIngestWorker) importCards(ctx context.Context, args VCardIngestArg
 			"activity", args.Activity, "card", r.Index+1,
 			"outcome", string(r.Outcome), "reason", r.Reason)
 	}
-	return w.stageReviews(actorCtx, entries, results)
+	return w.stageReviews(actorCtx, args.Activity, entries, results)
 }
 
 // stageReviews turns every near-match into a proposal a human can decide.
@@ -178,42 +178,37 @@ func (w *vcardIngestWorker) importCards(ctx context.Context, args VCardIngestArg
 // and that verdict is only worth having if the question outlives the import. The
 // browser upload stages each one; without this the mailed path would log the
 // same verdict and drop it, so a contact who posted their card is never created
-// and nothing ever reaches a queue — the exact silence this feature exists to
-// end, reintroduced one branch deeper.
+// and nothing ever reaches a queue.
 //
 // The stager is self-only and takes the ACTING principal as the proposal's
 // subject, which here is the mailbox's granting human. That is the right
 // reviewer: the card arrived in their mailbox.
-func (w *vcardIngestWorker) stageReviews(ctx context.Context, entries []people.VCardEntry, results []people.VCardResult) error {
-	return stageReviewsWith(ctx, w.log, vcardCreateStager(w.pool), entries, results)
+func (w *vcardIngestWorker) stageReviews(ctx context.Context, activity ids.UUID, entries []people.VCardEntry, results []people.VCardResult) error {
+	return stageReviewsWith(ctx, w.log, activity, vcardCreateStager(w.pool), entries, results)
 }
 
 // stageReviewsWith is stageReviews against an injected stager, so a test can
 // make one card's stage fail without needing a real staging conflict — what
 // is under test is the aggregation below, not vcardCreateStager's own SQL.
 //
-// EVERY ELIGIBLE CARD GETS ITS OWN ATTEMPT, one card's staging fault does not
-// cost its siblings in the same message their own review. ImportVCards
-// (people/vcardimport.go) already keeps this promise one step earlier — "a
-// file of forty cards with one bad row should import thirty-nine people" —
-// and this used to break it again one step later: the first staging fault
-// returned immediately, so a message with two near-matches lost the SECOND
-// one's review to the first one's failure, and the whole job with it. Nobody
-// is watching this job's own report to notice an early return the way an
-// upload's reader watches theirs.
+// Every eligible card gets its own attempt: one card's staging fault must not
+// cost its siblings in the same message their own review, the way ImportVCards
+// already holds for the import itself.
 //
 // A card that failed is still worth a retry — the fault may be the database,
-// not the data — so the aggregate error is returned when any card failed,
-// and River still retries the whole message against vcardIngestMaxAttempts.
-// What changed is that a retry (or the log line below, read after the fact)
-// no longer has to explain why cards that staged fine on attempt one are
-// simply missing.
+// not the data — so the aggregate error is returned when any card failed, and
+// River still retries the whole message against vcardIngestMaxAttempts. It
+// wraps every card's error with errors.Join rather than reporting only the
+// count: Work classifies this error by errors.Is (ErrPermissionDenied,
+// ErrNotFound mean "not a fault, do not retry"), and a plain count would make
+// every staging failure look like a fault regardless of what actually failed.
 func stageReviewsWith(
-	ctx context.Context, log *slog.Logger,
+	ctx context.Context, log *slog.Logger, activity ids.UUID,
 	stage func(ctx context.Context, entry people.VCardEntry, candidate *ids.PersonID) error,
 	entries []people.VCardEntry, results []people.VCardResult,
 ) error {
-	var eligible, failed int
+	var eligible int
+	var failures []error
 	for _, r := range results {
 		// The index is ImportVCards' own position in the slice it was handed, so
 		// the bound is a belt on a contract that already holds — but a panic in
@@ -224,13 +219,13 @@ func stageReviewsWith(
 		eligible++
 		if err := stage(ctx, entries[r.Index], r.PersonID); err != nil {
 			log.ErrorContext(ctx, "a card attached to captured mail could not be staged for review",
-				"card", r.Index+1, "err", err)
-			failed++
-			continue
+				"activity", activity, "card", r.Index+1, "err", err)
+			failures = append(failures, err)
 		}
 	}
-	if failed > 0 {
-		return fmt.Errorf("compose: staging %d of %d mailed cards for review", failed, eligible)
+	if len(failures) > 0 {
+		return fmt.Errorf("compose: staging %d of %d mailed cards for review: %w",
+			len(failures), eligible, errors.Join(failures...))
 	}
 	return nil
 }

--- a/backend/internal/compose/vcardingest.go
+++ b/backend/internal/compose/vcardingest.go
@@ -185,7 +185,35 @@ func (w *vcardIngestWorker) importCards(ctx context.Context, args VCardIngestArg
 // subject, which here is the mailbox's granting human. That is the right
 // reviewer: the card arrived in their mailbox.
 func (w *vcardIngestWorker) stageReviews(ctx context.Context, entries []people.VCardEntry, results []people.VCardResult) error {
-	stage := vcardCreateStager(w.pool)
+	return stageReviewsWith(ctx, w.log, vcardCreateStager(w.pool), entries, results)
+}
+
+// stageReviewsWith is stageReviews against an injected stager, so a test can
+// make one card's stage fail without needing a real staging conflict — what
+// is under test is the aggregation below, not vcardCreateStager's own SQL.
+//
+// EVERY ELIGIBLE CARD GETS ITS OWN ATTEMPT, one card's staging fault does not
+// cost its siblings in the same message their own review. ImportVCards
+// (people/vcardimport.go) already keeps this promise one step earlier — "a
+// file of forty cards with one bad row should import thirty-nine people" —
+// and this used to break it again one step later: the first staging fault
+// returned immediately, so a message with two near-matches lost the SECOND
+// one's review to the first one's failure, and the whole job with it. Nobody
+// is watching this job's own report to notice an early return the way an
+// upload's reader watches theirs.
+//
+// A card that failed is still worth a retry — the fault may be the database,
+// not the data — so the aggregate error is returned when any card failed,
+// and River still retries the whole message against vcardIngestMaxAttempts.
+// What changed is that a retry (or the log line below, read after the fact)
+// no longer has to explain why cards that staged fine on attempt one are
+// simply missing.
+func stageReviewsWith(
+	ctx context.Context, log *slog.Logger,
+	stage func(ctx context.Context, entry people.VCardEntry, candidate *ids.PersonID) error,
+	entries []people.VCardEntry, results []people.VCardResult,
+) error {
+	var eligible, failed int
 	for _, r := range results {
 		// The index is ImportVCards' own position in the slice it was handed, so
 		// the bound is a belt on a contract that already holds — but a panic in
@@ -193,9 +221,16 @@ func (w *vcardIngestWorker) stageReviews(ctx context.Context, entries []people.V
 		if r.Outcome != people.VCardNeedsReview || r.Index < 0 || r.Index >= len(entries) {
 			continue
 		}
+		eligible++
 		if err := stage(ctx, entries[r.Index], r.PersonID); err != nil {
-			return fmt.Errorf("compose: staging a mailed card for review: %w", err)
+			log.ErrorContext(ctx, "a card attached to captured mail could not be staged for review",
+				"card", r.Index+1, "err", err)
+			failed++
+			continue
 		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("compose: staging %d of %d mailed cards for review", failed, eligible)
 	}
 	return nil
 }

--- a/backend/internal/compose/vcardingest_test.go
+++ b/backend/internal/compose/vcardingest_test.go
@@ -6,6 +6,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/riverqueue/river"
@@ -28,32 +29,79 @@ func TestVCardIngestDeclaresABoundedRetryLadder(t *testing.T) {
 	}
 }
 
-// TestAFailedStageDoesNotCostItsSiblingsTheirOwnReview — margince#3410's
-// remaining half: a mailed message carrying two near-matches used to lose
-// the second card's review to the first one's staging fault, and the whole
-// job with it. Both cards must get their own attempt regardless of order.
+// TestAFailedStageDoesNotCostItsSiblingsTheirOwnReview: a mailed message
+// carrying two near-matches used to lose the second card's review to the
+// first one's staging fault, and the whole job with it. Both cards must get
+// their own attempt regardless of which one fails.
 func TestAFailedStageDoesNotCostItsSiblingsTheirOwnReview(t *testing.T) {
 	entries := []people.VCardEntry{{FullName: "Broken Card"}, {FullName: "Fine Card"}}
 	results := []people.VCardResult{
 		{Index: 0, Outcome: people.VCardNeedsReview},
 		{Index: 1, Outcome: people.VCardNeedsReview},
 	}
-	var staged []int
+	var attempts int
 	failing := errors.New("a staging conflict a test forced")
 	stage := func(_ context.Context, entry people.VCardEntry, _ *ids.PersonID) error {
-		staged = append(staged, len(staged))
+		attempts++
 		if entry.FullName == "Broken Card" {
 			return failing
 		}
 		return nil
 	}
 
-	err := stageReviewsWith(context.Background(), quietTestLogger(), stage, entries, results)
+	err := stageReviewsWith(context.Background(), quietTestLogger(), ids.UUID{}, stage, entries, results)
 	if err == nil {
 		t.Fatal("a batch with one failed card returned no error — nothing would tell River to retry it")
 	}
-	if len(staged) != 2 {
-		t.Fatalf("stage was called %d times, want 2 — the second card must get its own attempt regardless of the first's outcome", len(staged))
+	if !errors.Is(err, failing) {
+		t.Fatalf("aggregate error does not wrap the card's own error: %v — Work classifies retryability by errors.Is", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("stage was called %d times, want 2 — the second card must get its own attempt regardless of the first's outcome", attempts)
+	}
+}
+
+// TestAFailedStageDoesNotCostItsSiblingsTheirOwnReview's mirror: the failure
+// lands on the SECOND card, so a bug that only kept going after a successful
+// attempt (rather than after any attempt) would still pass the first test.
+func TestALaterCardsFailureDoesNotSkipAnEarlierCardsAttempt(t *testing.T) {
+	entries := []people.VCardEntry{{FullName: "Fine Card"}, {FullName: "Broken Card"}}
+	results := []people.VCardResult{
+		{Index: 0, Outcome: people.VCardNeedsReview},
+		{Index: 1, Outcome: people.VCardNeedsReview},
+	}
+	var attempts int
+	stage := func(_ context.Context, entry people.VCardEntry, _ *ids.PersonID) error {
+		attempts++
+		if entry.FullName == "Broken Card" {
+			return errors.New("a staging conflict a test forced")
+		}
+		return nil
+	}
+
+	if err := stageReviewsWith(context.Background(), quietTestLogger(), ids.UUID{}, stage, entries, results); err == nil {
+		t.Fatal("a batch with one failed card returned no error — nothing would tell River to retry it")
+	}
+	if attempts != 2 {
+		t.Fatalf("stage was called %d times, want 2", attempts)
+	}
+}
+
+// TestEveryCardFailingNamesTheFullCount — the aggregate error's count must
+// track every failure, not just whether at least one occurred.
+func TestEveryCardFailingNamesTheFullCount(t *testing.T) {
+	entries := []people.VCardEntry{{FullName: "First"}, {FullName: "Second"}}
+	results := []people.VCardResult{
+		{Index: 0, Outcome: people.VCardNeedsReview},
+		{Index: 1, Outcome: people.VCardNeedsReview},
+	}
+	stage := func(context.Context, people.VCardEntry, *ids.PersonID) error {
+		return errors.New("a staging conflict a test forced")
+	}
+
+	err := stageReviewsWith(context.Background(), quietTestLogger(), ids.UUID{}, stage, entries, results)
+	if err == nil || !strings.Contains(err.Error(), "staging 2 of 2") {
+		t.Fatalf("got %v, want an error naming both cards failed", err)
 	}
 }
 
@@ -65,7 +113,7 @@ func TestStageReviewsSucceedsWhenEveryCardStages(t *testing.T) {
 	results := []people.VCardResult{{Index: 0, Outcome: people.VCardNeedsReview}}
 	stage := func(context.Context, people.VCardEntry, *ids.PersonID) error { return nil }
 
-	if err := stageReviewsWith(context.Background(), quietTestLogger(), stage, entries, results); err != nil {
+	if err := stageReviewsWith(context.Background(), quietTestLogger(), ids.UUID{}, stage, entries, results); err != nil {
 		t.Fatalf("every card staged cleanly, want no error, got: %v", err)
 	}
 }
@@ -82,7 +130,7 @@ func TestStageReviewsSkipsCardsThatDoNotNeedReview(t *testing.T) {
 		return nil
 	}
 
-	if err := stageReviewsWith(context.Background(), quietTestLogger(), stage, entries, results); err != nil {
+	if err := stageReviewsWith(context.Background(), quietTestLogger(), ids.UUID{}, stage, entries, results); err != nil {
 		t.Fatalf("no eligible card, want no error, got: %v", err)
 	}
 	if called {

--- a/backend/internal/compose/vcardingest_test.go
+++ b/backend/internal/compose/vcardingest_test.go
@@ -4,9 +4,14 @@
 package compose
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/riverqueue/river"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // The insert carries the declared constant, and that constant is itself a
@@ -20,5 +25,67 @@ func TestVCardIngestDeclaresABoundedRetryLadder(t *testing.T) {
 	}
 	if got <= 0 || got >= river.MaxAttemptsDefault {
 		t.Fatalf("MaxAttempts = %d, want a positive bound well below River's own default of %d", got, river.MaxAttemptsDefault)
+	}
+}
+
+// TestAFailedStageDoesNotCostItsSiblingsTheirOwnReview — margince#3410's
+// remaining half: a mailed message carrying two near-matches used to lose
+// the second card's review to the first one's staging fault, and the whole
+// job with it. Both cards must get their own attempt regardless of order.
+func TestAFailedStageDoesNotCostItsSiblingsTheirOwnReview(t *testing.T) {
+	entries := []people.VCardEntry{{FullName: "Broken Card"}, {FullName: "Fine Card"}}
+	results := []people.VCardResult{
+		{Index: 0, Outcome: people.VCardNeedsReview},
+		{Index: 1, Outcome: people.VCardNeedsReview},
+	}
+	var staged []int
+	failing := errors.New("a staging conflict a test forced")
+	stage := func(_ context.Context, entry people.VCardEntry, _ *ids.PersonID) error {
+		staged = append(staged, len(staged))
+		if entry.FullName == "Broken Card" {
+			return failing
+		}
+		return nil
+	}
+
+	err := stageReviewsWith(context.Background(), quietTestLogger(), stage, entries, results)
+	if err == nil {
+		t.Fatal("a batch with one failed card returned no error — nothing would tell River to retry it")
+	}
+	if len(staged) != 2 {
+		t.Fatalf("stage was called %d times, want 2 — the second card must get its own attempt regardless of the first's outcome", len(staged))
+	}
+}
+
+// TestStageReviewsSucceedsWhenEveryCardStages — the ordinary case still
+// answers cleanly, so the aggregate-error path above is additive rather
+// than a permanent fault where none existed before.
+func TestStageReviewsSucceedsWhenEveryCardStages(t *testing.T) {
+	entries := []people.VCardEntry{{FullName: "Fine Card"}}
+	results := []people.VCardResult{{Index: 0, Outcome: people.VCardNeedsReview}}
+	stage := func(context.Context, people.VCardEntry, *ids.PersonID) error { return nil }
+
+	if err := stageReviewsWith(context.Background(), quietTestLogger(), stage, entries, results); err != nil {
+		t.Fatalf("every card staged cleanly, want no error, got: %v", err)
+	}
+}
+
+// TestStageReviewsSkipsCardsThatDoNotNeedReview — a created, updated or
+// skipped card (any outcome but VCardNeedsReview) is not a staging
+// candidate at all, and must never reach the stager.
+func TestStageReviewsSkipsCardsThatDoNotNeedReview(t *testing.T) {
+	entries := []people.VCardEntry{{FullName: "Created Card"}}
+	results := []people.VCardResult{{Index: 0, Outcome: people.VCardCreated}}
+	called := false
+	stage := func(context.Context, people.VCardEntry, *ids.PersonID) error {
+		called = true
+		return nil
+	}
+
+	if err := stageReviewsWith(context.Background(), quietTestLogger(), stage, entries, results); err != nil {
+		t.Fatalf("no eligible card, want no error, got: %v", err)
+	}
+	if called {
+		t.Error("stage was called for a card that does not need review")
 	}
 }


### PR DESCRIPTION
## Summary

- `stageReviews` returned on the first mailed card's staging error, which lost every remaining eligible card in the same message to that one card's failure and aborted the whole ingest job.
- Every eligible card now gets its own staging attempt (`stageReviewsWith`, injectable so a test can force one card's stage to fail without a real staging conflict). A failed card is logged and counted; the aggregate error still tells River to retry the whole message against `vcardIngestMaxAttempts` when any card failed — a card's fault may be the database, not the data.
- Closes margince#3410 (the mailed-path half of the cascade-failure; the ORG-less-card half was already fixed).

## Test plan

- [x] New unit test in `vcardingest_test.go` exercises `stageReviewsWith` directly: one card's stage failing does not stop a sibling card from also being staged, and the aggregate error names the failed/eligible count.
- [x] `make check-all` (backend + frontend + integration lane, real Postgres) green with 0 failures, 0 skips, on this branch rebased onto current `main`.
- No UAT video — this is a backend job-worker fix with no user-facing surface (River-queued vCard ingest worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRuXiSKkD1X1D1U5yRF4Qn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mailed vCard ingest so a staging failure on one card no longer prevents sibling cards in the same message from receiving review. Previously, the first failure aborted staging and the job; now every eligible card is attempted, and any failure still returns an aggregate error so River retries the message.

**Bug Fixes**

- Keeps each card's own error in the aggregate via `errors.Join`, so Work's `errors.Is` classification still distinguishes real faults from permission/not-found refusals instead of retrying those.
- Logs each failed card with its activity and reports the failed and eligible card counts.
- Adds tests for first- and later-card failures, successful staging, and non-review cards.
- Closes margince#3410's mailed-path cascade-failure case.

<sup>Written for commit 4b1accde8e90060c231f73b39a49d7bb33e01c6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

