### PR TITLE
fix(comms): a scheduled send carries the origin its unsubscribe link needs

### DIFF
--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -230,7 +230,11 @@ func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, cap
 		// The registry that resolves a staged delivery's mailbox: the SAME
 		// sweep registry the capture polls use, so the connector set that
 		// syncs a mailbox is the one that transmits from it.
-		SendRegistry:      captureReg,
+		SendRegistry: captureReg,
+		// The origin a fired message builds its unsubscribe link on — the same
+		// pair sendPath hands the api's immediate send, so a message scheduled
+		// for later carries the link a message sent now would.
+		SendOrigin:        compose.SendOrigin{PublicBaseURL: cfg.publicBaseURL, Environment: cfg.posture},
 		SendPacing:        compose.SendPacing{Limit: cfg.sendRateLimit, Window: cfg.sendRateWindow, MaxAge: cfg.sendMaxAge},
 		CloseDateInterval: cfg.closeDateInterval,
 		ReconcileInterval: cfg.reconcileInterval,

--- a/backend/internal/compose/commsscheduled.go
+++ b/backend/internal/compose/commsscheduled.go
@@ -112,10 +112,15 @@ type scheduledSendWorker struct {
 // immediate one is: the signature, the sender name, the unsubscribe linker and
 // the draft-outcome recorder all present, all identical. A hand-built store
 // here would be a second send path wearing the first one's name.
-func newScheduledSendWorker(pool *pgxpool.Pool, delivery DeliveryMachinery, blob blobstore.Store, pacing SendPacing) *scheduledSendWorker {
+func newScheduledSendWorker(pool *pgxpool.Pool, delivery DeliveryMachinery, blob blobstore.Store, pacing SendPacing, origin SendOrigin) *scheduledSendWorker {
 	return &scheduledSendWorker{
-		pool:      pool,
-		store:     sendStore(pool, SendPath{}).WithBlobstore(blob),
+		pool: pool,
+		// The ORIGIN travels, because a fired message builds its unsubscribe
+		// link from it. An empty send path here refuses every scheduled
+		// correspondence and marketing send at fire time while the
+		// transactional ones beside it go out — which is what it did, and what
+		// nothing noticed, because every fixture scheduled a transactional one.
+		store:     sendStore(pool, origin.sendPath()).WithBlobstore(blob),
 		authority: identity.NewService(pool),
 		consent:   consentGateFor(pool),
 		// The SAME machinery every other send stages with, handed in rather

--- a/backend/internal/compose/commsscheduled_integration.go
+++ b/backend/internal/compose/commsscheduled_integration.go
@@ -38,12 +38,15 @@ import (
 //
 // A snooze is not an error: a message whose moment has moved reports one, and
 // the lane reads the ROW to see what happened rather than the return.
-func DriveScheduledSendForTest(ctx context.Context, pool *pgxpool.Pool, workspace, id ids.UUID) error {
+func DriveScheduledSendForTest(ctx context.Context, pool *pgxpool.Pool, workspace, id ids.UUID, origin SendOrigin) error {
 	inserter, err := jobs.NewInserter(pool, slog.New(slog.DiscardHandler))
 	if err != nil {
 		return err
 	}
-	worker := newScheduledSendWorker(pool, NewDeliveryStager(pool, inserter), nil, SendPacing{})
+	// The origin the worker role composes. Without it this harness assembles a
+	// worker production does not have, and a message carrying an unsubscribe
+	// link refuses here for a reason no deployment would hit.
+	worker := newScheduledSendWorker(pool, NewDeliveryStager(pool, inserter), nil, SendPacing{}, origin)
 	err = worker.Work(ctx, &river.Job[ScheduledSendArgs]{
 		JobRow: &rivertype.JobRow{Attempt: 1, MaxAttempts: scheduledSendMaxAttempts},
 		Args:   ScheduledSendArgs{Workspace: workspace, ScheduledSendID: id.String()},
@@ -60,8 +63,8 @@ func DriveScheduledSendForTest(ctx context.Context, pool *pgxpool.Pool, workspac
 // HoldScheduledSendForTest drives the store's hold under an observed row
 // version, standing in for a worker whose attempt failed and is now holding
 // what it saw. The lane needs it to prove a STALE observation declines.
-func HoldScheduledSendForTest(ctx context.Context, pool *pgxpool.Pool, workspace, id ids.UUID, reason string, observed int64) error {
-	store := sendStore(pool, SendPath{})
+func HoldScheduledSendForTest(ctx context.Context, pool *pgxpool.Pool, workspace, id ids.UUID, reason string, observed int64, origin SendOrigin) error {
+	store := sendStore(pool, origin.sendPath())
 	return store.HoldScheduledSend(sendWorkerScope(principal.WithWorkspaceID(ctx, workspace)), id, reason, observed)
 }
 
@@ -81,12 +84,13 @@ func ScheduleAsAgentForTest(
 	anchor ids.ActivityID,
 	in activities.SendEmailInput,
 	at time.Time,
+	origin SendOrigin,
 ) (activities.SendOutcome, error) {
 	inserter, err := jobs.NewInserter(pool, slog.New(slog.DiscardHandler))
 	if err != nil {
 		return activities.SendOutcome{}, err
 	}
-	store := sendStore(pool, SendPath{})
+	store := sendStore(pool, origin.sendPath())
 	agentCtx := principal.WithCorrelationID(
 		principal.WithActor(principal.WithWorkspaceID(ctx, workspace), actor), ids.NewV7())
 	return store.SendOrSchedule(agentCtx, activities.FromActivity(anchor), in,
@@ -102,13 +106,13 @@ func ScheduleAsAgentForTest(
 // tenant, so a helper that supplied one would prove the HELPER works while
 // production resolved nothing. The worker resolves the installation itself,
 // which is the behaviour under test.
-func DriveScheduledSendRecoveryForTest(ctx context.Context, pool *pgxpool.Pool) error {
+func DriveScheduledSendRecoveryForTest(ctx context.Context, pool *pgxpool.Pool, origin SendOrigin) error {
 	inserter, err := jobs.NewInserter(pool, slog.New(slog.DiscardHandler))
 	if err != nil {
 		return err
 	}
 	worker := newScheduledSendRecoveryWorker(
-		identity.NewService(pool), sendStore(pool, SendPath{}), NewScheduleTimer(inserter), slog.New(slog.DiscardHandler))
+		identity.NewService(pool), sendStore(pool, origin.sendPath()), NewScheduleTimer(inserter), slog.New(slog.DiscardHandler))
 	return worker.Work(ctx, &river.Job[ScheduledSendRecoveryArgs]{
 		JobRow: &rivertype.JobRow{Attempt: 1, MaxAttempts: 1},
 	})

--- a/backend/internal/compose/integration/scheduledsend_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsend_integration_test.go
@@ -194,7 +194,7 @@ func (p *preflightEnv) countDeliveries(t *testing.T) int {
 func (p *preflightEnv) fire(t *testing.T, id ids.UUID) {
 	t.Helper()
 	ws := p.workspaceID(t)
-	if err := compose.DriveScheduledSendForTest(context.Background(), p.Pool, ws, id); err != nil {
+	if err := compose.DriveScheduledSendForTest(context.Background(), p.Pool, ws, id, compose.SendOrigin{PublicBaseURL: preflightBaseURL}); err != nil {
 		t.Fatalf("driving the scheduled-send timer: %v", err)
 	}
 }
@@ -492,7 +492,8 @@ func (p *preflightEnv) rowVersion(t *testing.T, id ids.UUID) int64 {
 // for a worker whose attempt failed and is now holding what it saw.
 func (p *preflightEnv) holdAs(t *testing.T, id ids.UUID, reason string, observed int64) error {
 	t.Helper()
-	return compose.HoldScheduledSendForTest(context.Background(), p.Pool, p.workspaceID(t), id, reason, observed)
+	return compose.HoldScheduledSendForTest(context.Background(), p.Pool, p.workspaceID(t), id, reason, observed,
+		compose.SendOrigin{PublicBaseURL: preflightBaseURL})
 }
 
 // runRecovery drives the recovery pass once, through the production worker on
@@ -500,7 +501,7 @@ func (p *preflightEnv) holdAs(t *testing.T, id ids.UUID, reason string, observed
 // and a helper that supplied one would prove only that the helper works.
 func (p *preflightEnv) runRecovery(t *testing.T) error {
 	t.Helper()
-	return compose.DriveScheduledSendRecoveryForTest(context.Background(), p.Pool)
+	return compose.DriveScheduledSendRecoveryForTest(context.Background(), p.Pool, compose.SendOrigin{PublicBaseURL: preflightBaseURL})
 }
 
 // releasedActivity reads the activity a fired scheduled send produced.

--- a/backend/internal/compose/integration/scheduledsendagent_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendagent_integration_test.go
@@ -50,7 +50,7 @@ func (p *preflightEnv) scheduleAsAgent(t *testing.T, actor principal.Principal, 
 			Subject:        "Monday morning",
 			Body:           "Written the night before, by a tool.",
 			ConsentPurpose: "transactional",
-		}, at)
+		}, at, compose.SendOrigin{PublicBaseURL: preflightBaseURL})
 	if err != nil {
 		t.Fatalf("scheduling as an agent: %v", err)
 	}

--- a/backend/internal/compose/integration/scheduledsendorigin_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendorigin_integration_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The origin a scheduled message's unsubscribe link is built on.
+//
+// Split from the scheduled-send suite because it is about a different thing:
+// that suite asks when a message fires and who it is attributed to, and this
+// asks what the worker was composed WITH. The distinction is what the lane was
+// missing — every case there claims the one purpose that needs no link, so the
+// worker's send path was never asked for an origin and a missing one passed.
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// A scheduled message that CARRIES an unsubscribe link fires.
+//
+// This is the case the whole lane was missing. Every other scheduled-send
+// fixture claims the transactional purpose, which needs no link — so the lane
+// exercised the one shape that cannot reach the origin, and the worker composed
+// with none passed everything. A fixture that always picks the cheap option is
+// a census of one.
+//
+// The link is built from the installation's public base URL, and an empty one
+// refuses rather than emitting a forgeable address. Without the origin on the
+// worker's send path that refusal is what a marketing or correspondence message
+// meets at fire time, in production, having been accepted at schedule time.
+func TestAScheduledMessageCarryingAnUnsubscribeLinkStillFires(t *testing.T) {
+	p := setupPreflight(t)
+	// Without the send grant the schedule refuses at the pre-flight, and this
+	// case would fail before it reached the origin it is about.
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+	p.seedConsentedRecipient(t, "Link Recipient", "linked@preflight.test")
+	// The recipient wrote to us first, which is the qualifying event a
+	// correspondence send derives its basis from. The purpose matters here only
+	// because business_correspondence CARRIES a one-click unsubscribe link,
+	// which is the whole subject: the link is what needs an origin to point at.
+	var person struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if status := p.Call(t, "GET", "/v1/people?q=linked@preflight.test", nil, nil, &person); status != http.StatusOK || len(person.Data) == 0 {
+		t.Fatalf("finding the seeded recipient → %d (%d rows)", status, len(person.Data))
+	}
+	if status := p.Call(t, "POST", "/v1/activities", AnyMap{
+		"kind": "email", "subject": "Inbound question", "direction": "inbound",
+		"links": []AnyMap{{"entity_type": "person", "entity_id": person.Data[0].ID}},
+	}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("logging the inbound the reply answers → %d", status)
+	}
+
+	var scheduled struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
+		"subject": "Re: your question", "body": "Written the night before.",
+		"to": []string{"linked@preflight.test"}, "consent_purpose": "business_correspondence",
+		"scheduled_at": time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
+		"scheduled_tz": "Europe/Berlin",
+	}, nil, &scheduled)
+	if status != http.StatusCreated {
+		t.Fatalf("scheduling a link-carrying message → %d, want 201", status)
+	}
+	id, err := ids.Parse(scheduled.ID)
+	if err != nil {
+		t.Fatalf("scheduling returned no id: %v", err)
+	}
+
+	p.makeDue(t, id)
+	p.fire(t, id)
+
+	if state, reason := p.scheduledStatus(t, id); state != activities.ScheduledStatusReleased {
+		t.Fatalf("a link-carrying message fired to %q (%q), want released — the worker's send path carries no public origin, so the link it must build has nowhere to point",
+			state, reason)
+	}
+}

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -118,6 +118,16 @@ type JobRunnerConfig struct {
 	// delivery and its dispatch job, and a role that cannot do that would only
 	// wake a message to fail it.
 	SendDelivery DeliveryMachinery
+	// SendOrigin is the installation's public base URL and the posture it is
+	// judged under — the same pair the api's send path carries.
+	//
+	// A fired message that carries a one-click unsubscribe link builds it from
+	// this. Empty refuses that send rather than emitting a forgeable link,
+	// which means an unset origin does not disable a feature: it makes every
+	// scheduled correspondence and marketing message fail at fire time, while
+	// the transactional ones beside them go out. No worker is gated on it,
+	// because a role that can fire a link-less message should still fire it.
+	SendOrigin SendOrigin
 
 	// CloseDateInterval is the deals close-date hygiene sweep's cadence — the
 	// operator-facing --close-date-interval. No worker is gated on it: the

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -100,7 +100,7 @@ func addCapturePipelineJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerC
 		// machinery exists — a role that cannot send cannot fire either.
 		if cfg.SendDelivery != nil {
 			addDeclaredWorker[ScheduledSendArgs](reg,
-				newScheduledSendWorker(pool, cfg.SendDelivery, cfg.SendBlob, cfg.SendPacing))
+				newScheduledSendWorker(pool, cfg.SendDelivery, cfg.SendBlob, cfg.SendPacing, cfg.SendOrigin))
 		}
 	}
 

--- a/backend/internal/compose/scheduledsendrecovery.go
+++ b/backend/internal/compose/scheduledsendrecovery.go
@@ -139,6 +139,6 @@ func addScheduledSendRecoveryJob(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRu
 		return nil
 	}
 	addDeclaredWorker[ScheduledSendRecoveryArgs](reg, newScheduledSendRecoveryWorker(
-		identity.NewService(pool), sendStore(pool, SendPath{}), NewScheduleTimer(inserter), log))
+		identity.NewService(pool), sendStore(pool, cfg.SendOrigin.sendPath()), NewScheduleTimer(inserter), log))
 	return periodicFor(cfg, ScheduledSendRecoveryArgs{})
 }

--- a/backend/internal/compose/sendorigin.go
+++ b/backend/internal/compose/sendorigin.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The public origin a send builds its links on, carried to the roles that fire
+// one.
+//
+// SendPath already holds this pair for the api's immediate send. The scheduled
+// worker is composed from JobsConfig rather than from a SendPath, so the pair
+// travels on its own rather than by handing the whole send path to a role that
+// needs two fields of it — and it stays a PAIR, because a base URL judged under
+// the wrong posture is the failure netguard exists to catch: a loopback origin
+// is a working dev stack or a link the recipient cannot open, and only the
+// environment says which.
+
+import "github.com/margince/margince/backend/internal/shared/runtimeenv"
+
+// SendOrigin is the installation's public base URL and the posture it is judged
+// under. The zero value is an unconfigured origin in production posture, which
+// is the direction that fails safe.
+type SendOrigin struct {
+	PublicBaseURL string
+	Environment   runtimeenv.Environment
+}
+
+// sendPath renders the origin as the send path a store is built from. Spelled
+// here so the two fields cannot be copied across one at a time.
+func (o SendOrigin) sendPath() SendPath {
+	return SendPath{PublicBaseURL: o.PublicBaseURL, Environment: o.Environment}
+}


### PR DESCRIPTION
Closes the production half of #5153.

## The bug

`newScheduledSendWorker` composed `sendStore(pool, SendPath{})` — an **empty** send path. So `PublicBaseURL` was `""`, and any fired message carrying a one-click unsubscribe link refused at fire time:

```
comms_scheduled_send: firing 01a0858f-…: send: public base URL is not configured
```

`SendPath.PublicBaseURL`'s own doc says what empty means:

> Empty means a marketing send refuses (the store's fail-loud branch) rather than emitting a forgeable link.

**This is the production worker.** `jobs_capture.go:103` composes it the same way; so does the recovery pass, and three test seams. A scheduled correspondence or marketing message has been accepted at schedule time and refused at fire time.

## Why nothing caught it

Every scheduled-send fixture claims the **transactional** purpose, which needs no link. So the whole scheduled lane was exercised in the one shape that cannot reach the origin, and a worker composed with none passed everything.

The corpus is not narrowed and the detection is not blind — the lane simply only ever asked the question in the shape that cannot fail. A fixture that always picks the cheap option is a census of one.

## The fix

`JobsConfig` gains a `SendOrigin` carrying the base URL and the posture as a **pair** — netguard needs both to tell a working dev stack from a link the recipient cannot open, and a base judged under the wrong posture is the failure it exists to catch. `cmd/worker` populates it from `--public-base-url`: the same value `sendPath` already hands the api's immediate send, so a message scheduled for later carries the link a message sent now would.

The three test seams take it too. Each claimed **in its own doc** to assemble the worker "the way the worker role assembles it", and that was true in the wrong direction — they were composing something production does not have.

## The case the lane was missing

`TestAScheduledMessageCarryingAnUnsubscribeLinkStillFires`, in its own file because it asks a different question from the suite it came out of: not when a message fires or who it is attributed to, but what the worker was composed **with**.

Mutation-verified, and the split is the whole point:

```
restore sendStore(pool, SendPath{}):
--- PASS: TestAScheduledMessageWritesNothingUntilItFires          ← transactional, unaffected
--- FAIL: TestAScheduledMessageCarryingAnUnsubscribeLinkStillFires
```

The transactional case passing under the mutation is exactly why this survived.

## Not fixed here

`heldSendActors` stays on #5153. An approved held message is re-armed through it and composes an empty `SendPath` too, but threading an origin there crosses the approvals composition — `approvalsServiceWithEffects` takes a pool alone and is called from server, signals, LinkedIn and attention wiring. That is a change of its own.

## Verification

`make check-go`, `make craft-static` green; `internal/compose/integration` green (194s).

Supersedes #5166, which I opened when `main` was red — the fixtures there landed via #5152 and this is the half that did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC