### PR TITLE
feat(frontend): the agent panel says what the agent can reach

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1874,6 +1874,30 @@ test.describe("§3.8: 390px mobile", () => {
     await expectNoAaViolations(page, "brief — the agent's panel (390px)");
   });
 
+  // AC-shell-8, restated against the taskbar. It described the record-scoped Ask
+  // composer on a floating button, which the agent surfaces no longer offer —
+  // but the sentence that button carried is a promise about what the agent can
+  // REACH, and row scope still bounds it. Deleting the control deleted the
+  // promise from the product and left the property in place, which is the wrong
+  // direction: a guarantee nobody is told about is one nobody can rely on.
+  //
+  // So the criterion is now about the claim rather than about its container,
+  // and it is asserted on the surface a reader meets the agent on.
+  test("AC-shell-8: the agent's panel states what the agent can reach", async ({
+    page,
+  }) => {
+    await page.goto("/#/brief");
+    await page.waitForLoadState("networkidle");
+    await expectShellRendered(page);
+
+    await page.getByRole("button", { name: "Expand the agent panel" }).click();
+    await expect(
+      page
+        .locator(".arpanel")
+        .getByText("Ihr Agent liest nur das, was Sie sehen können."),
+    ).toBeVisible();
+  });
+
   // The whole keyboard path this surface has: it opens from the bar, Escape
   // closes it from inside, and focus lands back on the control that opened it
   // rather than on <body> — from where the next Tab starts at the top of a page

--- a/frontend/src/app/agentrail-edgelight.tsx
+++ b/frontend/src/app/agentrail-edgelight.tsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { Switch } from "../design-system/switch";
+import { setEdgeLightShown, useEdgeLightShown } from "./agent-edge-preference";
+import { LABELS } from "./agentrail-copy";
+
+/**
+ * The panel's foot: whether the window's own margins light while the agent
+ * works.
+ *
+ * It belongs to the agent rather than to the settings screen because it is a
+ * reading of the agent, and the panel is where a person is already looking at
+ * that reading — a preference about a surface you can see from here is one you
+ * should be able to answer from here. It is also the only control on this
+ * panel, which is why the foot carries nothing else: everything above it
+ * REPORTS, and a second verb down here would blur what the surface is for.
+ *
+ * The margin is decoration with a job (`agent-edge.tsx`), and turning it off
+ * costs a reader nothing they cannot get in words: the block above says what
+ * the agent is doing, in a sentence, whether or not the window is lit. So this
+ * needs no warning and no confirmation — it is a preference, not a trade.
+ *
+ * A `Switch` rather than a `Checkbox` because flipping it IS the write: the
+ * margins go dark on the flip and the browser remembers, with no Save anywhere
+ * on this surface to press.
+ */
+export function EdgeLightSetting() {
+  const shown = useEdgeLightShown();
+  return (
+    <div className="arfoot">
+      <Switch
+        label={LABELS.edgeLight}
+        checked={shown}
+        onChange={setEdgeLightShown}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -912,6 +912,13 @@
   border-top: 1px solid var(--borderSubtle);
 }
 
+/* The scope claim, above the runtime rows it shares the strip with. It keeps
+   the strip's small-print size and takes air under it so it reads as its own
+   sentence rather than as the first of the rows. */
+.arclaim {
+  margin: 0 0 var(--space-2);
+}
+
 /* ===== The foot =====
  *
  * The panel's one control, at the far end of the last line: everything above it

--- a/frontend/src/app/agentrail.scope.test.tsx
+++ b/frontend/src/app/agentrail.scope.test.tsx
@@ -1,0 +1,107 @@
+/** @vitest-environment jsdom */
+
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { de } from "../i18n/de";
+import { en } from "../i18n/en";
+import { AgentRail } from "./agentrail";
+import { meFixture } from "./mefixture";
+
+// AC-shell-8, on the surface that carries it now.
+//
+// The claim is a promise about what the agent can REACH — row scope bounds it
+// on the server — and it is the one line on the panel that no read produces.
+// It has been deleted once already, by a surface rewrite that moved the agent
+// from a floating button to this panel and took the sentence with it, leaving
+// the guarantee true and unstated. Nothing went red, which is why it stayed
+// gone. These assertions are the thing that goes red.
+//
+// The AC proper lives in `frontend/e2e/ac.spec.ts` beside the other shell ACs,
+// over the shipped surface. This is its fast half: it runs on every PR, where
+// the e2e lane does not, so the deletion is caught in the diff that makes it.
+//
+// They live apart from agentrail.test.tsx because that file is at the size a
+// test file may grow to.
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Every read the section makes, answered with the least the panel needs: the
+// claim is not a reading, so no answer here should be able to remove it.
+function stubApi() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      const pathname = new URL(request.url).pathname;
+      if (pathname.endsWith("/me")) {
+        return jsonResponse(meFixture({ allow: {} }));
+      }
+      if (pathname.endsWith("/me/ai-activity")) {
+        return jsonResponse({ running: [], recent: [] });
+      }
+      if (pathname.endsWith("/connectors")) {
+        return jsonResponse({ data: [] });
+      }
+      return jsonResponse({
+        data: [],
+        page: { has_more: false, next_cursor: null },
+      });
+    }),
+  );
+}
+
+async function openPanel(locale: "en" | "de") {
+  stubApi();
+  const user = userEvent.setup();
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const { container } = render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial={locale}>
+        <AgentRail route={{ screen: "deals" }} />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+  const trigger = container.querySelector(".arhit");
+  if (!trigger) throw new Error("no .arhit trigger in the rendered tree");
+  await user.click(trigger);
+  const opened = document.querySelector(".arpanel");
+  if (!opened) throw new Error("no .arpanel on the document after the click");
+  return opened;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("AC-shell-8: the agent panel states what the agent can reach", () => {
+  it("carries the scope claim", async () => {
+    const opened = await openPanel("en");
+    await waitFor(() =>
+      expect(opened.textContent).toContain(en["shell.agent.scope"]),
+    );
+  });
+
+  // A promise a reader cannot read is not a promise. The surface it replaced
+  // was English-only in its last weeks, and the sentence that states a
+  // guarantee is the last one that may be.
+  it("states it in the reader's own language", async () => {
+    const opened = await openPanel("de");
+    await waitFor(() =>
+      expect(opened.textContent).toContain(de["shell.agent.scope"]),
+    );
+    expect(de["shell.agent.scope"]).not.toBe(en["shell.agent.scope"]);
+  });
+});

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -21,7 +21,6 @@ import {
   type MarginceCoreState,
 } from "../design-system/margince-core";
 import { usePrefersReducedMotion } from "../design-system/motion";
-import { Switch } from "../design-system/switch";
 import {
   formatMoney,
   formatNumber,
@@ -33,7 +32,6 @@ import type { MessageKey } from "../i18n/en";
 import { usePendingApprovals } from "../screens/approvals.queries";
 import { useConnectors } from "../screens/connectors";
 import { useLicenseEntitlement } from "../screens/license";
-import { setEdgeLightShown, useEdgeLightShown } from "./agent-edge-preference";
 import {
   type AgentEdgeRegister,
   clearAgentEdge,
@@ -47,6 +45,7 @@ import {
   RUNNING,
   TASK_SAID,
 } from "./agentrail-copy";
+import { EdgeLightSetting } from "./agentrail-edgelight";
 import { RailLine } from "./agentrail-line";
 import { useAgentTicker } from "./agentrail-ticker";
 import { type AiActivity, useAiActivity } from "./ai-activity";
@@ -576,39 +575,6 @@ function RunSection({
   );
 }
 
-/**
- * The panel's foot: whether the window's own margins light while the agent
- * works.
- *
- * It belongs to the agent rather than to the settings screen because it is a
- * reading of the agent, and the panel is where a person is already looking at
- * that reading — a preference about a surface you can see from here is one you
- * should be able to answer from here. It is also the only control on this
- * panel, which is why the foot carries nothing else: everything above it
- * REPORTS, and a second verb down here would blur what the surface is for.
- *
- * The margin is decoration with a job (`agent-edge.tsx`), and turning it off
- * costs a reader nothing they cannot get in words: the block above says what
- * the agent is doing, in a sentence, whether or not the window is lit. So this
- * needs no warning and no confirmation — it is a preference, not a trade.
- *
- * A `Switch` rather than a `Checkbox` because flipping it IS the write: the
- * margins go dark on the flip and the browser remembers, with no Save anywhere
- * on this surface to press.
- */
-function EdgeLightSetting() {
-  const shown = useEdgeLightShown();
-  return (
-    <div className="arfoot">
-      <Switch
-        label={LABELS.edgeLight}
-        checked={shown}
-        onChange={setEdgeLightShown}
-      />
-    </div>
-  );
-}
-
 function AgentPanel({
   state,
   line,
@@ -635,6 +601,7 @@ function AgentPanel({
   frame: PanelFrame;
 }>) {
   const { locale } = useLocale();
+  const t = useT();
   return (
     <section
       className="arpanel"
@@ -734,6 +701,14 @@ function AgentPanel({
           the small print of the panel, and small print that takes a heading and
           four rows reads as more important than the counts above it. */}
       <div className="arstrip">
+        {/* The bound comes FIRST, above the runtime rows, because it is the one
+            line here that is true whatever those rows managed to read: the model
+            can be unknown and the licence unreadable, and the agent still reaches
+            no further than this reader does. It is a promise rather than a
+            reading, which is also why it is not in the strip's rows — a row
+            reports what a call answered, and nothing answered this.
+            Held by AC-shell-8. */}
+        <p className="arclaim t-sub">{t("shell.agent.scope")}</p>
         <RuntimeRows
           offline={signals.offline}
           model={model}

--- a/frontend/src/app/palette.test.tsx
+++ b/frontend/src/app/palette.test.tsx
@@ -20,8 +20,10 @@ import {
 } from "./palette";
 
 // B-EP09.5 (AC-shell-3..7) and RS-1 (live /search records + see-all)
-// acceptance. B-EP09.6 (AC-shell-8) covered the record-scoped Ask composer,
-// which the agent surfaces that carried it no longer offer.
+// acceptance. AC-shell-8 is no longer about this file: it covered the
+// record-scoped Ask composer, and now covers the claim that composer carried
+// about what the agent can reach — asserted on the panel that carries it, in
+// frontend/e2e/ac.spec.ts and agentrail.scope.test.tsx.
 
 afterEach(() => {
   cleanup();

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -209,6 +209,7 @@ export const de = {
   "shell.more": "Mehr",
   "shell.unknownPage": "Nicht gefunden",
   "shell.closeMenu": "Schließen",
+  "shell.agent.scope": "Ihr Agent liest nur das, was Sie sehen können.",
   "shell.capture.importing": "E-Mail-Verlauf wird importiert",
   "shell.capture.share": "{percent} · {scanned} von {total} Nachrichten",
   "shell.capture.count": "Bisher {scanned} Nachrichten",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -216,6 +216,12 @@ export const en = {
   "shell.more": "More",
   "shell.unknownPage": "Not found",
   "shell.closeMenu": "Close",
+  // The agent panel's one promise, as opposed to its readings: what the agent
+  // can REACH. Row scope bounds it on the server, and a guarantee nobody is
+  // told about is one nobody can rely on — "what can this thing see" is the
+  // question a person most reasonably has about an agent working over their
+  // data. Held by AC-shell-8.
+  "shell.agent.scope": "Your agent reads only what you can see.",
   "shell.capture.importing": "Importing mail history",
   "shell.capture.share": "{percent} · {scanned} of {total} messages",
   "shell.capture.count": "{scanned} messages so far",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -215,6 +215,7 @@ export const vi = {
   "shell.more": "Thêm",
   "shell.unknownPage": "Không tìm thấy",
   "shell.closeMenu": "Đóng",
+  "shell.agent.scope": "Trợ lý của bạn chỉ đọc những gì bạn xem được.",
   "shell.capture.importing": "Đang nhập lịch sử thư",
   "shell.capture.share": "{percent} · {scanned} trên {total} thư",
   "shell.capture.count": "{scanned} thư cho đến nay",


### PR DESCRIPTION
Closes #1814. Builds the ruling: restore the claim on the taskbar panel, and
restate `AC-shell-8` against it.

## The claim

The Ask FAB carried *"Your agent reads only what you can see."* The surface that
replaced it carries nothing equivalent, and the sentence appears nowhere in
`frontend/src`. So the rewrite deleted the **promise** from the product and left
the **property** in place — row scope still bounds what the agent reads. That is
the wrong direction: a guarantee nobody is told about is one nobody can rely on.

It goes on the panel, in the small-print strip and **above** the runtime rows. It
is the one line there that is true whatever those rows managed to read: the model
can be unknown and the licence unreadable, and the agent still reaches no further
than this reader does. It is a promise rather than a reading, which is also why it
is not one of the rows — a row reports what a call answered, and nothing answered
this.

**Translated**, unlike the panel's other words, which are English literals in
`agentrail-copy.ts`. A promise a reader cannot read is not a promise, and the
sentence that states a guarantee is the last one that may be English-only. It
joins the `shell.*` keys this file already reads through `t()`, in en/de/vi.

## The AC

Restated, not retired. Retiring it fixes the bookkeeping and leaves the restored
sentence **unasserted**, so the next surface rewrite removes it again exactly as
this one did and nothing goes red — which is the whole mechanism of the defect.

- `frontend/e2e/ac.spec.ts` — `AC-shell-8: the agent's panel states what the agent
  can reach`, beside the other shell ACs, over the shipped surface. That answers
  the ruling's open question about where the ACs live: they live here.
- `frontend/src/app/agentrail.scope.test.tsx` — the fast half, which runs on every
  PR where the browser lane does not, so a deletion is caught in the diff that
  makes it. Also asserts the German rendering, since the claim being readable is
  half of it being a promise.
- `palette.test.tsx`'s stale note now points at both rather than describing a
  control the product does not have.

## Two things worth flagging

**The panel's one control moved file.** `scripts/fe-file-length-waivers.txt`
freezes `agentrail.tsx` at 1571 lines and allows only shrinking, so the sentence
had to be paid for. `EdgeLightSetting` moved to `agentrail-edgelight.tsx`
unchanged — a self-contained leaf, the smallest thing in the file that leaves
without dragging anything with it. Net: 1571 → 1548.

**The e2e AC sits in the `§3.8: 390px mobile` block**, because that is the block
that opens the panel. The claim is width-independent, so this is the stricter
placement rather than a narrower one.

## Checks

- `make check-fe` green — unit, lint, typecheck (both projects), design-system
  gates, file-length ratchet.
- `playwright test -g "AC-shell-8"` green.
- Mutation-checked both. The unit tests fail on the sentence being removed. The
  e2e needed a rebuild to mean anything — `vite preview` serves `dist/`, so the
  first mutation run passed against a stale build and proved nothing; and the
  obvious mutation does not compile (`t` unused). Rebuilt, with the key swapped
  for another real one, it fails.