### PR TITLE
test(ui): the truncation spec reads the rule, not the sheet's line breaks

### DIFF
--- a/frontend/src/design-system/panel.test.tsx
+++ b/frontend/src/design-system/panel.test.tsx
@@ -343,14 +343,19 @@ describe("the panel head is one band, fixed at the height every panel shares", (
   // and only they give way: a badge or a button squeezed by a long title reads
   // as a different control.
   it("truncates the two lines and lets nothing else give way", () => {
-    const truncated =
-      /(?:^|\n)\.panel-head \.panel-title,\n\.panel-head-sub\s*\{([^}]*)\}/.exec(
-        panelCss(),
-      )?.[1] ?? "";
-    expect(truncated).toMatch(/white-space:\s*nowrap/);
-    expect(truncated).toMatch(/overflow:\s*hidden/);
-    expect(truncated).toMatch(/text-overflow:\s*ellipsis/);
-    expect(truncated).toMatch(/min-width:\s*0/);
+    const rules = cssRules(panelCss());
+    for (const selector of [".panel-head .panel-title", ".panel-head-sub"]) {
+      const declared = rules
+        .filter((rule) => rule.selector === selector)
+        .map((rule) => rule.block)
+        .join(";");
+      expect(declaredValue(declared, "white-space"), selector).toBe("nowrap");
+      expect(declaredValue(declared, "overflow"), selector).toBe("hidden");
+      expect(declaredValue(declared, "text-overflow"), selector).toBe(
+        "ellipsis",
+      );
+      expect(declaredValue(declared, "min-width"), selector).toBe("0");
+    }
 
     const stack = /(?:^|\n)\.panel-head-text\s*\{([^}]*)\}/.exec(panelCss());
     expect(stack?.[1]).toMatch(/min-width:\s*0/);


### PR DESCRIPTION
Follow-up to #5157, landing the one CodeRabbit finding that PR's auto-merge fired before it could take: the truncation spec in `panel.test.tsx` located the `.panel-head .panel-title, .panel-head-sub` rule with a regex that required the two selectors on separate lines, so a formatter joining them would have failed the test with the CSS unchanged. It now finds each selector through the file's existing `cssRules` parser and reads `white-space`, `overflow`, `text-overflow` and `min-width` by name.

Gates run locally: `pnpm vitest run src/design-system/panel.test.tsx` (19 passed), `make fe-lint`, `make fe-typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the panel truncation spec to read CSS rules through the existing parser instead of requiring selectors to appear on separate lines. This prevents formatter-only changes from breaking the test while continuing to enforce `white-space`, `overflow`, `text-overflow`, and `min-width` for both title selectors.

- Verified with the panel tests, `make fe-lint`, and `make fe-typecheck`.

<sup>Written for commit 090eb052ab6a42fa47ef8409424c09752171eca8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

