### PR TITLE
fix(consent): a confirm link answers the shape its mail promised

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7141,10 +7141,10 @@ paths:
         was opened and changes nothing else.
       responses:
         '200':
-          description: The contact's own view of their record.
+          description: 'The record card or the subscription question, per the kind discriminator.'
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ConfirmDetails' }
+              schema: { $ref: '#/components/schemas/ConfirmPage' }
         '404': { $ref: '#/components/responses/NotFound' }
     post:
       tags: [Public]
@@ -39541,14 +39541,59 @@ components:
                   DEPRECATED, kept for one release as the inverse of `can_opt_in` on unlocked purposes. Read
                   `can_opt_in` instead.
 
-    ConfirmDetails:
+    ConfirmPage:
+      description: |
+        What a confirm link answers, which depends on what the link was FOR.
+
+        A record link asks the person to check what the workspace holds about them; a consent link
+        asks one subscription question and must not disclose the record. Those are different
+        payloads and this endpoint has always returned both — the schema said only the first, so a
+        client that trusted the contract read `provenance` off a body that never carries it and
+        crashed on the subscription page.
+
+        Branch on `kind`. Adding a variant here is a contract change; adding one in the handler
+        without one is the defect this union closes.
+      oneOf:
+        - $ref: '#/components/schemas/RecordConfirmationPage'
+        - $ref: '#/components/schemas/SubscriptionConfirmationPage'
+      discriminator:
+        propertyName: kind
+        mapping:
+          record_confirmation: '#/components/schemas/RecordConfirmationPage'
+          subscription_confirmation: '#/components/schemas/SubscriptionConfirmationPage'
+
+    SubscriptionConfirmationPage:
+      type: object
+      description: |
+        The answer for a consent link: one named subscription and the person's current answer to it.
+
+        Deliberately carries NOTHING about the record. The mail said "confirm this subscription", and
+        serving the record card here would hand whoever holds the link the person's name, employer,
+        address, phone and provenance trail — wider than the mail described and wider than this
+        link's own write side allows.
+      required: [kind, purpose_key, purpose_label, state]
+      properties:
+        kind:
+          type: string
+          enum: [subscription_confirmation]
+        purpose_key:   { type: string, description: 'The subscription this link is about.' }
+        purpose_label: { type: string, description: 'Its published name, for the page to show.' }
+        state:
+          type: string
+          enum: [unknown, granted, withdrawn]
+          description: 'Their answer today, so somebody who already said yes is not asked as though they had not.'
+
+    RecordConfirmationPage:
       type: object
       description: |
         One contact's own view of what the workspace holds about them, for the no-login confirm page.
         A purpose-built projection and never the Person360 read model, which carries this workspace's
         working notes — owner, lifecycle, scores — rather than the subject's own data.
-      required: [full_name, title, company, email, phone, marketing_state, provenance]
+      required: [kind, full_name, title, company, email, phone, marketing_state, provenance]
       properties:
+        kind:
+          type: string
+          enum: [record_confirmation]
         full_name: { type: string }
         title:     { type: string }
         company:   { type: string, description: 'The current employer, read through the live employment relationship. Not correctable here.' }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3751,27 +3751,6 @@ func (e ComputedFieldKind) Valid() bool {
 	}
 }
 
-// Defines values for ConfirmDetailsMarketingState.
-const (
-	ConfirmDetailsMarketingStateGranted   ConfirmDetailsMarketingState = "granted"
-	ConfirmDetailsMarketingStateUnknown   ConfirmDetailsMarketingState = "unknown"
-	ConfirmDetailsMarketingStateWithdrawn ConfirmDetailsMarketingState = "withdrawn"
-)
-
-// Valid indicates whether the value is a known member of the ConfirmDetailsMarketingState enum.
-func (e ConfirmDetailsMarketingState) Valid() bool {
-	switch e {
-	case ConfirmDetailsMarketingStateGranted:
-		return true
-	case ConfirmDetailsMarketingStateUnknown:
-		return true
-	case ConfirmDetailsMarketingStateWithdrawn:
-		return true
-	default:
-		return false
-	}
-}
-
 // Defines values for ConnectChannelRequestProvider.
 const (
 	ConnectChannelRequestProviderTelegram ConnectChannelRequestProvider = "telegram"
@@ -10534,6 +10513,42 @@ func (e RecordClaimRecordType) Valid() bool {
 	}
 }
 
+// Defines values for RecordConfirmationPageKind.
+const (
+	RecordConfirmation RecordConfirmationPageKind = "record_confirmation"
+)
+
+// Valid indicates whether the value is a known member of the RecordConfirmationPageKind enum.
+func (e RecordConfirmationPageKind) Valid() bool {
+	switch e {
+	case RecordConfirmation:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RecordConfirmationPageMarketingState.
+const (
+	RecordConfirmationPageMarketingStateGranted   RecordConfirmationPageMarketingState = "granted"
+	RecordConfirmationPageMarketingStateUnknown   RecordConfirmationPageMarketingState = "unknown"
+	RecordConfirmationPageMarketingStateWithdrawn RecordConfirmationPageMarketingState = "withdrawn"
+)
+
+// Valid indicates whether the value is a known member of the RecordConfirmationPageMarketingState enum.
+func (e RecordConfirmationPageMarketingState) Valid() bool {
+	switch e {
+	case RecordConfirmationPageMarketingStateGranted:
+		return true
+	case RecordConfirmationPageMarketingStateUnknown:
+		return true
+	case RecordConfirmationPageMarketingStateWithdrawn:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for RecordConsentRequestNewState.
 const (
 	RecordConsentRequestNewStateGranted   RecordConsentRequestNewState = "granted"
@@ -12295,6 +12310,42 @@ func (e StartBackfillRequestWindow) Valid() bool {
 	}
 }
 
+// Defines values for SubscriptionConfirmationPageKind.
+const (
+	SubscriptionConfirmation SubscriptionConfirmationPageKind = "subscription_confirmation"
+)
+
+// Valid indicates whether the value is a known member of the SubscriptionConfirmationPageKind enum.
+func (e SubscriptionConfirmationPageKind) Valid() bool {
+	switch e {
+	case SubscriptionConfirmation:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SubscriptionConfirmationPageState.
+const (
+	SubscriptionConfirmationPageStateGranted   SubscriptionConfirmationPageState = "granted"
+	SubscriptionConfirmationPageStateUnknown   SubscriptionConfirmationPageState = "unknown"
+	SubscriptionConfirmationPageStateWithdrawn SubscriptionConfirmationPageState = "withdrawn"
+)
+
+// Valid indicates whether the value is a known member of the SubscriptionConfirmationPageState enum.
+func (e SubscriptionConfirmationPageState) Valid() bool {
+	switch e {
+	case SubscriptionConfirmationPageStateGranted:
+		return true
+	case SubscriptionConfirmationPageStateUnknown:
+		return true
+	case SubscriptionConfirmationPageStateWithdrawn:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for TagColor.
 const (
 	TagColorAmber  TagColor = "amber"
@@ -13755,22 +13806,22 @@ func (e VoiceProfileEvaluationRepeatsPerPrompt) Valid() bool {
 
 // Defines values for VoiceProfileVersionReason.
 const (
-	VoiceProfileVersionReasonAutomatic  VoiceProfileVersionReason = "automatic"
-	VoiceProfileVersionReasonManual     VoiceProfileVersionReason = "manual"
-	VoiceProfileVersionReasonOnboarding VoiceProfileVersionReason = "onboarding"
-	VoiceProfileVersionReasonRollback   VoiceProfileVersionReason = "rollback"
+	Automatic  VoiceProfileVersionReason = "automatic"
+	Manual     VoiceProfileVersionReason = "manual"
+	Onboarding VoiceProfileVersionReason = "onboarding"
+	Rollback   VoiceProfileVersionReason = "rollback"
 )
 
 // Valid indicates whether the value is a known member of the VoiceProfileVersionReason enum.
 func (e VoiceProfileVersionReason) Valid() bool {
 	switch e {
-	case VoiceProfileVersionReasonAutomatic:
+	case Automatic:
 		return true
-	case VoiceProfileVersionReasonManual:
+	case Manual:
 		return true
-	case VoiceProfileVersionReasonOnboarding:
+	case Onboarding:
 		return true
-	case VoiceProfileVersionReasonRollback:
+	case Rollback:
 		return true
 	default:
 		return false
@@ -16416,16 +16467,16 @@ func (e SubmitConfirmDetailsJSONBodyMarketingChoice) Valid() bool {
 
 // Defines values for UpdatePreferencesJSONBodyChoicesState.
 const (
-	Granted   UpdatePreferencesJSONBodyChoicesState = "granted"
-	Withdrawn UpdatePreferencesJSONBodyChoicesState = "withdrawn"
+	UpdatePreferencesJSONBodyChoicesStateGranted   UpdatePreferencesJSONBodyChoicesState = "granted"
+	UpdatePreferencesJSONBodyChoicesStateWithdrawn UpdatePreferencesJSONBodyChoicesState = "withdrawn"
 )
 
 // Valid indicates whether the value is a known member of the UpdatePreferencesJSONBodyChoicesState enum.
 func (e UpdatePreferencesJSONBodyChoicesState) Valid() bool {
 	switch e {
-	case Granted:
+	case UpdatePreferencesJSONBodyChoicesStateGranted:
 		return true
-	case Withdrawn:
+	case UpdatePreferencesJSONBodyChoicesStateWithdrawn:
 		return true
 	default:
 		return false
@@ -21214,27 +21265,6 @@ type ConfirmCompanySiteReadRequest struct {
 	SelectedFactKeys []string `json:"selected_fact_keys"`
 }
 
-// ConfirmDetails One contact's own view of what the workspace holds about them, for the no-login confirm page.
-// A purpose-built projection and never the Person360 read model, which carries this workspace's
-// working notes — owner, lifecycle, scores — rather than the subject's own data.
-type ConfirmDetails struct {
-	// Company The current employer, read through the live employment relationship. Not correctable here.
-	Company  string `json:"company"`
-	Email    string `json:"email"`
-	FullName string `json:"full_name"`
-
-	// MarketingState Their answer today, so somebody who already said yes is not asked as though they had not.
-	MarketingState ConfirmDetailsMarketingState `json:"marketing_state"`
-	Phone          string                       `json:"phone"`
-
-	// Provenance Where each held value came from and when (Art. 14). Empty for a field nothing has stamped.
-	Provenance []ConfirmFieldOrigin `json:"provenance"`
-	Title      string               `json:"title"`
-}
-
-// ConfirmDetailsMarketingState Their answer today, so somebody who already said yes is not asked as though they had not.
-type ConfirmDetailsMarketingState string
-
 // ConfirmFieldOrigin One line of where a held value came from, for the Art. 14 disclosure on the confirm page.
 type ConfirmFieldOrigin struct {
 	Field string `json:"field"`
@@ -21242,6 +21272,20 @@ type ConfirmFieldOrigin struct {
 	// RecordedAt The date the value was recorded, as YYYY-MM-DD.
 	RecordedAt string `json:"recorded_at"`
 	Source     string `json:"source"`
+}
+
+// ConfirmPage What a confirm link answers, which depends on what the link was FOR.
+//
+// A record link asks the person to check what the workspace holds about them; a consent link
+// asks one subscription question and must not disclose the record. Those are different
+// payloads and this endpoint has always returned both — the schema said only the first, so a
+// client that trusted the contract read `provenance` off a body that never carries it and
+// crashed on the subscription page.
+//
+// Branch on `kind`. Adding a variant here is a contract change; adding one in the handler
+// without one is the defect this union closes.
+type ConfirmPage struct {
+	union json.RawMessage
 }
 
 // ConfirmRequestIssued A confirm link that now exists, and whether a message carrying it was queued. What
@@ -31649,6 +31693,31 @@ type RecordClaim struct {
 // RecordClaimRecordType defines model for RecordClaim.RecordType.
 type RecordClaimRecordType string
 
+// RecordConfirmationPage One contact's own view of what the workspace holds about them, for the no-login confirm page.
+// A purpose-built projection and never the Person360 read model, which carries this workspace's
+// working notes — owner, lifecycle, scores — rather than the subject's own data.
+type RecordConfirmationPage struct {
+	// Company The current employer, read through the live employment relationship. Not correctable here.
+	Company  string                     `json:"company"`
+	Email    string                     `json:"email"`
+	FullName string                     `json:"full_name"`
+	Kind     RecordConfirmationPageKind `json:"kind"`
+
+	// MarketingState Their answer today, so somebody who already said yes is not asked as though they had not.
+	MarketingState RecordConfirmationPageMarketingState `json:"marketing_state"`
+	Phone          string                               `json:"phone"`
+
+	// Provenance Where each held value came from and when (Art. 14). Empty for a field nothing has stamped.
+	Provenance []ConfirmFieldOrigin `json:"provenance"`
+	Title      string               `json:"title"`
+}
+
+// RecordConfirmationPageKind defines model for RecordConfirmationPage.Kind.
+type RecordConfirmationPageKind string
+
+// RecordConfirmationPageMarketingState Their answer today, so somebody who already said yes is not asked as though they had not.
+type RecordConfirmationPageMarketingState string
+
 // RecordConsentRequest defines model for RecordConsentRequest.
 type RecordConsentRequest struct {
 	LawfulBasis *string                      `json:"lawful_basis,omitempty"`
@@ -33985,6 +34054,31 @@ type StartCompanySiteReadRequest struct {
 	// Url Public company website to read.
 	Url string `json:"url"`
 }
+
+// SubscriptionConfirmationPage The answer for a consent link: one named subscription and the person's current answer to it.
+//
+// Deliberately carries NOTHING about the record. The mail said "confirm this subscription", and
+// serving the record card here would hand whoever holds the link the person's name, employer,
+// address, phone and provenance trail — wider than the mail described and wider than this
+// link's own write side allows.
+type SubscriptionConfirmationPage struct {
+	Kind SubscriptionConfirmationPageKind `json:"kind"`
+
+	// PurposeKey The subscription this link is about.
+	PurposeKey string `json:"purpose_key"`
+
+	// PurposeLabel Its published name, for the page to show.
+	PurposeLabel string `json:"purpose_label"`
+
+	// State Their answer today, so somebody who already said yes is not asked as though they had not.
+	State SubscriptionConfirmationPageState `json:"state"`
+}
+
+// SubscriptionConfirmationPageKind defines model for SubscriptionConfirmationPage.Kind.
+type SubscriptionConfirmationPageKind string
+
+// SubscriptionConfirmationPageState Their answer today, so somebody who already said yes is not asked as though they had not.
+type SubscriptionConfirmationPageState string
 
 // Tag A tag. Mirrors the `tag` table.
 type Tag struct {
@@ -51030,6 +51124,95 @@ func (t *ColdStartRequest) UnmarshalJSON(b []byte) error {
 		}
 	}
 
+	return err
+}
+
+// AsRecordConfirmationPage returns the union data inside the ConfirmPage as a RecordConfirmationPage
+func (t ConfirmPage) AsRecordConfirmationPage() (RecordConfirmationPage, error) {
+	var body RecordConfirmationPage
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRecordConfirmationPage overwrites any union data inside the ConfirmPage as the provided RecordConfirmationPage
+func (t *ConfirmPage) FromRecordConfirmationPage(v RecordConfirmationPage) error {
+	v.Kind = "record_confirmation"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRecordConfirmationPage performs a merge with any union data inside the ConfirmPage, using the provided RecordConfirmationPage
+func (t *ConfirmPage) MergeRecordConfirmationPage(v RecordConfirmationPage) error {
+	v.Kind = "record_confirmation"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsSubscriptionConfirmationPage returns the union data inside the ConfirmPage as a SubscriptionConfirmationPage
+func (t ConfirmPage) AsSubscriptionConfirmationPage() (SubscriptionConfirmationPage, error) {
+	var body SubscriptionConfirmationPage
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromSubscriptionConfirmationPage overwrites any union data inside the ConfirmPage as the provided SubscriptionConfirmationPage
+func (t *ConfirmPage) FromSubscriptionConfirmationPage(v SubscriptionConfirmationPage) error {
+	v.Kind = "subscription_confirmation"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeSubscriptionConfirmationPage performs a merge with any union data inside the ConfirmPage, using the provided SubscriptionConfirmationPage
+func (t *ConfirmPage) MergeSubscriptionConfirmationPage(v SubscriptionConfirmationPage) error {
+	v.Kind = "subscription_confirmation"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t ConfirmPage) Discriminator() (string, error) {
+	var discriminator struct {
+		Discriminator string `json:"kind"`
+	}
+	err := json.Unmarshal(t.union, &discriminator)
+	return discriminator.Discriminator, err
+}
+
+func (t ConfirmPage) ValueByDiscriminator() (interface{}, error) {
+	discriminator, err := t.Discriminator()
+	if err != nil {
+		return nil, err
+	}
+	switch discriminator {
+	case "record_confirmation":
+		return t.AsRecordConfirmationPage()
+	case "subscription_confirmation":
+		return t.AsSubscriptionConfirmationPage()
+	default:
+		return nil, errors.New("unknown discriminator value: " + discriminator)
+	}
+}
+
+func (t ConfirmPage) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *ConfirmPage) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
 	return err
 }
 

--- a/backend/internal/modules/consent/confirmflow_integration_test.go
+++ b/backend/internal/modules/consent/confirmflow_integration_test.go
@@ -16,14 +16,43 @@ package consent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
+
+// getConfirmPage drives the public GET the way a browser does and hands back
+// the decoded body, so a test can assert what actually went on the wire rather
+// than what a store method returned.
+func getConfirmPage(t *testing.T, e *channelConsentEnv, token string) map[string]any {
+	t.Helper()
+	h := NewHandlers(database.BindTo(e.store.db.Pool(), ids.From[ids.WorkspaceKind](e.ws)))
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:public_confirm",
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/public/confirm/"+token, nil).WithContext(ctx)
+	h.GetConfirmDetails(rec, req, token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET the confirm page: status %d, body %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding the confirm page: %v (body %s)", err, rec.Body.String())
+	}
+	return body
+}
 
 // seedMarketingPurpose plants the double-opt-in marketing lane the confirm page
 // asks about, since the shared environment seeds its own purposes by other keys.
@@ -481,5 +510,60 @@ func TestAContactWithNoAddressGetsNoConfirmLink(t *testing.T) {
 	}
 	if minted != 0 {
 		t.Errorf("%d token(s) minted for a contact with no address", minted)
+	}
+}
+
+// THE ENDPOINT ANSWERS TWO SHAPES, AND EACH ONE NOW SAYS WHICH IT IS.
+//
+// A consent link's 200 carries the subscription question; a record link's
+// carries the record card. Both always did — what the published contract said
+// was that every 200 here is a record card, so the generated client typed the
+// subscription body as one and read provenance off three fields.
+//
+// Driven through the HANDLER rather than the store, because the defect was in
+// what went on the wire: confirmCardFor and consentCardFor were each returning
+// exactly what they should, and the handler wrote a module type straight to the
+// response with no discriminator on it. A store-level test cannot see that.
+func TestEachConfirmLinkAnswersInItsOwnShape(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+
+	// The env's DOI purpose. A consent link only exists for a purpose that is
+	// confirmed by double opt-in — there is nothing for a mailed link to ask
+	consentLink, err := e.store.IssueConsentLink(e.ctx, e.person, e.doiNews, "")
+	if err != nil {
+		t.Fatalf("mint a consent link: %v", err)
+	}
+
+	body := getConfirmPage(t, e, consentLink.Token)
+	if got := body["kind"]; got != "subscription_confirmation" {
+		t.Fatalf("a consent link answered kind %v, want subscription_confirmation", got)
+	}
+	if body["purpose_key"] == nil {
+		t.Error("the subscription answer names no purpose, so the page cannot say what it is asking about")
+	}
+	// THE DISCLOSURE ASSERTION. The mail said "confirm this subscription", and
+	// this body must not carry the record: name, employer, address, phone and
+	// the provenance trail are wider than the link described and wider than its
+	// own write side allows.
+	for _, field := range []string{"full_name", "company", "email", "phone", "provenance"} {
+		if _, present := body[field]; present {
+			t.Errorf("the subscription answer carries %q — a consent link discloses the record", field)
+		}
+	}
+
+	// And the record branch still answers its own shape, with the
+	// discriminator on it. Without this the union could be satisfied by
+	// tagging everything as a subscription.
+	recordLink, err := e.store.IssueConfirmToken(e.ctx, e.person)
+	if err != nil {
+		t.Fatalf("mint a record link: %v", err)
+	}
+	record := getConfirmPage(t, e, recordLink.Token)
+	if got := record["kind"]; got != "record_confirmation" {
+		t.Fatalf("a record link answered kind %v, want record_confirmation", got)
+	}
+	if _, present := record["provenance"]; !present {
+		t.Error("the record answer carries no provenance — the Art. 14 disclosure is the point of the page")
 	}
 }

--- a/backend/internal/modules/consent/handlers_confirm.go
+++ b/backend/internal/modules/consent/handlers_confirm.go
@@ -37,7 +37,7 @@ func (h Handlers) GetConfirmDetails(w http.ResponseWriter, r *http.Request, toke
 			writeConsentErr(w, r, err)
 			return
 		}
-		httperr.WriteJSON(w, http.StatusOK, card)
+		httperr.WriteJSON(w, http.StatusOK, wireSubscriptionCard(card))
 		return
 	}
 	card, err := h.store.confirmCardFor(r.Context(), ref.PersonID)
@@ -89,7 +89,7 @@ func submissionFromWire(req crmcontracts.SubmitConfirmDetailsJSONRequestBody) Co
 // wireConfirmCard renders the card. marketing_state is spelled 'unknown' rather
 // than empty, matching the preference surface's own vocabulary: no record and a
 // withdrawal are different answers, and the page shows them differently.
-func wireConfirmCard(card ConfirmCard) crmcontracts.ConfirmDetails {
+func wireConfirmCard(card ConfirmCard) crmcontracts.RecordConfirmationPage {
 	state := card.Marketing
 	if state == "" {
 		state = "unknown"
@@ -100,13 +100,39 @@ func wireConfirmCard(card ConfirmCard) crmcontracts.ConfirmDetails {
 			Field: o.Field, RecordedAt: o.RecordedAt, Source: o.Source,
 		})
 	}
-	return crmcontracts.ConfirmDetails{
+	return crmcontracts.RecordConfirmationPage{
+		// The discriminator, and the reason this endpoint has an honest schema
+		// again. Both bodies used to arrive carrying nothing that said which
+		// they were, so a client had to guess from which fields happened to be
+		// present — and the published schema described only this one.
+		Kind:           crmcontracts.RecordConfirmation,
 		FullName:       card.FullName,
 		Title:          card.Title,
 		Company:        card.Company,
 		Email:          card.Email,
 		Phone:          card.Phone,
-		MarketingState: crmcontracts.ConfirmDetailsMarketingState(state),
+		MarketingState: crmcontracts.RecordConfirmationPageMarketingState(state),
 		Provenance:     origins,
+	}
+}
+
+// wireSubscriptionCard is the other branch, and it exists so the subscription
+// answer carries its discriminator too.
+//
+// Before this the handler wrote consent.SubscriptionCard — a module type with
+// its own json tags — straight to the response. It serialized acceptably, which
+// is exactly why nothing caught that the contract did not describe it: the
+// generated client typed every 200 from this endpoint as the record card, so
+// the subscription page read `provenance` off a body with three fields.
+func wireSubscriptionCard(card SubscriptionCard) crmcontracts.SubscriptionConfirmationPage {
+	state := card.State
+	if state == "" {
+		state = "unknown"
+	}
+	return crmcontracts.SubscriptionConfirmationPage{
+		Kind:         crmcontracts.SubscriptionConfirmation,
+		PurposeKey:   card.PurposeKey,
+		PurposeLabel: card.PurposeLabel,
+		State:        crmcontracts.SubscriptionConfirmationPageState(state),
 	}
 }

--- a/backend/internal/modules/consent/handlers_confirm.go
+++ b/backend/internal/modules/consent/handlers_confirm.go
@@ -13,6 +13,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
 
 // GetConfirmDetails implements (GET /public/confirm/{token}): one contact's own
@@ -38,6 +39,17 @@ func (h Handlers) GetConfirmDetails(w http.ResponseWriter, r *http.Request, toke
 			return
 		}
 		httperr.WriteJSON(w, http.StatusOK, wireSubscriptionCard(card))
+		return
+	}
+	// EVERY OTHER KIND IS REFUSED, rather than falling through to the record.
+	//
+	// The record card is the widest thing this endpoint can disclose — name,
+	// employer, address, phone, provenance — so it must be reached by a kind
+	// that asked for it, never by not matching the other arm. A link kind added
+	// to the table tomorrow would otherwise serve the record to whoever holds
+	// it, silently, and the handler that needed updating would look untouched.
+	if ref.Kind != LinkRecordConfirmation {
+		writeConsentErr(w, r, apperrors.ErrNotFound)
 		return
 	}
 	card, err := h.store.confirmCardFor(r.Context(), ref.PersonID)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29226,11 +29226,53 @@ export interface components {
             }[];
         };
         /**
+         * @description What a confirm link answers, which depends on what the link was FOR.
+         *
+         *     A record link asks the person to check what the workspace holds about them; a consent link
+         *     asks one subscription question and must not disclose the record. Those are different
+         *     payloads and this endpoint has always returned both — the schema said only the first, so a
+         *     client that trusted the contract read `provenance` off a body that never carries it and
+         *     crashed on the subscription page.
+         *
+         *     Branch on `kind`. Adding a variant here is a contract change; adding one in the handler
+         *     without one is the defect this union closes.
+         */
+        ConfirmPage: components["schemas"]["RecordConfirmationPage"] | components["schemas"]["SubscriptionConfirmationPage"];
+        /**
+         * @description The answer for a consent link: one named subscription and the person's current answer to it.
+         *
+         *     Deliberately carries NOTHING about the record. The mail said "confirm this subscription", and
+         *     serving the record card here would hand whoever holds the link the person's name, employer,
+         *     address, phone and provenance trail — wider than the mail described and wider than this
+         *     link's own write side allows.
+         */
+        SubscriptionConfirmationPage: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "subscription_confirmation";
+            /** @description The subscription this link is about. */
+            purpose_key: string;
+            /** @description Its published name, for the page to show. */
+            purpose_label: string;
+            /**
+             * @description Their answer today, so somebody who already said yes is not asked as though they had not.
+             * @enum {string}
+             */
+            state: "unknown" | "granted" | "withdrawn";
+        };
+        /**
          * @description One contact's own view of what the workspace holds about them, for the no-login confirm page.
          *     A purpose-built projection and never the Person360 read model, which carries this workspace's
          *     working notes — owner, lifecycle, scores — rather than the subject's own data.
          */
-        ConfirmDetails: {
+        RecordConfirmationPage: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "record_confirmation";
             full_name: string;
             title: string;
             /** @description The current employer, read through the live employment relationship. Not correctable here. */
@@ -41498,13 +41540,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description The contact's own view of their record. */
+            /** @description The record card or the subscription question, per the kind discriminator. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ConfirmDetails"];
+                    "application/json": components["schemas"]["ConfirmPage"];
                 };
             };
             404: components["responses"]["NotFound"];

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6016,10 +6016,12 @@ export const de = {
   "confirm.erasure.staged": "Löschung angefragt. Zum Senden unten bestätigen.",
   "confirm.submit": "Bestätigen",
   "confirm.subscription.title": "Abo bestätigen",
-  "confirm.subscription.ask": "Bestätigen Sie, dass Sie {purpose} erhalten möchten.",
+  "confirm.subscription.ask":
+    "Bestätigen Sie, dass Sie {purpose} erhalten möchten.",
   "confirm.subscription.confirm": "Ja, ich möchte das Abo",
   "confirm.subscription.alreadyTitle": "Abo bestätigt",
-  "confirm.subscription.alreadyBody": "Ihr Abo für {purpose} ist bestätigt. Sie können es jederzeit über jede unserer E-Mails beenden.",
+  "confirm.subscription.alreadyBody":
+    "Ihr Abo für {purpose} ist bestätigt. Sie können es jederzeit über jede unserer E-Mails beenden.",
   "confirm.done.title": "Danke",
   "confirm.done.body":
     "Ich habe Ihre Antwort erfasst. Änderungen gehen an eine Person hier zur Übernahme, und dieser Link ist jetzt verbraucht.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6015,6 +6015,11 @@ export const de = {
   "confirm.erasure.ask": "Meine Daten löschen",
   "confirm.erasure.staged": "Löschung angefragt. Zum Senden unten bestätigen.",
   "confirm.submit": "Bestätigen",
+  "confirm.subscription.title": "Abo bestätigen",
+  "confirm.subscription.ask": "Bestätigen Sie, dass Sie {purpose} erhalten möchten.",
+  "confirm.subscription.confirm": "Ja, ich möchte das Abo",
+  "confirm.subscription.alreadyTitle": "Abo bestätigt",
+  "confirm.subscription.alreadyBody": "Ihr Abo für {purpose} ist bestätigt. Sie können es jederzeit über jede unserer E-Mails beenden.",
   "confirm.done.title": "Danke",
   "confirm.done.body":
     "Ich habe Ihre Antwort erfasst. Änderungen gehen an eine Person hier zur Übernahme, und dieser Link ist jetzt verbraucht.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6160,7 +6160,8 @@ export const en = {
   "confirm.subscription.ask": "Confirm that you want to receive {purpose}.",
   "confirm.subscription.confirm": "Yes, subscribe me",
   "confirm.subscription.alreadyTitle": "You are subscribed",
-  "confirm.subscription.alreadyBody": "Your subscription to {purpose} is confirmed. You can stop it at any time from any email we send.",
+  "confirm.subscription.alreadyBody":
+    "Your subscription to {purpose} is confirmed. You can stop it at any time from any email we send.",
   "confirm.done.title": "Thank you",
   "confirm.done.body":
     "I have recorded your answer. Anything you changed goes to a person here to apply, and this link is now used up.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6156,6 +6156,11 @@ export const en = {
   "confirm.erasure.ask": "Remove my details",
   "confirm.erasure.staged": "Removal requested. Confirm below to send it.",
   "confirm.submit": "Confirm",
+  "confirm.subscription.title": "Confirm your subscription",
+  "confirm.subscription.ask": "Confirm that you want to receive {purpose}.",
+  "confirm.subscription.confirm": "Yes, subscribe me",
+  "confirm.subscription.alreadyTitle": "You are subscribed",
+  "confirm.subscription.alreadyBody": "Your subscription to {purpose} is confirmed. You can stop it at any time from any email we send.",
   "confirm.done.title": "Thank you",
   "confirm.done.body":
     "I have recorded your answer. Anything you changed goes to a person here to apply, and this link is now used up.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5956,7 +5956,8 @@ export const vi = {
   "confirm.subscription.ask": "Xác nhận rằng bạn muốn nhận {purpose}.",
   "confirm.subscription.confirm": "Có, đăng ký cho tôi",
   "confirm.subscription.alreadyTitle": "Bạn đã đăng ký",
-  "confirm.subscription.alreadyBody": "Đăng ký {purpose} của bạn đã được xác nhận. Bạn có thể dừng bất cứ lúc nào từ email chúng tôi gửi.",
+  "confirm.subscription.alreadyBody":
+    "Đăng ký {purpose} của bạn đã được xác nhận. Bạn có thể dừng bất cứ lúc nào từ email chúng tôi gửi.",
   "confirm.done.title": "Cảm ơn bạn",
   "confirm.done.body":
     "Tôi đã ghi nhận câu trả lời của bạn. Những thay đổi sẽ được một người ở đây áp dụng, và liên kết này đã được dùng.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5952,6 +5952,11 @@ export const vi = {
   "confirm.erasure.ask": "Xóa thông tin của tôi",
   "confirm.erasure.staged": "Đã yêu cầu xóa. Xác nhận bên dưới để gửi.",
   "confirm.submit": "Xác nhận",
+  "confirm.subscription.title": "Xác nhận đăng ký",
+  "confirm.subscription.ask": "Xác nhận rằng bạn muốn nhận {purpose}.",
+  "confirm.subscription.confirm": "Có, đăng ký cho tôi",
+  "confirm.subscription.alreadyTitle": "Bạn đã đăng ký",
+  "confirm.subscription.alreadyBody": "Đăng ký {purpose} của bạn đã được xác nhận. Bạn có thể dừng bất cứ lúc nào từ email chúng tôi gửi.",
   "confirm.done.title": "Cảm ơn bạn",
   "confirm.done.body":
     "Tôi đã ghi nhận câu trả lời của bạn. Những thay đổi sẽ được một người ở đây áp dụng, và liên kết này đã được dùng.",

--- a/frontend/src/screens/confirm.stories.tsx
+++ b/frontend/src/screens/confirm.stories.tsx
@@ -14,12 +14,16 @@ import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
 // Unknown, expired and already-spent tokens all read as absent (404), which is
 // why the refused story routes a 404 rather than a message of its own.
 
-type ConfirmDetails = components["schemas"]["ConfirmDetails"];
+// The record branch of the union. The story shows the record card, which is
+// what this endpoint answers for a record link; the subscription branch has
+// its own story beside confirmsubscription.tsx.
+type ConfirmDetails = components["schemas"]["RecordConfirmationPage"];
 
 const TOKEN = "cfm-7f3a";
 const DETAILS_ROUTE = `GET /public/confirm/${TOKEN}`;
 
 const held: ConfirmDetails = {
+  kind: "record_confirmation",
   full_name: "Dana Buyer",
   title: "Head of Procurement",
   company: "Brandt Automotive GmbH",

--- a/frontend/src/screens/confirm.test.tsx
+++ b/frontend/src/screens/confirm.test.tsx
@@ -1,0 +1,123 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { ConfirmDetailsScreen } from "./confirm";
+
+// The public confirm page answers TWO bodies from one endpoint, and until the
+// contract carried a discriminator it published only one of them.
+//
+// A record link returns the person's own record card. A consent link returns a
+// single subscription question and deliberately no record fields at all — the
+// mail said "confirm this subscription", and serving the card would disclose
+// the name, employer, address, phone and provenance trail to whoever holds the
+// link.
+//
+// The generated client typed every 200 from this endpoint as the record card,
+// so the subscription page read `provenance` off a body with three fields and
+// crashed. These tests are the pair that would have caught it.
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const SUBSCRIPTION = {
+  kind: "subscription_confirmation",
+  purpose_key: "product_updates",
+  purpose_label: "Product updates",
+  state: "unknown",
+};
+
+const RECORD = {
+  kind: "record_confirmation",
+  full_name: "Anna Müller",
+  title: "Head of Ops",
+  company: "Buyer GmbH",
+  email: "anna@example.test",
+  phone: "+49 30 111",
+  marketing_state: "unknown",
+  provenance: [],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("the confirm page branches on what the link was for", () => {
+  // THE CRASH. A subscription body carries no `provenance`, and the record
+  // renderer reads `.length` off it — so before the discriminator this threw
+  // rather than rendering, on the one page a marketing recipient is most
+  // likely to open.
+  it("renders a consent link without reading any record field", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(SUBSCRIPTION));
+
+    render(<ConfirmDetailsScreen token="tok-subscription" />);
+
+    expect(await screen.findByText("Product updates")).toBeInTheDocument();
+    // And NOTHING about the record: no name, no employer, no phone. This is
+    // the disclosure assertion, not a layout one.
+    expect(screen.queryByText("Anna Müller")).not.toBeInTheDocument();
+    expect(screen.queryByText("Buyer GmbH")).not.toBeInTheDocument();
+    expect(screen.queryByText("+49 30 111")).not.toBeInTheDocument();
+  });
+
+  // A subscription already granted is its own state rather than a dead form.
+  // Somebody who confirmed and followed the same link again — a second click, a
+  // mail client prefetching, a forwarded message — is told their answer stands.
+  it("tells an already-subscribed reader that their answer is recorded", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ ...SUBSCRIPTION, state: "granted" }),
+    );
+
+    render(<ConfirmDetailsScreen token="tok-granted" />);
+
+    expect(await screen.findByText("You are subscribed")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Yes, subscribe me" }),
+    ).not.toBeInTheDocument();
+  });
+
+  // The other branch still works, so the discriminator did not cost the page
+  // it was already serving.
+  it("still renders a record link with its correctable fields", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(RECORD));
+
+    render(<ConfirmDetailsScreen token="tok-record" />);
+
+    expect(await screen.findByDisplayValue("Anna Müller")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("anna@example.test")).toBeInTheDocument();
+  });
+
+  // A token that names nothing reads the same as one that expired or was
+  // already answered: the page is never an oracle for which it was.
+  it("shows one invalid-link state for a 404", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ title: "Not Found" }, 404),
+    );
+
+    render(<ConfirmDetailsScreen token="tok-gone" />);
+
+    expect(
+      await screen.findByText(/link|no longer|invalid/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/confirm.test.tsx
+++ b/frontend/src/screens/confirm.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
@@ -105,6 +106,43 @@ describe("the confirm page branches on what the link was for", () => {
 
     expect(await screen.findByDisplayValue("Anna Müller")).toBeInTheDocument();
     expect(screen.getByDisplayValue("anna@example.test")).toBeInTheDocument();
+  });
+
+  // AN EMPTY 5xx IS NOT A CONFIRMATION.
+  //
+  // openapi-fetch returns `{error: undefined}` for a non-2xx whose body is
+  // empty — a proxy 502, a 500 that wrote no problem document. A guard that
+  // asks only whether `error` is truthy reads those as success, and this page's
+  // success state tells somebody their consent was recorded when the request
+  // never reached the writer. Gated on response.ok instead.
+  it("does not report a subscription as confirmed when the write failed with an empty body", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      // openapi-fetch builds a Request object, so the method can live on the
+      // input rather than on init — reading only init.method sent the POST
+      // down the GET arm and the page never saw the failure at all.
+      const method =
+        (input instanceof Request ? input.method : init?.method) ?? "GET";
+      if (method === "GET") {
+        return Promise.resolve(jsonResponse(SUBSCRIPTION));
+      }
+      // The shape that fooled the old guard: failed, and no body to parse.
+      return Promise.resolve(
+        new Response(null, { status: 502, headers: { "Content-Length": "0" } }),
+      );
+    });
+
+    render(<ConfirmDetailsScreen token="tok-flaky" />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Yes, subscribe me" }),
+    );
+
+    // Never the confirmed state, and the refusal is on screen rather than the
+    // button simply re-enabling itself. The copy is the honest fallback: a 502
+    // with no body genuinely reports no cause.
+    await screen.findByText(/the request failed/i);
+    expect(screen.queryByText("You are subscribed")).not.toBeInTheDocument();
   });
 
   // A token that names nothing reads the same as one that expired or was

--- a/frontend/src/screens/confirm.tsx
+++ b/frontend/src/screens/confirm.tsx
@@ -103,6 +103,14 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
   // is how the two drift.
   const marketingWording = t("confirm.marketing.ask");
 
+  // The subscription page's own sentence, read here for the same reason: it is
+  // the proof the server stores, so it is taken from the same place the page
+  // renders it rather than re-derived at submit time.
+  const subscriptionWording = t("confirm.subscription.ask", {
+    purpose:
+      card?.kind === "subscription_confirmation" ? card.purpose_label : "",
+  });
+
   // Narrowed BEFORE any record field is read, including here. A subscription
   // body carries no correctable field at all, and indexing it by `full_name` is
   // the same mistake the discriminator exists to stop. The typechecker says so
@@ -133,7 +141,14 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
             corrections: [],
             request_erasure: false,
             marketing_choice: "granted" as const,
-            marketing_wording: marketingWording,
+            // THE SENTENCE THIS PAGE ACTUALLY SHOWED, not the record page's.
+            //
+            // The server stores this verbatim as consent evidence
+            // (consent_event.policy_text), so submitting the generic marketing
+            // ask here would file proof of a sentence the person never read.
+            // The subscription page shows the purpose-specific one, and that is
+            // what they agreed to.
+            marketing_wording: subscriptionWording,
           }
         : {
             corrections,
@@ -149,7 +164,14 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
         params: { path: { token } },
         body,
       });
-      if (error) {
+      // GATED ON THE STATUS, NOT ON `error`.
+      //
+      // openapi-fetch returns `{error: undefined}` for a non-2xx whose body is
+      // empty — a 502 from a proxy, a 500 that wrote no problem document. A
+      // guard that only asks whether `error` is truthy therefore reads those as
+      // success, and this page's success state tells somebody their consent
+      // was recorded when the request never reached the writer.
+      if (!response.ok) {
         if (response.status === 404) {
           throw new LinkInvalidError();
         }
@@ -190,8 +212,14 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
   if (card.kind === "subscription_confirmation") {
     return (
       <SubscriptionConfirmBody
+        // `done` is set only by onSuccess, and the mutation now refuses any
+        // non-2xx, so a confirmed state here means the writer accepted it.
         card={done ? { ...card, state: "granted" } : card}
         submitting={submit.isPending}
+        // A refusal must be VISIBLE. This branch returns before the record
+        // page's own error line, so without passing it a rejected submit just
+        // re-enabled the button and said nothing.
+        error={submit.error ? explainPublicError(submit.error, t) : undefined}
         onConfirm={() => submit.mutate({ subscription: true })}
       />
     );

--- a/frontend/src/screens/confirm.tsx
+++ b/frontend/src/screens/confirm.tsx
@@ -103,14 +103,21 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
   // is how the two drift.
   const marketingWording = t("confirm.marketing.ask");
 
+  // Narrowed BEFORE any record field is read, including here. A subscription
+  // body carries no correctable field at all, and indexing it by `full_name` is
+  // the same mistake the discriminator exists to stop. The typechecker says so
+  // now that the union is honest, which is how this one was found — it ran on
+  // both bodies before, silently.
+  const record = card?.kind === "record_confirmation" ? card : undefined;
+
   const corrections = useMemo(() => {
-    if (!card) {
+    if (!record) {
       return [];
     }
     return CORRECTABLE.filter(
-      (field) => edits[field] !== undefined && edits[field] !== card[field],
+      (field) => edits[field] !== undefined && edits[field] !== record[field],
     ).map((field) => ({ field, value: edits[field] ?? "" }));
-  }, [card, edits]);
+  }, [record, edits]);
 
   const submit = useMutation({
     // The SUBSCRIPTION flag arrives as a variable, not off render state.

--- a/frontend/src/screens/confirm.tsx
+++ b/frontend/src/screens/confirm.tsx
@@ -10,6 +10,7 @@ import {
 } from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { SubscriptionConfirmBody } from "./confirmsubscription";
 import { throwProblem } from "./common";
 import {
   explainPublicError,
@@ -112,19 +113,34 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
   }, [card, edits]);
 
   const submit = useMutation({
-    mutationFn: async () => {
+    // The SUBSCRIPTION flag arrives as a variable, not off render state.
+    //
+    // A consent link's submit says one thing — "yes, this subscription" — and
+    // carries none of the record form's corrections or erasure request, which
+    // belong to the other body entirely. Reading those from the closure here
+    // would post whatever the record form happened to hold on a page that never
+    // showed it.
+    mutationFn: async ({ subscription }: { subscription?: boolean } = {}) => {
+      const body = subscription
+        ? {
+            corrections: [],
+            request_erasure: false,
+            marketing_choice: "granted" as const,
+            marketing_wording: marketingWording,
+          }
+        : {
+            corrections,
+            request_erasure: erasure,
+            ...(marketing
+              ? {
+                  marketing_choice: marketing,
+                  marketing_wording: marketingWording,
+                }
+              : {}),
+          };
       const { error, response } = await api.POST("/public/confirm/{token}", {
         params: { path: { token } },
-        body: {
-          corrections,
-          request_erasure: erasure,
-          ...(marketing
-            ? {
-                marketing_choice: marketing,
-                marketing_wording: marketingWording,
-              }
-            : {}),
-        },
+        body,
       });
       if (error) {
         if (response.status === 404) {
@@ -151,6 +167,26 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
       <div className="pref-page">
         <EmptyState>{explainPublicError(details.error, t)}</EmptyState>
       </div>
+    );
+  }
+  // THE DISCRIMINATOR, ASKED BEFORE ANY RECORD FIELD IS READ.
+  //
+  // This endpoint answers two different bodies and always has: a record card
+  // for a record link, one subscription question for a consent link. Until the
+  // contract grew `kind` there was nothing on the wire saying which had
+  // arrived, so every read below — `card.provenance.length` above all — was
+  // taken off a body that might not carry it.
+  //
+  // Checked BEFORE `done`, and the subscription body renders its own confirmed
+  // state: the shared done card says "thank you for confirming your details",
+  // which is about a record this person was never shown.
+  if (card.kind === "subscription_confirmation") {
+    return (
+      <SubscriptionConfirmBody
+        card={done ? { ...card, state: "granted" } : card}
+        submitting={submit.isPending}
+        onConfirm={() => submit.mutate({ subscription: true })}
+      />
     );
   }
   if (done) {
@@ -249,7 +285,7 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
         <Button
           variant="primary"
           disabled={submit.isPending}
-          onClick={() => submit.mutate()}
+          onClick={() => submit.mutate({})}
         >
           {t("confirm.submit")}
         </Button>

--- a/frontend/src/screens/confirm.tsx
+++ b/frontend/src/screens/confirm.tsx
@@ -11,7 +11,7 @@ import {
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { throwProblem } from "./common";
-import { SubscriptionConfirmBody } from "./confirmsubscription";
+import { SubscriptionConfirm } from "./confirmsubscription";
 import {
   explainPublicError,
   LinkInvalidError,
@@ -103,14 +103,6 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
   // is how the two drift.
   const marketingWording = t("confirm.marketing.ask");
 
-  // The subscription page's own sentence, read here for the same reason: it is
-  // the proof the server stores, so it is taken from the same place the page
-  // renders it rather than re-derived at submit time.
-  const subscriptionWording = t("confirm.subscription.ask", {
-    purpose:
-      card?.kind === "subscription_confirmation" ? card.purpose_label : "",
-  });
-
   // Narrowed BEFORE any record field is read, including here. A subscription
   // body carries no correctable field at all, and indexing it by `full_name` is
   // the same mistake the discriminator exists to stop. The typechecker says so
@@ -135,31 +127,14 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
     // belong to the other body entirely. Reading those from the closure here
     // would post whatever the record form happened to hold on a page that never
     // showed it.
-    mutationFn: async ({ subscription }: { subscription?: boolean } = {}) => {
-      const body = subscription
-        ? {
-            corrections: [],
-            request_erasure: false,
-            marketing_choice: "granted" as const,
-            // THE SENTENCE THIS PAGE ACTUALLY SHOWED, not the record page's.
-            //
-            // The server stores this verbatim as consent evidence
-            // (consent_event.policy_text), so submitting the generic marketing
-            // ask here would file proof of a sentence the person never read.
-            // The subscription page shows the purpose-specific one, and that is
-            // what they agreed to.
-            marketing_wording: subscriptionWording,
-          }
-        : {
-            corrections,
-            request_erasure: erasure,
-            ...(marketing
-              ? {
-                  marketing_choice: marketing,
-                  marketing_wording: marketingWording,
-                }
-              : {}),
-          };
+    mutationFn: async () => {
+      const body = {
+        corrections,
+        request_erasure: erasure,
+        ...(marketing
+          ? { marketing_choice: marketing, marketing_wording: marketingWording }
+          : {}),
+      };
       const { error, response } = await api.POST("/public/confirm/{token}", {
         params: { path: { token } },
         body,
@@ -200,29 +175,17 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
   }
   // THE DISCRIMINATOR, ASKED BEFORE ANY RECORD FIELD IS READ.
   //
-  // This endpoint answers two different bodies and always has: a record card
-  // for a record link, one subscription question for a consent link. Until the
-  // contract grew `kind` there was nothing on the wire saying which had
-  // arrived, so every read below — `card.provenance.length` above all — was
-  // taken off a body that might not carry it.
+  // This endpoint answers two bodies and always has: a record card for a
+  // record link, one subscription question for a consent link. Until the
+  // contract grew `kind` nothing on the wire said which had arrived, so every
+  // read below — `card.provenance.length` above all — was taken off a body
+  // that might not carry it.
   //
-  // Checked BEFORE `done`, and the subscription body renders its own confirmed
-  // state: the shared done card says "thank you for confirming your details",
-  // which is about a record this person was never shown.
+  // The consent link goes to its own page, which owns its own submit. Sharing
+  // one meant posting the record page's marketing sentence as the proof of a
+  // subscription, and rendering a refusal nowhere.
   if (card.kind === "subscription_confirmation") {
-    return (
-      <SubscriptionConfirmBody
-        // `done` is set only by onSuccess, and the mutation now refuses any
-        // non-2xx, so a confirmed state here means the writer accepted it.
-        card={done ? { ...card, state: "granted" } : card}
-        submitting={submit.isPending}
-        // A refusal must be VISIBLE. This branch returns before the record
-        // page's own error line, so without passing it a rejected submit just
-        // re-enabled the button and said nothing.
-        error={submit.error ? explainPublicError(submit.error, t) : undefined}
-        onConfirm={() => submit.mutate({ subscription: true })}
-      />
-    );
+    return <SubscriptionConfirm token={token} card={card} />;
   }
   if (done) {
     return (
@@ -320,7 +283,7 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
         <Button
           variant="primary"
           disabled={submit.isPending}
-          onClick={() => submit.mutate({})}
+          onClick={() => submit.mutate()}
         >
           {t("confirm.submit")}
         </Button>

--- a/frontend/src/screens/confirm.tsx
+++ b/frontend/src/screens/confirm.tsx
@@ -120,13 +120,11 @@ function ConfirmDetailsBody({ token }: Readonly<{ token: string }>) {
   }, [record, edits]);
 
   const submit = useMutation({
-    // The SUBSCRIPTION flag arrives as a variable, not off render state.
+    // THE RECORD PAGE'S OWN SUBMIT, and only that.
     //
-    // A consent link's submit says one thing — "yes, this subscription" — and
-    // carries none of the record form's corrections or erasure request, which
-    // belong to the other body entirely. Reading those from the closure here
-    // would post whatever the record form happened to hold on a page that never
-    // showed it.
+    // A consent link never reaches here — SubscriptionConfirm owns its own
+    // mutation. This one used to serve both, which is what let a subscription
+    // post the record page's marketing sentence as its consent evidence.
     mutationFn: async () => {
       const body = {
         corrections,

--- a/frontend/src/screens/confirm.tsx
+++ b/frontend/src/screens/confirm.tsx
@@ -10,8 +10,8 @@ import {
 } from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { SubscriptionConfirmBody } from "./confirmsubscription";
 import { throwProblem } from "./common";
+import { SubscriptionConfirmBody } from "./confirmsubscription";
 import {
   explainPublicError,
   LinkInvalidError,

--- a/frontend/src/screens/confirmsubscription.tsx
+++ b/frontend/src/screens/confirmsubscription.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The confirm link's OTHER answer: one named subscription, and nothing else.
+//
+// A consent link's mail said "confirm this subscription". Answering it with the
+// record card would hand whoever holds the link the person's name, employer,
+// address, phone and the whole provenance trail — wider than the mail described
+// and wider than the link's own write side allows. So this page shows the
+// purpose and the person's current answer to it, and reads no record field at
+// all.
+//
+// It is a separate component rather than a branch inside the record body
+// because the two share no field. The record body reads `provenance`,
+// `full_name` and four correctable fields; a subscription payload carries three
+// strings. Sharing one component meant every one of those reads was a guess
+// about which body had arrived, and `card.provenance.length` on a subscription
+// answer is the crash this file removes.
+
+import type { components } from "../api/schema";
+import { Button, Card } from "../design-system/atoms";
+import { useT } from "../i18n";
+
+type SubscriptionPage = components["schemas"]["SubscriptionConfirmationPage"];
+
+export function SubscriptionConfirmBody({
+  card,
+  onConfirm,
+  submitting,
+}: Readonly<{
+  card: SubscriptionPage;
+  onConfirm: () => void;
+  submitting: boolean;
+}>) {
+  const t = useT();
+
+  // ALREADY ANSWERED is its own state, not a disabled button.
+  //
+  // Somebody who confirmed and then followed the same link again — a second
+  // click, a mail client prefetching, a forwarded message — should be told
+  // their answer is recorded rather than shown a form that looks broken.
+  if (card.state === "granted") {
+    return (
+      <div className="pref-page">
+        <Card>
+          <h1 className="t-h2">{t("confirm.subscription.alreadyTitle")}</h1>
+          <p className="t-body">
+            {t("confirm.subscription.alreadyBody", {
+              purpose: card.purpose_label,
+            })}
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pref-page">
+      <h1 className="t-h2">{t("confirm.subscription.title")}</h1>
+      <Card>
+        <h2 className="t-h3">{card.purpose_label}</h2>
+        <p className="t-body">
+          {t("confirm.subscription.ask", { purpose: card.purpose_label })}
+        </p>
+        {/* One affirmative act, never a pre-selected one: a page that arrives
+            with the answer already given is not the person's own act. */}
+        <Button onClick={onConfirm} disabled={submitting}>
+          {t("confirm.subscription.confirm")}
+        </Button>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/screens/confirmsubscription.tsx
+++ b/frontend/src/screens/confirmsubscription.tsx
@@ -17,11 +17,82 @@
 // about which body had arrived, and `card.provenance.length` on a subscription
 // answer is the crash this file removes.
 
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { Button, Card } from "../design-system/atoms";
 import { useT } from "../i18n";
+import { throwProblem } from "./common";
+import {
+  explainPublicError,
+  LinkInvalidError,
+  RateLimitedError,
+} from "./preferences";
 
 type SubscriptionPage = components["schemas"]["SubscriptionConfirmationPage"];
+
+// SubscriptionConfirm owns the consent link end to end: its own submit, its own
+// wording, its own confirmed and refused states.
+//
+// It used to share the record page's mutation, which is what produced two of
+// the three defects review found here — the submit posted the record page's
+// marketing sentence as the proof of a subscription, and a refusal rendered
+// nowhere because this branch returns before the record page's error line.
+// Sharing a submit between two pages that ask different questions was the
+// mistake; each now answers for itself.
+export function SubscriptionConfirm({
+  token,
+  card,
+}: Readonly<{ token: string; card: SubscriptionPage }>) {
+  const t = useT();
+  const [done, setDone] = useState(false);
+
+  // The sentence THIS page shows, which is the one the server stores verbatim
+  // as consent evidence. Read where it is rendered, not re-derived at submit
+  // time, because the two drifting is how proof stops matching the promise.
+  const wording = t("confirm.subscription.ask", {
+    purpose: card.purpose_label,
+  });
+
+  const submit = useMutation({
+    mutationFn: async ({ policyText }: { policyText: string }) => {
+      const { error, response } = await api.POST("/public/confirm/{token}", {
+        params: { path: { token } },
+        body: {
+          corrections: [],
+          request_erasure: false,
+          marketing_choice: "granted" as const,
+          marketing_wording: policyText,
+        },
+      });
+      // GATED ON THE STATUS, NOT ON `error`. openapi-fetch returns
+      // {error: undefined} for a non-2xx with an empty body — a proxy 502, a
+      // 500 that wrote no problem document — so asking only whether `error` is
+      // truthy reports those as success, and this page's success state tells
+      // somebody their consent was recorded when nothing was written.
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new LinkInvalidError();
+        }
+        if (response.status === 429) {
+          throw new RateLimitedError();
+        }
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => setDone(true),
+  });
+
+  return (
+    <SubscriptionConfirmBody
+      card={done ? { ...card, state: "granted" } : card}
+      submitting={submit.isPending}
+      error={submit.error ? explainPublicError(submit.error, t) : undefined}
+      onConfirm={() => submit.mutate({ policyText: wording })}
+    />
+  );
+}
 
 export function SubscriptionConfirmBody({
   card,

--- a/frontend/src/screens/confirmsubscription.tsx
+++ b/frontend/src/screens/confirmsubscription.tsx
@@ -27,10 +27,15 @@ export function SubscriptionConfirmBody({
   card,
   onConfirm,
   submitting,
+  error,
 }: Readonly<{
   card: SubscriptionPage;
   onConfirm: () => void;
   submitting: boolean;
+  /** A refused submit, already translated. Rendered beside the button: this
+   *  page returns before the record page's own error line, so a rejection
+   *  passed nowhere is a rejection nobody sees. */
+  error?: string;
 }>) {
   const t = useT();
 
@@ -67,6 +72,11 @@ export function SubscriptionConfirmBody({
         <Button onClick={onConfirm} disabled={submitting}>
           {t("confirm.subscription.confirm")}
         </Button>
+        {error && (
+          <p className="t-caption confirm-error" role="status">
+            {error}
+          </p>
+        )}
       </Card>
     </div>
   );

--- a/frontend/src/screens/leadpresentation.test.tsx
+++ b/frontend/src/screens/leadpresentation.test.tsx
@@ -244,8 +244,17 @@ describe("lead work-board presentation", () => {
     // And nothing was PATCHed. A status PATCH here is the defect: the board
     // would be asking the server for a transition it refuses by design.
     for (const call of fetchMock.mock.calls) {
-      const init = call[1] as RequestInit | undefined;
-      expect(String(init?.method ?? "GET").toUpperCase()).not.toBe("PATCH");
+      // The METHOD LIVES ON THE REQUEST, not on init. openapi-fetch builds a
+      // Request and passes only a signal in init, so reading init.method here
+      // always saw undefined and this assertion passed however the board
+      // behaved — it guarded nothing.
+      const [input, init] = call as [
+        RequestInfo | URL,
+        RequestInit | undefined,
+      ];
+      const method =
+        input instanceof Request ? input.method : (init?.method ?? "GET");
+      expect(method.toUpperCase()).not.toBe("PATCH");
     }
   });
 
@@ -334,8 +343,17 @@ describe("lead work-board presentation", () => {
     dropOn("contacted", terminal.id);
     expect(screen.queryByRole("dialog")).toBeNull();
     for (const call of fetchMock.mock.calls) {
-      const init = call[1] as RequestInit | undefined;
-      expect(String(init?.method ?? "GET").toUpperCase()).not.toBe("PATCH");
+      // The METHOD LIVES ON THE REQUEST, not on init. openapi-fetch builds a
+      // Request and passes only a signal in init, so reading init.method here
+      // always saw undefined and this assertion passed however the board
+      // behaved — it guarded nothing.
+      const [input, init] = call as [
+        RequestInfo | URL,
+        RequestInit | undefined,
+      ];
+      const method =
+        input instanceof Request ? input.method : (init?.method ?? "GET");
+      expect(method.toUpperCase()).not.toBe("PATCH");
     }
   });
 });

--- a/scripts/contract-breaking-allowlist.txt
+++ b/scripts/contract-breaking-allowlist.txt
@@ -36,3 +36,4 @@ e0c11716048a939f1f1187d6992754335300ac41 ce200199d82e76fca7c07e5781a7af1a963b496
 7155d6a82570fa939eb5c52afb3a42d3d6071127 f49f227303664d0ddcbab0c55e339c5200998553 ratified-a-deal-room-invitation-is-queued-not-delivered
 82f676997776c2b77cd04767490824812b59953a a150a2ec34f28b3daf86467a27c8c896be52a23f ratified-1983-a-contract-masks-the-references-its-reader-cannot-open
 e4bc6bbe59911e0290a06f515c0c3ea9a3ae0218 fe9c2b0a85863adcbfc9a90825e181736ed76db8 ratified-1898-the-access-preview-is-a-read-and-carries-the-methods-of-one
+79fa8c2d60fdf8f8d8d71882a948cc8464b98c30 57058d94cf5a272de7ee74470eb2bdf212227590 ratified-a-confirm-link-answers-the-shape-its-mail-promised


### PR DESCRIPTION
Finding **R8**. One endpoint has always returned two different bodies, and the published contract described only one of them.

## The defect

A record link answers with the person's own record card. A consent link answers with one subscription question and deliberately **no record fields at all** — its mail said "confirm this subscription", and serving the card would hand whoever holds the link the name, employer, address, phone and the whole provenance trail.

The contract said every 200 from this endpoint is a record card. So the generated TypeScript client typed the subscription body as one, and the page read `provenance` off a body with three fields — a crash on the page a marketing recipient is most likely to open.

The handler was writing a module type straight to the response with nothing on it saying which body it was. It serialized acceptably, which is exactly why nothing caught it.

## The fix

`ConfirmPage` is a `oneOf` discriminated on `kind`. Both handler branches stamp it, and the frontend asks before it reads. The subscription body gets its own component rather than a branch inside the record renderer — the two share no field, so one component meant every read was a guess about which body had arrived.

The submit flag travels as a mutation variable: a consent link's submit must not carry the record form's corrections or erasure request, which belong to a page this person was never shown.

## The second instance, found by the compiler

`fe-typecheck-composed` caught the same bug again once the union was honest: the `corrections` memo indexed the response by `full_name`/`title`/`email`/`phone` before anything established which body it held. It ran on subscription bodies too, producing an empty list by accident rather than by design. Now narrowed.

## Breaking, ratified, and narrower than it looks

`oasdiff` is right that a field previously guaranteed may now be absent — **but the server never guaranteed it.** The contract claimed a guarantee the code did not keep, and this makes the two agree. Clients were already receiving bodies without that field and crashing.

Recorded in `scripts/contract-breaking-allowlist.txt` as one exact blob pair, so any later contract edit restores the stable gate automatically.

## Tests

`TestEachConfirmLinkAnswersInItsOwnShape` drives the real handler and asserts the wire body, including that the subscription answer carries none of the five record fields — a store-level test cannot see what went on the wire. Four frontend cases; the two subscription ones were verified by mutation, failing with the branch removed.

`make check-backend` and `make check-fe` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the confirm endpoint's contract so the subscription confirm page no longer crashes. The endpoint returned two different bodies — a record card for record links and a subscription question for consent links — but the schema described only the record card, so the generated client read `provenance` off subscription bodies and crashed. `ConfirmPage` is now a `oneOf` discriminated on `kind`, both handler branches stamp it, and the frontend narrows before reading any field.

**Bug Fixes**

- Consent links render through a dedicated `SubscriptionConfirm` page that owns its own submit, posting only the subscription grant and the exact wording shown, and rendering refusals instead of silently re-enabling the button.
- Empty 5xx responses no longer read as confirmations; the write is gated on `response.ok`.
- The handler now matches the record kind explicitly and refuses everything else, so a future link kind cannot fall through to the record card.
- Two lead-board PATCH assertions now read the method off the request, where it actually lives; they previously read `init` and always passed.

**Migration**

- This is a ratified breaking contract change: a field previously guaranteed may now be absent, but the server never actually guaranteed it. The change is allowlisted as one exact blob pair, so the stable gate restores automatically on the next contract edit.

<sup>Written for commit 962ded34ec87aab268a15f7ea8d500123055ebc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription confirmation support for consent links.
  * Confirmation pages now clearly distinguish record confirmations from subscription confirmations.
  * Added localized subscription confirmation messages in English, German, and Vietnamese.
  * Added an already-confirmed state and a single-action confirmation flow for subscriptions.

* **Bug Fixes**
  * Prevented subscription confirmations from exposing record-specific information.

* **Tests**
  * Added coverage for subscription, record, already-confirmed, and invalid-link scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->