### PR TITLE
fix: SPA/server deadline mismatch, logo re-encode cost, ai-egress doc honesty

### DIFF
--- a/backend/gates/modelroutes_test.go
+++ b/backend/gates/modelroutes_test.go
@@ -30,11 +30,13 @@ package gates
 import (
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
@@ -238,4 +240,48 @@ func clientModelRoutes(t *testing.T) map[string]string {
 		t.Fatalf("no entries parsed out of %s's %s — a gate that reads nothing agrees with everything", modelRouteClient, marker)
 	}
 	return entries
+}
+
+// tsNumericConst reads one `export const NAME = 1_234;` declaration's value,
+// underscores and all — TypeScript's numeric separators, which strconv does
+// not accept.
+var tsNumericConst = regexp.MustCompile(`export const (\w+)\s*=\s*([\d_]+);`)
+
+// TestTheClientsModelRouteDeadlineMatchesTheServers holds the client's
+// MODEL_ROUTE_TIMEOUT_MS to the server's ai.RouteWriteDeadline: the two ends
+// of one wait, and nothing else compares them. A client deadline shorter than
+// the server's gives up on work the server is still doing — the reader sees a
+// stall, and their own retry serves the answer instantly from cache because
+// the first request finished in the meantime.
+//
+// >=, not ==: the client is allowed to wait longer than the server can
+// possibly take (there is no cost to that, the server ends the call first
+// either way) but never shorter.
+func TestTheClientsModelRouteDeadlineMatchesTheServers(t *testing.T) {
+	t.Parallel()
+	source, err := os.ReadFile(modelRouteClient)
+	if err != nil {
+		t.Fatalf("reading the client: %v", err)
+	}
+	const name = "MODEL_ROUTE_TIMEOUT_MS"
+	clientMs := int64(-1)
+	for _, m := range tsNumericConst.FindAllStringSubmatch(string(source), -1) {
+		if m[1] != name {
+			continue
+		}
+		v, convErr := strconv.ParseInt(strings.ReplaceAll(m[2], "_", ""), 10, 64)
+		if convErr != nil {
+			t.Fatalf("%s: %s = %q is not a number", modelRouteClient, name, m[2])
+		}
+		clientMs = v
+	}
+	if clientMs < 0 {
+		t.Fatalf("%s declares no `export const %s = ...;` — this gate is reading a shape that is gone", modelRouteClient, name)
+	}
+
+	serverMs := ai.RouteWriteDeadline.Milliseconds()
+	if clientMs < serverMs {
+		t.Errorf("%s's %s is %dms, %s's ai.RouteWriteDeadline is %dms — the client gives up on a model route %dms before the server does, which is exactly the defect this gate exists to hold shut",
+			modelRouteClient, name, clientMs, "ai.RouteWriteDeadline", serverMs, serverMs-clientMs)
+	}
 }

--- a/backend/gates/modelroutes_test.go
+++ b/backend/gates/modelroutes_test.go
@@ -247,12 +247,22 @@ func clientModelRoutes(t *testing.T) map[string]string {
 // not accept.
 var tsNumericConst = regexp.MustCompile(`export const (\w+)\s*=\s*([\d_]+);`)
 
+// clientDeadlineHeadroomMs is how much LONGER the client's model-route
+// deadline must sit above the server's, mirroring ai.outboundtransport.go's
+// own writeHeadroom and for the same reason on the other end of the wire: the
+// client's clock starts at fetch(), before the request has reached the
+// network, while the server's starts only once the request has arrived —
+// so a client deadline merely EQUAL to the server's is shorter in practice
+// by however long that transit took.
+const clientDeadlineHeadroomMs = 30_000
+
 // TestTheClientsModelRouteDeadlineMatchesTheServers holds the client's
 // MODEL_ROUTE_TIMEOUT_MS to the server's ai.RouteWriteDeadline: the two ends
 // of one wait, and nothing else compares them. A client deadline shorter than
-// the server's gives up on work the server is still doing — the reader sees a
-// stall, and their own retry serves the answer instantly from cache because
-// the first request finished in the meantime.
+// the server's (plus the transit headroom above) gives up on work the server
+// is still doing — the reader sees a stall, and their own retry serves the
+// answer instantly from cache because the first request finished in the
+// meantime.
 //
 // >=, not ==: the client is allowed to wait longer than the server can
 // possibly take (there is no cost to that, the server ends the call first
@@ -263,25 +273,32 @@ func TestTheClientsModelRouteDeadlineMatchesTheServers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading the client: %v", err)
 	}
+	// Comments stripped first, the same as clientModelRoutes above: a
+	// commented-out or example declaration mentioning the same name is not a
+	// second real one, and without this the LAST match in source order would
+	// silently win over the real, live one above it.
+	text := tsComment.ReplaceAllString(string(source), " ")
 	const name = "MODEL_ROUTE_TIMEOUT_MS"
-	clientMs := int64(-1)
-	for _, m := range tsNumericConst.FindAllStringSubmatch(string(source), -1) {
-		if m[1] != name {
-			continue
+	var found []string
+	for _, m := range tsNumericConst.FindAllStringSubmatch(text, -1) {
+		if m[1] == name {
+			found = append(found, m[2])
 		}
-		v, convErr := strconv.ParseInt(strings.ReplaceAll(m[2], "_", ""), 10, 64)
-		if convErr != nil {
-			t.Fatalf("%s: %s = %q is not a number", modelRouteClient, name, m[2])
-		}
-		clientMs = v
 	}
-	if clientMs < 0 {
+	if len(found) == 0 {
 		t.Fatalf("%s declares no `export const %s = ...;` — this gate is reading a shape that is gone", modelRouteClient, name)
 	}
+	if len(found) > 1 {
+		t.Fatalf("%s declares %s more than once (%v) — this gate cannot tell which is the real one", modelRouteClient, name, found)
+	}
+	clientMs, convErr := strconv.ParseInt(strings.ReplaceAll(found[0], "_", ""), 10, 64)
+	if convErr != nil {
+		t.Fatalf("%s: %s = %q is not a number", modelRouteClient, name, found[0])
+	}
 
-	serverMs := ai.RouteWriteDeadline.Milliseconds()
-	if clientMs < serverMs {
-		t.Errorf("%s's %s is %dms, %s's ai.RouteWriteDeadline is %dms — the client gives up on a model route %dms before the server does, which is exactly the defect this gate exists to hold shut",
-			modelRouteClient, name, clientMs, "ai.RouteWriteDeadline", serverMs, serverMs-clientMs)
+	wantMs := ai.RouteWriteDeadline.Milliseconds() + clientDeadlineHeadroomMs
+	if clientMs < wantMs {
+		t.Errorf("%s's %s is %dms, want at least %dms (ai.RouteWriteDeadline's %dms plus %dms of transit headroom) — the client can give up on a model route while the server is still doing the work, which is exactly the defect this gate exists to hold shut",
+			modelRouteClient, name, clientMs, wantMs, ai.RouteWriteDeadline.Milliseconds(), clientDeadlineHeadroomMs)
 	}
 }

--- a/backend/internal/compose/integration/knowledgeorphan_integration_test.go
+++ b/backend/internal/compose/integration/knowledgeorphan_integration_test.go
@@ -51,10 +51,17 @@ func newCountingBlobstore() *countingBlobstore {
 }
 
 func (c *countingBlobstore) Put(ctx context.Context, key string, r io.Reader, size int64, contentType string) error {
+	err := c.Store.Put(ctx, key, r, size, contentType)
+	if err != nil {
+		return err
+	}
+	// Recorded only once the write has actually landed: a waiter polling
+	// putCount for a background write-back must see the count rise no
+	// sooner than the bytes it counts are readable back out.
 	c.mu.Lock()
 	c.put = append(c.put, key)
 	c.mu.Unlock()
-	return c.Store.Put(ctx, key, r, size, contentType)
+	return nil
 }
 
 func (c *countingBlobstore) Get(ctx context.Context, key string) (io.ReadCloser, blobstore.Object, error) {

--- a/backend/internal/compose/integration/knowledgeorphan_integration_test.go
+++ b/backend/internal/compose/integration/knowledgeorphan_integration_test.go
@@ -71,6 +71,19 @@ func (c *countingBlobstore) getCount() int {
 	return c.gets
 }
 
+// putCount reports how many times Put wrote to key so far.
+func (c *countingBlobstore) putCount(key string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, k := range c.put {
+		if k == key {
+			n++
+		}
+	}
+	return n
+}
+
 func (c *countingBlobstore) Delete(ctx context.Context, key string) error {
 	c.mu.Lock()
 	c.gone[key] = true

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -433,6 +433,19 @@ func waitAttempted(t *testing.T, g *gatedBlobstore, op, key string) {
 	}
 }
 
+// drainAttempted discards signals a setup write already queued (seedLoggedOrg's
+// own Put, most often), so a later waitAttempted cannot return on a stale
+// match and pass without the call under test ever running.
+func drainAttempted(g *gatedBlobstore) {
+	for {
+		select {
+		case <-g.attempted:
+		default:
+			return
+		}
+	}
+}
+
 // hold arms the gate: the next Put(s) to key block after entering (signalling
 // on entered) until releaseHeld is called.
 func (g *gatedBlobstore) hold(key string) {
@@ -685,6 +698,10 @@ func TestOrganizationLogoWriteBackLogsRatherThanFailsWhenThePutErrors(t *testing
 	}
 	url := "/v1/organizations/" + orgID.String() + "/logo"
 
+	// Discards seedLoggedOrg's own "put key" signal above: waitAttempted below
+	// must observe the write-back's failing attempt, not the write that set
+	// this object up, or a write-back that never ran would pass just as well.
+	drainAttempted(blob)
 	blob.failPut(key)
 	rec := httptest.NewRecorder()
 	handlers.GetOrganizationLogo(rec, httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx), crmcontracts.Id(orgID.UUID))

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -14,6 +14,7 @@ package integration
 import (
 	"bytes"
 	"context"
+	"errors"
 	"image"
 	"image/color"
 	"image/png"
@@ -66,6 +67,42 @@ func waitForPutCount(t *testing.T, blob *countingBlobstore, key string, want int
 		}
 		//craft:ignore test-sleep the poll interval for a condition wait bounded by the deadline above, not the fixed-duration sleep this check exists to catch
 		time.Sleep(time.Millisecond)
+	}
+}
+
+// failingFlushWriter forces http.ResponseController.Flush to report an
+// error: ResponseController prefers a FlushError() error method over the
+// plain Flusher it falls back to, and a bare httptest.ResponseRecorder only
+// implements the latter — so nothing exercises streamLogo's flush-failure
+// branch without this.
+type failingFlushWriter struct {
+	*httptest.ResponseRecorder
+}
+
+func (w *failingFlushWriter) FlushError() error {
+	return errors.New("forced flush failure")
+}
+
+// A flush failure is best-effort, logged and nothing else: the reader
+// already has their bytes buffered in the ResponseWriter by the time this
+// runs, and a store that then also fails the write-back (memory, seeded
+// with real bytes) still leaves the response streamLogo already decided.
+func TestOrganizationLogoLogsRatherThanFailsWhenTheFlushErrors(t *testing.T) {
+	e := Setup(t)
+	blob := blobstore.NewMemory()
+	handlers := people.NewHandlers(e.DB()).WithBlobstore(blob)
+	ctx := e.Admin()
+	orgID := seedLoggedOrg(ctx, t, e, blob, logoPNG(t))
+
+	rec := &failingFlushWriter{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "/v1/organizations/"+orgID.String()+"/logo", nil).WithContext(ctx)
+	handlers.GetOrganizationLogo(rec, req, crmcontracts.Id(orgID.UUID))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET logo = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Equal(rec.Body.Bytes(), logoPNG(t)) {
+		t.Fatal("a failed flush must not change the bytes the reader receives")
 	}
 }
 

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -382,6 +383,217 @@ func TestOrganizationLogoAnswers304WithoutTouchingBlobStorageWhenTheClientAlread
 	}
 	if got := blob.getCount(); got != 2 {
 		t.Fatalf("blob.Get calls after the stale-etag request = %d, want 2", got)
+	}
+}
+
+// gatedBlobstore lets a test hold one key's Put open at the exact instant a
+// concurrent write would race it — the write-back's own goroutine gives no
+// other hook to land a test's step in the middle of it. Unarmed by default so
+// seedLoggedOrg's own write to the SAME key (the object write-back later
+// overwrites) is never held.
+type gatedBlobstore struct {
+	*countingBlobstore
+	mu      sync.Mutex
+	heldKey string
+	armed   bool
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newGatedBlobstore(inner *countingBlobstore) *gatedBlobstore {
+	return &gatedBlobstore{countingBlobstore: inner}
+}
+
+// hold arms the gate: the next Put(s) to key block after entering (signalling
+// on entered) until releaseHeld is called.
+func (g *gatedBlobstore) hold(key string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.heldKey = key
+	g.armed = true
+	g.entered = make(chan struct{}, 8)
+	g.release = make(chan struct{})
+}
+
+func (g *gatedBlobstore) releaseHeld() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.armed = false
+	close(g.release)
+}
+
+func (g *gatedBlobstore) Put(ctx context.Context, key string, r io.Reader, size int64, contentType string) error {
+	g.mu.Lock()
+	gate := g.armed && key == g.heldKey
+	entered, release := g.entered, g.release
+	g.mu.Unlock()
+	if gate {
+		entered <- struct{}{}
+		<-release
+	}
+	return g.countingBlobstore.Put(ctx, key, r, size, contentType)
+}
+
+// waitForNotFound polls rather than asserting immediately, for the same
+// reason waitForPutCount does: the collection this proves runs on the
+// write-back's own goroutine.
+func waitForNotFound(t *testing.T, blob blobstore.Store, key string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, _, err := blob.Get(context.Background(), key)
+		if errors.Is(err, blobstore.ErrNotFound) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Get(%s) never answered ErrNotFound after 2s (err=%v)", key, err)
+		}
+		//craft:ignore test-sleep the poll interval for a condition wait bounded by the deadline above, not the fixed-duration sleep this check exists to catch
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// A burst of readers landing on the same untrimmed object must start at most
+// ONE write-back for it: streamLogo coalesces by key (handlers_organizationlogo.go)
+// precisely so a request storm right after an upload or a migration cannot pile
+// up one goroutine per reader, all racing to write the identical bytes to the
+// identical key.
+func TestOrganizationLogoWriteBackCoalescesConcurrentReadersOfTheSameUntrimmedKey(t *testing.T) {
+	e := Setup(t)
+	inner := newCountingBlobstore()
+	blob := newGatedBlobstore(inner)
+	handlers := people.NewHandlers(e.DB()).WithBlobstore(blob)
+	ctx := e.Admin()
+	wide := image.NewNRGBA(image.Rect(0, 0, 32, 8))
+	for y := range 8 {
+		for x := range 32 {
+			wide.SetNRGBA(x, y, color.NRGBA{R: 255, G: 90, A: 255})
+		}
+	}
+	legacy, err := imagenorm.SquarePNG(wide, 32)
+	if err != nil {
+		t.Fatalf("encoding a legacy square-canvas logo: %v", err)
+	}
+	orgID := seedLoggedOrg(ctx, t, e, blob, legacy)
+	key, err := e.People.OrganizationLogoKey(ctx, orgID, people.LogoWide)
+	if err != nil {
+		t.Fatalf("read the stored logo key: %v", err)
+	}
+	url := "/v1/organizations/" + orgID.String() + "/logo"
+
+	blob.hold(key)
+	const readers = 5
+	var wg sync.WaitGroup
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			handlers.GetOrganizationLogo(rec,
+				httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx),
+				crmcontracts.Id(orgID.UUID))
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case <-blob.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no write-back reached blob.Put within 2s")
+	}
+	select {
+	case <-blob.entered:
+		t.Fatal("a second write-back reached blob.Put concurrently — the readers were not coalesced")
+	case <-time.After(50 * time.Millisecond):
+	}
+	blob.releaseHeld()
+
+	// One write-back, whichever of the readers claimed it: the seed Put plus
+	// this one is 2, not 1+readers.
+	waitForPutCount(t, inner, key, 2)
+}
+
+// writeBackTrimmedLogo re-checks the slot's current key AFTER blob.Put, not
+// only before: a replace landing WHILE the write is in flight can otherwise
+// let a write-back resurrect the exact orphan deleteUnreferencedLogo exists to
+// prevent (handlers_organizationlogo.go). This proves the after-check: a
+// replace that lands mid-Put gets its own resurrected object collected, not
+// left for nothing to ever reference again.
+func TestOrganizationLogoWriteBackCollectsItsOwnObjectWhenAReplaceRacesTheWrite(t *testing.T) {
+	e := Setup(t)
+	inner := newCountingBlobstore()
+	blob := newGatedBlobstore(inner)
+	handlers := people.NewHandlers(e.DB()).WithBlobstore(blob)
+	ctx := e.Admin()
+	wide := image.NewNRGBA(image.Rect(0, 0, 32, 8))
+	for y := range 8 {
+		for x := range 32 {
+			wide.SetNRGBA(x, y, color.NRGBA{R: 255, G: 90, A: 255})
+		}
+	}
+	legacy, err := imagenorm.SquarePNG(wide, 32)
+	if err != nil {
+		t.Fatalf("encoding a legacy square-canvas logo: %v", err)
+	}
+	// The anchor organization, not a fresh one: a REPLACE that can actually
+	// out-rank the first mark needs the human-authored path (SetCompanyLogo),
+	// and that path always targets the installation's own company rather than
+	// taking a record id (companylogo.go says why).
+	offer, icp := "Revenue operations software", "RevOps at SaaS scale-ups"
+	company, err := e.People.SaveCompany(ctx, people.SaveCompanyInput{
+		DisplayName: "Voltaq Systems GmbH",
+		Fields:      map[string]*string{"offer_summary": &offer, "icp": &icp},
+	})
+	if err != nil {
+		t.Fatalf("save the company: %v", err)
+	}
+	orgID := company.OrganizationID
+	staleKey := blobstore.WorkspaceKey(ids.From[ids.WorkspaceKind](e.WS), "organization_logo", orgID.String()+"/"+ids.NewV7().String())
+	if err := blob.Put(ctx, staleKey, bytes.NewReader(legacy), int64(len(legacy)), imagenorm.ContentType); err != nil {
+		t.Fatalf("store the legacy logo bytes: %v", err)
+	}
+	if written, _, err := e.People.SetOrganizationLogo(ctx, orgID, staleKey, "https://voltaq.test/legacy.png"); err != nil {
+		t.Fatalf("SetOrganizationLogo (seed): %v", err)
+	} else if !written {
+		t.Fatal("the seed write reported no change on a fresh anchor organization")
+	}
+	url := "/v1/organizations/" + orgID.String() + "/logo"
+
+	blob.hold(staleKey)
+	rec := httptest.NewRecorder()
+	handlers.GetOrganizationLogo(rec, httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx), crmcontracts.Id(orgID.UUID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET logo = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	select {
+	case <-blob.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the write-back never reached blob.Put within 2s")
+	}
+
+	// A person replaces the mark WHILE the write-back above is blocked inside
+	// blob.Put(staleKey, ...) — the exact window the after-check exists for.
+	// SetCompanyLogo never declines, unlike a second resolve against the
+	// mark this test's own seed already set — the human write is the one
+	// case production actually lets race the write-back this way.
+	replacement := "organization_logo/" + orgID.String() + "/" + ids.NewV7().String()
+	if err := blob.Put(ctx, replacement, bytes.NewReader(logoPNG(t)), int64(len(logoPNG(t))), imagenorm.ContentType); err != nil {
+		t.Fatalf("store the replacement logo bytes: %v", err)
+	}
+	if _, err := e.People.SetCompanyLogo(ctx, people.LogoWide, replacement, "replacement.png"); err != nil {
+		t.Fatalf("SetCompanyLogo (replacement): %v", err)
+	}
+
+	blob.releaseHeld()
+	waitForPutCount(t, inner, staleKey, 2)
+	waitForNotFound(t, blob, staleKey)
+
+	current, err := e.People.OrganizationLogoKey(ctx, orgID, people.LogoWide)
+	if err != nil {
+		t.Fatalf("read the stored logo key: %v", err)
+	}
+	if current != replacement {
+		t.Fatalf("current logo key = %q, want the replacement %q", current, replacement)
 	}
 }
 

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -393,15 +393,39 @@ func TestOrganizationLogoAnswers304WithoutTouchingBlobStorageWhenTheClientAlread
 // overwrites) is never held.
 type gatedBlobstore struct {
 	*countingBlobstore
-	mu      sync.Mutex
-	heldKey string
-	armed   bool
-	entered chan struct{}
-	release chan struct{}
+	mu         sync.Mutex
+	heldKey    string
+	armed      bool
+	entered    chan struct{}
+	release    chan struct{}
+	failPutKey string
+	failDelKey string
+	// attempted fires once per Put/Delete call, keyed by "op key" — the
+	// signal a failed call still needs, since failPut/failDelete short-circuit
+	// before countingBlobstore ever records anything.
+	attempted chan string
 }
 
 func newGatedBlobstore(inner *countingBlobstore) *gatedBlobstore {
-	return &gatedBlobstore{countingBlobstore: inner}
+	return &gatedBlobstore{countingBlobstore: inner, attempted: make(chan string, 32)}
+}
+
+// waitAttempted blocks until op ("put"/"delete") is attempted against key, or
+// fails the test after 2s.
+func waitAttempted(t *testing.T, g *gatedBlobstore, op, key string) {
+	t.Helper()
+	want := op + " " + key
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case got := <-g.attempted:
+			if got == want {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("%q was never attempted within 2s", want)
+		}
+	}
 }
 
 // hold arms the gate: the next Put(s) to key block after entering (signalling
@@ -422,11 +446,44 @@ func (g *gatedBlobstore) releaseHeld() {
 	close(g.release)
 }
 
+// failPut makes the next Put(s) to key answer an error instead of storing —
+// the store this call's caller must log rather than fail its own request
+// over, since the response it answers is already on the wire.
+func (g *gatedBlobstore) failPut(key string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.failPutKey = key
+}
+
+// failDelete is failPut's twin for the collection write-back runs when a
+// replace raced its own Put.
+func (g *gatedBlobstore) failDelete(key string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.failDelKey = key
+}
+
+func (g *gatedBlobstore) Delete(ctx context.Context, key string) error {
+	g.mu.Lock()
+	failing := g.failDelKey != "" && key == g.failDelKey
+	g.mu.Unlock()
+	g.attempted <- "delete " + key
+	if failing {
+		return errors.New("simulated delete failure")
+	}
+	return g.countingBlobstore.Delete(ctx, key)
+}
+
 func (g *gatedBlobstore) Put(ctx context.Context, key string, r io.Reader, size int64, contentType string) error {
 	g.mu.Lock()
 	gate := g.armed && key == g.heldKey
+	failing := g.failPutKey != "" && key == g.failPutKey
 	entered, release := g.entered, g.release
 	g.mu.Unlock()
+	g.attempted <- "put " + key
+	if failing {
+		return errors.New("simulated put failure")
+	}
 	if gate {
 		entered <- struct{}{}
 		<-release
@@ -594,6 +651,152 @@ func TestOrganizationLogoWriteBackCollectsItsOwnObjectWhenAReplaceRacesTheWrite(
 	}
 	if current != replacement {
 		t.Fatalf("current logo key = %q, want the replacement %q", current, replacement)
+	}
+}
+
+// A store whose write-back Put fails costs nothing but that read's own CPU:
+// the response is already on the wire, and the object at key still holds the
+// correct, if untrimmed, picture for the next read to try again against.
+func TestOrganizationLogoWriteBackLogsRatherThanFailsWhenThePutErrors(t *testing.T) {
+	e := Setup(t)
+	inner := newCountingBlobstore()
+	blob := newGatedBlobstore(inner)
+	handlers := people.NewHandlers(e.DB()).WithBlobstore(blob)
+	ctx := e.Admin()
+	wide := image.NewNRGBA(image.Rect(0, 0, 32, 8))
+	for y := range 8 {
+		for x := range 32 {
+			wide.SetNRGBA(x, y, color.NRGBA{R: 255, G: 90, A: 255})
+		}
+	}
+	legacy, err := imagenorm.SquarePNG(wide, 32)
+	if err != nil {
+		t.Fatalf("encoding a legacy square-canvas logo: %v", err)
+	}
+	orgID := seedLoggedOrg(ctx, t, e, blob, legacy)
+	key, err := e.People.OrganizationLogoKey(ctx, orgID, people.LogoWide)
+	if err != nil {
+		t.Fatalf("read the stored logo key: %v", err)
+	}
+	url := "/v1/organizations/" + orgID.String() + "/logo"
+
+	blob.failPut(key)
+	rec := httptest.NewRecorder()
+	handlers.GetOrganizationLogo(rec, httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx), crmcontracts.Id(orgID.UUID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET logo = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	// The response is always the freshly TRIMMED bytes — the crop runs before
+	// the write-back is even considered — so a failed persist changes only
+	// what is STORED, never what this read answers.
+	displayed, err := png.Decode(rec.Body)
+	if err != nil {
+		t.Fatalf("display response is not a PNG: %v", err)
+	}
+	if bounds := displayed.Bounds(); bounds.Dx() != 32 || bounds.Dy() != 8 {
+		t.Fatalf("displayed logo is %v, want the trimmed 4:1 wordmark even though the write-back failed", bounds)
+	}
+
+	// Best-effort: the failed Put is attempted exactly once and never retried
+	// inline, and the object at key must still hold the ORIGINAL untrimmed
+	// bytes — only the seed's own successful Put (count 1), never a second.
+	waitAttempted(t, blob, "put", key)
+	if got := inner.putCount(key); got != 1 {
+		t.Fatalf("Put(%s) succeeded %d times, want only the seed's own 1", key, got)
+	}
+	rc, _, err := blob.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("reading the object back: %v", err)
+	}
+	stored, err := io.ReadAll(rc)
+	if closeErr := rc.Close(); closeErr != nil {
+		t.Fatalf("closing the object reader: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("reading the object's bytes: %v", err)
+	}
+	if !bytes.Equal(stored, legacy) {
+		t.Fatal("the object at key must still hold the untrimmed bytes after a failed write-back")
+	}
+}
+
+// A store whose collecting Delete fails, after a replace raced the write-back's
+// own Put, costs storage and nothing else — the row already names the
+// replacement, so nothing serves the resurrected object; it is logged rather
+// than retried inline.
+func TestOrganizationLogoWriteBackLogsRatherThanFailsWhenTheCollectingDeleteErrors(t *testing.T) {
+	e := Setup(t)
+	inner := newCountingBlobstore()
+	blob := newGatedBlobstore(inner)
+	handlers := people.NewHandlers(e.DB()).WithBlobstore(blob)
+	ctx := e.Admin()
+	wide := image.NewNRGBA(image.Rect(0, 0, 32, 8))
+	for y := range 8 {
+		for x := range 32 {
+			wide.SetNRGBA(x, y, color.NRGBA{R: 255, G: 90, A: 255})
+		}
+	}
+	legacy, err := imagenorm.SquarePNG(wide, 32)
+	if err != nil {
+		t.Fatalf("encoding a legacy square-canvas logo: %v", err)
+	}
+	offer, icp := "Revenue operations software", "RevOps at SaaS scale-ups"
+	company, err := e.People.SaveCompany(ctx, people.SaveCompanyInput{
+		DisplayName: "Voltaq Systems GmbH",
+		Fields:      map[string]*string{"offer_summary": &offer, "icp": &icp},
+	})
+	if err != nil {
+		t.Fatalf("save the company: %v", err)
+	}
+	orgID := company.OrganizationID
+	staleKey := blobstore.WorkspaceKey(ids.From[ids.WorkspaceKind](e.WS), "organization_logo", orgID.String()+"/"+ids.NewV7().String())
+	if err := blob.Put(ctx, staleKey, bytes.NewReader(legacy), int64(len(legacy)), imagenorm.ContentType); err != nil {
+		t.Fatalf("store the legacy logo bytes: %v", err)
+	}
+	if written, _, err := e.People.SetOrganizationLogo(ctx, orgID, staleKey, "https://voltaq.test/legacy.png"); err != nil {
+		t.Fatalf("SetOrganizationLogo (seed): %v", err)
+	} else if !written {
+		t.Fatal("the seed write reported no change on a fresh anchor organization")
+	}
+	url := "/v1/organizations/" + orgID.String() + "/logo"
+
+	blob.hold(staleKey)
+	blob.failDelete(staleKey)
+	rec := httptest.NewRecorder()
+	handlers.GetOrganizationLogo(rec, httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx), crmcontracts.Id(orgID.UUID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET logo = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	select {
+	case <-blob.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the write-back never reached blob.Put within 2s")
+	}
+
+	replacement := "organization_logo/" + orgID.String() + "/" + ids.NewV7().String()
+	if err := blob.Put(ctx, replacement, bytes.NewReader(logoPNG(t)), int64(len(logoPNG(t))), imagenorm.ContentType); err != nil {
+		t.Fatalf("store the replacement logo bytes: %v", err)
+	}
+	if _, err := e.People.SetCompanyLogo(ctx, people.LogoWide, replacement, "replacement.png"); err != nil {
+		t.Fatalf("SetCompanyLogo (replacement): %v", err)
+	}
+
+	blob.releaseHeld()
+	waitForPutCount(t, inner, staleKey, 2)
+	waitAttempted(t, blob, "delete", staleKey)
+
+	// The failed collect leaves the resurrected object behind rather than
+	// retrying inline — logged, not fatal, and never blocking the row from
+	// already naming the replacement.
+	if _, _, err := blob.Get(ctx, staleKey); err != nil {
+		t.Fatalf("the object at staleKey should still exist after a failed Delete: %v", err)
+	}
+	current, err := e.People.OrganizationLogoKey(ctx, orgID, people.LogoWide)
+	if err != nil {
+		t.Fatalf("read the stored logo key: %v", err)
+	}
+	if current != replacement {
+		t.Fatalf("current logo key = %q, want the replacement %q — a failed collect must not roll back the row", current, replacement)
 	}
 }
 

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"image"
 	"image/color"
 	"image/png"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -171,6 +172,75 @@ func TestOrganizationLogoRemovesLegacyTransparentCanvasAtTheDisplayBoundary(t *t
 	}
 	if bounds := displayed.Bounds(); bounds.Dx() != 32 || bounds.Dy() != 8 {
 		t.Fatalf("displayed logo is %v, want the original 4:1 wordmark", bounds)
+	}
+}
+
+// margince#4913: TrimTransparentPNG's decode-and-scan is unavoidable per read,
+// but a legacy letterboxed logo used to pay its re-encode on every single
+// request forever — the stored bytes never changed, so the crop it produced
+// was thrown away and redone next time. The read that first computes a crop
+// now writes it back over the object it read, so this proves the SECOND read
+// finds already-tight bytes and needs no further write.
+func TestOrganizationLogoWritesBackATrimmedLegacyLogoSoTheNextReadNeedsNoCrop(t *testing.T) {
+	e := Setup(t)
+	blob := newCountingBlobstore()
+	handlers := people.NewHandlers(e.DB()).WithBlobstore(blob)
+	ctx := e.Admin()
+	wide := image.NewNRGBA(image.Rect(0, 0, 32, 8))
+	for y := range 8 {
+		for x := range 32 {
+			wide.SetNRGBA(x, y, color.NRGBA{R: 255, G: 90, A: 255})
+		}
+	}
+	legacy, err := imagenorm.SquarePNG(wide, 32)
+	if err != nil {
+		t.Fatalf("encoding a legacy square-canvas logo: %v", err)
+	}
+	orgID := seedLoggedOrg(ctx, t, e, blob, legacy)
+	key, err := e.People.OrganizationLogoKey(ctx, orgID, people.LogoWide)
+	if err != nil {
+		t.Fatalf("read the stored logo key: %v", err)
+	}
+	url := "/v1/organizations/" + orgID.String() + "/logo"
+
+	first := httptest.NewRecorder()
+	handlers.GetOrganizationLogo(first, httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx), crmcontracts.Id(orgID.UUID))
+	if first.Code != http.StatusOK {
+		t.Fatalf("first GET = %d, want 200: %s", first.Code, first.Body.String())
+	}
+	if got := blob.putCount(key); got != 2 {
+		t.Fatalf("Put(%s) calls after the first read = %d, want 2 (the seed and the write-back)", key, got)
+	}
+
+	rc, _, err := blob.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("reading the object back: %v", err)
+	}
+	stored, err := io.ReadAll(rc)
+	if closeErr := rc.Close(); closeErr != nil {
+		t.Fatalf("closing the object reader: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("reading the object's bytes: %v", err)
+	}
+	decoded, err := png.Decode(bytes.NewReader(stored))
+	if err != nil {
+		t.Fatalf("the written-back object is not a PNG: %v", err)
+	}
+	if bounds := decoded.Bounds(); bounds.Dx() != 32 || bounds.Dy() != 8 {
+		t.Fatalf("the object stored after write-back is %v, want the trimmed 4:1 wordmark — it should not still be the 32x32 legacy canvas", bounds)
+	}
+
+	second := httptest.NewRecorder()
+	handlers.GetOrganizationLogo(second, httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx), crmcontracts.Id(orgID.UUID))
+	if second.Code != http.StatusOK {
+		t.Fatalf("second GET = %d, want 200: %s", second.Code, second.Body.String())
+	}
+	if !bytes.Equal(second.Body.Bytes(), stored) {
+		t.Fatal("the second read's bytes are not the written-back object's bytes")
+	}
+	if got := blob.putCount(key); got != 2 {
+		t.Fatalf("Put(%s) calls after the second read = %d, want still 2 — a read of already-tight bytes must not write back", key, got)
 	}
 }
 

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -56,8 +56,13 @@ func logoPNG(t *testing.T) []byte {
 // Bounded by the deadline rather than a fixed sleep: an in-memory store
 // settles in microseconds, so this returns on its first or second check in
 // the ordinary case, and only fails as slowly as a genuine regression would.
-func waitForPutCount(t *testing.T, blob *countingBlobstore, key string, want int) {
+//
+// Every caller waits for exactly 2: the seed's own Put plus the one
+// write-back a successful trim produces. A literal rather than a `want`
+// parameter, since every call site passed the same value.
+func waitForPutCount(t *testing.T, blob *countingBlobstore, key string) {
 	t.Helper()
+	const want = 2
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		if got := blob.putCount(key); got == want {
@@ -274,7 +279,7 @@ func TestOrganizationLogoWritesBackATrimmedLegacyLogoSoTheNextReadNeedsNoCrop(t 
 	// returns; an in-memory store's Put settles in microseconds, so the loop
 	// exits on its first or second check in the ordinary case and only the
 	// bound (not a fixed sleep) protects against a real regression hanging.
-	waitForPutCount(t, blob, key, 2)
+	waitForPutCount(t, blob, key)
 
 	rc, _, err := blob.Get(ctx, key)
 	if err != nil {
@@ -567,7 +572,7 @@ func TestOrganizationLogoWriteBackCoalescesConcurrentReadersOfTheSameUntrimmedKe
 
 	// One write-back, whichever of the readers claimed it: the seed Put plus
 	// this one is 2, not 1+readers.
-	waitForPutCount(t, inner, key, 2)
+	waitForPutCount(t, inner, key)
 }
 
 // writeBackTrimmedLogo re-checks the slot's current key AFTER blob.Put, not
@@ -642,7 +647,7 @@ func TestOrganizationLogoWriteBackCollectsItsOwnObjectWhenAReplaceRacesTheWrite(
 	}
 
 	blob.releaseHeld()
-	waitForPutCount(t, inner, staleKey, 2)
+	waitForPutCount(t, inner, staleKey)
 	waitForNotFound(t, blob, staleKey)
 
 	current, err := e.People.OrganizationLogoKey(ctx, orgID, people.LogoWide)
@@ -782,7 +787,7 @@ func TestOrganizationLogoWriteBackLogsRatherThanFailsWhenTheCollectingDeleteErro
 	}
 
 	blob.releaseHeld()
-	waitForPutCount(t, inner, staleKey, 2)
+	waitForPutCount(t, inner, staleKey)
 	waitAttempted(t, blob, "delete", staleKey)
 
 	// The failed collect leaves the resurrected object behind rather than

--- a/backend/internal/compose/integration/organizationlogo_integration_test.go
+++ b/backend/internal/compose/integration/organizationlogo_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/people"
@@ -45,6 +46,27 @@ func logoPNG(t *testing.T) []byte {
 		t.Fatalf("encoding the fixture: %v", err)
 	}
 	return out.Bytes()
+}
+
+// waitForPutCount polls rather than asserting immediately, for a caller
+// whose write runs on its own goroutine (organization logo write-back,
+// deliberately backgrounded so a slow store cannot hold a handler open).
+// Bounded by the deadline rather than a fixed sleep: an in-memory store
+// settles in microseconds, so this returns on its first or second check in
+// the ordinary case, and only fails as slowly as a genuine regression would.
+func waitForPutCount(t *testing.T, blob *countingBlobstore, key string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if got := blob.putCount(key); got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Put(%s) calls = %d after 2s, want %d", key, blob.putCount(key), want)
+		}
+		//craft:ignore test-sleep the poll interval for a condition wait bounded by the deadline above, not the fixed-duration sleep this check exists to catch
+		time.Sleep(time.Millisecond)
+	}
 }
 
 // seedLoggedOrg creates an organization and stores a logo for it: the bytes in
@@ -175,12 +197,11 @@ func TestOrganizationLogoRemovesLegacyTransparentCanvasAtTheDisplayBoundary(t *t
 	}
 }
 
-// margince#4913: TrimTransparentPNG's decode-and-scan is unavoidable per read,
-// but a legacy letterboxed logo used to pay its re-encode on every single
-// request forever — the stored bytes never changed, so the crop it produced
-// was thrown away and redone next time. The read that first computes a crop
-// now writes it back over the object it read, so this proves the SECOND read
-// finds already-tight bytes and needs no further write.
+// TrimTransparentPNG's decode-and-scan is unavoidable per read, but a legacy
+// letterboxed logo's crop is deterministic on bytes that never change — so
+// paying the re-encode on every single request is waste. The read that first
+// computes a crop writes it back over the object it read, so this proves the
+// SECOND read finds already-tight bytes and needs no further write.
 func TestOrganizationLogoWritesBackATrimmedLegacyLogoSoTheNextReadNeedsNoCrop(t *testing.T) {
 	e := Setup(t)
 	blob := newCountingBlobstore()
@@ -208,9 +229,14 @@ func TestOrganizationLogoWritesBackATrimmedLegacyLogoSoTheNextReadNeedsNoCrop(t 
 	if first.Code != http.StatusOK {
 		t.Fatalf("first GET = %d, want 200: %s", first.Code, first.Body.String())
 	}
-	if got := blob.putCount(key); got != 2 {
-		t.Fatalf("Put(%s) calls after the first read = %d, want 2 (the seed and the write-back)", key, got)
-	}
+	// The write-back runs on its own goroutine (handlers_organizationlogo.go)
+	// precisely so a slow store cannot hold the handler open — see there for
+	// why. That makes it genuinely concurrent with this assertion, so this
+	// polls rather than asserting the count immediately after the call
+	// returns; an in-memory store's Put settles in microseconds, so the loop
+	// exits on its first or second check in the ordinary case and only the
+	// bound (not a fixed sleep) protects against a real regression hanging.
+	waitForPutCount(t, blob, key, 2)
 
 	rc, _, err := blob.Get(ctx, key)
 	if err != nil {

--- a/backend/internal/modules/people/handlers.go
+++ b/backend/internal/modules/people/handlers.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -40,11 +41,18 @@ type Handlers struct {
 	// (OPS-CFG-12), injected by WithUploadLimit. Zero refuses every upload,
 	// which is the honest reading of "nobody has said" for a bound.
 	uploadLimit int64
+	// logoWritesInFlight tracks which object keys already have a trimmed-logo
+	// write-back running (see streamLogo/writeBackTrimmedLogo): a pointer, so
+	// every copy this builder's With* chain produces still shares the one map
+	// the routes it is eventually bound to will serve concurrent requests
+	// through. Allocated once here rather than lazily, so a stream that never
+	// calls WithBlobstore still holds a usable, if unused, map.
+	logoWritesInFlight *sync.Map
 }
 
 // NewHandlers builds the module's HTTP surface over a workspace-bound handle.
 func NewHandlers(db *database.DB) Handlers {
-	return Handlers{store: NewStore(db)}
+	return Handlers{store: NewStore(db), logoWritesInFlight: &sync.Map{}}
 }
 
 // WithMatchStager wires the pass that turns this member's suggested LinkedIn

--- a/backend/internal/modules/people/handlers_organizationlogo.go
+++ b/backend/internal/modules/people/handlers_organizationlogo.go
@@ -11,10 +11,12 @@ package people
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"log/slog"
 	"net/http"
+	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
@@ -28,6 +30,11 @@ import (
 // carries — 200 and 304 alike, so a client revalidating gets the same
 // freshness window as one that fetched fresh bytes.
 const logoCacheControl = "private, max-age=300"
+
+// logoWriteBackTimeout bounds the write-back below, the same shape
+// ai.flushDetached gives its own post-response write: generous for one small
+// PUT, and short enough that a dead blob store cannot pin a handler goroutine.
+const logoWriteBackTimeout = 5 * time.Second
 
 // GetOrganizationLogo streams the organization's wide mark — the lockup a
 // record page and an expanded sidebar draw.
@@ -113,4 +120,34 @@ func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontr
 		Download: httperr.Download{ContentType: imagenorm.ContentType, Inline: true, Size: int64(len(logo))},
 		Body:     io.NopCloser(bytes.NewReader(logo)),
 	}, "organization logo "+id.String())
+	// Only when a crop actually happened: TrimTransparentPNG returns src
+	// itself, unchanged, when the canvas was already tight, and writing
+	// identical bytes back would cost a PUT for nothing. After this write, the
+	// NEXT read of this same key finds visible == canvas on its own decode and
+	// pays no re-encode — the slowest of the three steps this endpoint was
+	// paying on every request, per margince#4913. The decode and the per-pixel
+	// scan are still paid on every read; closing that fully is the "trim at
+	// store time" fix margince#4913 leaves as a separate, decision-gated
+	// change (a backfill, or normalizing at upload instead of at read).
+	if !bytes.Equal(logo, source) {
+		h.writeBackTrimmedLogo(r.Context(), key, logo)
+	}
+}
+
+// writeBackTrimmedLogo persists a freshly trimmed image over the object a
+// caller just read, so every read after this one finds bytes that need no
+// further crop.
+//
+// Detached from the request's own context (ai.flushDetached is the same
+// shape, for the same reason): the response has already been written by the
+// time this runs, so an unmount or a client that walked away must not cancel
+// a write purely for the NEXT reader's benefit. Best-effort — a failure here
+// costs nothing but the CPU this read already spent; the object at key still
+// holds the correct, if untrimmed, picture, and the next read tries again.
+func (h Handlers) writeBackTrimmedLogo(ctx context.Context, key string, logo []byte) {
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), logoWriteBackTimeout)
+	defer cancel()
+	if err := h.blob.Put(writeCtx, key, bytes.NewReader(logo), int64(len(logo)), imagenorm.ContentType); err != nil {
+		slog.WarnContext(ctx, "writing back a trimmed organization logo", "err", err)
+	}
 }

--- a/backend/internal/modules/people/handlers_organizationlogo.go
+++ b/backend/internal/modules/people/handlers_organizationlogo.go
@@ -54,7 +54,8 @@ func (h Handlers) GetOrganizationLogoIcon(w http.ResponseWriter, r *http.Request
 // the client's response to all three is the same monogram, and telling them
 // apart would leak which organizations exist.
 func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, slot LogoSlot, operation string) {
-	key, err := h.store.OrganizationLogoKey(r.Context(), pathID[ids.OrganizationKind](id), slot)
+	orgID := pathID[ids.OrganizationKind](id)
+	key, err := h.store.OrganizationLogoKey(r.Context(), orgID, slot)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return
@@ -120,17 +121,25 @@ func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontr
 		Download: httperr.Download{ContentType: imagenorm.ContentType, Inline: true, Size: int64(len(logo))},
 		Body:     io.NopCloser(bytes.NewReader(logo)),
 	}, "organization logo "+id.String())
+	// A body this small can sit in net/http's own write buffer until the
+	// handler returns, so without an explicit flush here the reader would
+	// wait on the write-back below before receiving anything they asked for
+	// — silently trading their own latency for the NEXT reader's benefit.
+	if fErr := http.NewResponseController(w).Flush(); fErr != nil {
+		slog.WarnContext(r.Context(), "flushing the organization logo response", "err", fErr)
+	}
 	// Only when a crop actually happened: TrimTransparentPNG returns src
 	// itself, unchanged, when the canvas was already tight, and writing
-	// identical bytes back would cost a PUT for nothing. After this write, the
-	// NEXT read of this same key finds visible == canvas on its own decode and
-	// pays no re-encode — the slowest of the three steps this endpoint was
-	// paying on every request, per margince#4913. The decode and the per-pixel
-	// scan are still paid on every read; closing that fully is the "trim at
-	// store time" fix margince#4913 leaves as a separate, decision-gated
-	// change (a backfill, or normalizing at upload instead of at read).
+	// identical bytes back would cost a PUT for nothing.
+	//
+	// Backgrounded, not merely context-detached: logoWriteBackTimeout only
+	// bounds a Store whose Put actually watches its context, and the shipped
+	// filesystem and in-memory stores both discard theirs (blobstore.Put's own
+	// doc comment makes no promise either way). A blocked write on one of
+	// those must not hold this handler's goroutine, and with it the reader's
+	// connection, open for as long as the disk stays stuck.
 	if !bytes.Equal(logo, source) {
-		h.writeBackTrimmedLogo(r.Context(), key, logo)
+		go h.writeBackTrimmedLogo(context.WithoutCancel(r.Context()), orgID, slot, key, logo)
 	}
 }
 
@@ -138,15 +147,30 @@ func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontr
 // caller just read, so every read after this one finds bytes that need no
 // further crop.
 //
-// Detached from the request's own context (ai.flushDetached is the same
-// shape, for the same reason): the response has already been written by the
-// time this runs, so an unmount or a client that walked away must not cancel
-// a write purely for the NEXT reader's benefit. Best-effort — a failure here
-// costs nothing but the CPU this read already spent; the object at key still
-// holds the correct, if untrimmed, picture, and the next read tries again.
-func (h Handlers) writeBackTrimmedLogo(ctx context.Context, key string, logo []byte) {
-	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), logoWriteBackTimeout)
+// Runs on its own goroutine (see the call site) with its own timeout-bounded
+// context: the response is already on the wire by the time this starts, so an
+// unmount or a client that walked away must not cancel a write purely for the
+// NEXT reader's benefit. Best-effort — a failure here costs nothing but the
+// CPU this read already spent; the object at key still holds the correct, if
+// untrimmed, picture, and the next read tries again.
+//
+// Re-reads the slot's CURRENT key first and refuses to write if it has moved
+// on: this read may have raced a replace or an archive whose own cleanup
+// (deleteUnreferencedLogo, sitelogoreclaim.go) already deleted the object at
+// key, and a write-back landing after that delete would resurrect bytes
+// nothing references — the exact orphan knowledgeorphan_integration_test.go
+// exists to catch, one module over.
+func (h Handlers) writeBackTrimmedLogo(ctx context.Context, orgID ids.OrganizationID, slot LogoSlot, key string, logo []byte) {
+	writeCtx, cancel := context.WithTimeout(ctx, logoWriteBackTimeout)
 	defer cancel()
+	current, err := h.store.OrganizationLogoKey(writeCtx, orgID, slot)
+	if err != nil {
+		slog.WarnContext(ctx, "re-reading the current logo key before write-back", "err", err)
+		return
+	}
+	if current != key {
+		return
+	}
 	if err := h.blob.Put(writeCtx, key, bytes.NewReader(logo), int64(len(logo)), imagenorm.ContentType); err != nil {
 		slog.WarnContext(ctx, "writing back a trimmed organization logo", "err", err)
 	}

--- a/backend/internal/modules/people/handlers_organizationlogo.go
+++ b/backend/internal/modules/people/handlers_organizationlogo.go
@@ -138,8 +138,17 @@ func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontr
 	// doc comment makes no promise either way). A blocked write on one of
 	// those must not hold this handler's goroutine, and with it the reader's
 	// connection, open for as long as the disk stays stuck.
+	// Coalesced by key: a burst of readers landing on the same untrimmed
+	// object right after an upload or a migration would otherwise each start
+	// their own write-back of the identical bytes to the identical key. Only
+	// the first claims it; the rest find it already in flight and skip —
+	// once that one write-back finishes, every later read finds the object
+	// already trimmed and TrimTransparentPNG returns src unchanged, so the
+	// map never needs more than one entry per key at a time.
 	if !bytes.Equal(logo, source) {
-		go h.writeBackTrimmedLogo(context.WithoutCancel(r.Context()), orgID, slot, key, logo)
+		if _, running := h.logoWritesInFlight.LoadOrStore(key, struct{}{}); !running {
+			go h.writeBackTrimmedLogo(context.WithoutCancel(r.Context()), orgID, slot, key, logo)
+		}
 	}
 }
 
@@ -154,13 +163,17 @@ func (h Handlers) streamLogo(w http.ResponseWriter, r *http.Request, id crmcontr
 // CPU this read already spent; the object at key still holds the correct, if
 // untrimmed, picture, and the next read tries again.
 //
-// Re-reads the slot's CURRENT key first and refuses to write if it has moved
-// on: this read may have raced a replace or an archive whose own cleanup
-// (deleteUnreferencedLogo, sitelogoreclaim.go) already deleted the object at
-// key, and a write-back landing after that delete would resurrect bytes
-// nothing references — the exact orphan knowledgeorphan_integration_test.go
-// exists to catch, one module over.
+// Re-reads the slot's CURRENT key both before and after the write: this read
+// may race a replace or an archive whose own cleanup (deleteUnreferencedLogo,
+// sitelogoreclaim.go) deletes the object at key, and a write-back landing on
+// either side of that delete would resurrect bytes nothing references — the
+// exact orphan knowledgeorphan_integration_test.go exists to catch, one
+// module over. The before check skips the write outright; the after check
+// covers the narrower race where the replace lands WHILE blob.Put is in
+// flight, by deleting straight back out what this call just wrote rather
+// than leaving it for nothing to ever reference again.
 func (h Handlers) writeBackTrimmedLogo(ctx context.Context, orgID ids.OrganizationID, slot LogoSlot, key string, logo []byte) {
+	defer h.logoWritesInFlight.Delete(key)
 	writeCtx, cancel := context.WithTimeout(ctx, logoWriteBackTimeout)
 	defer cancel()
 	current, err := h.store.OrganizationLogoKey(writeCtx, orgID, slot)
@@ -173,5 +186,17 @@ func (h Handlers) writeBackTrimmedLogo(ctx context.Context, orgID ids.Organizati
 	}
 	if err := h.blob.Put(writeCtx, key, bytes.NewReader(logo), int64(len(logo)), imagenorm.ContentType); err != nil {
 		slog.WarnContext(ctx, "writing back a trimmed organization logo", "err", err)
+		return
+	}
+	after, err := h.store.OrganizationLogoKey(writeCtx, orgID, slot)
+	if err != nil {
+		slog.WarnContext(ctx, "re-reading the current logo key after write-back", "err", err)
+		return
+	}
+	if after == key {
+		return
+	}
+	if err := h.blob.Delete(writeCtx, key); err != nil {
+		slog.WarnContext(ctx, "collecting a write-back that raced a logo replacement", "err", err)
 	}
 }

--- a/backend/tools/gen-aitasks/emitegress.go
+++ b/backend/tools/gen-aitasks/emitegress.go
@@ -49,9 +49,16 @@ they last wrote this page down.
 
 Two different promises, and a task can make either without the other:
 
-- **Stays local** — the task's ladder names only rungs that run on this
-  installation's own hardware, so no binding an operator chooses can send its
-  text to a hosted provider.
+- **Stays local** — the task's ladder names only rungs (` + "`local_small`" + `,
+  ` + "`local_large`" + `) meant to run on this installation's own hardware. Under
+  the ` + "`sovereign`" + ` profile that is also enforced: validation refuses a cloud
+  binding for either tier outright, so no cloud client for one is ever
+  constructed. Under every OTHER profile (` + "`eu_hosted`" + `, ` + "`cloud_frontier`" + `) it
+  is a naming convention, not an enforced rule — an operator's own binding can
+  point ` + "`local_small`" + ` or ` + "`local_large`" + ` at a hosted provider, and this
+  column would then answer "yes" for a task that does, in fact, leave the
+  machine. Read ` + "`GET /v1/ai/routing`" + ` for what a given deployment actually
+  bound.
 - **Prompt not retained** — the task declares ` + "`no_payload`" + `, so its prompt is
   never written to ` + "`ai_call_payload`" + ` whatever the deployment's capture posture
   says.
@@ -81,6 +88,13 @@ for the tasks that read mail: ` + "`capture_classify`" + `, ` + "`capture_counte
 and ` + "`capture_confidentiality_verdict`" + `. The last two decide whether a sender or a
 thread is private, so sending their text away to ask would be the question
 answering itself the wrong way round.
+
+**On this installation, specifically — not in general.** "Yes" here names a
+ladder that CAN run entirely on this machine; it is a guarantee only under the
+` + "`sovereign`" + ` profile. Under ` + "`eu_hosted`" + ` or ` + "`cloud_frontier`" + `, both mailbox
+classifiers stay local unless an admin binds a cloud model to ` + "`local_small`" + `
+or ` + "`local_large`" + ` — read ` + "`GET /v1/ai/routing`" + ` on the deployment in question
+for what it actually bound, rather than trusting this column alone.
 
 "Is a copy kept?" is the **Prompt not retained** column, and it is about this
 installation's own database rather than about the provider. What a bound

--- a/backend/tools/gen-aitasks/emitegress.go
+++ b/backend/tools/gen-aitasks/emitegress.go
@@ -49,16 +49,17 @@ they last wrote this page down.
 
 Two different promises, and a task can make either without the other:
 
-- **Stays local** — the task's ladder names only rungs (` + "`local_small`" + `,
-  ` + "`local_large`" + `) meant to run on this installation's own hardware. Under
-  the ` + "`sovereign`" + ` profile that is also enforced: validation refuses a cloud
-  binding for either tier outright, so no cloud client for one is ever
-  constructed. Under every OTHER profile (` + "`eu_hosted`" + `, ` + "`cloud_frontier`" + `) it
-  is a naming convention, not an enforced rule — an operator's own binding can
-  point ` + "`local_small`" + ` or ` + "`local_large`" + ` at a hosted provider, and this
-  column would then answer "yes" for a task that does, in fact, leave the
-  machine. Read ` + "`GET /v1/ai/routing`" + ` for what a given deployment actually
-  bound.
+- **Local-only ladder** — the task's ladder names only rungs (` + "`local_small`" + `,
+  ` + "`local_large`" + `) meant to run on this installation's own hardware. That is a
+  fact about the LADDER'S NAMES, not a guarantee that text stays put: whether
+  it is enforced depends on the deployment's AI profile. Under ` + "`sovereign`" + `
+  it is enforced — validation refuses a cloud binding for either tier
+  outright, so no cloud client for one is ever constructed. Under every OTHER
+  profile (` + "`eu_hosted`" + `, ` + "`cloud_frontier`" + `) it is unenforced: an operator's
+  own binding can point ` + "`local_small`" + ` or ` + "`local_large`" + ` at a hosted
+  provider, and a task with a local-only ladder then leaves the machine
+  anyway. Read ` + "`GET /v1/ai/routing`" + ` for what a given deployment actually
+  bound, and ` + "`GET /v1/ai/profile`" + ` for which of the two rules applies to it.
 - **Prompt not retained** — the task declares ` + "`no_payload`" + `, so its prompt is
   never written to ` + "`ai_call_payload`" + ` whatever the deployment's capture posture
   says.
@@ -68,7 +69,7 @@ for its ladder's rungs, and may retain the prompt for debugging. That is the
 ordinary case and is not a defect: it is the deployment's choice, stated here so
 it can be answered for.
 
-| Task | Ladder | Stays local | Prompt not retained | Status |
+| Task | Ladder | Local-only ladder | Prompt not retained | Status |
 | --- | --- | --- | --- | --- |
 `)
 	for _, name := range names {
@@ -83,18 +84,22 @@ it can be answered for.
 	b.WriteString(`
 ## Reading this against a data-protection question
 
-"Does our mail leave the building?" is answered by the **Stays local** column
-for the tasks that read mail: ` + "`capture_classify`" + `, ` + "`capture_counterparty_verdict`" + `
-and ` + "`capture_confidentiality_verdict`" + `. The last two decide whether a sender or a
+"Does our mail leave the building?" needs TWO facts, not one, for the tasks
+that read mail: ` + "`capture_classify`" + `, ` + "`capture_counterparty_verdict`" + ` and
+` + "`capture_confidentiality_verdict`" + `. The last two decide whether a sender or a
 thread is private, so sending their text away to ask would be the question
 answering itself the wrong way round.
 
-**On this installation, specifically — not in general.** "Yes" here names a
-ladder that CAN run entirely on this machine; it is a guarantee only under the
-` + "`sovereign`" + ` profile. Under ` + "`eu_hosted`" + ` or ` + "`cloud_frontier`" + `, both mailbox
-classifiers stay local unless an admin binds a cloud model to ` + "`local_small`" + `
-or ` + "`local_large`" + ` — read ` + "`GET /v1/ai/routing`" + ` on the deployment in question
-for what it actually bound, rather than trusting this column alone.
+The **Local-only ladder** column is the first fact and, on its own, does NOT
+answer the question — it names the ladder's tiers, not what a deployment does
+with them. The second fact is the AI profile: under ` + "`sovereign`" + `, a local-only
+ladder is enforced (validation refuses a cloud binding for it outright) and
+the column's "yes" is a real guarantee. Under ` + "`eu_hosted`" + ` or
+` + "`cloud_frontier`" + `, it is not — an admin's own binding can point ` + "`local_small`" + `
+or ` + "`local_large`" + ` at a hosted provider, and a "yes" task then leaves the
+machine anyway. Read ` + "`GET /v1/ai/profile`" + ` for which rule applies to the
+deployment in question, and ` + "`GET /v1/ai/routing`" + ` for what it actually bound
+— never this page alone.
 
 "Is a copy kept?" is the **Prompt not retained** column, and it is about this
 installation's own database rather than about the provider. What a bound

--- a/docs/reference/ai-egress.md
+++ b/docs/reference/ai-egress.md
@@ -9,9 +9,16 @@ they last wrote this page down.
 
 Two different promises, and a task can make either without the other:
 
-- **Stays local** — the task's ladder names only rungs that run on this
-  installation's own hardware, so no binding an operator chooses can send its
-  text to a hosted provider.
+- **Stays local** — the task's ladder names only rungs (`local_small`,
+  `local_large`) meant to run on this installation's own hardware. Under
+  the `sovereign` profile that is also enforced: validation refuses a cloud
+  binding for either tier outright, so no cloud client for one is ever
+  constructed. Under every OTHER profile (`eu_hosted`, `cloud_frontier`) it
+  is a naming convention, not an enforced rule — an operator's own binding can
+  point `local_small` or `local_large` at a hosted provider, and this
+  column would then answer "yes" for a task that does, in fact, leave the
+  machine. Read `GET /v1/ai/routing` for what a given deployment actually
+  bound.
 - **Prompt not retained** — the task declares `no_payload`, so its prompt is
   never written to `ai_call_payload` whatever the deployment's capture posture
   says.
@@ -61,6 +68,13 @@ for the tasks that read mail: `capture_classify`, `capture_counterparty_verdict`
 and `capture_confidentiality_verdict`. The last two decide whether a sender or a
 thread is private, so sending their text away to ask would be the question
 answering itself the wrong way round.
+
+**On this installation, specifically — not in general.** "Yes" here names a
+ladder that CAN run entirely on this machine; it is a guarantee only under the
+`sovereign` profile. Under `eu_hosted` or `cloud_frontier`, both mailbox
+classifiers stay local unless an admin binds a cloud model to `local_small`
+or `local_large` — read `GET /v1/ai/routing` on the deployment in question
+for what it actually bound, rather than trusting this column alone.
 
 "Is a copy kept?" is the **Prompt not retained** column, and it is about this
 installation's own database rather than about the provider. What a bound

--- a/docs/reference/ai-egress.md
+++ b/docs/reference/ai-egress.md
@@ -9,16 +9,17 @@ they last wrote this page down.
 
 Two different promises, and a task can make either without the other:
 
-- **Stays local** — the task's ladder names only rungs (`local_small`,
-  `local_large`) meant to run on this installation's own hardware. Under
-  the `sovereign` profile that is also enforced: validation refuses a cloud
-  binding for either tier outright, so no cloud client for one is ever
-  constructed. Under every OTHER profile (`eu_hosted`, `cloud_frontier`) it
-  is a naming convention, not an enforced rule — an operator's own binding can
-  point `local_small` or `local_large` at a hosted provider, and this
-  column would then answer "yes" for a task that does, in fact, leave the
-  machine. Read `GET /v1/ai/routing` for what a given deployment actually
-  bound.
+- **Local-only ladder** — the task's ladder names only rungs (`local_small`,
+  `local_large`) meant to run on this installation's own hardware. That is a
+  fact about the LADDER'S NAMES, not a guarantee that text stays put: whether
+  it is enforced depends on the deployment's AI profile. Under `sovereign`
+  it is enforced — validation refuses a cloud binding for either tier
+  outright, so no cloud client for one is ever constructed. Under every OTHER
+  profile (`eu_hosted`, `cloud_frontier`) it is unenforced: an operator's
+  own binding can point `local_small` or `local_large` at a hosted
+  provider, and a task with a local-only ladder then leaves the machine
+  anyway. Read `GET /v1/ai/routing` for what a given deployment actually
+  bound, and `GET /v1/ai/profile` for which of the two rules applies to it.
 - **Prompt not retained** — the task declares `no_payload`, so its prompt is
   never written to `ai_call_payload` whatever the deployment's capture posture
   says.
@@ -28,7 +29,7 @@ for its ladder's rungs, and may retain the prompt for debugging. That is the
 ordinary case and is not a defect: it is the deployment's choice, stated here so
 it can be answered for.
 
-| Task | Ladder | Stays local | Prompt not retained | Status |
+| Task | Ladder | Local-only ladder | Prompt not retained | Status |
 | --- | --- | --- | --- | --- |
 | `account_scan` | `cheap_cloud` → `premium` | no | yes | shipped |
 | `agent_loop` | `cheap_cloud` → `premium` | no | no | shipped |
@@ -63,18 +64,22 @@ it can be answered for.
 
 ## Reading this against a data-protection question
 
-"Does our mail leave the building?" is answered by the **Stays local** column
-for the tasks that read mail: `capture_classify`, `capture_counterparty_verdict`
-and `capture_confidentiality_verdict`. The last two decide whether a sender or a
+"Does our mail leave the building?" needs TWO facts, not one, for the tasks
+that read mail: `capture_classify`, `capture_counterparty_verdict` and
+`capture_confidentiality_verdict`. The last two decide whether a sender or a
 thread is private, so sending their text away to ask would be the question
 answering itself the wrong way round.
 
-**On this installation, specifically — not in general.** "Yes" here names a
-ladder that CAN run entirely on this machine; it is a guarantee only under the
-`sovereign` profile. Under `eu_hosted` or `cloud_frontier`, both mailbox
-classifiers stay local unless an admin binds a cloud model to `local_small`
-or `local_large` — read `GET /v1/ai/routing` on the deployment in question
-for what it actually bound, rather than trusting this column alone.
+The **Local-only ladder** column is the first fact and, on its own, does NOT
+answer the question — it names the ladder's tiers, not what a deployment does
+with them. The second fact is the AI profile: under `sovereign`, a local-only
+ladder is enforced (validation refuses a cloud binding for it outright) and
+the column's "yes" is a real guarantee. Under `eu_hosted` or
+`cloud_frontier`, it is not — an admin's own binding can point `local_small`
+or `local_large` at a hosted provider, and a "yes" task then leaves the
+machine anyway. Read `GET /v1/ai/profile` for which rule applies to the
+deployment in question, and `GET /v1/ai/routing` for what it actually bound
+— never this page alone.
 
 "Is a copy kept?" is the **Prompt not retained** column, and it is about this
 installation's own database rather than about the provider. What a bound

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   api,
   CACHE_ANSWER_GRACE_MS,
+  MODEL_ROUTE_TIMEOUT_MS,
   REQUEST_TIMEOUT_MS,
   RequestTimeoutError,
 } from "./client";
@@ -91,6 +92,28 @@ describe("the api client's request deadline", () => {
     // A timer still armed here would abort a controller nobody is listening to
     // and keep the page awake for the whole deadline after every answered request.
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  // The regression this deadline split exists to fix: a model route used to
+  // give up at REQUEST_TIMEOUT_MS, 24.5 minutes before the server's own
+  // deadline, so a slow-but-live model answer reached the reader as a stall.
+  it("still waits on a model route past REQUEST_TIMEOUT_MS", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", neverAnswers());
+    const draft = api.POST("/people/{id}/draft-email", {
+      params: { path: { id: "01a0-4cd2" } },
+      body: {},
+    });
+    const settled = vi.fn();
+    draft.then(settled, settled);
+
+    await vi.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS);
+    expect(settled).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(
+      MODEL_ROUTE_TIMEOUT_MS - REQUEST_TIMEOUT_MS,
+    );
+    await expect(draft).rejects.toBeInstanceOf(RequestTimeoutError);
   });
 });
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -61,7 +61,7 @@ export const REQUEST_TIMEOUT_MS = 360_000;
 
 // How long a request to a MODEL route may stay open — a declared mirror of
 // the server's ai.RouteWriteDeadline (backend/internal/modules/ai/outboundtransport.go),
-// held equal by backend/gates/modelroutes_test.go's
+// held to it (never shorter) by backend/gates/modelroutes_test.go's
 // TestTheClientsModelRouteDeadlineMatchesTheServers.
 //
 // Using REQUEST_TIMEOUT_MS here was the bug this constant exists to fix: 360s
@@ -70,13 +70,21 @@ export const REQUEST_TIMEOUT_MS = 360_000;
 // reader saw a stall, and their own retry served the answer instantly from
 // cache because the first request had finished in the meantime.
 //
+// 30 seconds ABOVE the server's own ai.RouteWriteDeadline (1,800,000ms),
+// mirroring the headroom the server's own formula already adds for the same
+// reason (writeHeadroom, outboundtransport.go): this clock starts when fetch
+// is called, before the request has even reached the network, while the
+// server's starts only once the request has arrived — so a client deadline
+// merely EQUAL to the server's is still shorter in practice by however long
+// that transit took.
+//
 // Deliberately its OWN constant rather than raising REQUEST_TIMEOUT_MS itself:
 // this client seam is shared by every route, and a single 30-minute deadline
 // on GET /v1/people would leave a request into a dead socket "pending" for
 // half an hour — exactly the eternal-pending state this deadline exists to
 // remove. modelWaitOf (below) is what routes a request to the right one of
 // the two.
-export const MODEL_ROUTE_TIMEOUT_MS = 1_830_000;
+export const MODEL_ROUTE_TIMEOUT_MS = 1_860_000;
 
 /**
  * A request that opened and never answered.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -51,7 +51,32 @@ function readerLanguage(): string | undefined {
 // reason. It sits above the server's own ceiling now, so the SERVER is what
 // ends a hopeless request — it knows what the work was — and this remains what
 // it was for: the request that opened and will never answer at all.
+//
+// NOT what a request to a model route waits for — see MODEL_ROUTE_TIMEOUT_MS
+// below. This value covers "sits above CallCeiling" and stops there: it is
+// well below RouteWriteDeadline, the bound that actually governs the response
+// a model route is writing, so a request to one of those routes must use the
+// longer of the two or it gives up on work the server is still doing.
 export const REQUEST_TIMEOUT_MS = 360_000;
+
+// How long a request to a MODEL route may stay open — a declared mirror of
+// the server's ai.RouteWriteDeadline (backend/internal/modules/ai/outboundtransport.go),
+// held equal by backend/gates/modelroutes_test.go's
+// TestTheClientsModelRouteDeadlineMatchesTheServers.
+//
+// Using REQUEST_TIMEOUT_MS here was the bug this constant exists to fix: 360s
+// sits 1470s — 24.5 minutes — short of the server's own deadline, so the
+// client gave up on a model route that was still legitimately working, the
+// reader saw a stall, and their own retry served the answer instantly from
+// cache because the first request had finished in the meantime.
+//
+// Deliberately its OWN constant rather than raising REQUEST_TIMEOUT_MS itself:
+// this client seam is shared by every route, and a single 30-minute deadline
+// on GET /v1/people would leave a request into a dead socket "pending" for
+// half an hour — exactly the eternal-pending state this deadline exists to
+// remove. modelWaitOf (below) is what routes a request to the right one of
+// the two.
+export const MODEL_ROUTE_TIMEOUT_MS = 1_830_000;
 
 /**
  * A request that opened and never answered.
@@ -84,6 +109,12 @@ export class RequestTimeoutError extends Error {
 // that one counts on a clock inside the platform, which no test can advance, and
 // a deadline nothing can exercise is a deadline nobody knows still works.
 async function fetchWithDeadline(request: Request): Promise<Response> {
+  // A model route gets the longer deadline; every other request keeps the
+  // shorter one. modelWaitOf is declared further down this file — safe to
+  // call here because nothing calls fetchWithDeadline until the module has
+  // finished loading and every binding below is initialised.
+  const timeoutMs =
+    modelWaitOf(request) === null ? REQUEST_TIMEOUT_MS : MODEL_ROUTE_TIMEOUT_MS;
   const deadline = new AbortController();
   // The REQUEST's own signal is what React Query aborts when a screen unmounts
   // or a query is cancelled. Without this the deadline was the only way a call
@@ -102,9 +133,9 @@ async function fetchWithDeadline(request: Request): Promise<Response> {
   }
   const expiry = globalThis.setTimeout(() => {
     deadline.abort(
-      new RequestTimeoutError(request.method, request.url, REQUEST_TIMEOUT_MS),
+      new RequestTimeoutError(request.method, request.url, timeoutMs),
     );
-  }, REQUEST_TIMEOUT_MS);
+  }, timeoutMs);
   try {
     return withGatewayProblem(
       await globalThis.fetch(request, { signal: deadline.signal }),


### PR DESCRIPTION
## Summary

Three independent QC findings, bundled into one PR to keep CI runs down (all small, unrelated modules):

**margince#4981** — the SPA gave up waiting on a slow-but-live AI-model route (a dossier, a growth-fit read) 24.5 minutes before the server's own deadline, with a client-side comment claiming the opposite of what the arithmetic actually says. A reader saw a silent stall while the server kept working and cached the answer; their own retry then served it instantly, making the six wasted minutes look like a fluke rather than a real bound.
- Added `MODEL_ROUTE_TIMEOUT_MS` — a declared mirror of the server's `ai.RouteWriteDeadline` — and `fetchWithDeadline` now picks per-route between it and the existing `REQUEST_TIMEOUT_MS` via `modelWaitOf`.
- Held together by a new gate, `TestTheClientsModelRouteDeadlineMatchesTheServers` (`backend/gates/modelroutes_test.go`), mirroring the existing `frontendminorunits`/`modelroutes` parity-gate pattern this repo already uses for exactly this shape of cross-language invariant.

**margince#4913** — `GetOrganizationLogo` decoded, per-pixel-scanned and re-encoded a legacy letterboxed logo on *every single* cache-miss request (243ms measured), even though the stored bytes never change between reads.
- The read that first computes a crop now writes it back over the object it read (detached from the request's own context, mirroring `ai.flushDetached`'s established pattern), so the next read finds already-tight bytes and pays no further re-encode.
- This closes the "encode" half of the cost; the "repeat-view" half was already closed by an ETag/304 path in an earlier commit. Full elimination of the per-read decode+scan needs a store-time normalization the issue itself flags as a separate, decision-gated change (a backfill vs. normalizing at upload) — left open, noted in the issue.

**margince#4343** — the generated `docs/reference/ai-egress.md` claimed two mail classifiers "stay local" unconditionally. That's only actually enforced under the `sovereign` profile (P7 zero-egress validation); every other profile (`eu_hosted`, `cloud_frontier`) lets an operator's own binding point `local_small`/`local_large` at a hosted provider — which the shipped dev config does today. Reworded the generator's own definition and its "reading this against a data-protection question" section to say so, matching the wording the whitepaper already used correctly.

## Test plan

- [x] New Go gate `TestTheClientsModelRouteDeadlineMatchesTheServers`, mutation-tested (reverted the client constant, confirmed the gate fails with the exact ms gap; restored, reconfirmed green).
- [x] New frontend test `client.test.ts` proving a model route still waits past `REQUEST_TIMEOUT_MS`, mutation-tested (reverted the per-route split, confirmed it fails; restored, reconfirmed green).
- [x] New integration test `TestOrganizationLogoWritesBackATrimmedLegacyLogoSoTheNextReadNeedsNoCrop`, mutation-tested (disabled the write-back call, confirmed it fails; restored, reconfirmed green) — run against a real Postgres instance.
- [x] Regenerated `docs/reference/ai-egress.md` via the actual generator (not hand-edited); existing `TestTheEgressPageMatchesTheTaskContract` gate still green; regenerating a second time produces no further drift.
- [x] `make check-go` green (build, vet, lint, arch-lint, full backend test suite, contract drift, composition reproducibility).
- [x] Full `backend/gates` suite green.
- [x] Frontend `src/api/` suite green.
- No UAT video — backend/platform fixes with no new user-facing screen (the client-timeout fix changes failure-mode timing, not anything visually observable in normal operation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRuXiSKkD1X1D1U5yRF4Qn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Model-route requests now wait 31 minutes instead of the previous 6-minute client timeout, while other requests keep the 6-minute limit. Legacy organization logos are trimmed once in a background write-back instead of being re-encoded on every cache miss, and the egress documentation now explains when local-only routing is actually enforced.

- `margince#4981`: Adds a 30-second buffer above the server deadline and a gate that keeps the client and server limits aligned.
- `margince#4913`: Flushes the logo response before starting the write-back, coalesces concurrent writes, and removes a write-back if the logo changes during the operation. Write-back failures are logged and don't affect the response.
- `margince#4343`: Renames "Stays local" to "Local-only ladder" and directs operators to check the deployment profile and routing endpoints.

<sup>Written for commit 57effd9341e3ea509291ef50b5aa11f2e276236d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organization logos now stream more reliably, with trimmed versions saved automatically for faster subsequent access.
  - Model-related requests can remain active for up to 31 minutes, while other requests retain the six-minute timeout.

- **Bug Fixes**
  - Concurrent logo requests now avoid duplicate write-backs, and background persistence failures no longer disrupt successful responses.

- **Documentation**
  - AI egress guidance now clarifies that local-only routing depends on the deployment’s AI profile and explains how to check routing and profile settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->