### PR TITLE
feat(capture): a failure streak says when it started

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -23080,6 +23080,7 @@ components:
         scopes: { type: array, items: { type: string }, description: The granted provider scopes. }
         last_synced_at: { type: [string, 'null'], format: date-time, description: 'Last sync attempt (CAP-DDL-5); null before the first.' }
         last_sync_error_class: { type: [string, 'null'], description: 'rate_limited | unreachable | auth | history_gone | internal — class only, detail in system_log.' }
+        sync_failing_since: { type: [string, 'null'], format: date-time, description: 'When the CURRENT failure streak began, null while healthy. Set on the first failure after a success and left alone until one clears it, so the duration read off it is the outage''s — last_synced_at moves on every postponed tick and dates the newest attempt instead.' }
         next_sync_due_at: { type: [string, 'null'], format: date-time, description: 'When the sweep will next pick this connection up (backoff-aware).' }
         backfill: { allOf: [ { $ref: '#/components/schemas/BackfillStatus' } ], description: 'Summary of the connection''s backfill run; state `none` when never run.' }
         signature_enrich_enabled:

--- a/backend/internal/compose/attention/healthlanes.go
+++ b/backend/internal/compose/attention/healthlanes.go
@@ -66,6 +66,15 @@ type CaptureConcern struct {
 	Provider     string
 	// AccountLabel is the display-only mailbox address when one was recorded.
 	AccountLabel string
+
+	// FailingSince is when this concern's failure streak began, nil for a
+	// condition that is a state rather than a streak — a disconnected mailbox
+	// is not failing, it is off. It is what makes this lane answer "has
+	// anything been wrong for a while" rather than only "is anything wrong":
+	// a sync that postpones itself is never late by any age reading, so an
+	// hour-old outage and a mailbox idling between ticks reach here identically
+	// without it.
+	FailingSince *time.Time
 }
 
 // AIWork is the reader's own AI runs that went wrong — failed inside the

--- a/backend/internal/compose/attention/renderhealthlanes.go
+++ b/backend/internal/compose/attention/renderhealthlanes.go
@@ -74,6 +74,17 @@ func captureItem(concern CaptureConcern) crmcontracts.AttentionItem {
 		label := mailbox
 		item.CauseLabel = &label
 	}
+	// WHEN the condition started, for the conditions that have a start. The
+	// reader's question about a failing mailbox is how long, not whether — a
+	// class alone is the same sentence at one minute and at six hours — and
+	// this is the field every other lane already answers it in. Absent for a
+	// condition that is a state rather than a streak, because a disconnected
+	// mailbox has no duration to report and inventing one from the row's
+	// timestamps would date the newest attempt rather than the outage.
+	if concern.FailingSince != nil {
+		started := *concern.FailingSince
+		item.OccurredAt = &started
+	}
 	return item
 }
 

--- a/backend/internal/compose/attentionopsseam.go
+++ b/backend/internal/compose/attentionopsseam.go
@@ -100,6 +100,7 @@ func (c attentionCaptureHealth) CaptureConcerns(ctx context.Context) ([]attentio
 			Kind:         concern.Kind,
 			Provider:     concern.Provider,
 			AccountLabel: concern.AccountLabel,
+			FailingSince: concern.FailingSince,
 		})
 	}
 	return out, nil

--- a/backend/internal/compose/connectors.go
+++ b/backend/internal/compose/connectors.go
@@ -29,8 +29,6 @@ import (
 	"strings"
 	"time"
 
-	openapi_types "github.com/oapi-codegen/runtime/types"
-
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/capture/gcal"
@@ -464,37 +462,4 @@ func postureOnWire(posture string) *crmcontracts.CaptureConnectionMailPosture {
 	}
 	p := crmcontracts.CaptureConnectionMailPosture(posture)
 	return &p
-}
-
-// toContractConnection maps a registry connection row onto the wire shape.
-// Storage now uses the contract's own status vocabulary (CAP-DDL-2 reconciled
-// capture_connection to it), so status is a straight cast — no translation. The
-// credential is never present.
-func toContractConnection(v capture.ConnectionView) crmcontracts.CaptureConnection {
-	c := crmcontracts.CaptureConnection{
-		Id:             openapi_types.UUID(v.ID),
-		Provider:       crmcontracts.CaptureConnectionProvider(v.Provider),
-		Status:         crmcontracts.CaptureConnectionStatus(v.Status),
-		Scopes:         v.ProviderScopes,
-		WatchExpiresAt: v.WatchExpiresAt,
-		AccountLabel:   v.AccountLabel,
-		// Carried as the pointer it is: null on the wire is this mailbox
-		// following the tenant default, not a field the read forgot.
-		SignatureEnrichEnabled: v.SignatureEnrichEnabled,
-		MailPosture:            postureOnWire(v.MailPosture),
-		ContextTag:             contextTagOnWire(v.ContextTag),
-	}
-	if c.Scopes == nil {
-		c.Scopes = []string{}
-	}
-	if len(v.Cursor) > 0 {
-		s := string(v.Cursor)
-		c.SyncCursor = &s
-	}
-	c.LastSyncedAt = v.LastSyncedAt
-	c.LastSyncErrorClass = v.LastErrorClass
-	c.NextSyncDueAt = v.NextSyncDueAt
-	bf := backfillStatusPayload(v.Backfill)
-	c.Backfill = &bf
-	return c
 }

--- a/backend/internal/compose/connectorwire.go
+++ b/backend/internal/compose/connectorwire.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The connection row on the wire.
+//
+// It lives beside its handlers rather than inside them: connectors.go is the
+// routes, and one mapping read by every one of them is the file's own concern
+// rather than any single route's.
+
+import (
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/capture"
+)
+
+// toContractConnection maps a registry connection row onto the wire shape.
+// Storage now uses the contract's own status vocabulary (CAP-DDL-2 reconciled
+// capture_connection to it), so status is a straight cast — no translation. The
+// credential is never present.
+func toContractConnection(v capture.ConnectionView) crmcontracts.CaptureConnection {
+	c := crmcontracts.CaptureConnection{
+		Id:             openapi_types.UUID(v.ID),
+		Provider:       crmcontracts.CaptureConnectionProvider(v.Provider),
+		Status:         crmcontracts.CaptureConnectionStatus(v.Status),
+		Scopes:         v.ProviderScopes,
+		WatchExpiresAt: v.WatchExpiresAt,
+		AccountLabel:   v.AccountLabel,
+		// Carried as the pointer it is: null on the wire is this mailbox
+		// following the tenant default, not a field the read forgot.
+		SignatureEnrichEnabled: v.SignatureEnrichEnabled,
+		MailPosture:            postureOnWire(v.MailPosture),
+		ContextTag:             contextTagOnWire(v.ContextTag),
+	}
+	if c.Scopes == nil {
+		c.Scopes = []string{}
+	}
+	if len(v.Cursor) > 0 {
+		s := string(v.Cursor)
+		c.SyncCursor = &s
+	}
+	c.LastSyncedAt = v.LastSyncedAt
+	c.LastSyncErrorClass = v.LastErrorClass
+	c.SyncFailingSince = v.FailingSince
+	c.NextSyncDueAt = v.NextSyncDueAt
+	bf := backfillStatusPayload(v.Backfill)
+	c.Backfill = &bf
+	return c
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19888,8 +19888,11 @@ type CaptureConnection struct {
 	Status CaptureConnectionStatus `json:"status"`
 
 	// SyncCursor Opaque provider watermark (Gmail historyId / IMAP UID / Graph delta) for incremental capture — read-only.
-	SyncCursor *string    `json:"sync_cursor,omitempty"`
-	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
+	SyncCursor *string `json:"sync_cursor,omitempty"`
+
+	// SyncFailingSince When the CURRENT failure streak began, null while healthy. Set on the first failure after a success and left alone until one clears it, so the duration read off it is the outage's — last_synced_at moves on every postponed tick and dates the newest attempt instead.
+	SyncFailingSince *time.Time `json:"sync_failing_since,omitempty"`
+	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
 
 	// WatchExpiresAt Push/delta subscription renewal deadline (Gmail Pub/Sub / Graph change-notification), or null.
 	WatchExpiresAt *time.Time `json:"watch_expires_at,omitempty"`

--- a/backend/internal/modules/capture/health.go
+++ b/backend/internal/modules/capture/health.go
@@ -13,6 +13,7 @@ package capture
 
 import (
 	"context"
+	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -50,6 +51,14 @@ type Concern struct {
 	// AccountLabel is the display-only mailbox address when the connector
 	// reported one; empty otherwise. Display, never routing.
 	AccountLabel string
+
+	// FailingSince is when this concern's failure streak began, nil for a
+	// concern that is not a streak — a parked connection is a state, not a
+	// duration. It is what separates "is anything wrong" from "has anything
+	// been wrong for a while": a sync that postpones itself is never late by
+	// any age reading, so a fleet screen reading only the condition cannot tell
+	// an hour-old outage from a connection idling between ticks.
+	FailingSince *time.Time
 }
 
 // HealthConcerns answers the CALLING human's unhealthy connections, in the
@@ -81,6 +90,7 @@ func (r *Registry) HealthConcerns(ctx context.Context) ([]Concern, error) {
 		if view.AccountLabel != nil {
 			concern.AccountLabel = *view.AccountLabel
 		}
+		concern.FailingSince = view.FailingSince
 		concerns = append(concerns, concern)
 	}
 	return concerns, nil

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -96,6 +96,26 @@ func (r *Registry) WithSyncInterval(d time.Duration) *Registry {
 	return r
 }
 
+// WithClock replaces the source of the instants this registry STAMPS — the
+// sync-state timestamps, not the schedule.
+//
+// The schedule is deliberately out of reach: next_sync_at is a delay the
+// database applies to its own clock, so nothing here can move it, which is the
+// property syncclock_test.go holds.
+//
+// It exists for the failure-streak case. failing_since is set once and left
+// alone across every failure after it, and the only way to see that is to fail
+// several times at instants an hour apart — which real time cannot do without
+// a sleep, and a test whose verdict depends on elapsed wall time is the
+// flakiness the suite refuses. A nil clock is ignored rather than installed:
+// a registry with no clock would panic on its first write.
+func (r *Registry) WithClock(now func() time.Time) *Registry {
+	if now != nil {
+		r.now = now
+	}
+	return r
+}
+
 // WithProgressPacing overrides how often a running backfill page writes its
 // live tally. Zero means every report is written — the pacing exists to keep a
 // long import from writing one row update per message, so removing it is only

--- a/backend/internal/modules/capture/registry_connections.go
+++ b/backend/internal/modules/capture/registry_connections.go
@@ -172,6 +172,16 @@ type ConnectionView struct {
 	LastErrorClass *string
 	NextSyncDueAt  *time.Time
 
+	// FailingSince is when the CURRENT failure streak began, nil while the
+	// connection is healthy. It answers the question the class cannot: a
+	// provider that has been unreachable for an hour and one that missed its
+	// last tick carry the same class, and a sync that postpones itself is never
+	// late by any age reading, so without this the two read identically on a
+	// fleet screen. Set on the first failure after a success and left alone
+	// until one clears it, so the duration a reader takes off it is the
+	// outage's rather than the newest attempt's.
+	FailingSince *time.Time
+
 	// Backfill is the newest CAP-DDL-4 run, nil when never started —
 	// the list surface's per-connection summary (contract state "none").
 	Backfill *BackfillRun
@@ -197,7 +207,7 @@ func (r *Registry) Connections(ctx context.Context) ([]ConnectionView, error) {
 			SELECT c.id, c.provider, c.status, c.sync_cursor, c.watch_expires_at, c.provider_scopes,
 			       c.account_label, c.signature_enrich_enabled, c.mail_posture,
 			       t.id, t.name, t.archived_at IS NOT NULL,
-			       s.last_synced_at, s.last_error_class, s.next_sync_at
+			       s.last_synced_at, s.last_error_class, s.next_sync_at, s.failing_since
 			FROM capture_connection c
 			LEFT JOIN capture_sync_state s ON s.connection_id = c.id
 			-- The word's own row, so the connection reports the name the
@@ -220,7 +230,7 @@ func (r *Registry) Connections(ctx context.Context) ([]ConnectionView, error) {
 			if err := rows.Scan(&v.ID, &v.Provider, &v.Status, &v.Cursor, &v.WatchExpiresAt, &v.ProviderScopes,
 				&v.AccountLabel, &v.SignatureEnrichEnabled, &v.MailPosture,
 				&tagID, &tagName, &tagArchived,
-				&v.LastSyncedAt, &v.LastErrorClass, &v.NextSyncDueAt); err != nil {
+				&v.LastSyncedAt, &v.LastErrorClass, &v.NextSyncDueAt, &v.FailingSince); err != nil {
 				return err
 			}
 			v.ContextTag = contextTagOf(tagID, tagName, tagArchived)

--- a/backend/internal/modules/capture/syncstate.go
+++ b/backend/internal/modules/capture/syncstate.go
@@ -91,14 +91,18 @@ func (r *Registry) recordSyncSuccess(ctx context.Context, connectionID ids.UUID)
 		// stay on its clock, which is the one that observed it.
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO capture_sync_state (connection_id, next_sync_at,
-			                                consecutive_failures, last_synced_at, last_success_at, last_error_class)
-			VALUES ($1, now() + make_interval(secs => $2), 0, $3, $3, NULL)
+			                                consecutive_failures, last_synced_at, last_success_at,
+			                                last_error_class, failing_since)
+			VALUES ($1, now() + make_interval(secs => $2), 0, $3, $3, NULL, NULL)
 			ON CONFLICT (connection_id) DO UPDATE SET
 			  next_sync_at = now() + make_interval(secs => $2),
 			  consecutive_failures = 0,
 			  last_synced_at = EXCLUDED.last_synced_at,
 			  last_success_at = EXCLUDED.last_success_at,
-			  last_error_class = NULL`,
+			  last_error_class = NULL,
+			  -- One success ends the streak, so the next failure starts a new
+			  -- one from its own instant rather than continuing this one.
+			  failing_since = NULL`,
 			connectionID, r.syncInterval.Seconds(), now); err != nil {
 			return err
 		}
@@ -220,12 +224,19 @@ func (r *Registry) recordSyncFailure(ctx context.Context, connectionID ids.UUID,
 		var failures int
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO capture_sync_state (connection_id, next_sync_at,
-			                                consecutive_failures, last_synced_at, last_error_class)
-			VALUES ($1, now() + make_interval(secs => $2), 1, $3, $4)
+			                                consecutive_failures, last_synced_at,
+			                                last_error_class, failing_since)
+			VALUES ($1, now() + make_interval(secs => $2), 1, $3, $4, $3)
 			ON CONFLICT (connection_id) DO UPDATE SET
 			  consecutive_failures = capture_sync_state.consecutive_failures + 1,
 			  last_synced_at = EXCLUDED.last_synced_at,
-			  last_error_class = EXCLUDED.last_error_class
+			  last_error_class = EXCLUDED.last_error_class,
+			  -- SET ONCE PER STREAK, and this COALESCE is the whole point of the
+			  -- column. last_synced_at beside it moves on every tick, so it dates
+			  -- the newest attempt; a duration read off it would say "failing for
+			  -- two minutes" through an outage of any length. The streak's own
+			  -- start does not move until a success clears it.
+			  failing_since = COALESCE(capture_sync_state.failing_since, EXCLUDED.failing_since)
 			RETURNING consecutive_failures`,
 			connectionID, backoffDelay(0).Seconds(), now, string(class)).Scan(&failures); err != nil {
 			return err

--- a/backend/internal/modules/capture/syncstreak_integration_test.go
+++ b/backend/internal/modules/capture/syncstreak_integration_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture_test
+
+// How long a connection has been failing, as opposed to what is wrong with it.
+//
+// A sync that postpones itself leaves its row scheduled in the future, so it is
+// never late by any age reading — correctly, since nothing scheduled ahead is
+// late — and River records no attempt error for a postponement. The class says
+// WHAT, consecutive_failures counts ticks whose length is the backoff ladder's
+// business, and last_synced_at moves on every one of them. Nothing said for how
+// long, so a provider unreachable since breakfast and a mailbox idling between
+// ticks read identically on a fleet screen.
+//
+// failing_since is that fact, and its whole content is that it does NOT move.
+// These cases are the two halves of that: it survives the ticks after it, and a
+// success ends the streak so the next failure starts a new one.
+//
+// The clock is injected because the property is only visible across instants
+// far apart. Real time would need a sleep to show an hour, and a verdict that
+// depends on elapsed wall time is the flakiness the suite refuses.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// haltingConnector fails until told otherwise, so one connection can run a
+// streak and then recover on the same registry.
+type haltingConnector struct {
+	fixtureConnector
+	recovered *bool
+}
+
+func (haltingConnector) Descriptor() connector.Descriptor {
+	return connector.Descriptor{Name: haltingProvider, Version: "fixture"}
+}
+
+func (c haltingConnector) Sync(context.Context, connector.Auth, connector.Cursor, connector.Sink) (connector.Cursor, error) {
+	if *c.recovered {
+		return nil, nil
+	}
+	return nil, connector.ErrUnreachable
+}
+
+// haltingProvider is the connection every case here drives. The connector
+// registers under it, and both readers below are keyed on it.
+const haltingProvider = "test_mailbox"
+
+// connectionOf reads back the id Connect wrote, so the ticks after the first
+// drive the same connection rather than a second one.
+func connectionOf(ctx context.Context, t *testing.T) ids.UUID {
+	t.Helper()
+	owner, _ := setupCaptureDB(t)
+	var id ids.UUID
+	if err := owner.QueryRow(ctx,
+		`SELECT id FROM capture_connection WHERE provider = $1`, haltingProvider).Scan(&id); err != nil {
+		t.Fatalf("reading back the %s connection: %v", haltingProvider, err)
+	}
+	return id
+}
+
+// streakState reads the two stamps that separate the streak from the tick.
+func streakState(ctx context.Context, t *testing.T) (failingSince, lastSynced *time.Time) {
+	t.Helper()
+	owner, _ := setupCaptureDB(t)
+	if err := owner.QueryRow(ctx, `
+		SELECT s.failing_since, s.last_synced_at
+		  FROM capture_sync_state s
+		  JOIN capture_connection c ON c.id = s.connection_id
+		 WHERE c.provider = $1`, haltingProvider).Scan(&failingSince, &lastSynced); err != nil {
+		t.Fatalf("reading the streak state: %v", err)
+	}
+	return failingSince, lastSynced
+}
+
+func TestAPostponingConnectionReportsAGrowingFailureDuration(t *testing.T) {
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
+	recovered := false
+	reg.Register(haltingConnector{recovered: &recovered})
+
+	start := time.Date(2026, 5, 4, 8, 0, 0, 0, time.UTC)
+	at := start
+	reg.WithClock(func() time.Time { return at })
+
+	if err := syncOnceOf(ctx, t, reg, haltingProvider); !errors.Is(err, connector.ErrUnreachable) {
+		t.Fatalf("SyncOnce = %v, want the connector's own failure", err)
+	}
+	failingSince, _ := streakState(ctx, t)
+	if failingSince == nil {
+		t.Fatal("the first failure recorded no start — a streak nothing dates is one nothing can time")
+	}
+	if !failingSince.Equal(start) {
+		t.Fatalf("the streak started at %s, want the instant of the first failure (%s)", failingSince, start)
+	}
+
+	// Two more ticks, an hour apart. This is the case that used to report
+	// nothing: each one is a fresh attempt and the row was already failing.
+	for _, tick := range []time.Duration{30 * time.Minute, time.Hour} {
+		at = start.Add(tick)
+		if err := reg.SyncOnce(ctx, connectionOf(ctx, t)); !errors.Is(err, connector.ErrUnreachable) {
+			t.Fatalf("SyncOnce at +%v = %v, want the connector's own failure", tick, err)
+		}
+	}
+
+	failingSince, lastSynced := streakState(ctx, t)
+	if failingSince == nil || !failingSince.Equal(start) {
+		t.Fatalf("after two more failures the streak starts at %v, want the first failure's instant (%s) — "+
+			"a stamp that moves with the ticks reports the newest attempt and never an outage", failingSince, start)
+	}
+	// The tick DID move, which is what makes the assertion above mean
+	// something: both stamps standing still would prove only that nothing wrote.
+	if lastSynced == nil || !lastSynced.After(start) {
+		t.Fatalf("the last-attempt stamp is %v, want it moved past the first failure — the writes under test did not happen", lastSynced)
+	}
+	// The reading the surfaces take: an hour, not the two minutes since the
+	// last attempt.
+	if got := at.Sub(*failingSince); got != time.Hour {
+		t.Errorf("the duration a reader takes off the streak is %v, want 1h", got)
+	}
+}
+
+func TestASuccessfulSyncEndsTheFailureStreak(t *testing.T) {
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
+	recovered := false
+	reg.Register(haltingConnector{recovered: &recovered})
+
+	start := time.Date(2026, 5, 4, 8, 0, 0, 0, time.UTC)
+	at := start
+	reg.WithClock(func() time.Time { return at })
+
+	if err := syncOnceOf(ctx, t, reg, haltingProvider); !errors.Is(err, connector.ErrUnreachable) {
+		t.Fatalf("SyncOnce = %v, want the connector's own failure", err)
+	}
+	connection := connectionOf(ctx, t)
+
+	recovered = true
+	at = start.Add(time.Hour)
+	if err := reg.SyncOnce(ctx, connection); err != nil {
+		t.Fatalf("SyncOnce after recovery: %v", err)
+	}
+	if failingSince, _ := streakState(ctx, t); failingSince != nil {
+		t.Fatalf("a recovered connection still dates a streak at %s — one success ends it, or the next outage "+
+			"would be reported as having run since this one", failingSince)
+	}
+
+	// And the NEXT failure starts a new streak from its own instant rather than
+	// resuming the one that ended. A clear that only blanked the surface would
+	// pass the assertion above and fail this one.
+	recovered = false
+	at = start.Add(3 * time.Hour)
+	if err := reg.SyncOnce(ctx, connection); !errors.Is(err, connector.ErrUnreachable) {
+		t.Fatalf("SyncOnce after relapse = %v, want the connector's own failure", err)
+	}
+	failingSince, _ := streakState(ctx, t)
+	if failingSince == nil || !failingSince.Equal(at) {
+		t.Fatalf("the new streak starts at %v, want the relapse's own instant (%s)", failingSince, at)
+	}
+}

--- a/backend/migrations/core/1788966374_a_failure_streak_says_when_it_started.down.sql
+++ b/backend/migrations/core/1788966374_a_failure_streak_says_when_it_started.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE capture_sync_state DROP COLUMN failing_since;

--- a/backend/migrations/core/1788966374_a_failure_streak_says_when_it_started.up.sql
+++ b/backend/migrations/core/1788966374_a_failure_streak_says_when_it_started.up.sql
@@ -1,0 +1,22 @@
+-- A connection that has been failing since Tuesday and one that failed a minute
+-- ago read identically today: last_error_class says WHAT is wrong and
+-- consecutive_failures counts ticks, whose length is the backoff ladder's
+-- business rather than a duration anybody can quote. A postponed sync leaves no
+-- attempt error and is never late by any age reading, because nothing scheduled
+-- in the future is late — so an outage running for an hour and a healthy
+-- connection idling between ticks look the same on a fleet screen.
+--
+-- failing_since is the missing fact: when the CURRENT streak began. Set on the
+-- first failure after a success, left alone across every failure after it, and
+-- cleared by a success. Refreshing it per tick is the defect, not the write.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE capture_sync_state ADD COLUMN failing_since timestamptz;
+
+-- Existing streaks start now rather than backdating to last_synced_at: that
+-- column is refreshed by every postponed tick, so it dates the newest attempt
+-- and not the streak, and a backfill from it would state a duration that is
+-- wrong in the direction that hides an outage. A row already failing reports its
+-- streak from this deployment forward, which is short and true rather than long
+-- and invented.
+UPDATE capture_sync_state SET failing_since = now() WHERE last_error_class IS NOT NULL;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1426,6 +1426,7 @@ public.capture_sync_state.capture_sync_state_pkey PRIMARY KEY (connection_id)
 public.capture_sync_state.connection_id uuid NOT NULL gen=- def=-
 public.capture_sync_state.consecutive_failures integer NOT NULL gen=- def=0
 public.capture_sync_state.created_at timestamp with time zone NOT NULL gen=- def=now()
+public.capture_sync_state.failing_since timestamp with time zone gen=- def=-
 public.capture_sync_state.last_error_class text gen=- def=-
 public.capture_sync_state.last_success_at timestamp with time zone gen=- def=-
 public.capture_sync_state.last_synced_at timestamp with time zone gen=- def=-

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15725,6 +15725,11 @@ export interface components {
             last_sync_error_class?: string | null;
             /**
              * Format: date-time
+             * @description When the CURRENT failure streak began, null while healthy. Set on the first failure after a success and left alone until one clears it, so the duration read off it is the outage's — last_synced_at moves on every postponed tick and dates the newest attempt instead.
+             */
+            sync_failing_since?: string | null;
+            /**
+             * Format: date-time
              * @description When the sweep will next pick this connection up (backoff-aware).
              */
             next_sync_due_at?: string | null;


### PR DESCRIPTION
Closes #1803. Builds the ruling: stamp when the current failure streak began,
set on the first failure, cleared on success, never refreshed per tick.

## The missing fact is duration, not visibility

`last_error_class` says WHAT is wrong and both connector screens render it.
`consecutive_failures` counts ticks whose length is the backoff ladder's
business rather than a duration anybody can quote. What nothing could say is
**for how long**:

- a sync that postpones itself leaves its row scheduled in the future, so it is
  never late by any age reading — and correctly so, since every age filter reads
  `scheduled_at <= now()`;
- a postponement records no attempt error, so the errors column stays empty;
- `last_synced_at` is refreshed by every postponed tick, so it dates the newest
  attempt and not the streak.

An outage running since breakfast and a mailbox idling between ticks therefore
reach a fleet screen identically.

## `failing_since`, and the COALESCE that is the whole column

```sql
failing_since = COALESCE(capture_sync_state.failing_since, EXCLUDED.failing_since)
```

Set on the first failure after a success, left alone by every failure after it,
`NULL` on success so the next outage starts a new streak from its own instant.
Refreshing it per tick is the defect, not the write — a stamp that moves with the
ticks reports the newest attempt and never an outage.

## Both surfaces

- **The connector screens** get `sync_failing_since` on `CaptureConnection`, so
  a bare class becomes "unreachable for 1h 12m".
- **The fleet lane** fills `occurred_at` on a capture concern. That is the field
  every other attention lane already answers "how long" in, so the fleet view
  needs no new shape — and it stays absent for a condition that is a state rather
  than a streak, because a disconnected mailbox has no duration and inventing one
  from the row's timestamps would date the newest attempt.

## The backfill direction

Existing streaks start at deploy rather than backdating from `last_synced_at`.
That column moves per tick, so a backfill off it would state a duration that is
wrong **in the direction that hides an outage**. A row already failing reports a
short true streak rather than a long invented one.

## The clock

`Registry.WithClock` replaces the source of the instants this registry *stamps*
— not the schedule, which stays a delay the database applies to its own clock
(the property `syncclock_test.go` holds). It exists because set-once is only
visible across instants an hour apart, and real time cannot show that without a
sleep.

`TestAPostponingConnectionReportsAGrowingFailureDuration` fails three times at
+0, +30m, +1h and asserts the stamp is still the first instant while
`last_synced_at` **did** move — both standing still would prove only that nothing
wrote. `TestASuccessfulSyncEndsTheFailureStreak` covers the clear and the relapse
after it, since a clear that only blanked the surface would pass the first
assertion and fail the second.

Mutation-checked: refreshing the stamp per tick fails the first; not clearing on
success fails the second.

## One file moved

The added field took `connectors.go` one line past the 500-LOC cap, so
`toContractConnection` moved to `connectorwire.go` — the wire mapping every route
reads is the file's own concern rather than any single route's.

## Checks

- `make check-backend` green.
- `craft static --strict` over the diff: 0/0/0.
- Integration: `capture`, `compose/attention`, `migrations` (head catalog
  regenerated and committed).