### PR TITLE
Four more refusals name the vocabulary they refuse against

### DIFF
--- a/backend/internal/modules/agents/badargsvocabulary_test.go
+++ b/backend/internal/modules/agents/badargsvocabulary_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// A refusal that names a closed vocabulary delivers it, whatever the caller sent.
+//
+// BadArgsError splits its message by provenance for this reason: Cause may quote
+// the CALLER, so it is bounded and escaped at maxBadArgsDetail, while Guidance is
+// OURS and is appended whole. A vocabulary therefore survives in Guidance and can
+// be truncated in Cause — which is not a style preference but the difference
+// between a caller who can fix their call and one who guesses.
+//
+// FOUR SITES GOT IT WRONG, in two shapes. `promote_lead`'s trigger, a project
+// phase and a relink target named NO vocabulary at all, so an agent was refused
+// against a closed set of a handful and told nothing about it — while the REST
+// twin of the first spelled all four out. `read_import_run`'s object and a list
+// filter's operand put the SET in Cause, where it shares a budget sized for an
+// echo of a caller's own word and neither said which value had been refused.
+//
+// So this drives each producer twice: once with an ordinary bad value, and once
+// with a flood, because a vocabulary that survives the first and not the second
+// is one a caller can erase.
+
+import (
+	"strings"
+	"testing"
+)
+
+// vocabularyRefusal is one closed set, and the way to be refused against it.
+type vocabularyRefusal struct {
+	what    string
+	members []string
+	refuse  func(value string) error
+}
+
+// vocabularyRefusals takes every set from the predicate that admits it, so a
+// member added or removed moves this test rather than leaving it certifying a
+// vocabulary that no longer exists.
+func vocabularyRefusals(t *testing.T) []vocabularyRefusal {
+	t.Helper()
+	subjects := []vocabularyRefusal{
+		{
+			what:    "the engagement a promotion rests on",
+			members: genuineTriggerNames(),
+			refuse:  requireGenuineTrigger,
+		},
+		{
+			what:    "a project's phase ladder",
+			members: projectPhaseNames(),
+			refuse:  func(v string) error { return requireProjectPhase(v, nil) },
+		},
+		{
+			what:    "what an activity may be relinked onto",
+			members: relinkTargetNames(),
+			refuse:  requireLinkTarget,
+		},
+		{
+			what:    "the objects an import takes",
+			members: importObjectEnum,
+			refuse:  refuseUnimportableObject,
+		},
+		{
+			what:    "the values one list filter takes",
+			members: []string{"open", "won", "lost"},
+			refuse: func(v string) error {
+				return refuseUnaskableOperand(
+					listFilter{Name: "status", Enum: []string{"open", "won", "lost"}}, v)
+			},
+		},
+	}
+	for _, s := range subjects {
+		if len(s.members) == 0 {
+			t.Fatalf("%s came back empty, so its case certifies nothing", s.what)
+		}
+	}
+	return subjects
+}
+
+func TestEveryRefusedVocabularyReachesTheCaller(t *testing.T) {
+	t.Parallel()
+	for _, subject := range vocabularyRefusals(t) {
+		t.Run(subject.what, func(t *testing.T) {
+			t.Parallel()
+			for _, value := range map[string]string{
+				"an ordinary wrong value": "not-a-member",
+				// The caller's own word is bounded; the vocabulary is not, so a
+				// flood must not be able to push the set out of the answer.
+				"a flooded value": strings.Repeat("k", 4000),
+			} {
+				err := subject.refuse(value)
+				if err == nil {
+					t.Fatalf("%q was admitted, so nothing is refused against %s", value[:16], subject.what)
+				}
+				said := err.Error()
+				for _, member := range subject.members {
+					if !strings.Contains(said, member) {
+						t.Errorf("the refusal never names %q, so a caller cannot pick it:\n%s",
+							member, said)
+					}
+				}
+			}
+		})
+	}
+}
+
+// The other half of the split, and the reason a vocabulary belongs in Guidance:
+// a caller's word must not be able to make the answer arbitrarily long.
+func TestARefusedValueIsBoundedInWhatItEchoes(t *testing.T) {
+	t.Parallel()
+	for _, subject := range vocabularyRefusals(t) {
+		t.Run(subject.what, func(t *testing.T) {
+			t.Parallel()
+			flood := strings.Repeat("k", 4000)
+			said := subject.refuse(flood).Error()
+
+			if strings.Contains(said, strings.Repeat("k", maxBadArgsDetail+1)) {
+				t.Errorf("%s echoed more than maxBadArgsDetail (%d) of the caller's value, so the "+
+					"caller chose how much this writes into the transcript",
+					subject.what, maxBadArgsDetail)
+			}
+		})
+	}
+}
+
+// WHAT THIS CANNOT SEE, stated rather than left to chance: two vocabularies on
+// this surface are refused inline inside an argument reader rather than by a
+// named predicate — enrich's depth and an approval's decision. Both were moved
+// to Guidance in the same change that added this file, and reaching them from
+// here means extracting the check the way requireGenuineTrigger already is,
+// which is worth doing when one of them next changes.

--- a/backend/internal/modules/agents/commandauto.go
+++ b/backend/internal/modules/agents/commandauto.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -313,7 +314,11 @@ func requireLinkTarget(entityType string) error {
 	if relinkTargets[entityType] {
 		return nil
 	}
-	return &BadArgsError{Cause: fmt.Errorf("entity_type %q is not a link target", entityType)}
+	return &BadArgsError{
+		Cause:    fmt.Errorf("entity_type %q is not a link target", entityType),
+		Field:    "entity_type",
+		Guidance: "a link target is one of: " + strings.Join(relinkTargetNames(), ", "),
+	}
 }
 
 // DecideApprovalCommand is one person's answer to one staged proposal,

--- a/backend/internal/modules/agents/commandlifecycle.go
+++ b/backend/internal/modules/agents/commandlifecycle.go
@@ -275,7 +275,14 @@ func (r *advanceProjectPhaseResolver) Guards(ctx context.Context, cmd AdvancePro
 // costs a human's yes.
 func requireProjectPhase(toPhase string, reason *string) error {
 	if !projectPhases[toPhase] {
-		return &BadArgsError{Cause: fmt.Errorf("to_phase %q is not a project phase", toPhase)}
+		// The ladder rides in Guidance, which is ours, and the caller's word in
+		// Cause, which is bounded. Naming no phase at all left an agent guessing
+		// at a closed set of four.
+		return &BadArgsError{
+			Cause:    fmt.Errorf("to_phase %q is not a project phase", toPhase),
+			Field:    "to_phase",
+			Guidance: "the phases are: " + strings.Join(projectPhaseNames(), ", "),
+		}
 	}
 	if toPhase == projectPhaseClosed && (reason == nil || strings.TrimSpace(*reason) == "") {
 		return &BadArgsError{Cause: errors.New("reason is required when to_phase is closed")}

--- a/backend/internal/modules/agents/tools_import.go
+++ b/backend/internal/modules/agents/tools_import.go
@@ -135,8 +135,15 @@ func refuseUnimportableObject(object string) error {
 			return nil
 		}
 	}
-	return &BadArgsError{Cause: fmt.Errorf("`object` must be one of %s",
-		strings.Join(importObjectEnum, ", "))}
+	// The caller's word in Cause, which is bounded and escaped, and the set in
+	// Guidance, which is ours. Both in Cause meant the vocabulary shared a
+	// budget sized for an echo, and the refusal never said which value was
+	// wrong — only what the right ones were.
+	return &BadArgsError{
+		Cause:    fmt.Errorf("`object` %q is not one this tool imports", object),
+		Field:    "object",
+		Guidance: "it is one of: " + strings.Join(importObjectEnum, ", "),
+	}
 }
 
 type readImportRun struct{ imports Imports }

--- a/backend/internal/modules/agents/tools_lifecycle.go
+++ b/backend/internal/modules/agents/tools_lifecycle.go
@@ -18,6 +18,8 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"maps"
+	"slices"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -420,4 +422,21 @@ func (t advanceProjectPhase) readArgs(in json.RawMessage) (advanceProjectPhaseAr
 		return advanceProjectPhaseArgs{}, err
 	}
 	return args, nil
+}
+
+// projectPhaseNames is the ladder as a refusal names it, derived from the
+// membership test rather than restated beside it: a second list is how the
+// sentence and the check come to disagree about what a phase is.
+func projectPhaseNames() []string {
+	names := slices.Collect(maps.Keys(projectPhases))
+	slices.Sort(names)
+	return names
+}
+
+// relinkTargetNames is the link-target vocabulary as a refusal names it,
+// derived for the same reason.
+func relinkTargetNames() []string {
+	names := slices.Collect(maps.Keys(relinkTargets))
+	slices.Sort(names)
+	return names
 }

--- a/backend/internal/modules/agents/tools_list.go
+++ b/backend/internal/modules/agents/tools_list.go
@@ -275,7 +275,14 @@ func refuseUnaskableOperand(filter listFilter, operand string) error {
 	if len(filter.Enum) == 0 || slices.Contains(filter.Enum, operand) {
 		return nil
 	}
-	return &BadArgsError{Cause: errors.New(filter.Name + " is one of " + strings.Join(filter.Enum, ", "))}
+	// Same split as refuseUnimportableObject: the operand the caller sent is
+	// bounded in Cause and says WHICH value was refused, and the closed set is
+	// ours in Guidance so a long operand cannot spend its budget.
+	return &BadArgsError{
+		Cause:    fmt.Errorf("%s %q is not a value it takes", filter.Name, operand),
+		Field:    filter.Name,
+		Guidance: filter.Name + " is one of: " + strings.Join(filter.Enum, ", "),
+	}
 }
 
 // describeNames lists a record type's filters for a refusal, or says plainly


### PR DESCRIPTION
Swept the tool surface for the shape that cost `case40` a passing run — a refusal
that names a closed set without delivering it — and found four more.

## Two were live: no vocabulary at all

```
  to_phase %q is not a project phase     ← four phases, none named
  entity_type %q is not a link target    ← five targets, none named
```

An agent refused against a closed set of a handful, told nothing about it. Both
now carry the set in `Guidance` (ours, appended whole) with the caller's word in
`Cause` (bounded and escaped) — the split `BadArgsError` documents. The names are
derived from the membership maps that admit them, not restated beside them.

## Two were latent: the set sat in the bounded half

`read_import_run`'s `object` and a list filter's operand put the **set** in
`Cause`. Neither truncates today because neither echoed the caller's value, so
there was nothing to crowd the set out — the risk was a longer enum, or the day
somebody added the echo. Both now echo the refused value **and** keep the set
safe, so the refusal says which value was wrong as well as what would have worked.

I'm calling these latent rather than live deliberately: the gate below stays
**green** on them when reverted, and that is the honest evidence.

## The gate

`TestEveryRefusedVocabularyReachesTheCaller` drives each producer twice — an
ordinary wrong value and a 4000-byte flood — because a vocabulary that survives
the first and not the second is one a caller can erase. Its corpus comes from the
predicates that admit each set, so a member added or removed moves the test
rather than leaving it certifying a vocabulary that no longer exists.

Watched failing: reverting all four reds the two that named nothing, on **every
member of both sets**.

Two vocabularies it cannot reach are named in the file — enrich's depth and an
approval's decision are refused inline inside an argument reader rather than by a
named predicate. Both were moved to `Guidance` in #5159; reaching them means
extracting the check the way `requireGenuineTrigger` already is.

## Why this matters for the scoring

`case40` on **haiku** went **2/3 → 3/3** after the trigger-vocabulary fix and the
`lead_id` rename landed. This is the same class, four more places. A refusal that
names what would have worked is the difference between a model that recovers in
one call and one that guesses — and that gap costs the mid-tier models most,
which is where the surface is being aimed.

## Verification

`make lint` 0 issues, `craft-static` 0 findings, agents and compose packages
green. Verdicts and the coverage page are deliberately **not** in this PR: a full
haiku sweep is running and will rewrite them, so they land together afterwards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four agent refusals that rejected a value against a closed set without naming the set, so callers could only guess. Each now delivers the vocabulary in `Guidance` and echoes the refused value in `Cause`; two had named no vocabulary at all, and two had put the set in the bounded half where a longer enum or an added echo could truncate it.

- Adds `TestEveryRefusedVocabularyReachesTheCaller`, which drives each producer with an ordinary wrong value and a 4000-byte flood so a caller can't erase the vocabulary.
- Derives refusal names from the membership maps that admit each set, so the test moves when a set changes.

<sup>Written for commit fabdbb0319fbaacae0b54f718eddbd6573266f3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

