### PR TITLE
fix(ci): every finding the reporter files names its priority and its area

### DIFF
--- a/docs/reference/ci-workflows.md
+++ b/docs/reference/ci-workflows.md
@@ -161,6 +161,13 @@ Eight workflows sit beside the gate, deliberately outside it:
   Findings become **issues** (`scripts/scheduled-report.sh`), one open issue per
   check keyed on an exact title, because a red scheduled run notifies nobody and
   these checks exist precisely for the case where nothing prompts a human to look.
+  Each finding carries the axes the rulebook requires — exactly one `priority:`
+  and exactly one `area:`, per arm, on top of its provenance label — because this
+  is the one filer in the tree that files with no human present, and
+  `docs/reference/issue-labels.md` protects the invariant that an unlabelled
+  issue is one nobody has looked at yet. The `area:` is a filing guess and is
+  meant to be: what is knowable when the alarm goes off is that CI observed it,
+  not where the fix will live.
   A check that comes back **green closes its own issue** — so the report job runs
   whatever the lanes said, rather than only when one failed. Without that half a
   finding outlives its fix until somebody closes it by hand, and the tracker

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -43,9 +43,23 @@ lookup() {
     "$open_issues"
 }
 
-# report <title> <label> <body>
+# report <title> <labels> <body>
+#
+# `labels` is a comma-separated list and carries the three axes the rulebook
+# requires, not a provenance word alone: exactly one `priority:`, exactly one
+# `area:`, and whatever provenance applies. Every issue this reporter filed used
+# to carry `bug` and nothing else, which made each one claim something false
+# about itself — docs/reference/issue-labels.md protects one invariant, that
+# UNLABELLED MEANS NOBODY HAS LOOKED AT IT YET, and this is the one filer in the
+# tree that files with no human present, so it is the one most likely to be read
+# by somebody who was not there when it was written.
+#
+# `area:` is a FILING guess and is meant to be. A red frontend lane may need its
+# fix in `frontend/`, but nothing here knows that; what is knowable is that CI is
+# what observed it. A human retriaging may move it, and moving a wrong label is a
+# different act from adding a missing one.
 report() {
-  local title="$1" label="$2" body="$3" existing
+  local title="$1" labels="$2" body="$3" existing
   existing="$(lookup "$title")"
   if [[ -n "$existing" ]]; then
     echo "already open as #$existing — commenting"
@@ -54,7 +68,15 @@ report() {
     return
   fi
   echo "filing: $title"
-  gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"
+  # One --label per name rather than one comma-joined value. Every label here
+  # carries a space, and leaving `gh` to split the list is a guess about a flag
+  # whose parsing is not ours.
+  local -a label_args=()
+  local one
+  while IFS= read -r one; do
+    [[ -n "$one" ]] && label_args+=(--label "$one")
+  done <<<"${labels//,/$'\n'}"
+  gh issue create --repo "$REPO" --title "$title" "${label_args[@]}" --body "$body"
 }
 
 # resolve <title> — the other half of report, for a check that came back GREEN.
@@ -98,7 +120,7 @@ is green, not that every question on the thread was answered."
 unreported=0
 
 if [[ "${VULN_RESULT:-}" = "failure" ]]; then
-  report "govulncheck reports a vulnerability reachable from main" security \
+  report "govulncheck reports a vulnerability reachable from main" "priority: critical,area: platform,security" \
 "\`make vuln\` failed on the scheduled run of \`main\`: $RUN_URL
 
 This is the finding a pull-request scan cannot produce. govulncheck answers
@@ -117,7 +139,7 @@ elif [[ "${VULN_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${GATE_RESULT:-}" = "failure" ]]; then
-  report "SonarCloud quality gate is not green on main" bug \
+  report "SonarCloud quality gate is not green on main" "priority: high,area: ci-tests,bug" \
 "The quality gate on \`main\` read \`${GATE_STATUS:-unknown}\` on the scheduled
 run: $RUN_URL
 
@@ -137,7 +159,7 @@ elif [[ "${GATE_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${LANE_RESULT:-}" = "failure" ]]; then
-  report "the backend merge gate is red on main" bug \
+  report "the backend merge gate is red on main" "priority: high,area: ci-tests,bug" \
 "\`make check-backend\` failed on the scheduled run of \`main\`: $RUN_URL
 
 Worth reading before assuming the last green run means anything. \`main\`'s
@@ -161,7 +183,7 @@ fi
 # learning about. PERF_OUTCOME is set by the step from the harness's own breach
 # message, so only a MEASURED breach is reported as one.
 if [[ "${PERF_RESULT:-}" = "failure" ]] && [[ "${PERF_OUTCOME:-}" != "breach" ]]; then
-  report "the weekly PERF-3/PERF-7 run could not complete" bug \
+  report "the weekly PERF-3/PERF-7 run could not complete" "priority: normal,area: ci-tests,bug" \
 "\`make bench-perf-check\` failed on the weekly run of \`main\` WITHOUT reaching a
 budget verdict: $RUN_URL
 
@@ -186,7 +208,7 @@ elif [[ "${PERF_RESULT:-}" = "success" ]] || [[ "${PERF_OUTCOME:-}" = "breach" ]
 fi
 
 if [[ "${PERF_OUTCOME:-}" = "breach" ]]; then
-  report "a PERF-3/PERF-7 budget is breaching on main" bug \
+  report "a PERF-3/PERF-7 budget is breaching on main" "priority: normal,area: ci-tests,bug" \
 "\`make bench-perf-check\` failed on the weekly run of \`main\`: $RUN_URL
 
 This alarm runs the SMB tier only, and that shapes what the finding means: SMB
@@ -214,7 +236,7 @@ fi
 # spec prints `perfbench [fast-3g/390px]: … p95=…` and THEN asserts, so the line
 # is present exactly when a number was measured.
 if [[ "${MOBILE_RESULT:-}" = "failure" ]] && [[ "${MOBILE_OUTCOME:-}" != "breach" ]]; then
-  report "the weekly MOBILE-AC-2 run could not complete" bug \
+  report "the weekly MOBILE-AC-2 run could not complete" "priority: normal,area: ci-tests,bug" \
 "\`make bench-mobile-check\` failed on the weekly run of \`main\` WITHOUT reaching a
 budget verdict: $RUN_URL
 
@@ -236,7 +258,7 @@ elif [[ "${MOBILE_RESULT:-}" = "success" ]] || [[ "${MOBILE_OUTCOME:-}" = "breac
 fi
 
 if [[ "${MOBILE_OUTCOME:-}" = "breach" ]]; then
-  report "PERF-1's perceived budget is breaching on main" bug \
+  report "PERF-1's perceived budget is breaching on main" "priority: normal,area: ci-tests,bug" \
 "\`make bench-mobile-check\` measured a p95 over the 300 ms perceived budget on
 the weekly run of \`main\`: $RUN_URL
 
@@ -262,7 +284,7 @@ elif [[ "${MOBILE_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${CLOCK_RESULT:-}" = "failure" ]]; then
-  report "the frontend suite's verdict depends on the calendar" bug \
+  report "the frontend suite's verdict depends on the calendar" "priority: normal,area: ci-tests,bug" \
 "\`make fe-clock-drift\` failed on the scheduled run of \`main\`: $RUN_URL
 
 The suite passes today and fails 200 days from now, which means at least one test
@@ -286,7 +308,7 @@ elif [[ "${CLOCK_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${CACHE_RESULT:-}" = "failure" ]]; then
-  report "the Actions build-cache reaper is failing" bug \
+  report "the Actions build-cache reaper is failing" "priority: normal,area: ci-tests,bug" \
 "\`scripts/reap-build-caches.sh\` failed on the scheduled run: $RUN_URL
 
 This one degrades quietly, which is why it is filed rather than left as a red
@@ -323,7 +345,7 @@ fi
 # person looking, which is worse than a dozen candidates and a failing test name.
 
 if [[ "${MAIN_GATES_RESULT:-}" = "failure" ]]; then
-  report "main is red: the backend gate fails on the tip" bug \
+  report "main is red: the backend gate fails on the tip" "priority: high,area: ci-tests,bug" \
 "\`make check-backend\` failed against \`main\` on the two-hourly health check:
 $RUN_URL
 
@@ -341,7 +363,7 @@ elif [[ "${MAIN_GATES_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${MAIN_INTEGRATION_RESULT:-}" = "failure" ]]; then
-  report "main is red: the integration lane fails on the tip" bug \
+  report "main is red: the integration lane fails on the tip" "priority: high,area: ci-tests,bug" \
 "The real-Postgres lane failed against \`main\` on the two-hourly health check:
 $RUN_URL
 
@@ -361,7 +383,7 @@ elif [[ "${MAIN_INTEGRATION_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${MAIN_FRONTEND_RESULT:-}" = "failure" ]]; then
-  report "main is red: the frontend lane fails on the tip" bug \
+  report "main is red: the frontend lane fails on the tip" "priority: high,area: ci-tests,bug" \
 "The SPA lane (biome + vitest + tsc + build) failed against \`main\` on the
 two-hourly health check: $RUN_URL
 
@@ -390,7 +412,7 @@ elif [[ "${MAIN_FRONTEND_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${MAIN_UAT_RESULT:-}" = "failure" ]]; then
-  report "main is red: the screen-acceptance UAT fails on the tip" bug \
+  report "main is red: the screen-acceptance UAT fails on the tip" "priority: high,area: ci-tests,bug" \
 "The UAT lane (AC screens + axe WCAG 2.2 AA + the 390px sweep, against the built
 app over the seed mock) failed against \`main\` on the two-hourly health check:
 $RUN_URL
@@ -417,7 +439,7 @@ elif [[ "${MAIN_UAT_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${MAIN_SONAR_RESULT:-}" = "failure" ]]; then
-  report "main's SonarCloud analysis was not published" bug \
+  report "main's SonarCloud analysis was not published" "priority: high,area: ci-tests,bug" \
 "The \`sonarcloud (main)\` job failed on the two-hourly health check, with every
 lane it depends on green: $RUN_URL
 
@@ -461,7 +483,7 @@ fi
 # step from the runner's own "scenarios: N passed" line, which it prints only
 # once every scenario has actually been driven.
 if [[ "${LLM_RESULT:-}" = "failure" ]] && [[ "${LLM_OUTCOME:-}" != "scenario-failed" ]]; then
-  report "the weekly model-driven use cases could not run" bug \
+  report "the weekly model-driven use cases could not run" "priority: normal,area: ci-tests,bug" \
 "\`make e2e-llm\` failed on the weekly run of \`main\` WITHOUT driving the
 scenarios: $RUN_URL
 
@@ -489,7 +511,7 @@ elif [[ "${LLM_RESULT:-}" = "success" ]] || [[ "${LLM_OUTCOME:-}" = "scenario-fa
 fi
 
 if [[ "${LLM_OUTCOME:-}" = "scenario-failed" ]]; then
-  report "a use case is failing when driven by a real model" bug \
+  report "a use case is failing when driven by a real model" "priority: normal,area: ci-tests,bug" \
 "\`make e2e-llm\` drove all six use cases on \`main\` and at least one did not
 reach its pass rate: $RUN_URL
 
@@ -540,7 +562,7 @@ if [[ "${MERGE_VERDICT_RESULT:-}" = "failure" ]]; then
   else
     merge_title="A merge landed on main with no pull request behind it"
   fi
-  report "$merge_title" bug \
+  report "$merge_title" "priority: high,area: ci-tests,bug" \
 "${MERGE_VERDICT_WHY:-a merge landed on \`main\` whose required check reported an adverse verdict; the run below says which}
 
 Found by the push-time check on \`main\`: $RUN_URL

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -138,6 +138,14 @@ elif [[ "${VULN_RESULT:-}" = "success" ]]; then
   resolve "govulncheck reports a vulnerability reachable from main"
 fi
 
+# `high` where its siblings are `critical`, and the difference is not a lane's
+# importance but who it stops. The taxonomy's honest test for `critical` is
+# "does this stop somebody else from working", and `main`'s required-status-check
+# ruleset names exactly ONE context: `ci`. A red lane inside `ci` is inherited by
+# every open pull request; a red SonarCloud verdict is inherited by nobody,
+# because `SonarCloud Code Analysis` is deliberately not required. That is the
+# same asymmetry this arm exists to compensate for — nothing is blocked, so
+# nothing prompts anyone to look, so the issue is the only signal.
 if [[ "${GATE_RESULT:-}" = "failure" ]]; then
   report "SonarCloud quality gate is not green on main" "priority: high,area: ci-tests,bug" \
 "The quality gate on \`main\` read \`${GATE_STATUS:-unknown}\` on the scheduled
@@ -159,7 +167,7 @@ elif [[ "${GATE_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${LANE_RESULT:-}" = "failure" ]]; then
-  report "the backend merge gate is red on main" "priority: high,area: ci-tests,bug" \
+  report "the backend merge gate is red on main" "priority: critical,area: ci-tests,bug" \
 "\`make check-backend\` failed on the scheduled run of \`main\`: $RUN_URL
 
 Worth reading before assuming the last green run means anything. \`main\`'s
@@ -345,7 +353,7 @@ fi
 # person looking, which is worse than a dozen candidates and a failing test name.
 
 if [[ "${MAIN_GATES_RESULT:-}" = "failure" ]]; then
-  report "main is red: the backend gate fails on the tip" "priority: high,area: ci-tests,bug" \
+  report "main is red: the backend gate fails on the tip" "priority: critical,area: ci-tests,bug" \
 "\`make check-backend\` failed against \`main\` on the two-hourly health check:
 $RUN_URL
 
@@ -363,7 +371,7 @@ elif [[ "${MAIN_GATES_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${MAIN_INTEGRATION_RESULT:-}" = "failure" ]]; then
-  report "main is red: the integration lane fails on the tip" "priority: high,area: ci-tests,bug" \
+  report "main is red: the integration lane fails on the tip" "priority: critical,area: ci-tests,bug" \
 "The real-Postgres lane failed against \`main\` on the two-hourly health check:
 $RUN_URL
 
@@ -383,7 +391,7 @@ elif [[ "${MAIN_INTEGRATION_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${MAIN_FRONTEND_RESULT:-}" = "failure" ]]; then
-  report "main is red: the frontend lane fails on the tip" "priority: high,area: ci-tests,bug" \
+  report "main is red: the frontend lane fails on the tip" "priority: critical,area: ci-tests,bug" \
 "The SPA lane (biome + vitest + tsc + build) failed against \`main\` on the
 two-hourly health check: $RUN_URL
 
@@ -412,7 +420,7 @@ elif [[ "${MAIN_FRONTEND_RESULT:-}" = "success" ]]; then
 fi
 
 if [[ "${MAIN_UAT_RESULT:-}" = "failure" ]]; then
-  report "main is red: the screen-acceptance UAT fails on the tip" "priority: high,area: ci-tests,bug" \
+  report "main is red: the screen-acceptance UAT fails on the tip" "priority: critical,area: ci-tests,bug" \
 "The UAT lane (AC screens + axe WCAG 2.2 AA + the 390px sweep, against the built
 app over the seed mock) failed against \`main\` on the two-hourly health check:
 $RUN_URL
@@ -438,6 +446,14 @@ elif [[ "${MAIN_UAT_RESULT:-}" = "success" ]]; then
   resolve "main is red: the screen-acceptance UAT fails on the tip"
 fi
 
+# `high` where its siblings are `critical`, and the difference is not a lane's
+# importance but who it stops. The taxonomy's honest test for `critical` is
+# "does this stop somebody else from working", and `main`'s required-status-check
+# ruleset names exactly ONE context: `ci`. A red lane inside `ci` is inherited by
+# every open pull request; a red SonarCloud verdict is inherited by nobody,
+# because `SonarCloud Code Analysis` is deliberately not required. That is the
+# same asymmetry this arm exists to compensate for — nothing is blocked, so
+# nothing prompts anyone to look, so the issue is the only signal.
 if [[ "${MAIN_SONAR_RESULT:-}" = "failure" ]]; then
   report "main's SonarCloud analysis was not published" "priority: high,area: ci-tests,bug" \
 "The \`sonarcloud (main)\` job failed on the two-hourly health check, with every

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -59,6 +59,10 @@ case "$1 ${2:-}" in
 		# issue with the wrong contents is indistinguishable from a working one
 		# unless something reads what it wrote.
 		if [ "${!i}" = "--body" ] && [ -n "${BODY_LOG:-}" ]; then j=$((i + 1)); printf '%s' "${!j}" >>"$BODY_LOG"; fi
+		# And the labels, for the same reason: the static census over the reporter
+		# proves the SOURCE names its axes, and cannot prove report() hands them
+		# to `gh`. A build that dropped label_args would satisfy the census.
+		if [ "${!i}" = "--label" ] && [ -n "${LABEL_LOG:-}" ]; then j=$((i + 1)); echo "${!j}" >>"$LABEL_LOG"; fi
 	done
 	;;
 *) echo "unexpected gh call: $*" >&2; exit 1 ;;
@@ -683,6 +687,116 @@ while IFS= read -r title; do
 	fi
 done <<<"$resolved"
 
+
+# --- the axes REACH `gh`, not only the source ------------------------------------
+#
+# One case, end to end, because the census below reads the reporter and a reader
+# could satisfy it while `report()` passed none of it on. This asserts on what the
+# stub was actually invoked with.
+export ACTION_LOG="$stub_dir/actions"
+export LABEL_LOG="$stub_dir/labels"
+: >"$ACTION_LOG"
+: >"$LABEL_LOG"
+set +e
+label_out="$(env OPEN_TITLES="" GH_TOKEN=stub REPO=owner/repo \
+	RUN_URL=https://example.test/run/1 GATE_RESULT=failure GATE_STATUS=ERROR \
+	"$root/scripts/scheduled-report.sh" 2>&1)"
+label_status=$?
+set -e
+got_labels="$(sort "$LABEL_LOG" | paste -sd, -)"
+want_labels="area: ci-tests,bug,priority: high"
+if [[ "$label_status" -ne 0 ]] || [[ "$got_labels" != "$want_labels" ]]; then
+	echo "FAIL: a filed issue does not carry its axes"
+	echo "  exit   want 0 got $label_status"
+	echo "  labels want '$want_labels' got '$got_labels'"
+	printf '  output: %s\n' "$label_out" | head -3
+	failures=$((failures + 1))
+else
+	echo "ok: a filed issue carries one priority, one area and its provenance"
+fi
+unset LABEL_LOG
+
+# --- every finding names its axes -----------------------------------------------
+#
+# docs/reference/issue-labels.md requires exactly one `priority:` and exactly one
+# `area:` on every issue, and states the invariant an auto-filer defeats:
+# UNLABELLED MEANS NOBODY HAS LOOKED AT IT YET. This reporter is the one filer in
+# the tree that files with no human present, so an arm that files on a provenance
+# word alone makes its issue claim something false about itself.
+#
+# Derived from BOTH owners and copied from neither: the arms from the reporter,
+# the vocabulary from the taxonomy page. A list kept here is exactly what let the
+# UAT arm inherit this gap — it "was written to match its siblings", and matching
+# your siblings is how a defect becomes a convention.
+labels_doc="$root/docs/reference/issue-labels.md"
+# `|| true` on both, for the reason the lane census below spells out: grep exits
+# 1 on no match and this file runs under `set -e`, so without it a taxonomy that
+# stopped matching would kill the suite mid-run with no message at all — a gate
+# that fails without saying what it found, which is barely better than one that
+# passes without looking. The empty case has to REACH the check below.
+priorities="$(grep -oE '`priority: [a-z]+`' "$labels_doc" | tr -d '`' | sed 's/^priority: //' | sort -u || true)"
+areas="$(sed -n '/^\*\*Area\*\* is where the fix lives/,/^$/p' "$labels_doc" |
+	grep -oE '`[a-z-]+`' | tr -d '`' | sort -u || true)"
+# A vocabulary that reads as empty would accept anything, which is the direction
+# a census must not fail in: it would report PASS over arms naming labels that do
+# not exist.
+if [[ -z "$priorities" ]] || [[ -z "$areas" ]]; then
+	echo "FAIL: the label taxonomy could not be read from docs/reference/issue-labels.md — the patterns stopped matching, the rule did not stop mattering"
+	failures=$((failures + 1))
+fi
+
+# EVERY report call, not only the ones with a literal title. The retraction
+# census above exempts `report "$merge_title"` because a computed title names one
+# past event and has no state to withdraw; the LABEL obligation has no such
+# exemption — that issue is read by a human like any other.
+arm_total="$(grep -cE '^  report ' "$reporter")"
+arms_with_labels="$(sed -nE 's/^  report "([^"]*)" "([^"]*)".*/\1\t\2/p' "$reporter")"
+arm_labelled="$(grep -c . <<<"$arms_with_labels" || true)"
+if [[ "$arm_total" -ne "$arm_labelled" ]]; then
+	echo "FAIL: the reporter has $arm_total report call(s) but $arm_labelled carry a quoted label list."
+	echo "      An arm filing on a bare provenance word files an issue that reads as untriaged,"
+	echo "      and this count is the only thing that notices — the arm itself works fine."
+	failures=$((failures + 1))
+fi
+
+while IFS=$'\t' read -r arm_title arm_label_list; do
+	[[ -z "$arm_title" ]] && continue
+	seen_priority=0
+	seen_area=0
+	while IFS= read -r one; do
+		[[ -z "$one" ]] && continue
+		case "$one" in
+		"priority: "*)
+			seen_priority=$((seen_priority + 1))
+			if ! grep -qxF "${one#priority: }" <<<"$priorities"; then
+				echo "FAIL: \"$arm_title\" files '$one', which is not a priority in docs/reference/issue-labels.md"
+				failures=$((failures + 1))
+			fi
+			;;
+		"area: "*)
+			seen_area=$((seen_area + 1))
+			if ! grep -qxF "${one#area: }" <<<"$areas"; then
+				echo "FAIL: \"$arm_title\" files '$one', which is not an area in docs/reference/issue-labels.md"
+				failures=$((failures + 1))
+			fi
+			;;
+		esac
+	done <<<"${arm_label_list//,/$'\n'}"
+	# EXACTLY one of each, not at least one. The rulebook says exactly, and a
+	# check that accepted two would not be holding the rule it cites — two
+	# priorities on one issue is a filter that double-counts it.
+	if [[ "$seen_priority" -ne 1 ]]; then
+		echo "FAIL: \"$arm_title\" files $seen_priority 'priority:' labels, want exactly 1"
+		failures=$((failures + 1))
+	fi
+	if [[ "$seen_area" -ne 1 ]]; then
+		echo "FAIL: \"$arm_title\" files $seen_area 'area:' labels, want exactly 1"
+		failures=$((failures + 1))
+	fi
+done <<<"$arms_with_labels"
+if [[ "$failures" -eq 0 ]]; then
+	echo "ok: all $arm_total arms name exactly one priority and one area, from the taxonomy page"
+fi
 # --- the report job is REACHED on a green run -----------------------------------
 #
 # One question per workflow, because it is one fact about the job: it must run


### PR DESCRIPTION
Fixes https://github.com/margince/margince/issues/2709.

## What

Every issue `scripts/scheduled-report.sh` files now carries **exactly one `priority:` and exactly one `area:`** alongside its provenance label, and a census derived from the reporter and the taxonomy page requires it of every arm.

## Why

Each issue it filed carried one label — `bug`, or `security` for the vulnerability arm — and nothing else. `docs/reference/issue-labels.md` requires three axes and states the invariant an auto-filer defeats:

> The labels protect one invariant: **unlabeled means nobody has looked at it yet.**

So every issue this reporter has ever filed was claiming something false about itself. It is the one filer in the tree that files with **no human present**, which makes it the one most likely to be read by somebody who was not there when it was written.

## The axes

From the ruling on #2709, applied verbatim where it speaks:

| arm | `priority:` | `area:` |
|---|---|---|
| `VULN_RESULT` | **critical** | platform |
| `GATE_RESULT` | high | ci-tests |
| `LANE_RESULT` | **critical** (see below) | ci-tests |
| `PERF_RESULT` (both titles) | normal | ci-tests |
| `CLOCK_RESULT` | normal | ci-tests |
| `CACHE_RESULT` | normal | ci-tests |
| main-health — backend gate / integration / frontend / UAT | **critical** (see below) | ci-tests |

`VULN_RESULT` is the single `critical`: an unpatched advisory is not a lane being red, and it is the one arm whose finding has a clock on it that is not ours. `main-health`'s arms are `high` rather than `critical` because that workflow says in its own header that it is not a gate.

### What the ruling did not cover, and what I chose

The ruling is from 2026-09-02. Five arms postdate it — four of them landed earlier today in https://github.com/margince/margince/pull/5156. These are **my extension of its stated principle**, not the ruling, and are the thing to push back on if any is wrong:

| arm | chosen | reasoning |
|---|---|---|
| `MOBILE_RESULT` (both titles) | normal / ci-tests | an exact mirror of `PERF_RESULT`, which the ruling sets |
| `LLM_RESULT` — could not run | normal / ci-tests | a lane that did not run is a lane problem |
| `LLM_OUTCOME` — a use case is failing | normal / ci-tests | its own issue body lists the three things it is usually NOT, and all three are harness or checker faults, so `ci-tests` is right by "where the fix lives" as well as by the ruling's filing-guess rule |
| `MAIN_SONAR_RESULT` | high / ci-tests | a main-health arm, per the ruling's row for the others |
| merge-attest | high / ci-tests | `main` is red now, and this alarm's whole value is naming the commit early |

### The tension I flagged, now resolved — `critical` for a lane inside `ci`

The first cut followed the ruling and filed the lane arms as `high`, flagging that `docs/reference/issue-labels.md` lists "``main``/CI red" under `critical`. Review raised it, and it was right on five of the six sites it named. Resolved in `242f2cb01`.

The taxonomy's test is not "is this bad" but ***"does this stop somebody else from working"***, and `main`'s required-status-check ruleset names exactly one context: `ci`. That splits the arms in two.

**Raised to `critical`** — the five lanes inside `ci`, each inherited by every open pull request the moment it goes red: the backend merge gate, and main-health's backend, integration, frontend and screen-acceptance arms. Today is the evidence: an integration red blocked every open PR for about four hours, two sessions independently opened `claim: main-red` PRs (#5154 and #5152, consolidated under the lower-number rule), and four unrelated PRs merged over it.

**Left at `high`** — the two SonarCloud arms, declined on the *same* test rather than in spite of it. `SonarCloud Code Analysis` is deliberately not required, so a red verdict is inherited by nobody, and `critical` means *drop other work* for a finding that stops none. The asymmetry was measurable this morning, when both reds were live at once:

| | inside `ci`? | picked up after |
|---|---|---|
| the docs-budget gate (#5118) | yes | **74 minutes** — a session tripped over it while driving an unrelated PR |
| the SonarCloud gate (#5117) | no | untouched until somebody read the tracker on purpose |

Marking the Sonar arm `critical` would not have shortened that; nothing was going to inherit it either way. Absence of a block is the thing that arm exists to compensate for, and that reasoning now sits in the source beside both Sonar arms rather than only in a review thread.

**This departs from the ruling on #2709**, which set the main-health arms at `high` because main-health "is not a gate" — that asks whether the *lane* gates merges, where the taxonomy asks whether the *condition* stops other people. For a lane inside `ci` those come apart. The departure is recorded on #2709 so the ruling is not left contradicting the code.

## Why the census is the part that matters

The ruling names this and it is the whole reason this was not a sweep. The UAT arm inherited the gap by being *"written to match its siblings"* — and matching your siblings is how a defect becomes a convention. So the obligation is derived from its two owners and copied from neither: **the arms from the reporter, the vocabulary from the taxonomy page.**

- **Exactly one of each, not at least one.** The rulebook says exactly, and a check that accepted two would not be holding the rule it cites — two areas on one issue is a filter that double-counts it.
- **The arm count is checked against the count carrying a label list.** That is the only thing that notices an arm reverting to a bare provenance word: the arm itself keeps working, files its issue, and reads as untriaged.
- **Every `report` call, including the computed-title one.** The retraction census added in #5156 exempts `report "$merge_title"` because a computed title names one past event with no state to withdraw. The label obligation has no such exemption — a human reads that issue like any other.
- **One runtime case**, because a static census over the reporter could be satisfied by a build that dropped `label_args` and passed nothing to `gh`.

## Two things found on the way

**My own guard was unreachable.** Both taxonomy reads now carry `|| true`, for the reason the lane census already documents in this file: `grep` exits 1 on no match and the suite runs under `set -e`, so a taxonomy whose heading drifted killed the suite mid-run **with no message at all** — thirteen `ok:` lines and then nothing. A gate that fails without saying what it found is barely better than one that passes without looking. Caught by mutating the heading and noticing the failure was silent.

**`$(printf '\n')` is the empty string.** Command substitution strips trailing newlines, so my first comma-split deleted the commas instead of splitting on them and every arm read as one giant label. `$'\n'` is the spelling that works — which is what the reporter already used, and what I failed to copy.

## How verified

`make test-scheduled-report`: **44 cases, all green.** Every new check mutation-tested:

| mutation | caught by |
| --- | --- |
| an arm reverts to a bare provenance word | `17 report call(s) but 16 carry a quoted label list` |
| an arm loses its `priority:` | `a filed issue does not carry its axes` |
| an arm names two areas | `files 2 'area:' labels, want exactly 1` |
| an arm invents `priority: urgent` | `not a priority in docs/reference/issue-labels.md` |
| `report()` stops passing labels to `gh` | `a filed issue does not carry its axes` |
| the taxonomy's `**Area**` heading drifts | `the label taxonomy could not be read` |

The four already-filed issues the ruling names are relabelled: https://github.com/margince/margince/issues/2632, https://github.com/margince/margince/issues/2633, https://github.com/margince/margince/issues/2344 (https://github.com/margince/margince/issues/2708 already had them). All four had been closed by the time I got there, so this is record repair rather than triage — worth doing because `gh issue list --label "area: <x>" --state all` is a real workflow, and the taxonomy page recommends it for finding an existing tracker.

- [x] `make check` is green — both halves, `EXIT=0` each. `check-backend` failed once at the gates package's 10-minute `go test` timeout, with goroutines parked 8 minutes in `t.Parallel()`; it passed on a re-run once the machine was quiet, and this diff contains **no Go file at all**. `check-fe` passed 651/651 test files, including the `worklist.today.test.tsx` case that failed twice under load earlier in the same session — recorded on https://github.com/margince/margince/issues/2661
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — it touches neither; no Go and no SQL
- [x] `make craft-static` reports no new blockers — it sweeps the Go trees, and this diff has none
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by Claude Code, working the ruling on #2709. The judgement calls are the five arms the ruling predates and the `critical`-versus-`high` tension, both sectioned above rather than buried.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
