### PR TITLE
feat(frontend): restore contact edit, merge and archive on the person record page

### DIFF
--- a/frontend/src/api/if-match-coverage.test.ts
+++ b/frontend/src/api/if-match-coverage.test.ts
@@ -50,7 +50,10 @@ const UNPINNED_WRITES: readonly string[] = [
   // screenful of rows at once, and it was the verb of three in that bar that
   // could not lose a race it should lose.
   "screens/companyheader.tsx DELETE /organizations/{id}",
-  "screens/contacts.tsx DELETE /people/{id}",
+  // PersonEditMergeArchive's own archive, shared by PersonScreen (contacts.tsx)
+  // and PersonPageV2 — the entry moved here with it, the same move merge-org's
+  // own line made out of organizations.tsx.
+  "screens/personeditmergearchive.tsx DELETE /people/{id}",
   "screens/personrail.tsx DELETE /relationships/{id}",
   "screens/relationships.tsx DELETE /relationships/{id}",
   "screens/contractform.tsx PATCH /contracts/{id}",

--- a/frontend/src/screens/contacts.tsx
+++ b/frontend/src/screens/contacts.tsx
@@ -2,10 +2,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { ifMatch, requireVersion } from "../api/version";
 import { usePageName } from "../app/pagemeta";
 import { useRecordZone } from "../app/recordzone";
-import { navigate } from "../app/router";
 import { activityTimeline } from "../design-system/activitytimeline";
 import { Badge, SegmentedControl } from "../design-system/atoms";
 import { RecordView } from "../design-system/composed";
@@ -22,7 +20,6 @@ import { primaryEmail } from "../format/primaryemail";
 import { normalizeProfileUrl } from "../format/profileurl";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { ArchiveAction } from "./archive";
 import {
   LoadMoreButton,
   OverlayUnavailable,
@@ -40,7 +37,6 @@ import {
   type ObjectCustomFields,
   useObjectCustomFields,
 } from "./customfields.form";
-import { EditAction } from "./edit";
 import { EntityRef } from "./entityref";
 import { RecordHistoryTab } from "./history";
 import {
@@ -53,7 +49,6 @@ import {
   useTagChips,
 } from "./listquery";
 import { LogActivity } from "./logactivity";
-import { MergeAction } from "./merge";
 import {
   IdentityRail,
   type Person360,
@@ -65,6 +60,8 @@ import {
 } from "./person360";
 import { EnrichedFields } from "./personcorrections";
 import { PersonDealRooms } from "./persondealrooms";
+import { PersonEditMergeArchive } from "./personeditmergearchive";
+import { contactCreateFields, mapPersonBody } from "./personformfields";
 import { PersonNetworkTab } from "./personnetwork";
 import { PersonProjects } from "./personprojects";
 import {
@@ -92,8 +89,6 @@ import { VCardImport } from "./vcard-import";
 // view-existing link (P-16) are the four shared blocks wired in here.
 
 type Person = components["schemas"]["Person"];
-type CreatePersonRequest = components["schemas"]["CreatePersonRequest"];
-type UpdatePersonRequest = components["schemas"]["UpdatePersonRequest"];
 
 async function fetchPeoplePage(
   query: ListQuery,
@@ -123,199 +118,6 @@ async function fetchPeoplePage(
       has_more: data.page.has_more,
     },
   };
-}
-
-// Merge-target search (P-2): reuses the list read, mapped down to the
-// {id, name} shape MergeAction renders — the caller filters out the source
-// row since this fetch has no notion of "the record being merged away".
-async function searchPeopleTargets(
-  q: string,
-): Promise<{ id: string; name: string }[]> {
-  const { data, error } = await api.GET("/people", {
-    params: { query: { q, limit: 10 } },
-  });
-  if (error) {
-    throwProblem(error);
-  }
-  return data.data.map((candidate) => ({
-    id: candidate.id,
-    name: candidate.full_name,
-  }));
-}
-
-function asEmailType(value: string | undefined): "work" | "personal" | "other" {
-  return value === "personal" || value === "other" ? value : "work";
-}
-
-function asPhoneType(
-  value: string | undefined,
-): "work" | "mobile" | "home" | "other" {
-  return value === "mobile" || value === "home" || value === "other"
-    ? value
-    : "work";
-}
-
-// The email rows a writer supplied, blank ones dropped and position taken from
-// where each one sits in the list.
-//
-// ONE MAPPER FOR BOTH REQUESTS, because `PersonEmailInput` is one schema for
-// both: create and update describing an address differently is exactly what
-// that shared schema exists to prevent.
-function personEmailInputs(rows: FormRows) {
-  return (rows.emails ?? [])
-    .filter((row) => (row.email ?? "").trim().length > 0)
-    .map((row, index) => ({
-      email: row.email.trim(),
-      email_type: asEmailType(row.email_type),
-      is_primary: row.is_primary === "true",
-      position: index,
-    }));
-}
-
-// The phone rows, the same way and for the same reason.
-function personPhoneInputs(rows: FormRows) {
-  return (rows.phones ?? [])
-    .filter((row) => (row.phone ?? "").trim().length > 0)
-    .map((row, index) => ({
-      phone: row.phone.trim(),
-      phone_type: asPhoneType(row.phone_type),
-      is_primary: row.is_primary === "true",
-      position: index,
-    }));
-}
-
-// Builds the create-contact request body: scalar fields trim to undefined
-// when blank (never sent rather than sent empty), `social.linkedin` folds
-// into the `social` object, and each repeatable row becomes an
-// emails/phones entry keyed by its position in the list.
-export function mapPersonBody(
-  values: Record<string, string>,
-  rows: FormRows,
-): CreatePersonRequest {
-  const linkedin = values["social.linkedin"]?.trim();
-  const emails = personEmailInputs(rows);
-  const phones = personPhoneInputs(rows);
-  return {
-    full_name: values.full_name.trim(),
-    first_name: values.first_name?.trim() || undefined,
-    last_name: values.last_name?.trim() || undefined,
-    title: values.title?.trim() || undefined,
-    social: linkedin ? { linkedin } : undefined,
-    emails: emails.length > 0 ? emails : undefined,
-    phones: phones.length > 0 ? phones : undefined,
-    source: "manual",
-  };
-}
-
-function stringField(value: unknown): string {
-  return typeof value === "string" ? value : "";
-}
-
-// Builds the PATCH body.
-//
-// `emails` and `phones` REPLACE their sets rather than adding to them, which is
-// what a correction needs: a bounced address is fixed by sending the set that
-// should stand, and an append-only field could never remove the one that is
-// dead. So an empty list is SENT, not omitted — a contact whose last address
-// was wrong and is now gone is a real answer, and omitting it would silently
-// keep the address the reader just deleted.
-//
-// `rows` is absent only where a caller has no repeatable fields at all; the
-// person form always has both, so the sets go out on every save.
-export function mapPersonUpdate(
-  values: Record<string, unknown>,
-  rows?: FormRows,
-): UpdatePersonRequest {
-  const linkedin = stringField(values["social.linkedin"]).trim();
-  return {
-    full_name: stringField(values.full_name).trim() || undefined,
-    first_name: stringField(values.first_name).trim() || undefined,
-    last_name: stringField(values.last_name).trim() || undefined,
-    title: stringField(values.title).trim() || undefined,
-    social: linkedin ? { linkedin } : undefined,
-    emails: rows ? personEmailInputs(rows) : undefined,
-    phones: rows ? personPhoneInputs(rows) : undefined,
-  };
-}
-
-// Built inside ContactsScreen (not module-level) because the email/phone
-// "Type" options are display text, not raw values — fieldControl (create.tsx)
-// renders option.label verbatim, so the human-readable string has to be
-// resolved via useT() before it reaches CreateField, unlike organizations.tsx's
-// size_band options, which are already display-ready raw labels ("1-10").
-function contactCreateFields(t: ReturnType<typeof useT>): CreateField[] {
-  return [
-    { key: "full_name", label: "create.fullName", required: true },
-    { key: "first_name", label: "create.firstName" },
-    { key: "last_name", label: "create.lastName" },
-    { key: "title", label: "create.personTitle" },
-    { key: "social.linkedin", label: "create.linkedin" },
-    {
-      key: "emails",
-      label: "create.email",
-      type: "repeatable",
-      addLabel: "field.addEmail",
-      rowFields: [
-        {
-          key: "email",
-          label: "create.email",
-          type: "email",
-          required: true,
-        },
-        {
-          key: "email_type",
-          label: "field.emailType",
-          type: "select",
-          options: [
-            { value: "work", label: t("field.emailWork") },
-            { value: "personal", label: t("field.emailPersonal") },
-            { value: "other", label: t("field.emailOther") },
-          ],
-        },
-      ],
-      primaryKey: "is_primary",
-    },
-    {
-      key: "phones",
-      label: "create.phone",
-      type: "repeatable",
-      addLabel: "field.addPhone",
-      rowFields: [
-        { key: "phone", label: "create.phone", required: true },
-        {
-          key: "phone_type",
-          label: "field.phoneType",
-          type: "select",
-          options: [
-            { value: "work", label: t("field.phoneWork") },
-            { value: "mobile", label: t("field.phoneMobile") },
-            { value: "home", label: t("field.phoneHome") },
-            { value: "other", label: t("field.phoneOther") },
-          ],
-        },
-      ],
-      primaryKey: "is_primary",
-    },
-  ];
-}
-
-// The edit form is contactCreateFields WITHOUT the create-only parts, so the
-// two cannot come to describe an address differently — the same reason one
-// mapper serves both request bodies.
-//
-// It carries the email and phone rows because nothing else in the product can
-// change them. A bounced send names the address that refused it and sends the
-// reader here; a form that omitted the field left that reader at a page which
-// reported the failure and could not fix it.
-//
-// Moving the primary marker between two addresses of the SAME type is refused
-// by the server with a bare 409 today. Not a limit of this form and not
-// introduced here — the same PATCH has answered that way since the field
-// existed — but the primary radio is the first control that reaches it, so the
-// conflict is shown rather than swallowed. Correcting an address, adding one
-// and removing one all work.
-function personEditFields(t: ReturnType<typeof useT>): CreateField[] {
-  return contactCreateFields(t);
 }
 
 async function createContact(
@@ -589,10 +391,6 @@ function PersonActionBadges({
   archivedReasonId,
 }: Readonly<{
   person: Person;
-  // Read at screen level and handed down, so the schema request runs BESIDE the
-  // person's rather than after it. Started here, it would begin only once the
-  // record had landed and the strip first rendered — and an edit opened in that
-  // gap would offer a form with no custom fields on it.
   cf: ObjectCustomFields;
   // Minted once for the page by the caller, because the archive is a fact
   // about the record rather than about any one verb that refuses.
@@ -601,7 +399,7 @@ function PersonActionBadges({
   const t = useT();
   const overlay = useSorMode() === "overlay";
   const viewerId = useViewerId();
-  const id = person.id;
+  const disabledReasonId = person.archived_at ? archivedReasonId : undefined;
   return (
     <>
       <ProvenanceTag provenance={provenanceOf(person.captured_by, viewerId)} />
@@ -623,114 +421,11 @@ function PersonActionBadges({
           pointing at the page's one sentence about the archive
           (STATE-4a): a missing control says nothing about the
           record, while a refused one names the reason. */}
-      <EditAction<Person>
-        disabledReasonId={person.archived_at ? archivedReasonId : undefined}
-        label={t("record.edit")}
-        savedMessage={(saved) =>
-          t("record.saveDone", { name: saved.full_name })
-        }
-        notice={overlay ? t("overlay.partialWriteBack") : undefined}
-        // An address is unique among LIVE rows across the workspace
-        // (uq_person_email_dedupe), so a correction can now collide with the
-        // contact that already holds it — 409 `duplicate_email`, naming that
-        // record. Create has always offered the way there; edit could not
-        // collide until it carried the address field, and a conflict the
-        // reader cannot follow is a dead end on the one screen that fixes
-        // addresses.
-        resolveExisting={(_code, existingId) => ({
-          screen: "contacts",
-          id: existingId,
-        })}
-        fields={[...personEditFields(t), ...cf.formFields]}
-        record={{
-          id: person.id,
-          version: person.version,
-          full_name: person.full_name,
-          first_name: person.first_name ?? "",
-          last_name: person.last_name ?? "",
-          title: person.title ?? "",
-          "social.linkedin": stringField(person.social?.linkedin),
-          // The rows the form prefills from. `is_primary` is stringified by
-          // prefillRows like every other cell, and read back as `=== "true"`,
-          // so the primary marker survives a save that did not touch it.
-          emails: person.emails ?? [],
-          phones: person.phones ?? [],
-          ...cf.recordSlice(person),
-        }}
-        update={async (values, rows, opened) => {
-          const { data, error } = await api.PATCH("/people/{id}", {
-            params: {
-              path: { id },
-              ...ifMatch(requireVersion(opened?.version)),
-            },
-            body: {
-              ...mapPersonUpdate(values, rows),
-              // A diff against what the form prefilled from: a
-              // snapshot sends `null` for every empty custom field,
-              // and the API reads that as clearing a column nobody
-              // touched.
-              ...cf.toPatch(values, opened ?? {}),
-            },
-          });
-          if (error) {
-            throwProblem(error);
-          }
-          return data;
-        }}
-        invalidate="people"
-        recordKey="person"
-      />
-      {/* Merge has no incumbent-first projection — the seam
-          refuses it outright (overlay/provider_writes.go
-          Merge) — unlike edit/archive below, which it
-          serves, so it stays hidden here. */}
-      {!overlay && (
-        <MergeAction
-          disabledReasonId={person.archived_at ? archivedReasonId : undefined}
-          label={t("merge.contact")}
-          sourceId={person.id}
-          sourceName={person.full_name}
-          searchTargets={searchPeopleTargets}
-          merge={async (targetId) => {
-            const { data, error } = await api.POST("/people/{id}/merge", {
-              params: {
-                path: { id: person.id },
-                ...ifMatch(requireVersion(person.version)),
-              },
-              body: { target_id: targetId },
-            });
-            if (error) {
-              throwProblem(error, t);
-            }
-            return data;
-          }}
-          invalidate="people"
-          recordKey="person"
-          survivorRoute={(targetId) => ({
-            screen: "contacts",
-            id: targetId,
-          })}
-        />
-      )}
-      <ArchiveAction
-        disabledReasonId={person.archived_at ? archivedReasonId : undefined}
-        label={t("record.archive")}
-        confirmText={t("record.archiveConfirm")}
-        archivedMessage={t("record.archiveDone", {
-          name: person.full_name,
-        })}
-        archive={async () => {
-          const { data, error } = await api.DELETE("/people/{id}", {
-            params: { path: { id } },
-          });
-          if (error) {
-            throwProblem(error);
-          }
-          return data;
-        }}
-        invalidate="people"
-        recordKey="person"
-        onArchived={() => navigate({ screen: "contacts" })}
+      <PersonEditMergeArchive
+        person={person}
+        cf={cf}
+        disabledReasonId={disabledReasonId}
+        overlay={overlay}
       />
       {/* A record grant probes the native row via
           auth.EnsureLinkTarget, which a mirrored record has
@@ -741,7 +436,7 @@ function PersonActionBadges({
         <ShareAction
           recordType="person"
           recordId={person.id}
-          disabledReasonId={person.archived_at ? archivedReasonId : undefined}
+          disabledReasonId={disabledReasonId}
         />
       )}
     </>

--- a/frontend/src/screens/overlay-refusal-coverage.test.ts
+++ b/frontend/src/screens/overlay-refusal-coverage.test.ts
@@ -157,8 +157,11 @@ describe("overlay refusal copy — translator coverage", () => {
   });
 
   it("merge-person (POST /people/{id}/merge)", () => {
+    // Edit, merge and archive moved out of contacts.tsx when that file
+    // passed its own length ratchet, into their own shared file so
+    // PersonPageV2's header could reach the same wiring PersonScreen's did.
     assertTranslatedRefusal(
-      "contacts.tsx",
+      "personeditmergearchive.tsx",
       '"/people/{id}/merge"',
       "merge-person",
     );

--- a/frontend/src/screens/overlay-refusal-coverage.test.ts
+++ b/frontend/src/screens/overlay-refusal-coverage.test.ts
@@ -157,9 +157,8 @@ describe("overlay refusal copy — translator coverage", () => {
   });
 
   it("merge-person (POST /people/{id}/merge)", () => {
-    // Edit, merge and archive moved out of contacts.tsx when that file
-    // passed its own length ratchet, into their own shared file so
-    // PersonPageV2's header could reach the same wiring PersonScreen's did.
+    // Edit, merge and archive live in their own shared file, imported by
+    // both PersonScreen's header (contacts.tsx) and PersonPageV2's.
     assertTranslatedRefusal(
       "personeditmergearchive.tsx",
       '"/people/{id}/merge"',

--- a/frontend/src/screens/personactions.tsx
+++ b/frontend/src/screens/personactions.tsx
@@ -23,11 +23,8 @@ import { primaryTransportAction, useTransports } from "./persontransports";
 import { EmailVerb } from "./recordemail";
 import { ShareAction } from "./share";
 
-// The header's verbs on the person record page (personpage.tsx), split out
-// once its own growth met the frontend's file-length ratchet — the wiring
-// this file adds (PersonEditMergeArchive on the header's badges, restoring
-// the contact edit form personpage.tsx had none of) needed the room this
-// component's own size was owed back.
+// The header's verbs on the person record page (personpage.tsx): writing,
+// calling, meeting, logging, and the research/full-history/share menu.
 
 type Person360 = components["schemas"]["Person360"];
 

--- a/frontend/src/screens/personactions.tsx
+++ b/frontend/src/screens/personactions.tsx
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import {
+  CalendarDays,
+  CheckSquare,
+  FileText,
+  Phone,
+  Search,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useId } from "react";
+import type { components } from "../api/schema";
+import { useCanWrite } from "../app/capability";
+import { navigate } from "../app/router";
+import { Button, OverflowMenu } from "../design-system/atoms";
+import { IconAction } from "../design-system/iconaction";
+import { useT } from "../i18n";
+import { useMe } from "./common";
+import { personTabRoute } from "./persontab";
+import type { Transport } from "./persontransports";
+import { primaryTransportAction, useTransports } from "./persontransports";
+import { EmailVerb } from "./recordemail";
+import { ShareAction } from "./share";
+
+// The header's verbs on the person record page (personpage.tsx), split out
+// once its own growth met the frontend's file-length ratchet — the wiring
+// this file adds (PersonEditMergeArchive on the header's badges, restoring
+// the contact edit form personpage.tsx had none of) needed the room this
+// component's own size was owed back.
+
+type Person360 = components["schemas"]["Person360"];
+
+// Why the lead verb may not be pressed, in the reader's words, or undefined
+// when it may.
+//
+// TWO facts refuse it and they are never merged into one sentence: consent says
+// we may not write to this person, reachability says there is nowhere to write
+// to. A rep who is told the wrong one goes looking in the wrong record.
+//
+// Reachability is asked first because it is the unconditional half — with no
+// transport the composer has nothing to send on whatever consent says, and a
+// consent sentence there would describe a decision that is not what stops them.
+// A guard that has not answered yet refuses nothing: the button is disabled
+// without a reason until the verdict is in, because claiming a refusal the
+// server has not made is worse than a control that is briefly quiet.
+function writeRefusal(
+  state: Readonly<{
+    transports: readonly Transport[];
+    consentAllows: boolean;
+    consentKnown: boolean;
+  }>,
+  t: ReturnType<typeof useT>,
+): string | undefined {
+  if (state.transports.length === 0) {
+    return t("person.action.noTransport");
+  }
+  if (state.consentAllows || !state.consentKnown) {
+    return undefined;
+  }
+  return t("person.action.consentRefused");
+}
+
+// The header's verbs, in the order every record page carries them: writing
+// first, then the record's other doors. None of them is filled — the move
+// worth doing is the one the call names, and that one carries the colour.
+export function PersonActions({
+  view,
+  consentAllows,
+  consentKnown,
+  personId,
+  overlay,
+  onWrite,
+  onResearch,
+  onLogActivity,
+  onAddTask,
+  refusedReasonId,
+}: Readonly<{
+  view: Person360;
+  consentAllows: boolean;
+  consentKnown: boolean;
+  personId: string;
+  // LogActivityAction itself renders nothing in overlay — a mirrored
+  // workspace has no activity write of its own, the same fact
+  // PersonEmailPanel already states for the record's email box — so a
+  // trigger drawn here would set drawer state a mount elsewhere refuses.
+  overlay: boolean;
+  onWrite: () => void;
+  onResearch: () => void;
+  onLogActivity: () => void;
+  onAddTask: () => void;
+  // The page's one sentence about why this contact takes no changes, while
+  // it does not. Only Share writes the RECORD here — a grant is asserted
+  // through the person's own write gate — so it is the one verb refused by
+  // it; logging and mail are activity writes with gates of their own.
+  refusedReasonId?: string;
+}>): ReactNode {
+  const t = useT();
+  // useCanWrite, not useCan: both this verb and Add task below issue the same
+  // POST, and a read seat is refused before RBAC is consulted. The buttons
+  // stay on the page and say why they will not press, so a reader can tell
+  // "not mine to do" from "this build has no such button".
+  const me = useMe();
+  const canLog = useCanWrite("activity", "create");
+  // Named once and pointed at by both buttons — Button's own contract for a
+  // surface where several controls are refused by ONE fact: printing the
+  // sentence beside each button says it as many times as there are buttons.
+  const logRefusedId = useId();
+  // A guard that has not answered yet refuses nothing: claiming a refusal
+  // `/me` has not decided is worse than a control that is briefly quiet —
+  // the same rule writeRefusal states for the identical shape, above.
+  const logGrantKnown = me.data?.authorization !== undefined;
+  const logRefused = logGrantKnown && !canLog ? logRefusedId : undefined;
+  const logPending = !logGrantKnown;
+  // The transports the composer would offer, read here so the button NAMES
+  // what pressing it does. The same reachability the drawer resolves: a label
+  // computed from anything else is a promise the composer then breaks.
+  const transports = useTransports(view);
+  const write = primaryTransportAction(transports, t);
+  const WriteIcon = write.icon;
+  const refusal = writeRefusal({ transports, consentAllows, consentKnown }, t);
+  return (
+    <>
+      {/* The shared Email verb, wearing the transport it will open when there
+          is exactly one, neutral when the composer will ask, and explaining
+          itself rather than merely dimming when it may not be pressed. */}
+      <EmailVerb
+        label={write.label}
+        icon={<WriteIcon size={15} aria-hidden="true" />}
+        disabled={!consentKnown}
+        reason={refusal}
+        onClick={onWrite}
+      />
+      {/* Square, because a phone and a calendar are verbs a reader already
+          knows from the glyph — and five labelled buttons in a row is a header
+          that reads as a toolbar, with the one action the page is FOR no more
+          prominent than the rest of them. `IconAction` owes each one its name
+          on hover as well as to a screen reader. */}
+      <IconAction
+        label={t("person.action.call")}
+        icon={<Phone size={15} aria-hidden="true" />}
+        onClick={() => navigate(personTabRoute(personId, "timeline"))}
+      />
+      <IconAction
+        label={t("person.action.meetings")}
+        icon={<CalendarDays size={15} aria-hidden="true" />}
+        onClick={() =>
+          navigate({ screen: "contacts", id: personId, id2: "meetings" })
+        }
+      />
+      {/* Neither verb is drawn in overlay: LogActivityAction, the form both
+          open, renders nothing there — a mirrored workspace has no activity
+          write of its own — so a trigger here would set drawer state a mount
+          elsewhere refuses to act on. */}
+      {!overlay && (
+        <>
+          {logRefused && (
+            <p className="t-caption" id={logRefusedId}>
+              {t("record.logActivityRefused")}
+            </p>
+          )}
+          {/* A CRM a rep cannot write a meeting into is a CRM that only
+              reads. This is the standing way in; the moment card offers the
+              same form when its rung decides logging is the thing to do
+              next. */}
+          <Button
+            disabled={logPending}
+            reasonId={logRefused}
+            onClick={onLogActivity}
+          >
+            <FileText size={15} aria-hidden="true" /> {t("log.title")}
+          </Button>
+          {/* Keeps its words. A tick box is the glyph for COMPLETING a task,
+              so squaring this one would name the opposite of what it does.
+              Files the task against THIS record — the same form Log activity
+              opens, started on its task kind, rather than a navigation to the
+              Worklist, which has no way to add one. */}
+          <Button
+            disabled={logPending}
+            reasonId={logRefused}
+            onClick={onAddTask}
+          >
+            <CheckSquare size={15} aria-hidden="true" />{" "}
+            {t("person.action.addTask")}
+          </Button>
+        </>
+      )}
+      {/* A real menu. This was a button labelled "More actions" that navigated
+          to the timeline tab — the same place the Call button went — so the one
+          control on the header promising there was more behind it delivered a
+          tab instead, and the promise was the only thing it did. Research moves
+          in here because a magnifier reads as "search" and this verb is not
+          search, and the timeline gets the honest name the product already uses
+          for it everywhere else. */}
+      <OverflowMenu label={t("record.moreActions")}>
+        <Button small onClick={onResearch}>
+          <Search size={15} aria-hidden="true" /> {t("person.action.research")}
+        </Button>
+        <Button
+          small
+          onClick={() => navigate(personTabRoute(personId, "timeline"))}
+        >
+          {t("record.fullHistory")}
+        </Button>
+        {/* Companies, deals, leads and projects all carry this. A contact did
+            not, so the one record type most likely to be private to one seat
+            was the one with no way to hand it to a colleague. */}
+        <ShareAction
+          recordType="person"
+          recordId={personId}
+          disabledReasonId={refusedReasonId}
+        />
+      </OverflowMenu>
+    </>
+  );
+}

--- a/frontend/src/screens/personeditmergearchive.tsx
+++ b/frontend/src/screens/personeditmergearchive.tsx
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { ifMatch, requireVersion } from "../api/version";
+import { navigate } from "../app/router";
+import { useT } from "../i18n";
+import { ArchiveAction } from "./archive";
+import { throwProblem } from "./common";
+import type { ObjectCustomFields } from "./customfields.form";
+import { EditAction } from "./edit";
+import { MergeAction } from "./merge";
+import { mapPersonUpdate, personEditFields } from "./personformfields";
+
+// Edit, merge and archive — the record's own core write verbs, shared
+// between PersonScreen's header (contacts.tsx) and PersonPageV2's
+// (personactions.tsx's sibling, wired from personpage.tsx), which had no
+// reachable edit form at all: the route moved to PersonPageV2 years before
+// this file existed, and this wiring stayed behind on the screen nothing
+// routes to any more. One writer of the PATCH/merge/archive config rather
+// than two, so a change to what a person edit form carries cannot fix one
+// page's form and silently leave the other stale.
+
+type Person = components["schemas"]["Person"];
+
+// Merge-target search (P-2): reuses the list read, mapped down to the
+// {id, name} shape MergeAction renders — the caller filters out the source
+// row since this fetch has no notion of "the record being merged away".
+async function searchPeopleTargets(
+  q: string,
+): Promise<{ id: string; name: string }[]> {
+  const { data, error } = await api.GET("/people", {
+    params: { query: { q, limit: 10 } },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data.data.map((candidate) => ({
+    id: candidate.id,
+    name: candidate.full_name,
+  }));
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+export function PersonEditMergeArchive({
+  person,
+  cf,
+  disabledReasonId,
+  overlay,
+}: Readonly<{
+  person: Person;
+  // Read at screen level and handed down, so the schema request runs BESIDE the
+  // person's rather than after it. Started here, it would begin only once the
+  // record had landed and the strip first rendered — and an edit opened in that
+  // gap would offer a form with no custom fields on it.
+  cf: ObjectCustomFields;
+  // The one sentence the caller points every refused verb at. What refuses
+  // varies by caller — PersonScreen asks only whether the record is archived,
+  // PersonPageV2's useRecordWriteRefusal also answers "not yours to change" —
+  // so the reason is the caller's to decide, not this component's.
+  disabledReasonId?: string;
+  overlay: boolean;
+}>) {
+  const t = useT();
+  const id = person.id;
+  return (
+    <>
+      <EditAction<Person>
+        disabledReasonId={disabledReasonId}
+        label={t("record.edit")}
+        savedMessage={(saved) =>
+          t("record.saveDone", { name: saved.full_name })
+        }
+        notice={overlay ? t("overlay.partialWriteBack") : undefined}
+        // An address is unique among LIVE rows across the workspace
+        // (uq_person_email_dedupe), so a correction can now collide with the
+        // contact that already holds it — 409 `duplicate_email`, naming that
+        // record. Create has always offered the way there; edit could not
+        // collide until it carried the address field, and a conflict the
+        // reader cannot follow is a dead end on the one screen that fixes
+        // addresses.
+        resolveExisting={(_code, existingId) => ({
+          screen: "contacts",
+          id: existingId,
+        })}
+        fields={[...personEditFields(t), ...cf.formFields]}
+        record={{
+          id: person.id,
+          version: person.version,
+          full_name: person.full_name,
+          first_name: person.first_name ?? "",
+          last_name: person.last_name ?? "",
+          title: person.title ?? "",
+          "social.linkedin": stringField(person.social?.linkedin),
+          // The rows the form prefills from. `is_primary` is stringified by
+          // prefillRows like every other cell, and read back as `=== "true"`,
+          // so the primary marker survives a save that did not touch it.
+          emails: person.emails ?? [],
+          phones: person.phones ?? [],
+          ...cf.recordSlice(person),
+        }}
+        update={async (values, rows, opened) => {
+          const { data, error } = await api.PATCH("/people/{id}", {
+            params: {
+              path: { id },
+              ...ifMatch(requireVersion(opened?.version)),
+            },
+            body: {
+              ...mapPersonUpdate(values, rows),
+              // A diff against what the form prefilled from: a
+              // snapshot sends `null` for every empty custom field,
+              // and the API reads that as clearing a column nobody
+              // touched.
+              ...cf.toPatch(values, opened ?? {}),
+            },
+          });
+          if (error) {
+            throwProblem(error);
+          }
+          return data;
+        }}
+        invalidate="people"
+        recordKey="person"
+      />
+      {/* Merge has no incumbent-first projection — the seam
+          refuses it outright (overlay/provider_writes.go
+          Merge) — unlike edit/archive below, which it
+          serves, so it stays hidden here. */}
+      {!overlay && (
+        <MergeAction
+          disabledReasonId={disabledReasonId}
+          label={t("merge.contact")}
+          sourceId={person.id}
+          sourceName={person.full_name}
+          searchTargets={searchPeopleTargets}
+          merge={async (targetId) => {
+            const { data, error } = await api.POST("/people/{id}/merge", {
+              params: {
+                path: { id: person.id },
+                ...ifMatch(requireVersion(person.version)),
+              },
+              body: { target_id: targetId },
+            });
+            if (error) {
+              throwProblem(error, t);
+            }
+            return data;
+          }}
+          invalidate="people"
+          recordKey="person"
+          survivorRoute={(targetId) => ({
+            screen: "contacts",
+            id: targetId,
+          })}
+        />
+      )}
+      <ArchiveAction
+        disabledReasonId={disabledReasonId}
+        label={t("record.archive")}
+        confirmText={t("record.archiveConfirm")}
+        archivedMessage={t("record.archiveDone", {
+          name: person.full_name,
+        })}
+        archive={async () => {
+          const { data, error } = await api.DELETE("/people/{id}", {
+            params: { path: { id } },
+          });
+          if (error) {
+            throwProblem(error);
+          }
+          return data;
+        }}
+        invalidate="people"
+        recordKey="person"
+        onArchived={() => navigate({ screen: "contacts" })}
+      />
+    </>
+  );
+}

--- a/frontend/src/screens/personeditmergearchive.tsx
+++ b/frontend/src/screens/personeditmergearchive.tsx
@@ -15,12 +15,10 @@ import { mapPersonUpdate, personEditFields } from "./personformfields";
 
 // Edit, merge and archive — the record's own core write verbs, shared
 // between PersonScreen's header (contacts.tsx) and PersonPageV2's
-// (personactions.tsx's sibling, wired from personpage.tsx), which had no
-// reachable edit form at all: the route moved to PersonPageV2 years before
-// this file existed, and this wiring stayed behind on the screen nothing
-// routes to any more. One writer of the PATCH/merge/archive config rather
-// than two, so a change to what a person edit form carries cannot fix one
-// page's form and silently leave the other stale.
+// (personactions.tsx's sibling, wired from personpage.tsx). One writer of
+// the PATCH/merge/archive config rather than two, so a change to what a
+// person edit form carries cannot fix one page's form and silently leave
+// the other stale.
 
 type Person = components["schemas"]["Person"];
 

--- a/frontend/src/screens/personeditmergearchive.tsx
+++ b/frontend/src/screens/personeditmergearchive.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { useQueryClient } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
@@ -12,6 +13,7 @@ import type { ObjectCustomFields } from "./customfields.form";
 import { EditAction } from "./edit";
 import { MergeAction } from "./merge";
 import { mapPersonUpdate, personEditFields } from "./personformfields";
+import { invalidateRecord } from "./recordwritekeys";
 
 // Edit, merge and archive — the record's own core write verbs, shared
 // between PersonScreen's header (contacts.tsx) and PersonPageV2's
@@ -65,6 +67,14 @@ export function PersonEditMergeArchive({
 }>) {
   const t = useT();
   const id = person.id;
+  // EditAction/MergeAction/ArchiveAction's own invalidate/recordKey props
+  // only reach the LIST cache and this record's own `["person", id]` read.
+  // A person's fields are ALSO served under `["person360", id]` (the page
+  // shell PersonPageV2 reads) and `["personBrief", id]`, three siblings
+  // under no common prefix (recordwritekeys.ts) — without this, a save on
+  // PersonPageV2 closes the form over a page still showing what the reader
+  // just corrected.
+  const queryClient = useQueryClient();
   return (
     <>
       <EditAction<Person>
@@ -119,6 +129,7 @@ export function PersonEditMergeArchive({
           if (error) {
             throwProblem(error);
           }
+          await invalidateRecord(queryClient, "person", id);
           return data;
         }}
         invalidate="people"
@@ -146,6 +157,11 @@ export function PersonEditMergeArchive({
             if (error) {
               throwProblem(error, t);
             }
+            // Both ends of the merge: the source is gone and the survivor
+            // may now carry fields the source contributed — a reader landing
+            // on either via survivorRoute must not see pre-merge state.
+            await invalidateRecord(queryClient, "person", person.id);
+            await invalidateRecord(queryClient, "person", targetId);
             return data;
           }}
           invalidate="people"
@@ -170,6 +186,7 @@ export function PersonEditMergeArchive({
           if (error) {
             throwProblem(error);
           }
+          await invalidateRecord(queryClient, "person", id);
           return data;
         }}
         invalidate="people"

--- a/frontend/src/screens/personformfields.ts
+++ b/frontend/src/screens/personformfields.ts
@@ -111,7 +111,7 @@ export function mapPersonUpdate(
   };
 }
 
-// Built inside ContactsScreen (not module-level) because the email/phone
+// Takes t rather than resolving its own strings because the email/phone
 // "Type" options are display text, not raw values — fieldControl (create.tsx)
 // renders option.label verbatim, so the human-readable string has to be
 // resolved via useT() before it reaches CreateField, unlike organizations.tsx's

--- a/frontend/src/screens/personformfields.ts
+++ b/frontend/src/screens/personformfields.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { components } from "../api/schema";
+import type { useT } from "../i18n";
+import type { CreateField, FormRows } from "./create";
+
+// The person form's field schema and its two request-body mappers — create
+// and edit both describe an address the same way, because ONE mapper for
+// each request is what stops the two coming to disagree about what a
+// PersonEmailInput or a repeatable phone row means. Its own file so
+// contacts.tsx's ContactsScreen (create) and personeditmergearchive.tsx's
+// PersonEditMergeArchive (edit, shared by both PersonScreen and
+// PersonPageV2) can each read it without importing one another.
+
+type CreatePersonRequest = components["schemas"]["CreatePersonRequest"];
+type UpdatePersonRequest = components["schemas"]["UpdatePersonRequest"];
+
+function asEmailType(value: string | undefined): "work" | "personal" | "other" {
+  return value === "personal" || value === "other" ? value : "work";
+}
+
+function asPhoneType(
+  value: string | undefined,
+): "work" | "mobile" | "home" | "other" {
+  return value === "mobile" || value === "home" || value === "other"
+    ? value
+    : "work";
+}
+
+// The email rows a writer supplied, blank ones dropped and position taken from
+// where each one sits in the list.
+//
+// ONE MAPPER FOR BOTH REQUESTS, because `PersonEmailInput` is one schema for
+// both: create and update describing an address differently is exactly what
+// that shared schema exists to prevent.
+function personEmailInputs(rows: FormRows) {
+  return (rows.emails ?? [])
+    .filter((row) => (row.email ?? "").trim().length > 0)
+    .map((row, index) => ({
+      email: row.email.trim(),
+      email_type: asEmailType(row.email_type),
+      is_primary: row.is_primary === "true",
+      position: index,
+    }));
+}
+
+// The phone rows, the same way and for the same reason.
+function personPhoneInputs(rows: FormRows) {
+  return (rows.phones ?? [])
+    .filter((row) => (row.phone ?? "").trim().length > 0)
+    .map((row, index) => ({
+      phone: row.phone.trim(),
+      phone_type: asPhoneType(row.phone_type),
+      is_primary: row.is_primary === "true",
+      position: index,
+    }));
+}
+
+// Builds the create-contact request body: scalar fields trim to undefined
+// when blank (never sent rather than sent empty), `social.linkedin` folds
+// into the `social` object, and each repeatable row becomes an
+// emails/phones entry keyed by its position in the list.
+export function mapPersonBody(
+  values: Record<string, string>,
+  rows: FormRows,
+): CreatePersonRequest {
+  const linkedin = values["social.linkedin"]?.trim();
+  const emails = personEmailInputs(rows);
+  const phones = personPhoneInputs(rows);
+  return {
+    full_name: values.full_name.trim(),
+    first_name: values.first_name?.trim() || undefined,
+    last_name: values.last_name?.trim() || undefined,
+    title: values.title?.trim() || undefined,
+    social: linkedin ? { linkedin } : undefined,
+    emails: emails.length > 0 ? emails : undefined,
+    phones: phones.length > 0 ? phones : undefined,
+    source: "manual",
+  };
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+// Builds the PATCH body.
+//
+// `emails` and `phones` REPLACE their sets rather than adding to them, which is
+// what a correction needs: a bounced address is fixed by sending the set that
+// should stand, and an append-only field could never remove the one that is
+// dead. So an empty list is SENT, not omitted — a contact whose last address
+// was wrong and is now gone is a real answer, and omitting it would silently
+// keep the address the reader just deleted.
+//
+// `rows` is absent only where a caller has no repeatable fields at all; the
+// person form always has both, so the sets go out on every save.
+export function mapPersonUpdate(
+  values: Record<string, unknown>,
+  rows?: FormRows,
+): UpdatePersonRequest {
+  const linkedin = stringField(values["social.linkedin"]).trim();
+  return {
+    full_name: stringField(values.full_name).trim() || undefined,
+    first_name: stringField(values.first_name).trim() || undefined,
+    last_name: stringField(values.last_name).trim() || undefined,
+    title: stringField(values.title).trim() || undefined,
+    social: linkedin ? { linkedin } : undefined,
+    emails: rows ? personEmailInputs(rows) : undefined,
+    phones: rows ? personPhoneInputs(rows) : undefined,
+  };
+}
+
+// Built inside ContactsScreen (not module-level) because the email/phone
+// "Type" options are display text, not raw values — fieldControl (create.tsx)
+// renders option.label verbatim, so the human-readable string has to be
+// resolved via useT() before it reaches CreateField, unlike organizations.tsx's
+// size_band options, which are already display-ready raw labels ("1-10").
+export function contactCreateFields(t: ReturnType<typeof useT>): CreateField[] {
+  return [
+    { key: "full_name", label: "create.fullName", required: true },
+    { key: "first_name", label: "create.firstName" },
+    { key: "last_name", label: "create.lastName" },
+    { key: "title", label: "create.personTitle" },
+    { key: "social.linkedin", label: "create.linkedin" },
+    {
+      key: "emails",
+      label: "create.email",
+      type: "repeatable",
+      addLabel: "field.addEmail",
+      rowFields: [
+        {
+          key: "email",
+          label: "create.email",
+          type: "email",
+          required: true,
+        },
+        {
+          key: "email_type",
+          label: "field.emailType",
+          type: "select",
+          options: [
+            { value: "work", label: t("field.emailWork") },
+            { value: "personal", label: t("field.emailPersonal") },
+            { value: "other", label: t("field.emailOther") },
+          ],
+        },
+      ],
+      primaryKey: "is_primary",
+    },
+    {
+      key: "phones",
+      label: "create.phone",
+      type: "repeatable",
+      addLabel: "field.addPhone",
+      rowFields: [
+        { key: "phone", label: "create.phone", required: true },
+        {
+          key: "phone_type",
+          label: "field.phoneType",
+          type: "select",
+          options: [
+            { value: "work", label: t("field.phoneWork") },
+            { value: "mobile", label: t("field.phoneMobile") },
+            { value: "home", label: t("field.phoneHome") },
+            { value: "other", label: t("field.phoneOther") },
+          ],
+        },
+      ],
+      primaryKey: "is_primary",
+    },
+  ];
+}
+
+// The edit form is contactCreateFields WITHOUT the create-only parts, so the
+// two cannot come to describe an address differently — the same reason one
+// mapper serves both request bodies.
+//
+// It carries the email and phone rows because nothing else in the product can
+// change them. A bounced send names the address that refused it and sends the
+// reader here; a form that omitted the field left that reader at a page which
+// reported the failure and could not fix it.
+//
+// Moving the primary marker between two addresses of the SAME type is refused
+// by the server with a bare 409 today. Not a limit of this form and not
+// introduced here — the same PATCH has answered that way since the field
+// existed — but the primary radio is the first control that reaches it, so the
+// conflict is shown rather than swallowed. Correcting an address, adding one
+// and removing one all work.
+export function personEditFields(t: ReturnType<typeof useT>): CreateField[] {
+  return contactCreateFields(t);
+}

--- a/frontend/src/screens/personpage.editverbs.test.tsx
+++ b/frontend/src/screens/personpage.editverbs.test.tsx
@@ -6,11 +6,9 @@ import type { components } from "../api/schema";
 import { mount, view } from "./personpage.testkit";
 import { jsonResponse } from "./story-utils";
 
-// PersonPageV2 offered no way to correct a bounced email, a wrong phone
-// number or a misspelled name — the edit/merge/archive wiring stayed behind
-// on the screen nothing routes to any more, and API-only was the only path
-// left. Its own file, split from personpage.test.tsx, over the frontend's
-// file-length ratchet.
+// The header's edit/merge/archive verbs, restored to the record page every
+// contact actually opens to. Its own file, sharing personpage.testkit.tsx's
+// fixture with personpage.test.tsx rather than duplicating it.
 
 type Person360 = components["schemas"]["Person360"];
 

--- a/frontend/src/screens/personpage.editverbs.test.tsx
+++ b/frontend/src/screens/personpage.editverbs.test.tsx
@@ -40,24 +40,40 @@ describe("a live contact that is not the viewer's to change refuses its core wri
 });
 
 describe("the header's core record verbs — edit, merge, archive", () => {
-  it("PATCHes /people/{id} from the header's edit form", async () => {
+  it("PATCHes /people/{id} from the header's edit form, and the page shows the save — not the stale 360 it had cached", async () => {
     let patchBody: unknown = null;
+    let saved = false;
     // version is the field EditAction's own record.version reads, and its
     // absence throws inside the update callback (requireVersion) rather than
     // sending nothing — the shared fixture carries no version because no
     // other spec that imports it writes the record.
     const withVersion: Person360 = {
       ...view,
-      person: { ...view.person, version: 3 },
+      person: { ...view.person, version: 3, title: "Old title" },
     };
     mount("overview", withVersion, [], {
       "PATCH /people/p-1": (body) => {
         patchBody = body;
+        saved = true;
         return jsonResponse({ ...withVersion.person, title: "New title" });
       },
+      // The page reads the person through /360, not through the edit
+      // response — a save that invalidates the wrong cache key answers the
+      // PATCH correctly and still shows the header title it had before.
+      "GET /people/p-1/360": () =>
+        jsonResponse(
+          saved
+            ? {
+                ...withVersion,
+                person: { ...withVersion.person, title: "New title" },
+              }
+            : withVersion,
+        ),
     });
 
     await waitFor(() => expect(screen.getByTestId("edit-record")).toBeTruthy());
+    const subtitle = () => document.querySelector(".record-sub");
+    await waitFor(() => expect(subtitle()?.textContent).toBe("Old title"));
     await userEvent.click(screen.getByTestId("edit-record"));
     const title = await screen.findByLabelText("Title");
     await userEvent.clear(title);
@@ -66,6 +82,7 @@ describe("the header's core record verbs — edit, merge, archive", () => {
 
     await waitFor(() => expect(patchBody).toBeTruthy());
     expect(patchBody).toMatchObject({ title: "New title" });
+    await waitFor(() => expect(subtitle()?.textContent).toBe("New title"));
   });
 
   it("archives the record from the header", async () => {

--- a/frontend/src/screens/personpage.editverbs.test.tsx
+++ b/frontend/src/screens/personpage.editverbs.test.tsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import type { components } from "../api/schema";
+import { mount, view } from "./personpage.testkit";
+import { jsonResponse } from "./story-utils";
+
+// PersonPageV2 offered no way to correct a bounced email, a wrong phone
+// number or a misspelled name — the edit/merge/archive wiring stayed behind
+// on the screen nothing routes to any more, and API-only was the only path
+// left. Its own file, split from personpage.test.tsx, over the frontend's
+// file-length ratchet.
+
+type Person360 = components["schemas"]["Person360"];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("a live contact that is not the viewer's to change refuses its core write verbs", () => {
+  const sentence =
+    "You cannot change this contact. Ask their owner to share them with you, or your administrator for the right to edit them.";
+  const notMine: Person360 = {
+    ...view,
+    person: { ...view.person, owner_id: "u-other", writable: false },
+  };
+
+  it("refuses edit, merge and archive from the same sentence", async () => {
+    mount("overview", notMine);
+
+    await screen.findByText(sentence);
+    for (const testId of ["edit-record", "merge-record", "archive-record"]) {
+      const verb = await screen.findByTestId(testId);
+      expect(verb.hasAttribute("disabled")).toBe(true);
+      expect(
+        document.getElementById(verb.getAttribute("aria-describedby") ?? "")
+          ?.textContent,
+      ).toBe(sentence);
+    }
+  });
+});
+
+describe("the header's core record verbs — edit, merge, archive", () => {
+  it("PATCHes /people/{id} from the header's edit form", async () => {
+    let patchBody: unknown = null;
+    // version is the field EditAction's own record.version reads, and its
+    // absence throws inside the update callback (requireVersion) rather than
+    // sending nothing — the shared fixture carries no version because no
+    // other spec that imports it writes the record.
+    const withVersion: Person360 = {
+      ...view,
+      person: { ...view.person, version: 3 },
+    };
+    mount("overview", withVersion, [], {
+      "PATCH /people/p-1": (body) => {
+        patchBody = body;
+        return jsonResponse({ ...withVersion.person, title: "New title" });
+      },
+    });
+
+    await waitFor(() => expect(screen.getByTestId("edit-record")).toBeTruthy());
+    await userEvent.click(screen.getByTestId("edit-record"));
+    const title = await screen.findByLabelText("Title");
+    await userEvent.clear(title);
+    await userEvent.type(title, "New title");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(patchBody).toBeTruthy());
+    expect(patchBody).toMatchObject({ title: "New title" });
+  });
+
+  it("archives the record from the header", async () => {
+    let archived = false;
+    mount("overview", view, [], {
+      "DELETE /people/p-1": () => {
+        archived = true;
+        return jsonResponse({
+          ...view.person,
+          archived_at: "2026-08-14T00:00:00Z",
+        });
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("archive-record")).toBeTruthy(),
+    );
+    await userEvent.click(screen.getByTestId("archive-record"));
+    await userEvent.click(await screen.findByTestId("archive-confirm"));
+
+    await waitFor(() => expect(archived).toBe(true));
+  });
+
+  it("offers merge from the header", async () => {
+    mount("overview");
+
+    // Reachability only — MergeAction's own search/confirm flow is exercised
+    // fully in contacts.test.tsx, against the identical shared component.
+    await waitFor(() =>
+      expect(screen.getByTestId("merge-record")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("merge-record").hasAttribute("disabled")).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -31,9 +31,9 @@ import {
 // panel switch and the routing between them — because the bug this file exists
 // to catch lived in the seam between them, not inside any one tab.
 //
-// The shared fixture and the ordinary mount are personpage.testkit.tsx's —
-// also used by personpage.editverbs.test.tsx, split out once this file's own
-// coverage met the frontend's file-length ratchet. Specs here that need a
+// The shared fixture and the ordinary mount are personpage.testkit.tsx's,
+// also used by personpage.editverbs.test.tsx — one fixture rather than a
+// second copy the two suites could disagree about. Specs here that need a
 // non-default mount (a route override outside `mount`'s own extraRoutes, a
 // distinct grant) still reach the same seam directly.
 

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -11,6 +11,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { components } from "../api/schema";
 import { en } from "../i18n/en";
 import { PersonPageV2 } from "./personpage";
+import {
+  mount,
+  type PersonConsentGuardEntry,
+  view,
+} from "./personpage.testkit";
 import { PERSON_TABS } from "./persontab";
 import {
   installFetchStub,
@@ -25,9 +30,14 @@ import {
 // like a tab with nothing on it. These mount the REAL page — the tab bar, the
 // panel switch and the routing between them — because the bug this file exists
 // to catch lived in the seam between them, not inside any one tab.
+//
+// The shared fixture and the ordinary mount are personpage.testkit.tsx's —
+// also used by personpage.editverbs.test.tsx, split out once this file's own
+// coverage met the frontend's file-length ratchet. Specs here that need a
+// non-default mount (a route override outside `mount`'s own extraRoutes, a
+// distinct grant) still reach the same seam directly.
 
 type Person360 = components["schemas"]["Person360"];
-type PersonConsentGuardEntry = components["schemas"]["PersonConsentGuardEntry"];
 
 const CAPTURED = {
   source: "manual",
@@ -35,49 +45,6 @@ const CAPTURED = {
   created_at: "2026-06-01T08:00:00Z",
   updated_at: "2026-08-01T08:00:00Z",
 } as const;
-
-const view: Person360 = {
-  as_of: "2026-08-13T09:00:00Z",
-  // With an address on file, so the header's lead verb is the Email one. The
-  // verb names the transport the composer would pick, so a contact with no way
-  // to be reached carries a different button — which is its own suite below.
-  person: {
-    id: "p-1",
-    full_name: "Dana Buyer",
-    // The server's own per-row answer, which every edit affordance on this
-    // page asks for. Absent it the fixture describes a contact this reader
-    // may not write, and the controls correctly disappear.
-    writable: true,
-    emails: [
-      {
-        id: "pe-1",
-        person_id: "p-1",
-        email: "dana@brandt.example",
-        email_type: "work",
-        is_primary: true,
-        position: 0,
-        ...CAPTURED,
-      },
-    ],
-    ...CAPTURED,
-  },
-  sections_omitted: [],
-  activities: {
-    data: [
-      {
-        id: "a-1",
-        kind: "email",
-        subject: "Fleet renewal",
-        occurred_at: "2026-08-11T12:00:00Z",
-        is_done: false,
-        ...CAPTURED,
-      },
-    ],
-    page: { has_more: false },
-  },
-  deal_roles: { data: [], page: { has_more: false } },
-  profile_fields: [],
-};
 
 // The gone-quiet rung, carrying the reason the server put in its destination.
 // The label promises a follow-up; the prefill is the only place the reason it
@@ -108,60 +75,6 @@ const mailAllowed: PersonConsentGuardEntry = {
   verdict: "allowed",
   reason: "she wrote to you on 11 August",
 };
-
-function mount(
-  tab: (typeof PERSON_TABS)[number],
-  page: Person360 = view,
-  guardEntries: readonly PersonConsentGuardEntry[] = [],
-  // Routes a test adds for the write it makes; the reads every mount needs
-  // stay here.
-  extraRoutes: RouteMap = {},
-  // What the caller may do. Logging needs `activity.create`, which the store
-  // behind the form requires, so a spec that logs must hold it here or it
-  // passes under an authorization production refuses.
-  allow: Parameters<typeof meRoute>[0] = {
-    person: ["read", "update"],
-    activity: ["create"],
-  },
-) {
-  installFetchStub({
-    "GET /me": meRoute(allow, { seat: "full" }),
-    "GET /people/p-1/360": () => jsonResponse(page),
-    "GET /people/p-1/brief": () =>
-      jsonResponse({ person_id: "p-1", sentences: [], generated_by: "rules" }),
-    "GET /people/p-1/consent/guard": () =>
-      jsonResponse({ person_id: "p-1", entries: guardEntries }),
-    // Which messaging providers exist is a deployment fact, so a channel has
-    // no name until the directory supplies one.
-    "GET /channel-providers": () =>
-      jsonResponse({
-        data: [
-          {
-            provider: "zalo_oa",
-            label: "Zalo OA",
-            credential_model: "workspace_bot",
-            supplies_transport: true,
-          },
-        ],
-      }),
-    // The reader's own connected mailbox, which is what makes an address on
-    // the page the composer's rather than their mail client's.
-    "GET /connectors": () =>
-      jsonResponse({
-        data: [
-          { id: "g1", provider: "gmail", status: "connected", scopes: [] },
-        ],
-      }),
-    // Last, so a spec that needs to override a read above (e.g. a /me that
-    // never resolves, for a pending-grant spec) can.
-    ...extraRoutes,
-  });
-  render(
-    <StoryProviders>
-      <PersonPageV2 id="p-1" tab={tab} />
-    </StoryProviders>,
-  );
-}
 
 // The record's header, which is where the page's verbs live. Found through the
 // heading it names rather than by class, because the header is a landmark for

--- a/frontend/src/screens/personpage.testkit.tsx
+++ b/frontend/src/screens/personpage.testkit.tsx
@@ -11,9 +11,8 @@ import {
 } from "./story-utils";
 
 // The fixture and the mount every `personpage*.test.tsx` suite shares, in one
-// place: PersonPageV2's own coverage outgrew one file's line-length ratchet,
-// and a second suite reading its own copy of this fixture is the shape that
-// drifts the two apart.
+// place: a second suite reading its own copy of this fixture is the shape
+// that drifts the two apart.
 
 type Person360 = components["schemas"]["Person360"];
 export type PersonConsentGuardEntry =

--- a/frontend/src/screens/personpage.testkit.tsx
+++ b/frontend/src/screens/personpage.testkit.tsx
@@ -1,0 +1,124 @@
+import { render } from "@testing-library/react";
+import type { components } from "../api/schema";
+import { PersonPageV2 } from "./personpage";
+import type { PERSON_TABS } from "./persontab";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  type RouteMap,
+  StoryProviders,
+} from "./story-utils";
+
+// The fixture and the mount every `personpage*.test.tsx` suite shares, in one
+// place: PersonPageV2's own coverage outgrew one file's line-length ratchet,
+// and a second suite reading its own copy of this fixture is the shape that
+// drifts the two apart.
+
+type Person360 = components["schemas"]["Person360"];
+export type PersonConsentGuardEntry =
+  components["schemas"]["PersonConsentGuardEntry"];
+
+const CAPTURED = {
+  source: "manual",
+  captured_by: "human:u-1",
+  created_at: "2026-06-01T08:00:00Z",
+  updated_at: "2026-08-01T08:00:00Z",
+} as const;
+
+export const view: Person360 = {
+  as_of: "2026-08-13T09:00:00Z",
+  // With an address on file, so the header's lead verb is the Email one. The
+  // verb names the transport the composer would pick, so a contact with no way
+  // to be reached carries a different button — which is its own suite below.
+  person: {
+    id: "p-1",
+    full_name: "Dana Buyer",
+    // The server's own per-row answer, which every edit affordance on this
+    // page asks for. Absent it the fixture describes a contact this reader
+    // may not write, and the controls correctly disappear.
+    writable: true,
+    emails: [
+      {
+        id: "pe-1",
+        person_id: "p-1",
+        email: "dana@brandt.example",
+        email_type: "work",
+        is_primary: true,
+        position: 0,
+        ...CAPTURED,
+      },
+    ],
+    ...CAPTURED,
+  },
+  sections_omitted: [],
+  activities: {
+    data: [
+      {
+        id: "a-1",
+        kind: "email",
+        subject: "Fleet renewal",
+        occurred_at: "2026-08-11T12:00:00Z",
+        is_done: false,
+        ...CAPTURED,
+      },
+    ],
+    page: { has_more: false },
+  },
+  deal_roles: { data: [], page: { has_more: false } },
+  profile_fields: [],
+};
+
+export function mount(
+  tab: (typeof PERSON_TABS)[number],
+  page: Person360 = view,
+  guardEntries: readonly PersonConsentGuardEntry[] = [],
+  // Routes a test adds for the write it makes; the reads every mount needs
+  // stay here.
+  extraRoutes: RouteMap = {},
+  // What the caller may do. Logging needs `activity.create`, which the store
+  // behind the form requires, so a spec that logs must hold it here or it
+  // passes under an authorization production refuses.
+  allow: Parameters<typeof meRoute>[0] = {
+    person: ["read", "update"],
+    activity: ["create"],
+  },
+) {
+  installFetchStub({
+    "GET /me": meRoute(allow, { seat: "full" }),
+    "GET /people/p-1/360": () => jsonResponse(page),
+    "GET /people/p-1/brief": () =>
+      jsonResponse({ person_id: "p-1", sentences: [], generated_by: "rules" }),
+    "GET /people/p-1/consent/guard": () =>
+      jsonResponse({ person_id: "p-1", entries: guardEntries }),
+    // Which messaging providers exist is a deployment fact, so a channel has
+    // no name until the directory supplies one.
+    "GET /channel-providers": () =>
+      jsonResponse({
+        data: [
+          {
+            provider: "zalo_oa",
+            label: "Zalo OA",
+            credential_model: "workspace_bot",
+            supplies_transport: true,
+          },
+        ],
+      }),
+    // The reader's own connected mailbox, which is what makes an address on
+    // the page the composer's rather than their mail client's.
+    "GET /connectors": () =>
+      jsonResponse({
+        data: [
+          { id: "g1", provider: "gmail", status: "connected", scopes: [] },
+        ],
+      }),
+    // Last, so a spec that needs to override a read above (e.g. a /me that
+    // never resolves, for a pending-grant spec) can.
+    ...extraRoutes,
+  });
+  render(
+    <StoryProviders>
+      <PersonPageV2 id="p-1" tab={tab} />
+    </StoryProviders>,
+  );
+}

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -1,27 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
-import {
-  CalendarDays,
-  CheckSquare,
-  FileText,
-  Link as LinkIcon,
-  Mail,
-  MapPin,
-  Phone,
-  Search,
-} from "lucide-react";
+import { Link as LinkIcon, Mail, MapPin, Phone } from "lucide-react";
 import type { ReactNode } from "react";
 import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCanWrite, useRecordWriteRefusal } from "../app/capability";
+import { useRecordWriteRefusal } from "../app/capability";
 import { PageAsideToggle, usePageAside } from "../app/pageaside";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { useUrlParams } from "../app/urlstate";
-import { Button, OverflowMenu } from "../design-system/atoms";
 import { RecordView } from "../design-system/composed";
 import { ContactLink } from "../design-system/contactlink";
-import { IconAction } from "../design-system/iconaction";
 import {
   IdentityFact,
   IdentityLine,
@@ -35,13 +24,15 @@ import { primaryEmail } from "../format/primaryemail";
 import { linkedinUrl } from "../format/weburl";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { throwProblem, useMe, useSorMode } from "./common";
+import { throwProblem, useSorMode } from "./common";
 import { ComposeModal } from "./compose";
 import { ConsentSection } from "./consent";
+import { useObjectCustomFields } from "./customfields.form";
 import { rosterOwnerName, useRoster, useRosterPartial } from "./entityref";
 import { LogActivityAction } from "./logactivity";
 import { PersonMeetingBrief } from "./meetingbrief";
 import { useOpenEmail } from "./openemail";
+import { PersonActions } from "./personactions";
 import {
   hasCommercial,
   hasMatters,
@@ -52,6 +43,7 @@ import {
 } from "./personcards";
 import { EnrichedFields } from "./personcorrections";
 import { PersonResearchDrawer } from "./persondrawers";
+import { PersonEditMergeArchive } from "./personeditmergearchive";
 import { PersonFilesTab } from "./personfiles";
 import { PersonMemory } from "./personmemory";
 import { PersonNetworkTab } from "./personnetwork";
@@ -66,15 +58,9 @@ import {
   PersonTimelineTab,
 } from "./persontabs";
 import { PersonToday } from "./persontoday";
-import type { Transport } from "./persontransports";
-import {
-  primaryTransportAction,
-  transportForActivity,
-  useTransports,
-} from "./persontransports";
+import { transportForActivity, useTransports } from "./persontransports";
 import { RecordReading, RecordReadingPair } from "./record360";
-import { EmailVerb, RecordEmailAside } from "./recordemail";
-import { ShareAction } from "./share";
+import { RecordEmailAside } from "./recordemail";
 import {
   useMailboxConnected,
   useWriteTo,
@@ -297,6 +283,10 @@ export function PersonPageV2({
   const t = useT();
   const recordZone = useRecordZone();
   const details = usePageAside();
+  // Read at screen level and handed down, so the schema request runs BESIDE
+  // the person's rather than after it — an edit opened before this landed
+  // would otherwise offer a form with no custom fields on it.
+  const cf = useObjectCustomFields("person");
   const view = useQuery({
     queryKey: ["person360", id],
     queryFn: async () => {
@@ -445,6 +435,21 @@ export function PersonPageV2({
           avatarSrc={null}
           subtitle={<PersonSubtitle view={view.data} />}
           pulse={<PersonIdentityLine view={view.data} />}
+          // Edit, merge, archive — the record's core write verbs. Before
+          // this, the form to correct an email, a phone or a misspelled
+          // name reached nothing on this page, and API-only was the only
+          // way left to do it. refusedReasonId is the SAME sentence the
+          // band below states and PersonActions' Share already points at —
+          // one write-gate for the whole header, not a narrower one for
+          // the verbs that live here.
+          badges={
+            <PersonEditMergeArchive
+              person={person}
+              cf={cf}
+              disabledReasonId={refusedReasonId}
+              overlay={overlay}
+            />
+          }
           actions={
             <PersonActions
               view={view.data}
@@ -880,36 +885,6 @@ function PersonIdentityLine({
   );
 }
 
-// Why the lead verb may not be pressed, in the reader's words, or undefined
-// when it may.
-//
-// TWO facts refuse it and they are never merged into one sentence: consent says
-// we may not write to this person, reachability says there is nowhere to write
-// to. A rep who is told the wrong one goes looking in the wrong record.
-//
-// Reachability is asked first because it is the unconditional half — with no
-// transport the composer has nothing to send on whatever consent says, and a
-// consent sentence there would describe a decision that is not what stops them.
-// A guard that has not answered yet refuses nothing: the button is disabled
-// without a reason until the verdict is in, because claiming a refusal the
-// server has not made is worse than a control that is briefly quiet.
-function writeRefusal(
-  state: Readonly<{
-    transports: readonly Transport[];
-    consentAllows: boolean;
-    consentKnown: boolean;
-  }>,
-  t: ReturnType<typeof useT>,
-): string | undefined {
-  if (state.transports.length === 0) {
-    return t("person.action.noTransport");
-  }
-  if (state.consentAllows || !state.consentKnown) {
-    return undefined;
-  }
-  return t("person.action.consentRefused");
-}
-
 // The rail's email box, and when the page may not draw it: not in overlay — a
 // mirrored workspace has no thread data, and the server refuses the
 // waiting-reply read there outright — and not on an archived contact, whose
@@ -1026,159 +1001,5 @@ function PersonActivityDrawer({
       openOnMount
       onClose={onClose}
     />
-  );
-}
-
-// The header's verbs, in the order every record page carries them: writing
-// first, then the record's other doors. None of them is filled — the move
-// worth doing is the one the call names, and that one carries the colour.
-function PersonActions({
-  view,
-  consentAllows,
-  consentKnown,
-  personId,
-  overlay,
-  onWrite,
-  onResearch,
-  onLogActivity,
-  onAddTask,
-  refusedReasonId,
-}: Readonly<{
-  view: Person360;
-  consentAllows: boolean;
-  consentKnown: boolean;
-  personId: string;
-  // LogActivityAction itself renders nothing in overlay — a mirrored
-  // workspace has no activity write of its own, the same fact
-  // PersonEmailPanel already states for the record's email box — so a
-  // trigger drawn here would set drawer state a mount elsewhere refuses.
-  overlay: boolean;
-  onWrite: () => void;
-  onResearch: () => void;
-  onLogActivity: () => void;
-  onAddTask: () => void;
-  // The page's one sentence about why this contact takes no changes, while
-  // it does not. Only Share writes the RECORD here — a grant is asserted
-  // through the person's own write gate — so it is the one verb refused by
-  // it; logging and mail are activity writes with gates of their own.
-  refusedReasonId?: string;
-}>): ReactNode {
-  const t = useT();
-  // useCanWrite, not useCan: both this verb and Add task below issue the same
-  // POST, and a read seat is refused before RBAC is consulted. The buttons
-  // stay on the page and say why they will not press, so a reader can tell
-  // "not mine to do" from "this build has no such button".
-  const me = useMe();
-  const canLog = useCanWrite("activity", "create");
-  // Named once and pointed at by both buttons — Button's own contract for a
-  // surface where several controls are refused by ONE fact: printing the
-  // sentence beside each button says it as many times as there are buttons.
-  const logRefusedId = useId();
-  // A guard that has not answered yet refuses nothing: claiming a refusal
-  // `/me` has not decided is worse than a control that is briefly quiet —
-  // the same rule writeRefusal states for the identical shape, above.
-  const logGrantKnown = me.data?.authorization !== undefined;
-  const logRefused = logGrantKnown && !canLog ? logRefusedId : undefined;
-  const logPending = !logGrantKnown;
-  // The transports the composer would offer, read here so the button NAMES
-  // what pressing it does. The same reachability the drawer resolves: a label
-  // computed from anything else is a promise the composer then breaks.
-  const transports = useTransports(view);
-  const write = primaryTransportAction(transports, t);
-  const WriteIcon = write.icon;
-  const refusal = writeRefusal({ transports, consentAllows, consentKnown }, t);
-  return (
-    <>
-      {/* The shared Email verb, wearing the transport it will open when there
-          is exactly one, neutral when the composer will ask, and explaining
-          itself rather than merely dimming when it may not be pressed. */}
-      <EmailVerb
-        label={write.label}
-        icon={<WriteIcon size={15} aria-hidden="true" />}
-        disabled={!consentKnown}
-        reason={refusal}
-        onClick={onWrite}
-      />
-      {/* Square, because a phone and a calendar are verbs a reader already
-          knows from the glyph — and five labelled buttons in a row is a header
-          that reads as a toolbar, with the one action the page is FOR no more
-          prominent than the rest of them. `IconAction` owes each one its name
-          on hover as well as to a screen reader. */}
-      <IconAction
-        label={t("person.action.call")}
-        icon={<Phone size={15} aria-hidden="true" />}
-        onClick={() => navigate(personTabRoute(personId, "timeline"))}
-      />
-      <IconAction
-        label={t("person.action.meetings")}
-        icon={<CalendarDays size={15} aria-hidden="true" />}
-        onClick={() =>
-          navigate({ screen: "contacts", id: personId, id2: "meetings" })
-        }
-      />
-      {/* Neither verb is drawn in overlay: LogActivityAction, the form both
-          open, renders nothing there — a mirrored workspace has no activity
-          write of its own — so a trigger here would set drawer state a mount
-          elsewhere refuses to act on. */}
-      {!overlay && (
-        <>
-          {logRefused && (
-            <p className="t-caption" id={logRefusedId}>
-              {t("record.logActivityRefused")}
-            </p>
-          )}
-          {/* A CRM a rep cannot write a meeting into is a CRM that only
-              reads. This is the standing way in; the moment card offers the
-              same form when its rung decides logging is the thing to do
-              next. */}
-          <Button
-            disabled={logPending}
-            reasonId={logRefused}
-            onClick={onLogActivity}
-          >
-            <FileText size={15} aria-hidden="true" /> {t("log.title")}
-          </Button>
-          {/* Keeps its words. A tick box is the glyph for COMPLETING a task,
-              so squaring this one would name the opposite of what it does.
-              Files the task against THIS record — the same form Log activity
-              opens, started on its task kind, rather than a navigation to the
-              Worklist, which has no way to add one. */}
-          <Button
-            disabled={logPending}
-            reasonId={logRefused}
-            onClick={onAddTask}
-          >
-            <CheckSquare size={15} aria-hidden="true" />{" "}
-            {t("person.action.addTask")}
-          </Button>
-        </>
-      )}
-      {/* A real menu. This was a button labelled "More actions" that navigated
-          to the timeline tab — the same place the Call button went — so the one
-          control on the header promising there was more behind it delivered a
-          tab instead, and the promise was the only thing it did. Research moves
-          in here because a magnifier reads as "search" and this verb is not
-          search, and the timeline gets the honest name the product already uses
-          for it everywhere else. */}
-      <OverflowMenu label={t("record.moreActions")}>
-        <Button small onClick={onResearch}>
-          <Search size={15} aria-hidden="true" /> {t("person.action.research")}
-        </Button>
-        <Button
-          small
-          onClick={() => navigate(personTabRoute(personId, "timeline"))}
-        >
-          {t("record.fullHistory")}
-        </Button>
-        {/* Companies, deals, leads and projects all carry this. A contact did
-            not, so the one record type most likely to be private to one seat
-            was the one with no way to hand it to a colleague. */}
-        <ShareAction
-          recordType="person"
-          recordId={personId}
-          disabledReasonId={refusedReasonId}
-        />
-      </OverflowMenu>
-    </>
   );
 }


### PR DESCRIPTION
## Summary

**margince#4823** — `PersonPageV2` (the route `/#/contacts/{id}` actually resolves to since routing moved off `PersonScreen`) offered no way to correct a bounced email, a wrong phone number, a misspelled name or a title. Every verb that would do it — Edit, Merge, Archive — was missing from the header. The working form still existed, fully tested, hanging off `PersonScreen` (`contacts.tsx`), which nothing routes to any more. API-only was the only path left for what should be an ordinary correction.

- `PersonEditMergeArchive` is now a shared component both pages render into their header's `badges` slot (`RecordView`'s `.record-badges` container, previously entirely absent from `PersonPageV2`'s DOM). One writer of the PATCH/merge/archive wiring rather than two.
- Each page passes its own correct write-refusal reason: `PersonScreen` keeps its simpler archived-only check; `PersonPageV2` uses its own `useRecordWriteRefusal`, which also answers "not yours to change" — a case the old page's own header verbs never had to consider, and which the shared component takes as a caller-supplied `disabledReasonId` rather than deciding itself.
- `PersonPageV2`'s own native `ShareAction` is untouched — the orphaned page's Share was deliberately *not* pulled across, since PersonPageV2 already has its own.

## Why so many new/moved files

`contacts.tsx` and `personpage.tsx` were both already over the frontend's file-length ratchet (`scripts/fe-file-length-waivers.txt`), which explicitly forbids absorbing growth into a waived file ("shrinking is allowed; growing is not"). Wiring the fix in without violating that meant splitting out:
- `personeditmergearchive.tsx` — the shared `PersonEditMergeArchive` component.
- `personformfields.ts` — the person form's field schema and request-body mappers (`contactCreateFields`/`personEditFields`/`mapPersonBody`/`mapPersonUpdate`), shared by both contacts.tsx's create flow and the new edit component, extracted specifically to avoid a circular import between the two.
- `personactions.tsx` — `PersonPageV2`'s existing header-verbs component (Email/Call/Meetings/Log/Add task/More actions), moved out wholesale to free the room the badges wiring needed; unrelated to the fix itself.
- `personpage.testkit.tsx` — the shared test fixture/mount helper, split out so the new test coverage (below) didn't push `personpage.test.tsx` over its own test-file ratchet, and because biome's `noExportsInTest` forbids exporting from a `.test.tsx` file directly.

Each touched file is *smaller* after this change than the waiver that governed it before — not merely no larger — confirmed via `make fe-file-length`.

## Test plan

- [x] New `personpage.editverbs.test.tsx`: PATCHes `/people/{id}` from the header's edit form and asserts the body; archives the record from the header; confirms merge is reachable; confirms edit/merge/archive are all refused with the page's own write-refusal sentence for a non-writable record. Mutation-tested (removed the `badges` wiring from `RecordView`, confirmed all 4 new tests fail; restored, reconfirmed green).
- [x] Existing `contacts.test.tsx` (40 tests) and `personpage.test.tsx` (44 tests) both still fully green after the extraction — behavior unchanged for `PersonScreen`.
- [x] Fixed `overlay-refusal-coverage.test.ts`'s source-scanning `merge-person` case to point at the new file location (an established pattern in this same file — `merge-org` already documents an identical prior move).
- [x] `make fe-quality` (ds-gates, drift, biome, composed tsc including test files) fully green.
- [x] Full `frontend/src/screens/` suite: 454 files, 6134 tests, 0 failures.
- [x] `make fe-file-length`: all three touched files now under their own prior waiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRuXiSKkD1X1D1U5yRF4Qn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores edit, merge, and archive on the person record page (the route `/#/contacts/{id}` resolves to), which previously offered no way to correct a bounced email, wrong phone number, misspelled name, or title. The working form existed on PersonScreen, but nothing routes there anymore, so API-only was the only path left.

**Refactors**

- Edit, merge, and archive now share one `PersonEditMergeArchive` component, rendered by both pages into the header's badges slot.
- Each page supplies its own write-refusal reason; PersonPageV2's also answers "not yours to change".
- Saves invalidate the `person360` and `personBrief` cache keys PersonPageV2 renders from, so a correction shows immediately instead of leaving stale state.
- The form's field schema and request mappers moved to `personformfields.ts` to avoid a circular import.
- `PersonActions`, the form fields, and the shared test fixture moved to their own files to stay within the frontend's file-length ratchet, which forbids growing waived files.
- New `personpage.editverbs.test.tsx` covers PATCH, archive, merge reachability, and write refusal from the header.

<sup>Written for commit ad16165a7a3e139e21c6d7e5b80ac441ff54cc15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

