### PR TITLE
A forecast total says what it does not cover

### DIFF
--- a/backend/internal/compose/forecastcoveragenote_test.go
+++ b/backend/internal/compose/forecastcoveragenote_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The statement of what a forecast total does not cover reaches the model door.
+//
+// forecastToolResult is a hand-maintained field list, so a field the readings
+// compose is not carried by it until somebody writes the line — and this is the
+// field where forgetting costs the most, because the envelope then hands over a
+// total and withholds the sentence saying how much pipeline it covers.
+//
+// WHAT THIS PAIR CANNOT SEE. It holds ONE converter, named by hand, and there
+// are other callers of forecasting.Compute: the snapshot freeze
+// (jobs_forecastsnapshot.go), the weekly closing freeze (weeklyforecastseam.go)
+// and the share handlers. None of them answers a model, and the human door
+// states the same fact in the reader's own language from the same counts
+// (`forecast.partial`), so there is nothing here to hold them to. A NEW
+// model-facing envelope built from these readings would pass this file while
+// carrying no note, and deriving the corpus is not available: what these
+// converters have in common is a hand-written struct literal, which no census
+// can tell from any other.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/forecasting"
+)
+
+// coverageNoteReadings computes readings the way the tool's own caller does, so
+// what the converter is handed is arithmetic and not a fixture. `unpriced` deals
+// carry no amount; the rest are priced, converted and committed.
+func coverageNoteReadings(t *testing.T, priced, unpriced int) (forecasting.Period, forecasting.Readings) {
+	t.Helper()
+	zone, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatalf("loading the test zone: %v", err)
+	}
+	asOf := time.Date(2026, time.May, 14, 12, 0, 0, 0, zone)
+	period, err := forecasting.ResolvePeriod(forecasting.PeriodQuarter, asOf, 1, zone)
+	if err != nil {
+		t.Fatalf("resolving the period: %v", err)
+	}
+
+	closeOn := time.Date(2026, time.May, 20, 0, 0, 0, 0, zone)
+	amount := int64(100_000)
+	deals := make([]forecasting.Deal, 0, priced+unpriced)
+	for i := range priced + unpriced {
+		deal := forecasting.Deal{
+			ID: "d" + string(rune('a'+i)), Owner: "u1", Currency: "EUR",
+			ExpectedCloseDate: &closeOn, Category: forecasting.CategoryCommit,
+			StageProbability: 50,
+		}
+		if i < priced {
+			deal.AmountMinor, deal.BaseMinor = &amount, &amount
+		}
+		deals = append(deals, deal)
+	}
+
+	readings, err := forecasting.Compute(period, asOf, deals)
+	if err != nil {
+		t.Fatalf("computing the readings: %v", err)
+	}
+	return period, readings
+}
+
+func TestTheForecastToolEnvelopeCarriesTheCoverageNote(t *testing.T) {
+	t.Parallel()
+	period, readings := coverageNoteReadings(t, 3, 1)
+	scope := forecasting.Scope{Kind: "workspace"}
+
+	want := readings.CoverageNote()
+	if want == "" {
+		t.Fatal("a population with an unpriced deal produced no note, so this pair " +
+			"compares two empty strings and asks nothing")
+	}
+	got := forecastToolResult(period, scope, readings, "EUR", period.StartDate, false).CoverageNote
+	if got != want {
+		t.Errorf("the envelope carries %q, want %q — a model quoting this total is not "+
+			"told what it leaves out", got, want)
+	}
+}
+
+// The other direction: readings that cover everything must not caveat a
+// complete total. An always-present note reads as a permanent gap, and a reader
+// who sees it beside every figure stops reading it.
+func TestTheForecastToolEnvelopeDoesNotCaveatATotalThatCoversEverything(t *testing.T) {
+	t.Parallel()
+	period, readings := coverageNoteReadings(t, 4, 0)
+	scope := forecasting.Scope{Kind: "workspace"}
+
+	if readings.EligibleCount != readings.PricedCount {
+		t.Fatalf("the fixture left %d of %d deals unpriced, so this case is the other one",
+			readings.EligibleCount-readings.PricedCount, readings.EligibleCount)
+	}
+	if got := forecastToolResult(period, scope, readings, "EUR", period.StartDate, false).CoverageNote; got != "" {
+		t.Errorf("the envelope caveats a total that covers every eligible deal: %q", got)
+	}
+}

--- a/backend/internal/compose/forecasttool.go
+++ b/backend/internal/compose/forecasttool.go
@@ -160,6 +160,7 @@ func forecastToolResult(
 		Timezone:           period.Zone.String(),
 		BaseCurrency:       baseCurrency,
 		ScopeLimited:       &limited,
+		CoverageNote:       in.CoverageNote(),
 	}
 	if scope.ID != nil {
 		id := scope.ID.String()

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -3551,6 +3551,9 @@
           "confirmed_date_count": {
             "type": "integer"
           },
+          "coverage_note": {
+            "type": "string"
+          },
           "current_call": {
             "type": "object"
           },

--- a/backend/internal/modules/agents/tools_forecast.go
+++ b/backend/internal/modules/agents/tools_forecast.go
@@ -55,10 +55,10 @@ func (t forecastReadings) Spec() mcp.ToolSpec {
 			"`won` counts deals by the day they ACTUALLY closed, not the day they were " +
 			"expected to. `evidence` is committed pipeline whose close date somebody " +
 			"confirmed; a provisional date stays in `open` and out of `evidence`. " +
-			"Read `eligible_count` against `priced_count` before quoting a total: an " +
-			"unpriced deal is real pipeline contributing zero money. `fx_missing_count` " +
-			"is priced deals no rate could convert — also absent from the totals rather " +
-			"than counted as zero. " +
+			"`coverage_note` says what the totals do not cover, and it is absent only when " +
+			"they cover every eligible deal — so quoting a total without it reports a " +
+			"partial pipeline as a complete one. `eligible_count`, `priced_count` and " +
+			"`fx_missing_count` are the counts it is written from. " +
 			"Quote `as_of`, `timezone` and `base_currency` with the number: a total placed " +
 			"in the reader's own zone is a different total.",
 		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
@@ -111,6 +111,11 @@ type ForecastReadingsResult struct {
 	AsOf         string `json:"as_of"`
 	Timezone     string `json:"timezone"`
 	BaseCurrency string `json:"base_currency"`
+
+	// CoverageNote says what the money above does not cover. Composed by
+	// forecasting.Readings and never here, and absent when the readings cover
+	// every eligible deal.
+	CoverageNote string `json:"coverage_note,omitempty"`
 
 	// ScopeLimited says deals the caller cannot read were left out. A boolean
 	// and never a count: a count of what somebody may not read is itself a

--- a/backend/internal/modules/forecasting/readings.go
+++ b/backend/internal/modules/forecasting/readings.go
@@ -6,6 +6,7 @@ package forecasting
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -60,10 +61,12 @@ type Readings struct {
 	OpenMinor     int64
 	WeightedMinor int64
 
-	// What the money does not cover. EligibleCount minus PricedCount is the
-	// gap a reader is owed: an unpriced deal is real pipeline contributing
-	// zero, and presenting the total without that gap invites the reading
-	// where every eligible deal was counted.
+	// What the money does not cover, in TWO gaps rather than one. An unpriced
+	// deal has no amount to contribute; a priced deal no rate could reach has
+	// one and still contributes nothing, so it sits inside PricedCount and
+	// outside every total. What the money covers is PricedCount minus
+	// FxMissingCount, and presenting a total without that figure invites the
+	// reading where every eligible deal was counted. CoverageNote says it.
 	EligibleCount      int
 	PricedCount        int
 	ConfirmedDateCount int
@@ -297,4 +300,61 @@ func EffectiveCategory(asOfDay time.Time, deal Deal) string {
 		return CategorySlipped
 	}
 	return deal.Category
+}
+
+// CoverageNote states, in one line, what the money readings do not cover —
+// empty when they cover everything.
+//
+// Written from the counts and adding no fact a caller could not compute, the
+// way PersonMoment.headline is the reason in one line written from the
+// evidence. What it buys is that the comparison is MADE: the counts arrive as
+// bare integers among nine, and a total quoted flat is arithmetically correct
+// while telling somebody something false about how much pipeline it covers.
+//
+// COVERED is priced minus unconvertible. A deal with an amount no rate could
+// reach carries a price and contributes nothing, so leading with the priced
+// count would understate the gap — the one direction this sentence exists to
+// prevent.
+//
+// FOR THE MODEL-FACING DOOR, and deliberately not the contract. The web app
+// states the same fact from the same counts in the reader's own language
+// (`forecast.partial`), and an English sentence on the wire would be a second
+// spelling that no localised client renders. A model has no i18n layer, which
+// is what makes prose the right shape there and the wrong shape here.
+func (r Readings) CoverageNote() string {
+	covered := r.PricedCount - r.FxMissingCount
+	var parts []string
+	if covered < r.EligibleCount {
+		parts = append(parts, fmt.Sprintf(
+			"the money readings cover %d of %d eligible deals", covered, r.EligibleCount))
+	}
+	if unpriced := r.EligibleCount - r.PricedCount; unpriced > 0 {
+		parts = append(parts, fmt.Sprintf("%s %s no amount and %s zero",
+			deals(unpriced), plural(unpriced, "carries", "carry"),
+			plural(unpriced, "contributes", "contribute")))
+	}
+	if r.FxMissingCount > 0 {
+		parts = append(parts, fmt.Sprintf(
+			"%s %s priced in a currency no rate could convert, so %s absent from the totals "+
+				"rather than counted as zero",
+			deals(r.FxMissingCount), plural(r.FxMissingCount, "was", "were"),
+			plural(r.FxMissingCount, "it is", "they are")))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// deals renders the count and its noun, so a sentence names its own subject.
+func deals(n int) string {
+	if n == 1 {
+		return "1 deal"
+	}
+	return fmt.Sprintf("%d deals", n)
+}
+
+// plural picks the form the count agrees with.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
 }

--- a/backend/internal/modules/forecasting/readings_test.go
+++ b/backend/internal/modules/forecasting/readings_test.go
@@ -5,8 +5,10 @@ package forecasting
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 )
@@ -376,5 +378,128 @@ func TestAPeriodWhoseHalvesDisagreeIsNotConsistent(t *testing.T) {
 	zoneless.Zone = nil
 	if zoneless.consistent() {
 		t.Error("a period with no zone passed the check — which day an instant falls on has no answer without one")
+	}
+}
+
+// The note is driven through Compute rather than assembled by hand, because
+// what it must agree with is the counts a real population produces — a
+// hand-built Readings could state a gap the arithmetic never had.
+func TestTheCoverageNoteNamesWhatTheMoneyLeftOut(t *testing.T) {
+	t.Parallel()
+	period := testPeriod(t)
+	asOf := *day(t, time.May, 14)
+
+	unpriced := healthyDeal(t)
+	unpriced.ID = "d2"
+	unpriced.AmountMinor = nil
+	unpriced.BaseMinor = nil
+
+	unconverted := healthyDeal(t)
+	unconverted.ID = "d3"
+	unconverted.BaseMinor = nil
+
+	cases := []struct {
+		what  string
+		deals []Deal
+		// The substrings the note must carry, and never a whole sentence: what
+		// is asserted is the FACT reaching the reader, not the copy.
+		says []string
+	}{
+		{
+			what:  "every eligible deal priced and converted",
+			deals: []Deal{healthyDeal(t)},
+			says:  nil,
+		},
+		{
+			what:  "one deal with no amount",
+			deals: []Deal{healthyDeal(t), unpriced},
+			says:  []string{"1 deal carries no amount"},
+		},
+		{
+			what:  "a deal priced in a currency no rate could convert",
+			deals: []Deal{healthyDeal(t), unconverted},
+			says:  []string{"1 deal was priced in a currency no rate could convert", "absent from the totals"},
+		},
+		{
+			// BOTH gaps, which is where the fraction has to be the money's own
+			// and not the priced count: two of these three deals carry an
+			// amount and only one of them reaches a total.
+			what:  "both gaps at once",
+			deals: []Deal{healthyDeal(t), unpriced, unconverted},
+			says:  []string{"1 deal carries no amount", "no rate could convert"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.what, func(t *testing.T) {
+			t.Parallel()
+			readings, err := Compute(period, asOf, tc.deals)
+			if err != nil {
+				t.Fatalf("computing: %v", err)
+			}
+			note := readings.CoverageNote()
+			if len(tc.says) == 0 {
+				if note != "" {
+					t.Errorf("readings that cover every eligible deal still carry a caveat: %q", note)
+				}
+				return
+			}
+			for _, want := range tc.says {
+				if !strings.Contains(note, want) {
+					t.Errorf("the note does not say %q, so the reader is not told:\n%s", want, note)
+				}
+			}
+			assertCoverageFractionIsTheMoneysOwn(t, readings, note)
+		})
+	}
+}
+
+// assertCoverageFractionIsTheMoneysOwn holds the fraction against the
+// contributions rather than against the counts the note was written from.
+//
+// The counts and the note come out of the same arithmetic, so an expectation
+// built from PricedCount cannot tell "quotes the right pair" from "quotes the
+// pair the code happens to use". What the money covers is decided per deal, by
+// whether contribute() found a reason to exclude it — an independent fact, and
+// the one a reader of the total is actually owed.
+func assertCoverageFractionIsTheMoneysOwn(t *testing.T, readings Readings, note string) {
+	t.Helper()
+	contributing := 0
+	for _, c := range readings.Contributions {
+		if c.ExclusionReason == "" {
+			contributing++
+		}
+	}
+	want := fmt.Sprintf("cover %d of %d eligible deals", contributing, len(readings.Contributions))
+	if !strings.Contains(note, want) {
+		t.Errorf("the note does not say %q — the money reaches %d of %d deals:\n%s",
+			want, contributing, len(readings.Contributions), note)
+	}
+}
+
+// A gap of more than one deal must not be reported in the singular, and the
+// fraction must still be the money's. Four unpriced deals beside one healthy
+// one is the plural case every clause has to agree with.
+func TestTheCoverageNoteAgreesWithACountAboveOne(t *testing.T) {
+	t.Parallel()
+	period := testPeriod(t)
+	asOf := *day(t, time.May, 14)
+
+	deals := []Deal{healthyDeal(t)}
+	for i := range 4 {
+		gap := healthyDeal(t)
+		gap.ID = fmt.Sprintf("gap%d", i)
+		gap.AmountMinor = nil
+		gap.BaseMinor = nil
+		deals = append(deals, gap)
+	}
+	readings, err := Compute(period, asOf, deals)
+	if err != nil {
+		t.Fatalf("computing: %v", err)
+	}
+	note := readings.CoverageNote()
+	assertCoverageFractionIsTheMoneysOwn(t, readings, note)
+	if !strings.Contains(note, "4 deals carry no amount") {
+		t.Errorf("four unpriced deals were not reported as four:\n%s", note)
 	}
 }

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,7 +6,7 @@
   "catalog": {
     "tools": 75,
     "system_frame_tokens": 353,
-    "tokens": 22630,
+    "tokens": 22639,
     "median_tool_tokens": 266,
     "mean_tool_tokens": 301
   },
@@ -151,15 +151,15 @@
       "tokens": 385
     },
     {
+      "name": "forecast_readings",
+      "tokens": 357
+    },
+    {
       "name": "forecast_movement",
       "tokens": 351
     },
     {
       "name": "describe_report_vocabulary",
-      "tokens": 349
-    },
-    {
-      "name": "forecast_readings",
       "tokens": 349
     },
     {

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1634 | 4% | 21576 | 6 | 6 |
 | `overnight_at_risk_sweep` | 7 | 2509 | 7% | 20701 | 15 | 10 |
-| _whole served catalog, for scale_ | 75 | 22630 | 69% | — | — | — |
+| _whole served catalog, for scale_ | 75 | 22639 | 69% | — | — | — |
 
 ### `morning_brief`
 
@@ -155,9 +155,9 @@ a term in an addition.
 | `enrich` | 393 | — |
 | `compose_analytics_report` | 390 | — |
 | `search_records` | 385 | 9 scenarios |
+| `forecast_readings` | 357 | — |
 | `forecast_movement` | 351 | — |
 | `describe_report_vocabulary` | 349 | — |
-| `forecast_readings` | 349 | — |
 | `search_context` | 345 | — |
 | `prep_for_meeting` | 326 | — |
 | `demote_lead` | 316 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 75,
     "resources": 12,
-    "tool_catalog_bytes": 215467,
+    "tool_catalog_bytes": 215535,
     "resource_catalog_bytes": 4584,
-    "approx_wire_tokens_total": 55012,
+    "approx_wire_tokens_total": 55029,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 53039,
+      "description_bytes": 53073,
       "input_schema_bytes": 45533,
-      "output_schema_bytes": 100704,
-      "description_plus_input_schema_bytes": 98572
+      "output_schema_bytes": 100738,
+      "description_plus_input_schema_bytes": 98606
     }
   },
   "tools": {
@@ -4741,7 +4741,7 @@
           "readOnlyHint": true,
           "title": "Read the forecast"
         },
-        "description": "What a period is expected to close, in four readings. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. Read `eligible_count` against `priced_count` before quoting a total: an unpriced deal is real pipeline contributing zero money. `fx_missing_count` is priced deals no rate could convert — also absent from the totals rather than counted as zero. Quote `as_of`, `timezone` and `base_currency` with the number: a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "What a period is expected to close, in four readings. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. `coverage_note` says what the totals do not cover, and it is absent only when they cover every eligible deal — so quoting a total without it reports a partial pipeline as a complete one. `eligible_count`, `priced_count` and `fx_missing_count` are the counts it is written from. Quote `as_of`, `timezone` and `base_currency` with the number: a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -4792,6 +4792,9 @@
                 },
                 "confirmed_date_count": {
                   "type": "integer"
+                },
+                "coverage_note": {
+                  "type": "string"
                 },
                 "current_call": {
                   "type": "object"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 75 |
 | Resources | 12 |
-| Tool catalog | 210.4 KB |
+| Tool catalog | 210.5 KB |
 | Resource catalog | 4.5 KB |
-| Approx. wire tokens | 55012 |
+| Approx. wire tokens | 55029 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,7 +29,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 98.3 KB | 46% | **No** — a result's shape, never listed to a model |
+| Output schemas | 98.4 KB | 46% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 51.8 KB | 24% | Yes, every step |
 | Input schemas | 44.5 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.8 KB | 7% | Partly |
@@ -5355,7 +5355,7 @@ The difference between two forecast snapshots, classified into named causes. Ope
 
 **Read the forecast**
 
-What a period is expected to close, in four readings. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. Read `eligible_count` against `priced_count` before quoting a total: an unpriced deal is real pipeline contributing zero money. `fx_missing_count` is priced deals no rate could convert — also absent from the totals rather than counted as zero. Quote `as_of`, `timezone` and `base_currency` with the number: a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope "read".)
+What a period is expected to close, in four readings. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. `coverage_note` says what the totals do not cover, and it is absent only when they cover every eligible deal — so quoting a total without it reports a partial pipeline as a complete one. `eligible_count`, `priced_count` and `fx_missing_count` are the counts it is written from. Quote `as_of`, `timezone` and `base_currency` with the number: a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -5416,6 +5416,9 @@ What a period is expected to close, in four readings. `won` counts deals by the 
         },
         "confirmed_date_count": {
           "type": "integer"
+        },
+        "coverage_note": {
+          "type": "string"
         },
         "current_call": {
           "type": "object"

--- a/docs/reference/mcp-tool-coverage.json
+++ b/docs/reference/mcp-tool-coverage.json
@@ -2020,7 +2020,7 @@
     },
     {
       "name": "forecast_readings",
-      "tokens": 349,
+      "tokens": 357,
       "agents": [],
       "required_by_cases": [
         "case21_what_are_we_closing"


### PR DESCRIPTION
## What

`forecast_readings` now carries `coverage_note`: one server-authored line saying what the money readings do not cover, absent when they cover everything.

```
the money readings cover 11 of 12 eligible deals; 1 deal carries no amount and contributes zero
```

## Why

The readings hand a model nine bare integers and a description — read *before* the numbers — telling it to compare two of them. A total quoted flat is arithmetically correct while saying something false about how much pipeline it covers: an unpriced deal is real pipeline contributing zero, and a priced deal no rate could convert is absent from every total rather than counted as zero.

The e2e-llm lane measures exactly this. `case21_what_are_we_closing` asks for the pipeline and how much of it the assistant will stand behind; haiku passed 1 of 3 runs, and the two failures quoted the total and never mentioned that one of the twelve deals carries no amount. Both counts were in the payload. Nothing deterministic can ask this, because every field arrives correctly either way — so the server makes the comparison instead of shipping the ingredients.

## What the money covers is priced MINUS unconvertible

A deal with an amount no rate could reach carries a price and contributes nothing, so a note leading with `priced_count` would *understate* the gap — the one direction this sentence exists to prevent. Caught in review before this was pushed; the struct comment that stated the gap as `eligible - priced` is corrected with it.

The pair holds the fraction against the **contributions** (`ExclusionReason == ""`), not against the counts the note was composed from: an expectation built from `PricedCount` cannot tell "quotes the right pair" from "quotes the pair the code happens to use".

## Model-facing only, deliberately not the contract

The web app already states the same fact from the same counts in the reader's own language — `forecast.partial`, three locales, rendered on the forecast screen. An English sentence on the REST wire would be a second spelling that no localised client renders. A model has no i18n layer, which is what makes prose the right shape there and the wrong shape on the twin. Said out loud in `CoverageNote`'s own comment so the next author does not "complete" the mirror.

## Tests

- `forecasting`: the note driven through `Compute` (not a hand-built `Readings`, which could state a gap the arithmetic never had) across four populations — complete, unpriced, unconvertible, both — plus plural agreement above one.
- `compose`: the tool envelope carries what the readings composed, and does not caveat a complete total. Mutation-verified in three directions (envelope drops it / an always-on note / the wrong fraction). The test says in its own header what it cannot see: it names one converter by hand, because what these converters have in common is a hand-written struct literal and no census can tell that from any other.

## Filed, not fixed here

`analyticssharesnapshot.go` scans `count(*) FILTER (WHERE c.base_minor IS NOT NULL)` into `PricedCount` — that is *converted*, not *priced*, so the share path's `priced_count` contradicts its own contract description ("How many carried an amount") and disagrees with `forecasting.Compute`. A one-word SQL fix, but proving it needs an fx-missing snapshot fixture in the integration lane, which would double this diff. Follow-up issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`forecast_readings` now includes an optional server-authored `coverage_note` explaining which eligible deals its money totals omit. Previously, models had to infer coverage from bare counts, so a correct total could imply complete pipeline coverage; the note is absent when every eligible deal contributes.

**Updates**
- The note distinguishes unpriced deals from priced deals missing FX conversion and is passed through the tool result.
- The REST contract is unchanged.
- Tool schemas, reference docs, and tests cover complete, unpriced, unconvertible, combined, and plural cases.

<sup>Written for commit 6dd3135b60d5682785728a8c92decea9e0851bb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

