### PR TITLE
The prose gate reads the tree git tracks, not what happens to be on disk

### DIFF
--- a/backend/gates/rlsclaimsprose_test.go
+++ b/backend/gates/rlsclaimsprose_test.go
@@ -20,6 +20,7 @@ package gates
 import (
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -65,12 +66,42 @@ var proseScanned = map[string]bool{
 	".example": true, ".mk": true,
 }
 
-// proseSkippedDirs are trees that are not this repository's prose: vendored
-// code, build output, and the generated client whose text comes from the
-// contract (fixing crm.yaml fixes it, and it regenerates).
-var proseSkippedDirs = map[string]bool{
-	"node_modules": true, ".git": true, "dist": true, "build": true,
-	".build": true, ".tmp": true, "coverage": true,
+// ignoredTrees answers which directories are not this repository's prose, by
+// asking git rather than by keeping a list of names.
+//
+// The list this replaced held seven names — node_modules, dist, build, .build,
+// .tmp, coverage — and every one of them is a path .gitignore already names. A
+// gate that keeps its own copy of that has become a second copy of its subject,
+// and it drifts in the direction nobody notices from the outside: a session with
+// an agent worktree under .claude/worktrees/ (ignored since it was added) had
+// this gate reporting 631 claims out of a stale copy of the whole tree, none of
+// them in anything that ships, while CI on a clean checkout stayed green. A
+// false red teaches a reader to stop reading the gate.
+//
+// It fails rather than falling back. Not getting the answer would mean walking
+// ignored trees again, which is the state this exists to leave — and a census
+// that quietly widens is one nobody can tell from one that quietly narrows.
+func ignoredTrees(t *testing.T) map[string]bool {
+	t.Helper()
+	// --directory collapses a wholly-ignored directory to one entry with a
+	// trailing slash, so the walk can skip the tree instead of every file in it.
+	out, err := exec.Command("git", "-C", "..",
+		"ls-files", "--others", "--ignored", "--exclude-standard", "--directory").Output()
+	if err != nil {
+		t.Fatalf("asking git which trees it ignores: %v", err)
+	}
+	ignored := map[string]bool{
+		// git never reports its own directory, and it is full of prose from
+		// every branch that ever mentioned the control.
+		"../.git": true,
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.HasSuffix(line, "/") {
+			continue
+		}
+		ignored["../"+strings.TrimSuffix(line, "/")] = true
+	}
+	return ignored
 }
 
 // proseExempt are CLAIMS that cannot be fixed by editing the line they sit on.
@@ -183,6 +214,7 @@ func TestNoProseClaimsRLSStillScopesARead(t *testing.T) {
 		}
 	}
 
+	skipped := ignoredTrees(t)
 	var claims []string
 	checked := 0
 	err := filepath.WalkDir("..", func(path string, d fs.DirEntry, err error) error {
@@ -190,7 +222,7 @@ func TestNoProseClaimsRLSStillScopesARead(t *testing.T) {
 			return err
 		}
 		if d.IsDir() {
-			if proseSkippedDirs[d.Name()] {
+			if skipped[filepath.ToSlash(path)] {
 				return fs.SkipDir
 			}
 			return nil


### PR DESCRIPTION
## The symptom

`make check-go` is red on `TestNoProseClaimsRLSStillScopesARead` in any checkout that has an agent worktree under `.claude/worktrees/` — 631 findings, every one of them from a stale copy of the whole repository:

```
../.claude/worktrees/agent-.../STATUS.md:544: RLS binds it and the other thirteen match zero rows…
../.claude/worktrees/agent-.../CHANGELOG.md:112: `FORCE ROW LEVEL SECURITY` requires, and a runbook
```

`.gitignore:139` ignores `/.claude/worktrees/`. CI checks out clean, so CI is green and only local runs are red — which is the worst arrangement: a gate that cries wolf on the machine where somebody is deciding whether to trust it.

## The cause

`proseSkippedDirs` was a list of directory **names**:

```go
var proseSkippedDirs = map[string]bool{
	"node_modules": true, ".git": true, "dist": true, "build": true,
	".build": true, ".tmp": true, "coverage": true,
}
```

Every name in it is a path `.gitignore` already names. This is the shape AGENTS.md's *Reuse before you build* rule 5 describes — a gate that hard-codes part of its subject has become a second copy of it — and the copy went stale the day `.claude/worktrees/` was added to `.gitignore` and not here.

## The fix

Ask git, once:

```
git ls-files --others --ignored --exclude-standard --directory
```

`--directory` collapses a wholly-ignored tree to a single entry, so skipping costs one comparison rather than one per file. `.git` is added by hand, because git never reports its own directory.

**It fails rather than falling back.** Not getting the answer would mean walking ignored trees again, which is the state this exists to leave — and a census that quietly widens is one nobody can tell from one that quietly narrows.

## What still guards the other direction

The pre-existing floor stays: fewer than 400 prose files read is a lost tree, not a clean one. Verified by planting a claim in a tracked doc and watching it fail:

```
--- FAIL: TestNoProseClaimsRLSStillScopesARead
    ../docs/reference/make-targets.md:402: RLS scopes every read of the deal table.
```

Note that untracked-but-not-ignored files are still walked — a new page nobody has `git add`ed yet is still held to the rule, which is why this asks for the *ignored* set rather than for `git ls-files`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the prose gate skip directories git actually ignores instead of a hardcoded list of names, so local runs no longer fail on stale copies of the repo (e.g., `.claude/worktrees/`).

- Asks `git ls-files --others --ignored --exclude-standard --directory` once; `.git` is added by hand since git never reports it.
- The gate fails if git doesn't answer rather than falling back to walking ignored trees.
- Untracked-but-not-ignored files are still walked, and the existing floor of 400 prose files still guards against a lost tree.

<sup>Written for commit 24cb428e274a28da493808a3af3d40483764e29b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

