### PR TITLE
A colleague nobody is called is not an empty workspace, and the fixture gives them real seats

### DIFF
--- a/backend/internal/modules/agents/explain.go
+++ b/backend/internal/modules/agents/explain.go
@@ -330,7 +330,13 @@ const maxRemedyBudget = 4 * httperr.MaxFaultText
 // The summary is the sentence the human's own card carries, so the person and
 // the agent are waiting on one described thing.
 //
-// IT ALSO SAYS WHAT IS NOT BLOCKED, because an agent reads a refusal as a stop.
+// IT ALSO SAYS WHAT IS NOT BLOCKED, AND TO REPORT WHAT ALREADY HAPPENED,
+// because an agent reads a refusal as a stop and then writes its answer about
+// the stop. Two measured runs merged a duplicate and archived a dead company
+// correctly and then said only "one approval waiting: reassign the account" —
+// two completed writes the reader was never told about. Doing the rest and
+// reporting the rest are separate instructions, and only the first was given.
+//
 // Asked to merge two words and then give the survivor a meaning, a measured run
 // staged the merge, relayed the summary correctly, and finished with "Confirm
 // and I'll proceed, then add the description afterward" — deferring an
@@ -352,5 +358,6 @@ func stagedExplanation(staged *workflow.StagedApprovalError) string {
 	return "Confirm-first (🟡): a person answers this before it runs. " + what +
 		" Tell them that, in those words; they release it in the CRM, and this exact call then " +
 		"repeats with \"approval_id\": \"" + staged.ApprovalID.String() + "\". " +
-		"Blocks THIS call only — do the rest of what you were asked that does not depend on it."
+		"Blocks THIS call only — do the rest of what you were asked that does not depend on it, " +
+		"and report what you DID alongside what is waiting."
 }

--- a/backend/internal/modules/agents/results_identity.go
+++ b/backend/internal/modules/agents/results_identity.go
@@ -38,6 +38,39 @@ type ListColleaguesResult struct {
 	// nothing would read a capped list as the whole roster and report that a
 	// colleague does not work here.
 	Truncated bool `json:"truncated,omitempty"`
+	// AllColleagues is the set the narrowing was matched against, present ONLY
+	// when a narrowing `q` matched none of it — the same obligation a refusal
+	// naming a closed vocabulary carries.
+	//
+	// An empty `colleagues` answers two different questions identically: this
+	// workspace employs nobody, and nobody here is spelled the way you asked.
+	// A caller cannot tell them apart, and the one it picks is the wrong one:
+	// asked to hand an account to a colleague, an assistant read `[]` and
+	// reported that the person does not work here — with the seat sitting in
+	// the roster under a spelling it had not tried.
+	//
+	// So the miss hands over the set it was matched against. `colleagues` stays
+	// empty, because that is the honest answer to what was asked.
+	//
+	// NOT named `roster`, which is what this whole result already is.
+	//
+	// A POINTER, so a successful fallback over a workspace that employs nobody
+	// serializes as `[]` and an unreadable one is absent. A plain slice made
+	// those two the same bytes — which is the defect this field exists to
+	// remove, one level up: "nobody works here" and "I could not find out" are
+	// different answers, and a caller cannot act on the difference it cannot
+	// see. The warnings say which; the data now says it too.
+	AllColleagues *[]Colleague `json:"all_colleagues,omitempty"`
+	// AllColleaguesTruncated bounds AllColleagues, and is its OWN flag rather
+	// than a second meaning for Truncated above.
+	//
+	// The two answer different questions — "your query has more matches than
+	// fit" and "the fallback list is capped" — and one flag beside an empty
+	// `colleagues` reads as the first. It would read as it in the case that
+	// matters most: a large workspace, the name absent from the first page, and
+	// a caller MORE certain the person does not work here than a bare empty
+	// list left it.
+	AllColleaguesTruncated bool `json:"all_colleagues_truncated,omitempty"`
 }
 
 // ListTagsResult is the workspace's tag vocabulary. Empty is a real answer —

--- a/backend/internal/modules/agents/stagedanswer_test.go
+++ b/backend/internal/modules/agents/stagedanswer_test.go
@@ -173,4 +173,13 @@ func TestAStagedAnswerSaysTheRestOfTheTaskIsNotBlocked(t *testing.T) {
 		t.Errorf("the answer does not say what is still doable, so a caller defers work the "+
 			"approval never blocked:\n%s", said)
 	}
+	// Doing the rest and REPORTING the rest are separate instructions, and an
+	// answer carrying only the first produces exactly what two measured runs
+	// produced: a duplicate merged, a dead company archived, and a final answer
+	// that mentions neither because it is written about the one thing that
+	// stopped.
+	if !strings.Contains(said, "report what you DID") {
+		t.Errorf("the answer does not ask for what already happened, so a caller reports the "+
+			"approval and silently drops the writes it completed:\n%s", said)
+	}
 }

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -4359,6 +4359,40 @@
       "data": {
         "type": "object",
         "properties": {
+          "all_colleagues": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "display_name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "is_agent": {
+                  "type": "boolean"
+                },
+                "seat_type": {
+                  "type": "string"
+                },
+                "user_id": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "required": [
+                "display_name",
+                "email",
+                "is_agent",
+                "seat_type",
+                "user_id"
+              ]
+            }
+          },
+          "all_colleagues_truncated": {
+            "type": "boolean"
+          },
           "colleagues": {
             "type": "array",
             "items": {

--- a/backend/internal/modules/agents/toolcopy_analyticsreport.go
+++ b/backend/internal/modules/agents/toolcopy_analyticsreport.go
@@ -6,6 +6,16 @@ package agents
 // Written copy for composing a report. See toolcopy.go for what each field
 // answers.
 //
+// THE PURPOSE LEADS WITH THE JOB, not with the mechanism, and that ordering is
+// load-bearing. Asked for "a short written pipeline section for the board pack",
+// three measured runs read a catalogue of 75 tools, took the figures from
+// forecast_readings and typed them into prose — the one thing this tool refuses
+// to let a document do. It was served every time and chosen none of them. Its
+// first sentence had been "Render a report whose every figure comes from a
+// saved analytics run": true, and about handles, run ids and cells, while the
+// words a caller scans for — write, document, section, summary — were absent or
+// buried. A tool nobody picks for the job it does is a tool that is not there.
+//
 // The BLOCK VOCABULARY is deliberately not here. Fourteen block kinds with
 // their fields would be run_report's 3.4KB mistake again — text every client
 // holds for a session and every scheduled run re-sends on every step, to answer
@@ -19,9 +29,11 @@ package agents
 // instruction to read first costs a turn on every goal, including the ones with
 // nothing to look up.
 var composeAnalyticsReportCopy = toolCopy{
-	Purpose: "Render a report whose every figure comes from a saved analytics run. The " +
-		"document carries the STRUCTURE and the WORDS; each number names a run id and a cell " +
-		"inside it, and the server resolves those handles under the reader's own authority.",
+	Purpose: "WRITE a document somebody reads — a board-pack section, a summary for a " +
+		"meeting, a written-up answer with figures in it — whose every number comes from a " +
+		"saved analytics run instead of being typed. The document carries the STRUCTURE and " +
+		"the WORDS; each figure names a run id and a cell inside it, and the server resolves " +
+		"those handles under the reader's own authority.",
 	Limits: "It writes no number of its own and refuses any document that does. A block " +
 		"carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the " +
 		"literal is what renders, the two can disagree, and no reader could tell the page " +

--- a/backend/internal/modules/agents/toolcopy_colleagues.go
+++ b/backend/internal/modules/agents/toolcopy_colleagues.go
@@ -8,7 +8,10 @@ var listColleaguesCopy = toolCopy{
 	Purpose: "List the people who work HERE — colleagues holding a seat, not the contacts stored " +
 		"as person records.",
 	Limits: "Reads only, and lists seats that can actually receive work — archived, suspended " +
-		"and locked-out ones are absent. `truncated` means there are more.",
+		"and locked-out ones are absent. `truncated` means there are more. A `q` matching nobody " +
+		"answers with `all_colleagues` and a warning; that list is ABSENT if it could not be read " +
+		"and partial if `all_colleagues_truncated`, so read the warning before concluding a " +
+		"person has no seat.",
 	Instead: "search_records/person finds a CUSTOMER contact; this finds a colleague.",
 	Retain:  "user_id is what assignee_id and owner_id take. Never assign to an is_agent seat.",
 }

--- a/backend/internal/modules/agents/tools_colleagues.go
+++ b/backend/internal/modules/agents/tools_colleagues.go
@@ -23,6 +23,7 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -83,5 +84,58 @@ func (t listColleagues) Handle(ctx context.Context, in json.RawMessage) (json.Ra
 	if colleagues == nil {
 		colleagues = []Colleague{}
 	}
-	return json.Marshal(ListColleaguesResult{Colleagues: colleagues, Truncated: truncated})
+	out := ListColleaguesResult{Colleagues: colleagues, Truncated: truncated}
+	if len(colleagues) == 0 && strings.TrimSpace(args.Q) != "" {
+		// TrimSpace because the roster read trims before deciding whether a
+		// narrowing was asked for at all; two spellings of "the caller narrowed"
+		// would disagree on `q` of "   ".
+		attachEveryColleague(ctx, t.list, &out)
+	}
+	return json.Marshal(out)
+}
+
+// CodeRosterUnreadable says the fallback roster could not be read, so an absent
+// `all_colleagues` is unknown rather than empty.
+const CodeRosterUnreadable = "colleague_roster_unreadable"
+
+// CodeNameMatchedNoColleague says the narrowing matched nobody and names what
+// the answer carries instead.
+const CodeNameMatchedNoColleague = "name_matched_no_colleague"
+
+// attachEveryColleague hands over the set the narrowing was matched against,
+// and says in the envelope what happened — the channel a degraded answer uses
+// here already (CodeSemanticRankingDegraded, CodeDuplicateCheckFailed), which
+// costs nothing until the miss and keeps the standing tool copy short.
+//
+// It returns nothing and cannot fail the call, for the reason reportDuplicates
+// gives: the question that was asked has already been answered correctly, and
+// throwing that away because a courtesy read failed hands the caller a tool
+// failure where it had a true answer.
+func attachEveryColleague(ctx context.Context, list ColleagueLister, out *ListColleaguesResult) {
+	everyone, truncated, err := list(ctx, "")
+	if err != nil {
+		noteWarning(ctx, CodeRosterUnreadable,
+			"Nobody here is spelled that way. The rest of the roster could not be read to show "+
+				"you who is, so treat this as unknown rather than as an empty workspace.")
+		return
+	}
+	if everyone == nil {
+		everyone = []Colleague{}
+	}
+	out.AllColleagues, out.AllColleaguesTruncated = &everyone, truncated
+	if len(everyone) == 0 {
+		noteWarning(ctx, CodeNameMatchedNoColleague,
+			"This workspace has no colleagues who can receive work.")
+		return
+	}
+	if truncated {
+		noteWarning(ctx, CodeNameMatchedNoColleague,
+			"Nobody here is spelled that way. `all_colleagues` is a CAPPED page of the roster, "+
+				"not all of it, so do not conclude from it that the person has no seat — narrow "+
+				"differently, on a surname or an email fragment.")
+		return
+	}
+	noteWarning(ctx, CodeNameMatchedNoColleague,
+		"Nobody here is spelled that way. `all_colleagues` is everyone who can receive work; "+
+			"pick from it, or tell the user the person has no seat.")
 }

--- a/backend/internal/modules/agents/tools_colleagues_test.go
+++ b/backend/internal/modules/agents/tools_colleagues_test.go
@@ -6,6 +6,9 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -43,9 +46,9 @@ func TestListColleaguesAnswersSeatsWithWhatAssignmentNeeds(t *testing.T) {
 	}
 }
 
-// A filter matching nobody is an answer, not an error, and it serializes as an
-// empty list rather than null — a caller iterating the result must not have to
-// guard for both.
+// A filter matching nobody is an answer, not an error, and every list in it
+// serializes as an empty array rather than null — a caller iterating the result
+// must not have to guard for both.
 func TestListColleaguesAnswersAnEmptyRosterAsAList(t *testing.T) {
 	out, err := listColleagues{list: func(context.Context, string) ([]Colleague, bool, error) {
 		return nil, false, nil
@@ -53,8 +56,11 @@ func TestListColleaguesAnswersAnEmptyRosterAsAList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("answered %v, want an empty roster", err)
 	}
-	if got := string(out); got != `{"colleagues":[]}` {
-		t.Errorf("empty roster serialized as %s, want an empty array", got)
+	// `all_colleagues` rides along because a narrowing that matched nobody is
+	// answered with the set it was matched against, and here that set is empty
+	// too — which the wire says as `[]` rather than by leaving the field out.
+	if got := string(out); got != `{"colleagues":[],"all_colleagues":[]}` {
+		t.Errorf("empty roster serialized as %s, want empty arrays", got)
 	}
 }
 
@@ -73,5 +79,247 @@ func TestListColleaguesSaysWhenTheRosterIsLongerThanTheAnswer(t *testing.T) {
 	}
 	if !got.Truncated {
 		t.Error("a capped roster did not report truncated")
+	}
+}
+
+// An empty list answers two different questions identically: this workspace
+// employs nobody, and nobody here is spelled the way you asked. A caller cannot
+// tell them apart, and the one it picks is the wrong one — asked to hand an
+// account to a colleague, an assistant read the empty list and reported that
+// the person does not work here, with the seat sitting in the roster under a
+// spelling it had not tried.
+func TestAColleagueMissHandsOverTheRosterItWasMatchedAgainst(t *testing.T) {
+	t.Parallel()
+	lena, tom := ids.NewV7(), ids.NewV7()
+	asked := []string{}
+	out, err := listColleagues{list: func(_ context.Context, q string) ([]Colleague, bool, error) {
+		asked = append(asked, q)
+		if q != "" {
+			return nil, false, nil
+		}
+		return []Colleague{
+			{UserID: lena, DisplayName: "Lena Fischer", Email: "lena.fischer@demo.test"},
+			{UserID: tom, DisplayName: "Tom Brand", Email: "tom@demo.test"},
+		}, false, nil
+	}}.Handle(context.Background(), json.RawMessage(`{"q":"Fischer, Lena"}`))
+	if err != nil {
+		t.Fatalf("answered %v, want a roster", err)
+	}
+
+	var got ListColleaguesResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(got.Colleagues) != 0 {
+		t.Errorf("the narrowed answer is not empty (%+v) — it must stay the honest answer to "+
+			"what was asked", got.Colleagues)
+	}
+	if got.AllColleagues == nil || len(*got.AllColleagues) != 2 {
+		t.Fatalf("the miss handed over %d seats, want the 2 it was matched against — a caller "+
+			"told only \"no match\" reports that the person does not work here", len(*got.AllColleagues))
+	}
+	if (*got.AllColleagues)[0].UserID != lena {
+		t.Errorf("the roster is not the seats the lister answered: %+v", *got.AllColleagues)
+	}
+	if want := []string{"Fischer, Lena", ""}; !slices.Equal(asked, want) {
+		t.Errorf("the lister was asked %v, want %v — the roster read happens ONLY on the miss", asked, want)
+	}
+}
+
+// And not on a hit: a narrowing that found somebody has no second question to
+// answer, and reading the whole roster to attach it would cost every successful
+// call an extra query.
+func TestAColleagueHitDoesNotAlsoReadTheWholeRoster(t *testing.T) {
+	t.Parallel()
+	reads := 0
+	out, err := listColleagues{list: func(_ context.Context, q string) ([]Colleague, bool, error) {
+		reads++
+		return []Colleague{{UserID: ids.NewV7(), DisplayName: "Lena Fischer"}}, false, nil
+	}}.Handle(context.Background(), json.RawMessage(`{"q":"Lena"}`))
+	if err != nil {
+		t.Fatalf("answered %v, want a roster", err)
+	}
+	if reads != 1 {
+		t.Errorf("the lister was read %d times for a query that matched, want 1", reads)
+	}
+	var got ListColleaguesResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if got.AllColleagues != nil {
+		t.Errorf("a matching query also carried the whole roster: %+v", got.AllColleagues)
+	}
+}
+
+// A roster read with no `q` has nothing to fall back to, and must not recurse
+// into itself looking for one.
+func TestAnEmptyWorkspaceAnswersEmptyWithoutAskingTwice(t *testing.T) {
+	t.Parallel()
+	reads := 0
+	out, err := listColleagues{list: func(context.Context, string) ([]Colleague, bool, error) {
+		reads++
+		return nil, false, nil
+	}}.Handle(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("answered %v, want an empty roster", err)
+	}
+	if reads != 1 {
+		t.Errorf("an unnarrowed empty roster was read %d times, want 1", reads)
+	}
+	if got := string(out); got != `{"colleagues":[]}` {
+		t.Errorf("an empty workspace answered %s", got)
+	}
+}
+
+// colleagueMiss drives one narrowing that finds nobody, with an envelope around
+// it so the warnings the miss raises are readable.
+func colleagueMiss(t *testing.T, q string, list ColleagueLister) (ListColleaguesResult, *envelopeFacts) {
+	t.Helper()
+	ctx, facts := withEnvelopeFacts(context.Background())
+	out, err := listColleagues{list: list}.Handle(ctx, json.RawMessage(`{"q":"`+q+`"}`))
+	if err != nil {
+		t.Fatalf("answered %v, want an answer", err)
+	}
+	var got ListColleaguesResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	return got, facts
+}
+
+func warnedWith(facts *envelopeFacts, code string) (Warning, bool) {
+	for _, w := range facts.warnings {
+		if w.Code == code {
+			return w, true
+		}
+	}
+	return Warning{}, false
+}
+
+// A CAPPED fallback is the case this whole affordance can get wrong. Two
+// hundred alphabetical names with the one asked for absent reads as proof the
+// person has no seat — a caller MORE certain of the wrong answer than a bare
+// empty list left it. So the cap rides its own flag, and the warning says do
+// not conclude absence from it.
+func TestACappedFallbackSaysItIsAPageAndNotTheWorkforce(t *testing.T) {
+	t.Parallel()
+	got, facts := colleagueMiss(t, "Fischer", func(_ context.Context, q string) ([]Colleague, bool, error) {
+		if q != "" {
+			return nil, false, nil
+		}
+		return []Colleague{{UserID: ids.NewV7(), DisplayName: "Aaron Adler"}}, true, nil
+	})
+
+	if got.Truncated {
+		t.Error("the query's own flag says the NARROWING has more matches — it matched nothing")
+	}
+	if !got.AllColleaguesTruncated {
+		t.Error("a capped fallback does not say it is capped, so a caller reads a page as the workforce")
+	}
+	warning, ok := warnedWith(facts, CodeNameMatchedNoColleague)
+	if !ok {
+		t.Fatalf("the miss raised no warning: %+v", facts.warnings)
+	}
+	if !strings.Contains(warning.Message, "CAPPED") {
+		t.Errorf("the warning does not say the list is a page:\n%s", warning.Message)
+	}
+}
+
+// The question that was asked has already been answered correctly by the time
+// the fallback runs. A courtesy read that fails must not turn that into a tool
+// failure — the shape reportDuplicates settled for the same situation — and an
+// absent fallback must read as unknown rather than as an empty workspace.
+func TestAnUnreadableFallbackDoesNotDestroyTheAnswerItWasAddedTo(t *testing.T) {
+	t.Parallel()
+	got, facts := colleagueMiss(t, "Fischer", func(_ context.Context, q string) ([]Colleague, bool, error) {
+		if q != "" {
+			return nil, false, nil
+		}
+		return nil, false, errors.New("the roster read failed")
+	})
+
+	if got.AllColleagues != nil {
+		t.Errorf("a failed fallback still attached a list: %+v", *got.AllColleagues)
+	}
+	warning, ok := warnedWith(facts, CodeRosterUnreadable)
+	if !ok {
+		t.Fatalf("a failed fallback is silent, so an absent list reads as an empty workspace: %+v",
+			facts.warnings)
+	}
+	if !strings.Contains(warning.Message, "unknown") {
+		t.Errorf("the warning does not say the answer is unknown:\n%s", warning.Message)
+	}
+}
+
+// A workspace that really employs nobody says THAT, rather than leaving the
+// caller to read an absent list.
+func TestAWorkspaceWithNoSeatsSaysSoRatherThanGoingQuiet(t *testing.T) {
+	t.Parallel()
+	_, facts := colleagueMiss(t, "Fischer", func(context.Context, string) ([]Colleague, bool, error) {
+		return nil, false, nil
+	})
+	warning, ok := warnedWith(facts, CodeNameMatchedNoColleague)
+	if !ok {
+		t.Fatalf("an empty workspace raised no warning: %+v", facts.warnings)
+	}
+	if !strings.Contains(warning.Message, "no colleagues") {
+		t.Errorf("the warning does not say the workspace has nobody:\n%s", warning.Message)
+	}
+}
+
+// Whitespace is not a narrowing. The roster read trims before deciding, so a
+// handler that did not would call it twice for a `q` the service treats as
+// absent — one invariant with two definitions across a seam.
+func TestWhitespaceIsNotANarrowingOnEitherSideOfTheSeam(t *testing.T) {
+	t.Parallel()
+	reads := 0
+	ctx, _ := withEnvelopeFacts(context.Background())
+	if _, err := (listColleagues{list: func(context.Context, string) ([]Colleague, bool, error) {
+		reads++
+		return nil, false, nil
+	}}).Handle(ctx, json.RawMessage(`{"q":"   "}`)); err != nil {
+		t.Fatalf("answered %v", err)
+	}
+	if reads != 1 {
+		t.Errorf("a whitespace `q` was read %d times, want 1 — the handler and the roster read "+
+			"disagree about what counts as narrowing", reads)
+	}
+}
+
+// The two fallback outcomes must differ in the BYTES, not only in a warning.
+//
+// A workspace that employs nobody and a roster that could not be read are
+// different answers, and a caller acting on `data` alone saw the same thing
+// from both — the omitted field. That is the defect this whole field exists to
+// remove, one level up.
+func TestAnEmptyFallbackAndAnUnreadableOneAreDifferentOnTheWire(t *testing.T) {
+	t.Parallel()
+	ctx, _ := withEnvelopeFacts(context.Background())
+
+	empty, err := listColleagues{list: func(context.Context, string) ([]Colleague, bool, error) {
+		return nil, false, nil
+	}}.Handle(ctx, json.RawMessage(`{"q":"Fischer"}`))
+	if err != nil {
+		t.Fatalf("answered %v", err)
+	}
+	if !strings.Contains(string(empty), `"all_colleagues":[]`) {
+		t.Errorf("a workspace that employs nobody does not say so in the data:\n%s", empty)
+	}
+
+	unreadable, err := listColleagues{list: func(_ context.Context, q string) ([]Colleague, bool, error) {
+		if q == "" {
+			return nil, false, errors.New("the roster read failed")
+		}
+		return nil, false, nil
+	}}.Handle(ctx, json.RawMessage(`{"q":"Fischer"}`))
+	if err != nil {
+		t.Fatalf("answered %v", err)
+	}
+	if strings.Contains(string(unreadable), "all_colleagues") {
+		t.Errorf("an unreadable roster claims a list it never read:\n%s", unreadable)
+	}
+	if string(empty) == string(unreadable) {
+		t.Errorf("both fallback outcomes serialize identically, so a caller reading the data "+
+			"cannot tell an empty workspace from one it could not see:\n%s", empty)
 	}
 }

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,9 +6,9 @@
   "catalog": {
     "tools": 75,
     "system_frame_tokens": 353,
-    "tokens": 22639,
+    "tokens": 22726,
     "median_tool_tokens": 266,
-    "mean_tool_tokens": 301
+    "mean_tool_tokens": 302
   },
   "agents": [
     {
@@ -127,6 +127,10 @@
       "tokens": 447
     },
     {
+      "name": "compose_analytics_report",
+      "tokens": 423
+    },
+    {
       "name": "annotate_brief",
       "tokens": 418
     },
@@ -141,10 +145,6 @@
     {
       "name": "enrich",
       "tokens": 393
-    },
-    {
-      "name": "compose_analytics_report",
-      "tokens": 390
     },
     {
       "name": "search_records",
@@ -291,6 +291,10 @@
       "tokens": 197
     },
     {
+      "name": "list_colleagues",
+      "tokens": 195
+    },
+    {
       "name": "who_knows",
       "tokens": 194
     },
@@ -337,10 +341,6 @@
     {
       "name": "get_record_tags",
       "tokens": 142
-    },
-    {
-      "name": "list_colleagues",
-      "tokens": 141
     },
     {
       "name": "whoami",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1634 | 4% | 21576 | 6 | 6 |
 | `overnight_at_risk_sweep` | 7 | 2509 | 7% | 20701 | 15 | 10 |
-| _whole served catalog, for scale_ | 75 | 22639 | 69% | — | — | — |
+| _whole served catalog, for scale_ | 75 | 22726 | 69% | — | — | — |
 
 ### `morning_brief`
 
@@ -126,7 +126,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 266 tokens, mean 301, across 75 served tools.
+Median 266 tokens, mean 302, across 75 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -149,11 +149,11 @@ a term in an addition.
 | `run_analytics_query` | 476 | — |
 | `create_record` | 473 | 1 scenario |
 | `advance_deal` | 447 | 1 scenario |
+| `compose_analytics_report` | 423 | — |
 | `annotate_brief` | 418 | — |
 | `review_commitments` | 401 | 1 scenario |
 | `book_meeting` | 393 | — |
 | `enrich` | 393 | — |
-| `compose_analytics_report` | 390 | — |
 | `search_records` | 385 | 9 scenarios |
 | `forecast_readings` | 357 | — |
 | `forecast_movement` | 351 | — |
@@ -190,6 +190,7 @@ a term in an addition.
 | `update_tag` | 205 | — |
 | `merge_tags` | 198 | — |
 | `relink_thread` | 197 | — |
+| `list_colleagues` | 195 | — |
 | `who_knows` | 194 | — |
 | `list_pipelines` | 191 | — |
 | `disqualify_lead` | 190 | — |
@@ -202,7 +203,6 @@ a term in an addition.
 | `read_approval` | 153 | — |
 | `list_input_checks` | 146 | — |
 | `get_record_tags` | 142 | — |
-| `list_colleagues` | 141 | — |
 | `whoami` | 128 | — |
 | `commit_import` | 118 | — |
 | `data_coverage` | 109 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 75,
     "resources": 12,
-    "tool_catalog_bytes": 215535,
+    "tool_catalog_bytes": 216235,
     "resource_catalog_bytes": 4584,
-    "approx_wire_tokens_total": 55029,
+    "approx_wire_tokens_total": 55204,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 53073,
+      "description_bytes": 53420,
       "input_schema_bytes": 45533,
-      "output_schema_bytes": 100738,
-      "description_plus_input_schema_bytes": 98606
+      "output_schema_bytes": 101091,
+      "description_plus_input_schema_bytes": 98953
     }
   },
   "tools": {
@@ -2016,7 +2016,7 @@
           "readOnlyHint": true,
           "title": "Compose an analytics report"
         },
-        "description": "Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "WRITE a document somebody reads — a board-pack section, a summary for a meeting, a written-up answer with figures in it — whose every number comes from a saved analytics run instead of being typed. The document carries the STRUCTURE and the WORDS; each figure names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -5737,7 +5737,7 @@
           "readOnlyHint": true,
           "title": "List colleagues"
         },
-        "description": "List the people who work HERE — colleagues holding a seat, not the contacts stored as person records. Reads only, and lists seats that can actually receive work — archived, suspended and locked-out ones are absent. `truncated` means there are more. search_records/person finds a CUSTOMER contact; this finds a colleague. user_id is what assignee_id and owner_id take. Never assign to an is_agent seat. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "List the people who work HERE — colleagues holding a seat, not the contacts stored as person records. Reads only, and lists seats that can actually receive work — archived, suspended and locked-out ones are absent. `truncated` means there are more. A `q` matching nobody answers with `all_colleagues` and a warning; that list is ABSENT if it could not be read and partial if `all_colleagues_truncated`, so read the warning before concluding a person has no seat. search_records/person finds a CUSTOMER contact; this finds a colleague. user_id is what assignee_id and owner_id take. Never assign to an is_agent seat. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -5753,6 +5753,40 @@
           "properties": {
             "data": {
               "properties": {
+                "all_colleagues": {
+                  "items": {
+                    "properties": {
+                      "display_name": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "is_agent": {
+                        "type": "boolean"
+                      },
+                      "seat_type": {
+                        "type": "string"
+                      },
+                      "user_id": {
+                        "format": "uuid",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "display_name",
+                      "email",
+                      "is_agent",
+                      "seat_type",
+                      "user_id"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "all_colleagues_truncated": {
+                  "type": "boolean"
+                },
                 "colleagues": {
                   "items": {
                     "properties": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 75 |
 | Resources | 12 |
-| Tool catalog | 210.5 KB |
+| Tool catalog | 211.2 KB |
 | Resource catalog | 4.5 KB |
-| Approx. wire tokens | 55029 |
+| Approx. wire tokens | 55204 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 98.4 KB | 46% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 51.8 KB | 24% | Yes, every step |
+| Output schemas | 98.7 KB | 46% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 52.2 KB | 24% | Yes, every step |
 | Input schemas | 44.5 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.8 KB | 7% | Partly |
-| **Description + input schema** | **96.3 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **96.6 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -76,7 +76,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
 | [`check_location_support`](#check_location_support) | Can a card read this device's location | yes | [`ui://margince/geo-probe.html`](#geo_probe_view) | 1.8 KB |
 | [`commit_import`](#commit_import) | Commit an import |  |  | 1.7 KB |
-| [`compose_analytics_report`](#compose_analytics_report) | Compose an analytics report | yes |  | 2.6 KB |
+| [`compose_analytics_report`](#compose_analytics_report) | Compose an analytics report | yes |  | 2.8 KB |
 | [`create_record`](#create_record) | Create a record |  |  | 3.5 KB |
 | [`create_tag`](#create_tag) | Create a tag |  |  | 1.9 KB |
 | [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
@@ -100,7 +100,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`intro_path_to`](#intro_path_to) | Find a warm introduction path | yes |  | 2.3 KB |
 | [`list_approvals`](#list_approvals) | List what is waiting for a decision | yes |  | 2.9 KB |
 | [`list_channel_providers`](#list_channel_providers) | List messaging transports | yes |  | 2.0 KB |
-| [`list_colleagues`](#list_colleagues) | List colleagues | yes |  | 1.9 KB |
+| [`list_colleagues`](#list_colleagues) | List colleagues | yes |  | 2.4 KB |
 | [`list_input_checks`](#list_input_checks) | What the forecast's inputs still need | yes |  | 2.1 KB |
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
 | [`list_records`](#list_records) | List records | yes |  | 3.3 KB |
@@ -2450,7 +2450,7 @@ Write a checked import into the workspace, once a person approves. Only from awa
 
 **Compose an analytics report**
 
-Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope "read".)
+WRITE a document somebody reads — a board-pack section, a summary for a meeting, a written-up answer with figures in it — whose every number comes from a saved analytics run instead of being typed. The document carries the STRUCTURE and the WORDS; each figure names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -6411,7 +6411,7 @@ Find out which messaging transports exist in THIS installation, and what each is
 
 **List colleagues**
 
-List the people who work HERE — colleagues holding a seat, not the contacts stored as person records. Reads only, and lists seats that can actually receive work — archived, suspended and locked-out ones are absent. `truncated` means there are more. search_records/person finds a CUSTOMER contact; this finds a colleague. user_id is what assignee_id and owner_id take. Never assign to an is_agent seat. (Governance: runs immediately; requires passport scope "read".)
+List the people who work HERE — colleagues holding a seat, not the contacts stored as person records. Reads only, and lists seats that can actually receive work — archived, suspended and locked-out ones are absent. `truncated` means there are more. A `q` matching nobody answers with `all_colleagues` and a warning; that list is ABSENT if it could not be read and partial if `all_colleagues_truncated`, so read the warning before concluding a person has no seat. search_records/person finds a CUSTOMER contact; this finds a colleague. user_id is what assignee_id and owner_id take. Never assign to an is_agent seat. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -6437,6 +6437,40 @@ List the people who work HERE — colleagues holding a seat, not the contacts st
   "properties": {
     "data": {
       "properties": {
+        "all_colleagues": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "is_agent": {
+                "type": "boolean"
+              },
+              "seat_type": {
+                "type": "string"
+              },
+              "user_id": {
+                "format": "uuid",
+                "type": "string"
+              }
+            },
+            "required": [
+              "display_name",
+              "email",
+              "is_agent",
+              "seat_type",
+              "user_id"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "all_colleagues_truncated": {
+          "type": "boolean"
+        },
         "colleagues": {
           "items": {
             "properties": {

--- a/docs/reference/mcp-tool-coverage.json
+++ b/docs/reference/mcp-tool-coverage.json
@@ -1929,7 +1929,7 @@
     },
     {
       "name": "compose_analytics_report",
-      "tokens": 390,
+      "tokens": 423,
       "agents": [],
       "required_by_cases": [
         "case20_put_it_in_the_board_pack"
@@ -2533,6 +2533,45 @@
       }
     },
     {
+      "name": "list_colleagues",
+      "tokens": 195,
+      "agents": [],
+      "required_by_cases": [
+        "case33_two_cards_for_one_company"
+      ],
+      "permitted_in_cases": [
+        "case30_a_word_for_it",
+        "case31_wrong_word_on_the_record",
+        "case32_two_words_for_one_thing"
+      ],
+      "driven": true,
+      "graded_by_certification_tasks": null,
+      "measured_by_model": {
+        "claude-haiku-4-5-20251001": {
+          "runs": 3,
+          "passed": 0,
+          "reliability": 0,
+          "cases_below_their_bar": [
+            "case33_two_cards_for_one_company"
+          ]
+        },
+        "claude-opus-5": {
+          "runs": 3,
+          "passed": 3,
+          "reliability": 1,
+          "cases_below_their_bar": []
+        },
+        "claude-sonnet-5": {
+          "runs": 3,
+          "passed": 1,
+          "reliability": 0.3333333333333333,
+          "cases_below_their_bar": [
+            "case33_two_cards_for_one_company"
+          ]
+        }
+      }
+    },
+    {
       "name": "disqualify_lead",
       "tokens": 190,
       "agents": [],
@@ -2763,45 +2802,6 @@
           "passed": 3,
           "reliability": 1,
           "cases_below_their_bar": []
-        }
-      }
-    },
-    {
-      "name": "list_colleagues",
-      "tokens": 141,
-      "agents": [],
-      "required_by_cases": [
-        "case33_two_cards_for_one_company"
-      ],
-      "permitted_in_cases": [
-        "case30_a_word_for_it",
-        "case31_wrong_word_on_the_record",
-        "case32_two_words_for_one_thing"
-      ],
-      "driven": true,
-      "graded_by_certification_tasks": null,
-      "measured_by_model": {
-        "claude-haiku-4-5-20251001": {
-          "runs": 3,
-          "passed": 0,
-          "reliability": 0,
-          "cases_below_their_bar": [
-            "case33_two_cards_for_one_company"
-          ]
-        },
-        "claude-opus-5": {
-          "runs": 3,
-          "passed": 3,
-          "reliability": 1,
-          "cases_below_their_bar": []
-        },
-        "claude-sonnet-5": {
-          "runs": 3,
-          "passed": 1,
-          "reliability": 0.3333333333333333,
-          "cases_below_their_bar": [
-            "case33_two_cards_for_one_company"
-          ]
         }
       }
     },

--- a/docs/reference/mcp-tool-coverage.md
+++ b/docs/reference/mcp-tool-coverage.md
@@ -249,13 +249,13 @@ Every run of every case requiring this tool passed, for the model named.
 | `archive_record` | 1.00 | 3 | `case33_two_cards_for_one_company` |
 | `apply_tag` | 1.00 | 3 | `case30_a_word_for_it` |
 | `relink_activities` | 1.00 | 3 | `case9_filed_in_the_wrong_place` |
+| `list_colleagues` | 1.00 | 3 | `case33_two_cards_for_one_company` |
 | `create_tag` | 1.00 | 3 | `case30_a_word_for_it` |
 | `list_channel_providers` | 1.00 | 3 | `case42_can_i_answer_on_whatsapp` |
 | `remove_tag` | 1.00 | 3 | `case31_wrong_word_on_the_record` |
 | `read_project_360` | 1.00 | 3 | `case41_close_the_project` |
 | `read_approval` | 1.00 | 3 | `case8_whats_waiting` |
 | `get_record_tags` | 1.00 | 3 | `case31_wrong_word_on_the_record` |
-| `list_colleagues` | 1.00 | 3 | `case33_two_cards_for_one_company` |
 | `commit_import` | 1.00 | 3 | `case10_finish_the_import` |
 | `data_coverage` | 1.00 | 3 | `case22_can_i_trust_the_numbers` |
 | `read_import_report` | 1.00 | 3 | `case10_finish_the_import` |
@@ -306,13 +306,13 @@ Driven, and not every run passed. Open the case to see what was asked.
 | `qualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
 | `update_tag` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
 | `merge_tags` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
+| `list_colleagues` | 0.00 | 0/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `disqualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
 | `list_channel_providers` | 0.67 | 2/3 | — | `case42_can_i_answer_on_whatsapp` |
 | `remove_tag` | 0.00 | 0/3 | `case31_wrong_word_on_the_record` | `case31_wrong_word_on_the_record` |
 | `read_project_360` | 0.00 | 0/3 | `case41_close_the_project` | `case41_close_the_project` |
 | `read_approval` | 0.33 | 1/3 | `case8_whats_waiting` | `case8_whats_waiting` |
 | `get_record_tags` | 0.00 | 0/3 | `case31_wrong_word_on_the_record` | `case31_wrong_word_on_the_record` |
-| `list_colleagues` | 0.00 | 0/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `commit_import` | 0.33 | 1/3 | `case10_finish_the_import` | `case10_finish_the_import` |
 | `data_coverage` | 0.67 | 2/3 | — | `case22_can_i_trust_the_numbers` |
 | `list_tags` | 0.50 | 3/6 | `case32_two_words_for_one_thing` | `case30_a_word_for_it`, `case32_two_words_for_one_thing` |
@@ -357,10 +357,10 @@ Driven, and not every run passed. Open the case to see what was asked.
 | `qualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
 | `update_tag` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
 | `merge_tags` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
+| `list_colleagues` | 0.33 | 1/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `disqualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
 | `read_project_360` | 0.00 | 0/3 | `case41_close_the_project` | `case41_close_the_project` |
 | `read_approval` | 0.67 | 2/3 | — | `case8_whats_waiting` |
-| `list_colleagues` | 0.33 | 1/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `list_tags` | 0.50 | 3/6 | `case32_two_words_for_one_thing` | `case30_a_word_for_it`, `case32_two_words_for_one_thing` |
 | `get_tag` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
 

--- a/e2e/llm/scenarios/case33-two-cards-for-one-company.yaml
+++ b/e2e/llm/scenarios/case33-two-cards-for-one-company.yaml
@@ -96,26 +96,28 @@ may_call:
   - whoami
 
 must_mention:
-  # Criterion 1: the surviving record is NAMED, and by its own name rather than
-  # as "the duplicate" or "the other one".
+  # Criterion 1, first half: the company is named at all.
+  - "Ostfriesen Kranbau"
+  # Criterion 1, second half: WHICH card survived, and that it survived.
   #
-  # EITHER TWIN MAY SURVIVE, and pinning one was this pattern asserting something
-  # the prompt never asked for. "Put it back to one record without losing any of
-  # that correspondence" is satisfied in both directions — a merge moves the
-  # source's activities onto the survivor — so a run that keeps the card the mail
-  # is already on has answered the question, and a run that keeps the older card
-  # has too. A measured run did exactly the first and was failed for the spelling:
-  # it merged correctly, archived correctly, said "Kept: Ostfriesen Kranbau
-  # Gesellschaft mbH (the one with the email history)", and the judge passed
-  # criterion 1 while this pattern reported a product defect that was not there.
+  # EITHER TWIN MAY SURVIVE. The prompt names no direction and a merge moves the
+  # source's activities onto the survivor either way, so keeping the card the
+  # mail is already on and keeping the older card both answer it.
   #
-  # The full suffix is required either way — "Ostfriesen Kranbau" alone would be
-  # satisfied by an answer naming neither card in particular, which is the thing
-  # criterion 1 exists to catch.
-  - "Ostfriesen Kranbau (?:GmbH|Gesellschaft mbH)"
-  # Criterion 1: and the direction is stated rather than left to the reader.
-  # Both orders, because an answer may lead with either record.
-  - "Ostfriesen Kranbau (?:GmbH|Gesellschaft mbH)[^.]{0,120}(?:surviv|kept|keeping|remains|stays|wins|the one I|target)|(?:surviv|kept|keeping|merged into|folded into|onto)[^.]{0,120}Ostfriesen Kranbau (?:GmbH|Gesellschaft mbH)"
+  # ANCHORED ON THE SUFFIX ALONE, because the suffix is the only thing that
+  # tells the two cards apart and an answer is not obliged to repeat the company
+  # name beside it. Three measured runs said it three ways — "kept the
+  # \"Gesellschaft mbH\" version", "kept \"Ostfriesen Kranbau Gesellschaft mbH\"
+  # as the surviving record", and a heading followed by "Kept Gesellschaft mbH"
+  # — all three correct, and a pattern demanding the name and the suffix be
+  # adjacent greened only the middle one.
+  #
+  # It still fails what it exists to fail: "I merged the two Ostfriesen Kranbau
+  # records into one" names no survivor and matches nothing here, because no
+  # suffix appears near the survival word. Whether the survivor NAMED is the one
+  # the merge actually produced stays the judge's question — that half can read
+  # the transcript and this one cannot.
+  - "(?:Gesellschaft mbH|GmbH)[^.]{0,140}(?:surviv|kept|keeping|remains|stays|wins|the one I|target)|(?:surviv|kept|keeping|merged into|folded into|onto)[^.]{0,140}(?:Gesellschaft mbH|GmbH)"
   # Criterion 2: the closed company was retired, and it is the closed company
   # that was retired. Anchored to Sauerland both ways round — an unanchored
   # "archived" is true of the merge's own source record and would green an

--- a/e2e/llm/seed-llm-fixtures.sh
+++ b/e2e/llm/seed-llm-fixtures.sh
@@ -79,6 +79,45 @@ api() {
   fi
 }
 
+# activate_seat gives a seeded colleague a password, which is what makes the
+# seat ACTIVE and therefore a colleague at all.
+#
+# POST /users writes status='invited' — a seat with no password_hash signs in
+# nowhere — and identity.Colleagues lists only status='active'. So every seat
+# this seed created was invisible to list_colleagues, on every call of every
+# run, and two scoring criteria across two cases could not be reached by any
+# model: the tool was right to find nobody and the fixture was what was wrong.
+#
+# The route back is the one the product itself uses for an installation with no
+# outbound email: mint a single-use set-password link, then redeem it. Issuance
+# admits an invited member deliberately, and redemption is what sets
+# status='active'.
+#
+# The token rides in the URL FRAGMENT, which is why it is split on `#` here
+# rather than read from a query parameter.
+activate_seat() {
+  local user_id="$1" who="$2" password="colleague-password-123"
+  local link
+  link="$(api POST "/users/$user_id/password-link" '{}' | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("set_password_url",""))
+except Exception:
+    print("")')"
+  [[ -n "$link" ]] || { echo "could not mint a set-password link for $who" >&2; exit 1; }
+  local token="${link##*#}"
+  token="${token##*token=}"
+  [[ -n "$token" && "$token" != "$link" ]] || {
+    echo "the set-password link for $who carries no fragment token: $link" >&2; exit 1; }
+  local code
+  code="$(status_of POST /auth/reset-password \
+    "$(printf '{"token":%s,"new_password":"%s"}' "$(json_string "$token")" "$password")")"
+  [[ "$code" = "204" ]] || { echo "redeeming $who's set-password link answered HTTP $code" >&2; exit 1; }
+}
+
+# json_string quotes a value as a JSON string, so a token containing a quote or
+# a backslash cannot break out of the body it is placed in.
+json_string() { printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'; }
+
 # id_of reads the id out of a create response, or empty when the create was
 # refused (a 409 on a natural key, which a re-run expects).
 id_of() { printf '%s' "$1" | python3 -c 'import json,sys
@@ -254,6 +293,7 @@ rows = json.load(sys.stdin).get("data", [])
 print(rows[0]["id"] if rows else "")')"
 fi
 [[ -n "$colleague" ]] || { echo "could not resolve the colleague seat" >&2; exit 1; }
+activate_seat "$colleague" "Sofia Meier"
 
 # --- CASE 4: companies in and around Köln, owned by the colleague ------------
 #
@@ -1000,6 +1040,7 @@ if [[ -z "$lena" ]]; then
     "email":"lena.fischer@demo.test","display_name":"Lena Fischer","role":"rep"}')")"
 fi
 [[ -n "$lena" ]] || { echo "could not resolve the Lena Fischer seat" >&2; exit 1; }
+activate_seat "$lena" "Lena Fischer"
 
 # --- CASE 40: the lead queue, one lead per terminal outcome -----------------
 #
@@ -1112,5 +1153,25 @@ if [[ -z "$nuria" ]]; then
   nuria="$(create_or_die "/people" "$body" "Nuria Sanz")"
   link_employment "$nuria" "$levante" "Nuria Sanz at Levante Cold Chain"
 fi
+
+# --- THE ROSTER IS VERIFIED, not assumed ---------------------------------
+#
+# The seats above are the fixture's most silent failure mode. A seat that stays
+# `invited` is not a colleague, list_colleagues answers `[]`, and a run reads
+# that as "this person does not work here" — a scenario failure with the fixture
+# as its cause and nothing saying so. It went unnoticed across whole sweeps.
+#
+# Asked of the ROSTER READ the tools use, not of the rows this script created:
+# a seat that exists and is not listed is exactly the state being guarded
+# against, so checking that the POST succeeded would prove nothing.
+roster="$(api GET '/users?limit=100' | python3 -c 'import json,sys
+rows = json.load(sys.stdin).get("data", [])
+print("\n".join(r.get("email","") for r in rows if r.get("status") == "active"))')"
+for seat in sofia.meier@demo.test lena.fischer@demo.test; do
+  printf '%s\n' "$roster" | grep -qx "$seat" || {
+    echo "$seat holds no ACTIVE seat, so list_colleagues will not name them and every case " \
+         "that hands work to a colleague fails for the fixture's reason" >&2
+    exit 1; }
+done
 
 echo "LLM fixtures seeded"

--- a/e2e/llm/why.py
+++ b/e2e/llm/why.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Why did a run not call the tool its scenario requires?
+
+A failing `must_call` says which tool was missed and nothing about why. The
+answer is almost always one of three things, and they need different fixes:
+
+  the tool was never served        -> a scope, a tier floor, or a registration
+  it was served and not chosen     -> the tool's own copy, read beside its rivals
+  it was chosen and refused        -> the refusal, which the transcript carries
+
+This prints the evidence for all three, per run, so the question is answered by
+reading rather than reconstructed by hand each time. Reads only what the lane
+already records; it drives no model and costs nothing.
+
+    e2e/llm/why.py case20_put_it_in_the_board_pack
+"""
+
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+RECORDS = ROOT / "e2e" / "llm" / "records"
+SCENARIOS = ROOT / "e2e" / "llm" / "scenarios"
+SERVED = ROOT / "docs" / "reference" / "mcp-info.json"
+
+
+def must_call(scenario):
+    """The tools the scenario requires, read off its own YAML.
+
+    Parsed by hand rather than with a YAML library: the patterns in these files
+    carry regex escapes a strict loader rejects, and this only needs one list.
+    """
+    for path in SCENARIOS.glob("*.yaml"):
+        if f"name: {scenario}" not in path.read_text():
+            continue
+        wanted, inside = [], False
+        for line in path.read_text().splitlines():
+            if line.startswith("must_call:"):
+                inside = True
+                continue
+            if inside:
+                if line.startswith("  - "):
+                    wanted.append(line[4:].strip())
+                elif line and not line.startswith((" ", "#")):
+                    break
+        return wanted
+    return []
+
+
+def served_descriptions():
+    """Every tool the surface publishes, by bare name."""
+    if not SERVED.exists():
+        return {}
+    out = {}
+
+    def walk(node):
+        if isinstance(node, dict):
+            name, text = node.get("name"), node.get("description")
+            if isinstance(name, str) and isinstance(text, str):
+                out[name] = text
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(json.load(SERVED.open()))
+    return out
+
+
+def read_run(path):
+    """One run's served tool list, its calls, and its final answer."""
+    offered, called, answer = [], [], ""
+    for line in path.read_text().splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "system" and event.get("subtype") == "init":
+            offered = [t.split("__")[-1] for t in event.get("tools") or []]
+        if event.get("type") == "assistant":
+            for block in event.get("message", {}).get("content", []):
+                if block.get("type") == "tool_use":
+                    called.append(block["name"].split("__")[-1])
+                elif block.get("type") == "text" and block["text"].strip():
+                    answer = block["text"]
+    return offered, called, answer
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+    scenario = sys.argv[1]
+    wanted = must_call(scenario)
+    descriptions = served_descriptions()
+    runs = sorted(RECORDS.glob(f"{scenario}.run*.jsonl"))
+    if not runs:
+        sys.exit(f"no transcripts for {scenario} under {RECORDS}")
+
+    print(f"{scenario}: must_call {wanted or '(none)'}\n")
+    missed_anywhere = set()
+    for path in runs:
+        offered, called, answer = read_run(path)
+        missed = [t for t in wanted if t not in called]
+        missed_anywhere.update(missed)
+        print(f"--- {path.name}")
+        print(f"    served : {len(offered)} tools")
+        print(f"    called : {', '.join(called) or '(nothing)'}")
+        for tool in missed:
+            where = "SERVED and not chosen" if tool in offered else "NEVER SERVED"
+            print(f"    missed : {tool} — {where}")
+        print(f"    answer : {answer[:160].replace(chr(10), ' ')}")
+        print()
+
+    for tool in sorted(missed_anywhere):
+        text = descriptions.get(tool)
+        if not text:
+            continue
+        # The copy is what a model chose against, so it is printed whole rather
+        # than summarised: the first sentence is what a scan reads.
+        print(f"=== {tool} reads, to a caller scanning for a job:")
+        print("    " + text.replace("\n", " ")[:600])
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Four changes, one story, measured end to end: **case33 on haiku goes 0/3 → 3/3.**

## 1. An empty colleague list was two different answers

```
  list_colleagues {q: "Lena Fischer"}  →  { "colleagues": [] }
                                              ↓
              "nobody works here"    OR    "nobody is spelled that way"
```

A caller cannot tell them apart, so it picks — and it picked the wrong one. In the lane, an assistant asked to hand an account to a colleague tried `q: "Lena Fischer"`, then `q: "Lena"`, and told the user she *"isn't in the system yet"*.

A narrowing that matches nobody now hands over the set it was matched against: `colleagues` stays empty (the honest answer to what was asked), `all_colleagues` carries the seats, and the envelope says in words what happened. Through the **warning channel**, not the tool copy — a sentence in `Limits` is paid for on every catalog listing of all 75 tools on every run, and this one is only true on the miss.

- **A successful empty fallback and an unreadable one are different bytes.** `all_colleagues` is a pointer: `[]` when the roster was read and holds nobody, absent when it could not be read. Identical serialisation would have reproduced this field's own defect one level up. *(CodeRabbit, Major — taken.)*
- **The cap rides its own flag.** 200 alphabetical names with the one asked for absent reads as *proof* of absence. `truncated` means the narrowing has more matches; `all_colleagues_truncated` means the fallback is a page, and the warning says not to conclude absence from it.
- **The fallback cannot fail the call** — the asked question is already answered by then, the shape `reportDuplicates` settled.

## 2. …and the tool was right all along — the fixture had no colleagues

`POST /users` writes `status='invited'`; a seat with no password signs in nowhere. `identity.Colleagues` lists only `status='active'`. So **every colleague this seed created was invisible on every call of every run** — verified across the last haiku sweep: 5 calls, 0 non-empty. Two scoring criteria on two cases were unreachable by any model, and both were being recorded as model failures.

The seed now mints a single-use set-password link and redeems it — the route the product itself uses for an installation with no outbound email, and the one that sets `status`. Then it **verifies the roster read**, not the rows it wrote: a seat that exists and is not listed is exactly the guarded state.

## 3. A staged call says what it staged *and what it already did*

#5193 told the agent to carry on with work the approval does not block. It did — and then wrote its answer about the one thing that stopped:

```
  before  "One approval waiting: reassign Ostfriesen to Lena Fischer."
          (a duplicate merged and a company archived, unreported)

  after   "Done: Ostfriesen Kranbau records are merged (kept the
           "Gesellschaft mbH" version with all correspondence), and
           Sauerland Kunststoff is archived. One approval waiting…"
```

Doing the rest and *reporting* the rest are separate instructions. I trimmed the second clause off #5193 for length before merging; these transcripts are why it belongs.

## 4. The case33 pattern demanded one surface form

Three runs said the same correct thing three ways — `kept the "Gesellschaft mbH" version`, `kept "Ostfriesen Kranbau Gesellschaft mbH" as the surviving record`, and a heading followed by `Kept Gesellschaft mbH`. The pattern required name and suffix **adjacent** and greened only the middle one.

It now anchors on the suffix, which is the only thing that tells the two cards apart. It still fails what it exists to fail — `"I merged the two Ostfriesen Kranbau records into one"` names no survivor and matches nothing. Whether the named survivor is the one the merge produced stays the judge's question; that half can read the transcript and a regex over the final answer cannot.

## Measured

| | |
|---|---|
| case33 haiku, before | **0/3** |
| + real seats | 1/3 — `Lena Fischer` gone from the failures entirely |
| + reporting clause | 1/3 — all three runs now report the writes |
| + the pattern | **3/3** |

Unit, gates, `craft-static` and `lint` green; the compose integration lane green apart from `TestPreferenceCenterOptOutBlocksAgentSend`, which **fails on a clean `origin/main`** and reds four of six shards on every PR. That is not from this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When a colleague search finds no matches, the roster can now be returned as a fallback, with warnings indicating whether it is empty, unavailable, or truncated.
  - Results now distinguish between an empty workspace roster and a search with no matching names.

- **Improvements**
  - Analytics report guidance now clearly emphasizes creating a document for people to read.
  - Approval messages now remind agents to report work already completed alongside pending work.

- **Documentation**
  - Updated tool descriptions and reference schemas to document the enhanced colleague search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->