### PR TITLE
Case 33 asks that the survivor be named, not which twin it is

### DIFF
--- a/e2e/llm/scenarios/case33-two-cards-for-one-company.yaml
+++ b/e2e/llm/scenarios/case33-two-cards-for-one-company.yaml
@@ -96,14 +96,26 @@ may_call:
   - whoami
 
 must_mention:
-  # Criterion 1: the surviving record is NAMED. "GmbH" is what separates it from
-  # "Ostfriesen Kranbau Gesellschaft mbH", the duplicate — the fixture spells the
-  # two apart on purpose, because check.py matches case-insensitively and a
-  # duplicate whose name contained the survivor's could not be told from it.
-  - "Ostfriesen Kranbau GmbH"
+  # Criterion 1: the surviving record is NAMED, and by its own name rather than
+  # as "the duplicate" or "the other one".
+  #
+  # EITHER TWIN MAY SURVIVE, and pinning one was this pattern asserting something
+  # the prompt never asked for. "Put it back to one record without losing any of
+  # that correspondence" is satisfied in both directions — a merge moves the
+  # source's activities onto the survivor — so a run that keeps the card the mail
+  # is already on has answered the question, and a run that keeps the older card
+  # has too. A measured run did exactly the first and was failed for the spelling:
+  # it merged correctly, archived correctly, said "Kept: Ostfriesen Kranbau
+  # Gesellschaft mbH (the one with the email history)", and the judge passed
+  # criterion 1 while this pattern reported a product defect that was not there.
+  #
+  # The full suffix is required either way — "Ostfriesen Kranbau" alone would be
+  # satisfied by an answer naming neither card in particular, which is the thing
+  # criterion 1 exists to catch.
+  - "Ostfriesen Kranbau (?:GmbH|Gesellschaft mbH)"
   # Criterion 1: and the direction is stated rather than left to the reader.
   # Both orders, because an answer may lead with either record.
-  - "Ostfriesen Kranbau GmbH[^.]{0,120}(?:surviv|kept|keeping|remains|stays|wins|the one I|target)|(?:surviv|kept|keeping|merged into|folded into|onto)[^.]{0,120}Ostfriesen Kranbau GmbH"
+  - "Ostfriesen Kranbau (?:GmbH|Gesellschaft mbH)[^.]{0,120}(?:surviv|kept|keeping|remains|stays|wins|the one I|target)|(?:surviv|kept|keeping|merged into|folded into|onto)[^.]{0,120}Ostfriesen Kranbau (?:GmbH|Gesellschaft mbH)"
   # Criterion 2: the closed company was retired, and it is the closed company
   # that was retired. Anchored to Sauerland both ways round — an unanchored
   # "archived" is true of the merge's own source record and would green an

--- a/e2e/llm/seed-llm-fixtures.sh
+++ b/e2e/llm/seed-llm-fixtures.sh
@@ -936,8 +936,13 @@ tag_record "$strategic_short" organization "$vorort"
 #
 # THE DUPLICATE is named so a case-insensitive pattern can tell the two apart:
 # "Ostfriesen Kranbau GmbH" is not a substring of "Ostfriesen Kranbau Gesellschaft
-# mbH", so an assertion naming the survivor cannot be satisfied by the record
-# that is merged away.
+# mbH", so an answer that names one card has not named the other.
+#
+# WHICH of them survives is the RUN's choice and not this fixture's. A merge
+# moves the source's activities onto the survivor either way, so keeping the card
+# the mail is already on and keeping the older card both answer the prompt. The
+# scenario asserts that the survivor is NAMED, and the naming above is what makes
+# that assertion possible; it does not pin a direction.
 #
 # IT IS A COMPANY NO OTHER CASE ASKS ABOUT, and that is the whole reason it is
 # not the Vietnam partner. Case 5 finds the Vietnam account from a description


### PR DESCRIPTION
## What the pattern asserted, and what the criterion says

```yaml
- "Ostfriesen Kranbau GmbH"
```

Criterion 1 is *"The duplicate is merged, and which record survives is said."* The prompt is *"put it back to one record without losing any of that correspondence, and tell me which of the two you kept."* Neither names a direction, and a merge moves the source's activities onto the survivor either way — so keeping the card the mail is already on and keeping the older card both answer the question.

## A measured run did the first and was failed for the spelling

From `case33_two_cards_for_one_company.run1.jsonl`, the assistant read both cards, chose, and reported:

> **Kept: Ostfriesen Kranbau Gesellschaft mbH** (the one with the email history). The duplicate has been merged into it. Sauerland Kunststoff is now archived.

`merge_records` and `archive_record` were both called, in the right direction for that choice. The judge passed criterion 1. Only this regex failed, and the lane recorded the case as a product failure.

## The change, trialled against the three recorded answers

| run | old survivor pattern | new |
|---|---|---|
| 1 | **MISS** | HIT |
| 2 | HIT | HIT |
| 3 | HIT | HIT |

The full suffix is still required either way: a bare `Ostfriesen Kranbau` would be satisfied by an answer naming neither card in particular, which is exactly what criterion 1 exists to catch. Whether the named survivor is the one the merge actually produced stays the **judge's** question — the half that can read the transcript — rather than something a regex over the final answer can decide.

Run 3 still misses the Sauerland pattern, which is a real gap in that run and is left alone.

The seed's rationale is corrected in the same change: spelling the two cards apart is what lets an assertion tell them apart, and never a way of pinning a direction.

## Not fixed here

case33 criterion 3 ("the account is handed to a named colleague") is unreachable for a different reason — the e2e workspace has no active colleague seats at all. That is #5189.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Case 33's survivor pattern required the answer to name "Ostfriesen Kranbau GmbH", but the prompt only asks for a named survivor, not a specific one. A run that correctly merged and named the other twin was failed for the spelling. The pattern now accepts either twin while still requiring the full name suffix.

**Bug Fixes**
- Accepts either `Ostfriesen Kranbau GmbH` or `Ostfriesen Kranbau Gesellschaft mbH` as the named survivor.
- Keeps the full suffix requirement so bare "Ostfriesen Kranbau" still fails.
- Corrects the fixture's comment to say spelling separates the cards, not pins a direction.

<sup>Written for commit 9e411476c6897646e80115f3890518e84108f28e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

