### PR TITLE
A refused field list carries the shapes, not just the names

### DIFF
--- a/backend/internal/modules/agents/command.go
+++ b/backend/internal/modules/agents/command.go
@@ -295,7 +295,7 @@ func (createResolver) Subject(_ context.Context, cmd CreateCommand) (StageInfo, 
 // fine, and a resolver that cannot tell which door asked has no way to
 // answer "does the executor support this" correctly for both.
 func (createResolver) Guards(_ context.Context, cmd CreateCommand) error {
-	return rejectUnknownFields(createShapes, cmd.RecordType, cmd.Fields)
+	return rejectUnknownFields(createWriteShapes, cmd.RecordType, cmd.Fields)
 }
 
 // PatchCommand is one whole-record field patch, whichever door asked for it.
@@ -362,7 +362,7 @@ func (patchResolver) Subject(_ context.Context, cmd PatchCommand) (StageInfo, er
 // webhook_subscription) are patched by their own module rather than through
 // this seam.
 func (p patchResolver) Guards(ctx context.Context, cmd PatchCommand) error {
-	if err := rejectUnknownFields(updateShapes, cmd.RecordType, cmd.Fields); err != nil {
+	if err := rejectUnknownFields(updateWriteShapes, cmd.RecordType, cmd.Fields); err != nil {
 		return err
 	}
 	if !servedByTheRecordSeam(cmd.RecordType) {

--- a/backend/internal/modules/agents/recordfields.go
+++ b/backend/internal/modules/agents/recordfields.go
@@ -149,8 +149,8 @@ const customFieldPrefix = "cf_"
 //
 // A cf_-prefixed key passes: whether that custom field is active in this
 // workspace is the store's ratified question, not a shape this tool can judge.
-func rejectUnknownFields(shapes map[datasource.EntityType]reflect.Type, recordType string, fields json.RawMessage) error {
-	shape, ok := shapes[datasource.EntityType(recordType)]
+func rejectUnknownFields(shapes writeShapes, recordType string, fields json.RawMessage) error {
+	shape, ok := shapes.types[datasource.EntityType(recordType)]
 	if !ok {
 		// An unknown record_type is the provider's refusal to make, and it
 		// names the served vocabulary when it does.
@@ -202,9 +202,10 @@ func rejectUnknownFields(shapes map[datasource.EntityType]reflect.Type, recordTy
 		// unknown KEYS inside it, which are not contract fields at all and
 		// which a client cannot look up. A refusal naming a key the schema does
 		// not have points at nothing.
-		Field:    fieldsArg,
-		Cause:    fmt.Errorf("%s does not accept %s", recordType, strings.Join(unknown, ", ")),
-		Guidance: "accepts " + strings.Join(contractFieldNames(shape), ", ") + " (or cf_<slug> for an active custom field)",
+		Field: fieldsArg,
+		Cause: fmt.Errorf("%s does not accept %s", recordType, strings.Join(unknown, ", ")),
+		Guidance: "accepts " + shapes.acceptedBy(recordType, shape) +
+			" (or cf_<slug> for an active custom field)",
 	}
 }
 
@@ -279,3 +280,41 @@ func UpdatableFields(recordType datasource.EntityType) ([]string, bool) {
 // fieldsArg is the argument name every refusal above blames, as the contract
 // spells it: the payload is `fields` on both the create and the patch shape.
 const fieldsArg = "fields"
+
+// writeShapes pairs the reflected types a decoder binds against with the
+// rendered shape a refusal hands back, so the two halves of "what this record
+// type accepts" cannot be looked up from different places and disagree.
+type writeShapes struct {
+	types map[datasource.EntityType]reflect.Type
+	// rendered is gen-recordfields' own line for each record type: every field
+	// with its JSON type, its closed vocabulary where it has one, and a `?` on
+	// the ones the body may omit.
+	rendered map[string]string
+}
+
+var (
+	createWriteShapes = writeShapes{types: createShapes, rendered: createRecordShapes}
+	updateWriteShapes = writeShapes{types: updateShapes, rendered: updateRecordShapes}
+)
+
+// acceptedBy renders what this record type accepts, for a caller that has just
+// proved it does not know.
+//
+// THE SHAPE, not the names. A bare name list answers the question the caller
+// already half-knew and leaves the next two refusals in place: a measured run
+// was told `organization` accepts `domains`, sent `["example.test"]`, was
+// refused for an array of strings, and then had to be told the item shape; a
+// second was told `relationship` accepts `kind` only after omitting it. Every
+// one of those facts is in gen-recordfields' line, which the tool DESCRIPTION
+// deliberately does not recite because reciting it there cost 18% of the whole
+// listing on every call. A refusal is paid only when it happens, and it is
+// paid by the caller who needs it.
+//
+// Falls back to the names when a record type has no rendered line — a shape the
+// generator did not reach is still a vocabulary this caller is owed.
+func (w writeShapes) acceptedBy(recordType string, shape reflect.Type) string {
+	if rendered, ok := w.rendered[recordType]; ok && rendered != "" {
+		return rendered
+	}
+	return strings.Join(contractFieldNames(shape), ", ")
+}

--- a/backend/internal/modules/agents/recordfields_test.go
+++ b/backend/internal/modules/agents/recordfields_test.go
@@ -120,14 +120,14 @@ func TestDescriptionsCarryNoControlCharacters(t *testing.T) {
 func TestWriteToolsRefuseFieldsTheRecordCannotStore(t *testing.T) {
 	cases := []struct {
 		name       string
-		shapes     map[datasource.EntityType]reflect.Type
+		shapes     writeShapes
 		recordType string
 		fields     string
 		wantNamed  string
 	}{
-		{"organization_id on a person create", createShapes, "person", `{"full_name":"A","organization_id":"x"}`, "organization_id"},
-		{"source on a person update", updateShapes, "person", `{"source":"manual"}`, "source"},
-		{"a typo next to a real field", createShapes, "organization", `{"displayname":"Firecrawl"}`, "displayname"},
+		{"organization_id on a person create", createWriteShapes, "person", `{"full_name":"A","organization_id":"x"}`, "organization_id"},
+		{"source on a person update", updateWriteShapes, "person", `{"source":"manual"}`, "source"},
+		{"a typo next to a real field", createWriteShapes, "organization", `{"displayname":"Firecrawl"}`, "displayname"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -164,13 +164,13 @@ func TestWriteToolsAcceptRealFieldsAndTheCustomFieldChannel(t *testing.T) {
 		`{"full_name":"Alex Nucci","cf_priority":"high"}`,
 		`{}`,
 	} {
-		if err := rejectUnknownFields(createShapes, "person", json.RawMessage(fields)); err != nil {
+		if err := rejectUnknownFields(createWriteShapes, "person", json.RawMessage(fields)); err != nil {
 			t.Errorf("rejectUnknownFields(%s) = %v, want accepted", fields, err)
 		}
 	}
 	// An unknown record_type is the provider's refusal to make: it answers
 	// with the vocabulary it serves, which this check cannot.
-	if err := rejectUnknownFields(createShapes, "invoice", json.RawMessage(`{"anything":1}`)); err != nil {
+	if err := rejectUnknownFields(createWriteShapes, "invoice", json.RawMessage(`{"anything":1}`)); err != nil {
 		t.Errorf("unknown record_type = %v, want it left to the provider", err)
 	}
 }
@@ -287,7 +287,7 @@ func TestWriteToolsRefuseTheCustomFieldPrefixWithNoSlug(t *testing.T) {
 		"null body":   `null`,
 	} {
 		t.Run(name, func(t *testing.T) {
-			err := rejectUnknownFields(createShapes, "person", json.RawMessage(fields))
+			err := rejectUnknownFields(createWriteShapes, "person", json.RawMessage(fields))
 			if err == nil {
 				t.Fatalf("%s was accepted — the value would be discarded with no signal", fields)
 			}
@@ -299,7 +299,7 @@ func TestWriteToolsRefuseTheCustomFieldPrefixWithNoSlug(t *testing.T) {
 	}
 	// A real slug still passes: whether that field is ACTIVE is the store's
 	// question, and refusing it here would break every workspace that has one.
-	if err := rejectUnknownFields(createShapes, "person", json.RawMessage(`{"full_name":"A","cf_priority":"high"}`)); err != nil {
+	if err := rejectUnknownFields(createWriteShapes, "person", json.RawMessage(`{"full_name":"A","cf_priority":"high"}`)); err != nil {
 		t.Errorf("a real custom-field key was refused: %v", err)
 	}
 }
@@ -369,4 +369,74 @@ func recordTypeEnum(t *testing.T, tool string, raw json.RawMessage) []string {
 		t.Fatalf("%s advertises no record_type enum — this walk would pass vacuously", tool)
 	}
 	return parsed.Properties.RecordType.Enum
+}
+
+// A refusal hands back the SHAPE, because the name alone leaves the next
+// refusal in place.
+//
+// Measured: a run told `organization` accepts `domains` sent
+// `["example.test"]`, was refused for an array of strings, and only then
+// learned the item shape; another omitted `relationship.kind` because nothing
+// had said which fields are required. Both facts are in the generated line the
+// tool description deliberately does not recite — reciting it THERE costs every
+// call, and a refusal costs only the caller who needed it.
+func TestARefusedFieldListCarriesTypesAndWhatIsRequired(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		what   string
+		shapes writeShapes
+		record string
+		fields string
+		says   []string
+	}{
+		{
+			what: "an organization create", shapes: createWriteShapes, record: "organization",
+			fields: `{"name":"Terralogic","domain":"terralogic.test"}`,
+			says: []string{
+				// The item shape, which a name list cannot carry.
+				"domains?: [{domain: string, is_primary?: boolean}]",
+				// Required, marked by the ABSENCE of a `?`.
+				"display_name: string",
+			},
+		},
+		{
+			what: "a relationship create", shapes: createWriteShapes, record: "relationship",
+			fields: `{"who":"x"}`,
+			// The closed vocabulary of a required field, in the same line.
+			says: []string{`kind: "employment"|`, "person_id?: uuid"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.what, func(t *testing.T) {
+			t.Parallel()
+			err := rejectUnknownFields(tc.shapes, tc.record, json.RawMessage(tc.fields))
+			var bad *BadArgsError
+			if !errors.As(err, &bad) {
+				t.Fatalf("err = %v, want a BadArgsError", err)
+			}
+			for _, want := range tc.says {
+				if !strings.Contains(bad.Guidance, want) {
+					t.Errorf("the guidance does not carry %q, so the caller learns the name and "+
+						"is refused again on the shape:\n%s", want, bad.Guidance)
+				}
+			}
+		})
+	}
+}
+
+// And an update's shape is the UPDATE's, not the create's — the two differ, and
+// handing back the wrong one sends a caller to a field this door does not take.
+func TestARefusedUpdateCarriesTheUpdateShape(t *testing.T) {
+	t.Parallel()
+	err := rejectUnknownFields(updateWriteShapes, "relationship", json.RawMessage(`{"who":"x"}`))
+	var bad *BadArgsError
+	if !errors.As(err, &bad) {
+		t.Fatalf("err = %v, want a BadArgsError", err)
+	}
+	if strings.Contains(bad.Guidance, "kind:") {
+		t.Errorf("an update-door refusal offers `kind`, which only the create body takes:\n%s", bad.Guidance)
+	}
+	if !strings.Contains(bad.Guidance, "role?: string") {
+		t.Errorf("the update-door refusal does not carry that door's own shape:\n%s", bad.Guidance)
+	}
 }

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -265,7 +265,7 @@ func (t createRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
-	if err := rejectUnknownFields(createShapes, args.RecordType, args.Fields); err != nil {
+	if err := rejectUnknownFields(createWriteShapes, args.RecordType, args.Fields); err != nil {
 		return nil, err
 	}
 	ref, err := t.p.Create(ctx, datasource.CreateInput{

--- a/backend/internal/modules/agents/tools_badargs_test.go
+++ b/backend/internal/modules/agents/tools_badargs_test.go
@@ -73,7 +73,7 @@ func TestALongUnknownKeyDoesNotEatTheAcceptedFieldList(t *testing.T) {
 	// list mid-word — deleting the only part of the message that says what to do
 	// next, precisely when the caller has proved it does not know.
 	long := strings.Repeat("wrongkey", 60)
-	err := rejectUnknownFields(createShapes, "person", json.RawMessage(`{"`+long+`":"x"}`))
+	err := rejectUnknownFields(createWriteShapes, "person", json.RawMessage(`{"`+long+`":"x"}`))
 
 	var bad *BadArgsError
 	if !errors.As(err, &bad) {

--- a/backend/internal/modules/agents/tools_update.go
+++ b/backend/internal/modules/agents/tools_update.go
@@ -109,7 +109,7 @@ func (t updateRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
-	if err := rejectUnknownFields(updateShapes, args.RecordType, args.Fields); err != nil {
+	if err := rejectUnknownFields(updateWriteShapes, args.RecordType, args.Fields); err != nil {
 		return nil, err
 	}
 	if ApprovalRedeemed(ctx) {


### PR DESCRIPTION
## Three round trips on one create

From the sonnet sweep, `case2_business_card`, run 1 — every line a real refusal:

```
create_record organization {"name": "Terralogic", "domain": "terralogic-vn.test"}
  → organization does not accept domain, name; accepts address, description,
    display_name, domains, industry, legal_name, owner_id, parent_org_id,
    size_band, source

create_record organization {"display_name": "Terralogic", "domains": ["terralogic-vn.test"]}
  → `domains` must be an array of objects, not an array of strings; each item is
    {domain: string, is_primary?: boolean}

create_record organization {"display_name": "Terralogic", "domains": [{"domain": "…", "is_primary": true}]}
  → created
```

and later, on the same task:

```
create_record relationship {…}  → kind is required
```

The first refusal knew everything the second and fourth had to teach. It handed back names.

## The shape was already generated

`gen-recordfields` writes each record type's contract body out with its types, its closed vocabularies, and a `?` on every field the body may omit:

```
{address?: {city?: string, …}, description?: string, display_name: string,
 domains?: [{domain: string, is_primary?: boolean}], industry?: string, …,
 size_band?: "1-10"|"11-50"|…, source?: string}
```

`display_name: string` with no `?` is the required marker; `domains?: [{domain: string, is_primary?: boolean}]` is the item shape the second refusal existed to teach. The refusal now carries that line.

## Why not in the tool description

Because reciting it there costs every call. `recordFieldsDescription`'s own comment measured it at 18% of the whole tool listing, and that judgement stands — this change does not touch it. A refusal is paid only when it happens, by the caller who has just proved it does not know the vocabulary. It is the same split `Cause` and `Guidance` already make on this error and for the same reason: the refused keys are the caller's own text and ride the echo bound, the accepted shape is ours and is not bounded.

## One pair, so the doors cannot disagree

`writeShapes` pairs the reflected types the decoder binds against with the rendered line a refusal hands back. Before, a caller could in principle be judged against one map and told about another; now `createWriteShapes` and `updateWriteShapes` are the only two things a call site can pass. Held by a test that an update refusal offers the update body's shape and not the create's — `relationship` differs sharply between the two.

## Tests

Two new, both mutation-verified (removing the rendered lookup reds them): an organization create refusal carries `domains?: [{domain: string, is_primary?: boolean}]` and the unmarked-required `display_name: string`; a relationship create refusal carries `kind`'s closed vocabulary. Plus the update-door pair above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refused create/update field lists now carry each record type's full contract shape — field types, required markers, and closed vocabularies — instead of just the accepted field names, so callers can fix a rejected payload in one round trip instead of several.

- Old refusals named accepted fields only; callers then got refused again on types and requirements (e.g. `domains` must be an array of objects, `kind` is required).
- Refusals now use the generated shape line from `gen-recordfields`, which includes JSON types, closed vocabularies, and the `?` marker for optional fields.
- The tool description still omits the shape (reciting it cost 18% of the listing on every call), so it's only paid on refusal.
- Create and update refusals now pair the validation type with the rendered shape, so the two doors can't disagree about what a record type accepts.

<sup>Written for commit 6d6ec3996154a1c303390adc60c5e243680267b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

