### PR TITLE
An approval blocks one call, not the rest of the task

### DIFF
--- a/backend/internal/modules/agents/explain.go
+++ b/backend/internal/modules/agents/explain.go
@@ -328,7 +328,14 @@ const maxRemedyBudget = 4 * httperr.MaxFaultText
 // human's inbox: what it would do, and which of the two moves to make.
 //
 // The summary is the sentence the human's own card carries, so the person and
-// the agent are waiting on one described thing. It is escaped and bounded here
+// the agent are waiting on one described thing.
+//
+// IT ALSO SAYS WHAT IS NOT BLOCKED, because an agent reads a refusal as a stop.
+// Asked to merge two words and then give the survivor a meaning, a measured run
+// staged the merge, relayed the summary correctly, and finished with "Confirm
+// and I'll proceed, then add the description afterward" — deferring an
+// independent auto-execute write behind a human's answer it never needed. The
+// approval binds one call; nothing in the answer said so. It is escaped and bounded here
 // because a caller chose part of it — a field name off the patch — and a
 // workspace record supplied the rest, and neither is this program's prose.
 func stagedExplanation(staged *workflow.StagedApprovalError) string {
@@ -342,8 +349,8 @@ func stagedExplanation(staged *workflow.StagedApprovalError) string {
 			" Do not stage another: repeat this call with \"approval_id\": \"" +
 			staged.ApprovalID.String() + "\"."
 	}
-	return "This is a confirm-first (🟡) action: a person answers it before it runs, and not the " +
-		"credential that proposed it. " + what + " Tell the user what it would do, in those words — " +
-		"they release it in the CRM, and read_approval shows the whole proposal. Once they have, " +
-		"repeat this call with \"approval_id\": \"" + staged.ApprovalID.String() + "\"."
+	return "Confirm-first (🟡): a person answers this before it runs. " + what +
+		" Tell them that, in those words; they release it in the CRM, and this exact call then " +
+		"repeats with \"approval_id\": \"" + staged.ApprovalID.String() + "\". " +
+		"Blocks THIS call only — do the rest of what you were asked that does not depend on it."
 }

--- a/backend/internal/modules/agents/stagedanswer_test.go
+++ b/backend/internal/modules/agents/stagedanswer_test.go
@@ -128,11 +128,49 @@ func TestTheStagedExplanationBoundsTheSummaryItRelays(t *testing.T) {
 	srv := NewDispatcher(nil, nil, "t", "0").
 		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
 
-	said := srv.explain("update_record", &workflow.StagedApprovalError{
-		ApprovalID: ids.New[ids.ApprovalKind](), Summary: strings.Repeat("k", 4000),
+	id := ids.New[ids.ApprovalKind]()
+	// Asserted as "the answer stops growing", which is what a bound IS — rather
+	// than against a byte figure beside the prose, which the next sentence added
+	// to this branch would have to be remembered in.
+	long := srv.explain("update_record", &workflow.StagedApprovalError{
+		ApprovalID: id, Summary: strings.Repeat("k", 4000),
 	})
-	if len(said) > workflow.MaxStagedSummary+400 {
-		t.Errorf("a 4000-byte summary produced a %d-byte answer, so the caller chose how much "+
-			"the server writes back at it", len(said))
+	longer := srv.explain("update_record", &workflow.StagedApprovalError{
+		ApprovalID: id, Summary: strings.Repeat("k", 40000),
+	})
+	if len(long) != len(longer) {
+		t.Errorf("a summary ten times longer produced a longer answer (%d then %d bytes), so the "+
+			"caller chooses how much the server writes back at it", len(long), len(longer))
+	}
+	// Asserted as growth and not as a byte ceiling. A ceiling here would have to
+	// restate the branch's own prose to know what to subtract — the two openings
+	// differ by the sentence that introduces the summary — and would then be a
+	// second copy of the text it guards. What the bound is FOR is that the
+	// caller cannot make this answer arbitrarily long, and that is what growth
+	// measures.
+	if len(long) > 4000 {
+		t.Errorf("a 4000-byte summary produced a %d-byte answer, so it was not bounded at all",
+			len(long))
+	}
+}
+
+// A 🟡 answer is read as a stop, and it is a stop for ONE call.
+//
+// Asked to merge two tags and then give the survivor a description, a measured
+// run staged the merge, relayed its summary correctly, and ended with "Confirm
+// and I'll proceed, then add the description afterward" — holding an
+// independent auto-execute write behind an approval it did not need. The answer
+// had told it what was blocked and never what was not.
+func TestAStagedAnswerSaysTheRestOfTheTaskIsNotBlocked(t *testing.T) {
+	t.Parallel()
+	srv := NewDispatcher(nil, nil, "t", "0").
+		WithLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+
+	said := srv.explain("merge_tags", &workflow.StagedApprovalError{
+		ApprovalID: ids.New[ids.ApprovalKind](), Summary: "Fold tag \"A\" into \"B\"",
+	})
+	if !strings.Contains(said, "THIS call only") {
+		t.Errorf("the answer does not say what is still doable, so a caller defers work the "+
+			"approval never blocked:\n%s", said)
 	}
 }


### PR DESCRIPTION
## What the transcript showed

`case32_two_words_for_one_thing` asks for two things: merge `Strategic Accts` into `Strategic Account`, and give the survivor a description. From the sonnet sweep, run 1:

```
merge_tags {"tag_id": "…Accts", "into_tag_id": "…Account"}
  → This is a confirm-first (🟡) action: … Nothing was changed yet; it would Fold
    tag "Strategic Accts" into "Strategic Account", releasing the name
    "Strategic Accts". Tell the user what it would do, in those words — …
```

and the final answer:

> This needs your approval: it would fold tag "Strategic Accts" into "Strategic Account", releasing the name "Strategic Accts" (not reversible). **Confirm and I'll proceed, then add the description afterward.**

The relay is exactly right — #5186 landed and the summary reached the caller verbatim. What went wrong next is that `update_tag` never ran. The model held an independent write behind an approval that did not block it, and criterion 3 ("the surviving word now carries the meaning the user asked for") failed on all three runs for that reason.

The answer told it what was blocked. It never said what was not.

## The change

```
Confirm-first (🟡): a person answers this before it runs. Nothing was changed yet;
it would "…". Tell them that, in those words; they release it in the CRM, and this
exact call then repeats with "approval_id": "…". Blocks THIS call only — do the
rest of what you were asked that does not depend on it.
```

The branch is tightened while the sentence goes in: it no longer points at `read_approval` for a description, because the description is now in the answer.

## The bound's test is asserted as growth

A byte ceiling here would have to restate the branch's own prose to know what to subtract — the summary and no-summary openings differ by the sentence that introduces the summary — and would become a second copy of the text it guards, failing on the next word added. What the bound is *for* is that a caller cannot make this answer arbitrarily long, so the test sends 4000 bytes and 40000 bytes and requires the same answer length. Mutation-verified: removing `echoSafe` reds both the escape and the bound.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the confirm-first approval answer so it says the approval blocks only this one call, not the rest of the task. The old answer told the agent what was blocked but never what wasn't, so a measured run deferred an independent auto-execute write behind an approval it never needed.

- The answer now tells the agent to do the rest of what was asked that doesn't depend on the approval.
- Removed the `read_approval` pointer since the summary is now part of the answer itself.
- The bound test now asserts the answer length stops growing (same for 4000 and 40000 byte summaries) instead of checking a byte ceiling.

<sup>Written for commit b20cdb779dc213ab1b523eb9d08bbc93462cbad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

