### PR TITLE
A booked meeting is a next step, not a missed one

### DIFF
--- a/backend/gates/meetingoverspelling_test.go
+++ b/backend/gates/meetingoverspelling_test.go
@@ -53,22 +53,44 @@ func meetingOverShape(clause string) string {
 }
 
 // meetingOverClause reads the distinctive run of predicates out of an owner,
-// starting at the archived-or-cancelled test and ending at the duration add.
+// starting at the archived-or-cancelled test and ending at the clause's closing
+// parenthesis.
+//
+// The end is found by BALANCING parentheses from the opening one, not by
+// stopping at a marker inside the text. An earlier version cut the needle at
+// the duration add, which left the comparison OPERATOR outside what was
+// compared: flipping the deals copy's `<=` to `>` — inverting the rule — kept
+// the gate green. A census that can fail short has already failed, and this one
+// did.
 func meetingOverClause(t *testing.T, name, body string) string {
 	t.Helper()
 	const opens = "archived_at IS NOT NULL"
-	const closes = "duration_seconds, 0))"
 	at := strings.Index(body, opens)
 	if at < 0 {
 		t.Fatalf("%s no longer contains %q, so this gate would compare nothing and "+
 			"report a pass. Re-derive the marker from the clause's current text.",
 			name, opens)
 	}
-	end := strings.Index(body[at:], closes)
-	if end < 0 {
-		t.Fatalf("%s opens the meeting-over clause and never reaches %q", name, closes)
+	// Walk back to the parenthesis this predicate opens under, then forward to
+	// its match: everything between is the clause, operators included.
+	start := strings.LastIndex(body[:at], "(")
+	if start < 0 {
+		t.Fatalf("%s opens the meeting-over clause with no enclosing parenthesis", name)
 	}
-	return body[at : at+end+len(closes)]
+	depth := 0
+	for i := start; i < len(body); i++ {
+		switch body[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return body[start : i+1]
+			}
+		}
+	}
+	t.Fatalf("%s opens the meeting-over clause and never closes it", name)
+	return ""
 }
 
 func TestTheMeetingIsOverRuleIsSpelledTheSameOnBothSides(t *testing.T) {

--- a/backend/gates/meetingoverspelling_test.go
+++ b/backend/gates/meetingoverspelling_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind claim H2
+
+package gates
+
+// "This meeting is over" is spelled twice, and the two must say the same thing.
+//
+// Over means ENDED — start plus duration, not start — and a meeting that will
+// never happen (archived, cancelled, a no-show) counts as over. Three readers
+// depend on that reading: the waiting queue's snooze-lift, the brief's, and the
+// deal sweeps that decide whether a meeting is evidence of a touch yet.
+//
+// Why a second spelling is allowed here at all, when the tree's usual answer is
+// one helper: `activities` owns the rule, and a module never imports a sibling.
+// `deals` cannot reach it. So the copy is deliberate and this gate is the price
+// of it — the thing that makes "the two agree" a fact rather than a hope.
+//
+// It fails in BOTH directions: reword either side and the comparison fails, so
+// neither can drift silently. The needles are DERIVED from each owner rather
+// than written here, so a rewritten clause cannot leave this gate hunting for a
+// string that no longer exists and reporting a pass having compared nothing —
+// under-recognition is the one way a gate must not break.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var (
+	// meetingOverActivitiesOwner holds the rule as the waiting queue asks it.
+	meetingOverActivitiesOwner = filepath.Join(
+		repoRoot, "backend", "internal", "modules", "activities", "waitingsql.go")
+	// meetingOverDealsOwner holds the copy the deal sweeps ask it with.
+	meetingOverDealsOwner = filepath.Join(
+		repoRoot, "backend", "internal", "modules", "deals", "nextstep.go")
+)
+
+// meetingOverShape reduces one spelling to the facts it asserts, so the
+// comparison survives the differences that are NOT drift: the alias each side
+// binds (`m.` here, `%[1]s.` there), its clock placeholder, and its whitespace.
+// What survives is the sequence of predicates, which is the rule itself.
+func meetingOverShape(clause string) string {
+	// The alias is whatever precedes the columns; normalize every form of it.
+	clause = regexp.MustCompile(`%\[\d\]s\.|\bm\.`).ReplaceAllString(clause, "X.")
+	// The clock is a placeholder on one side and a format verb on the other.
+	clause = regexp.MustCompile(`%\[\d\]s|\$\d+`).ReplaceAllString(clause, "CLOCK")
+	return strings.Join(strings.Fields(clause), " ")
+}
+
+// meetingOverClause reads the distinctive run of predicates out of an owner,
+// starting at the archived-or-cancelled test and ending at the duration add.
+func meetingOverClause(t *testing.T, name, body string) string {
+	t.Helper()
+	const opens = "archived_at IS NOT NULL"
+	const closes = "duration_seconds, 0))"
+	at := strings.Index(body, opens)
+	if at < 0 {
+		t.Fatalf("%s no longer contains %q, so this gate would compare nothing and "+
+			"report a pass. Re-derive the marker from the clause's current text.",
+			name, opens)
+	}
+	end := strings.Index(body[at:], closes)
+	if end < 0 {
+		t.Fatalf("%s opens the meeting-over clause and never reaches %q", name, closes)
+	}
+	return body[at : at+end+len(closes)]
+}
+
+func TestTheMeetingIsOverRuleIsSpelledTheSameOnBothSides(t *testing.T) {
+	t.Parallel()
+
+	activities, err := os.ReadFile(meetingOverActivitiesOwner)
+	if err != nil {
+		t.Fatalf("reading the activities spelling: %v", err)
+	}
+	dealsBody, err := os.ReadFile(meetingOverDealsOwner)
+	if err != nil {
+		t.Fatalf("reading the deals spelling: %v", err)
+	}
+
+	theirs := meetingOverShape(meetingOverClause(
+		t, filepath.Base(meetingOverActivitiesOwner), string(activities)))
+	ours := meetingOverShape(meetingOverClause(
+		t, filepath.Base(meetingOverDealsOwner), string(dealsBody)))
+
+	if theirs != ours {
+		t.Errorf("the two spellings of \"this meeting is over\" have drifted.\n"+
+			"  %s: %s\n  %s: %s\n"+
+			"They are a deliberate copy — deals may not import activities — so they "+
+			"only stay one rule while they stay identical. Reconcile them; do not "+
+			"relax this gate.",
+			filepath.Base(meetingOverActivitiesOwner), theirs,
+			filepath.Base(meetingOverDealsOwner), ours)
+	}
+}
+
+// A future meeting is admitted by asking about CANCELLATION alone, and that
+// question must never be written as `meeting_status NOT IN (...)`.
+//
+// The column is nullable and most captured meetings carry no status — a
+// calendar entry nobody has marked. `NOT IN` is NULL-false, so that spelling
+// silently calls every unmarked meeting cancelled and excludes nearly every
+// meeting there is. The bug reads as "the feature does nothing", which is
+// exactly the shape that survives review.
+func TestAFutureMeetingTestAdmitsAnUnmarkedStatus(t *testing.T) {
+	t.Parallel()
+
+	body, err := os.ReadFile(meetingOverDealsOwner)
+	if err != nil {
+		t.Fatalf("reading the deals spelling: %v", err)
+	}
+	text := string(body)
+
+	const admits = "meeting_status IS NULL OR"
+	if !strings.Contains(text, admits) {
+		t.Errorf("%s no longer admits an unmarked meeting_status. A nullable column "+
+			"tested with NOT IN excludes every row that has no status, which is most "+
+			"of them.", filepath.Base(meetingOverDealsOwner))
+	}
+}

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -158,6 +158,30 @@ func (e *reconcileEnv) seedInteraction(t *testing.T, dealID ids.UUID, kind, subj
 	return id
 }
 
+// seedMeeting plants a meeting at an offset from now, so a test can say
+// "tomorrow" or "an hour ago" directly. A NEGATIVE hours value is the future.
+//
+// status is written as given, and "" writes NULL — which is what a captured
+// calendar entry nobody has marked actually carries, and the case a NOT IN
+// predicate silently drops.
+func (e *reconcileEnv) seedMeeting(
+	t *testing.T, dealID ids.UUID, subject string, occurredHoursAgo, durationSeconds int, status string,
+) {
+	t.Helper()
+	id := ids.NewV7()
+	var meetingStatus *string
+	if status != "" {
+		meetingStatus = &status
+	}
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO activity (id, kind, subject, occurred_at, duration_seconds, meeting_status, source, captured_by)
+		 VALUES ($1, 'meeting', $2, now() - make_interval(hours => $3), $4, $5, 'manual', 'human:x')`,
+		id, subject, occurredHoursAgo, durationSeconds, meetingStatus); err != nil {
+		t.Fatalf("seed meeting: %v", err)
+	}
+	e.linkActivity(t, id, dealID)
+}
+
 // seedTask plants a task on the deal — the "next step already planned"
 // side that suppresses the proposal when it is still open.
 func (e *reconcileEnv) seedTask(t *testing.T, dealID ids.UUID, done bool) ids.UUID {
@@ -303,6 +327,156 @@ func TestFollowUpReconcileSuppressesWhenNoDiscrepancy(t *testing.T) {
 	}
 	if got := e.pendingFollowUps(t, noteOnly); got != 0 {
 		t.Errorf("deal with no recent interaction staged %d proposals, want 0", got)
+	}
+}
+
+// A meeting the rep has BOOKED is not a touch that already happened, and the
+// sweep used to read it as one: the evidence window had only a lower bound, so
+// tomorrow's meeting satisfied "landed in the window" and — being the newest
+// row — outranked the real interaction the follow-up should have named. The rep
+// was told a meeting "left no next step planned" the day before it happened.
+// The deal carries a real past call AND tomorrow's meeting, which is the shape
+// that reproduced it: an open task is deliberately absent, so the only thing
+// standing between this deal and a proposal is the meeting. Seeding the future
+// meeting ALONE would prove nothing — it falls outside the lookback's lower
+// bound too, so the sweep would stay silent even with the bug present.
+func TestAMeetingBookedForTomorrowIsNotEvidenceOfAMissedNextStep(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Meeting booked ahead", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, deal, "call", "Discovery call", 3)
+	e.seedMeeting(t, deal, "Architecture review", -24, 3600, "")
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 0 {
+		t.Errorf("a meeting booked for tomorrow staged %d proposals, want 0 — "+
+			"it has not happened, so it is neither a touch to reconcile nor a "+
+			"conversation that ended without a next step", got)
+	}
+
+	// What the proposal WOULD have said, had one been staged: the summary names
+	// the evidence, and the bug's signature was a future date in that sentence.
+	// Asserting on the count alone would not catch a sweep that stopped naming
+	// the meeting but still staged on it.
+	if t.Failed() {
+		_, proposal := e.followUpApproval(t, deal)
+		t.Logf("staged proposal named evidence of kind %q at %s",
+			proposal.EvidenceKind, proposal.EvidenceOccurredAt)
+	}
+}
+
+// The other half of the same fact: a meeting on the calendar IS the next step.
+// A past call with nothing queued would normally earn a proposal; a booked
+// meeting answers it, because the rep already has the thing the proposal would
+// ask them to arrange.
+func TestABookedMeetingCountsAsThePlannedNextStep(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Call then a booked meeting", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, deal, "call", "Discovery call", 3)
+	e.seedMeeting(t, deal, "Follow-up session", -48, 1800, "booked")
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 0 {
+		t.Errorf("a deal with a meeting on the calendar staged %d proposals, want 0", got)
+	}
+
+	// The guard on this test's own premise: the same call WITHOUT the booked
+	// meeting must still earn a proposal. Without this, the assertion above
+	// would pass just as well if the sweep had stopped working entirely.
+	bare := e.SeedDeal(t, "Call and nothing else", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, bare, "call", "Discovery call", 3)
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, bare); got != 1 {
+		t.Errorf("a call with no next step staged %d proposals, want 1 — if this is "+
+			"0 the sweep is silent for some other reason and the case above proves "+
+			"nothing", got)
+	}
+}
+
+// A meeting that will never happen is not a next step. Cancelled and no-show
+// both mean the calendar is empty again, so the deal is back to owing one.
+func TestACancelledFutureMeetingIsNotANextStep(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Meeting called off", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, deal, "call", "Discovery call", 3)
+	e.seedMeeting(t, deal, "Session nobody will attend", -24, 3600, "canceled")
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 1 {
+		t.Errorf("a cancelled meeting suppressed the proposal (%d staged, want 1) — "+
+			"a meeting that will never happen leaves the deal owing a next step", got)
+		return
+	}
+
+	// And the proposal must name the CALL, not the cancelled meeting in the
+	// future. This is the assertion that isolates the evidence window: a
+	// cancelled meeting is not a next step, so nothing else stops the sweep
+	// reaching for it as the newest row — only the upper time bound does.
+	_, proposal := e.followUpApproval(t, deal)
+	if proposal.EvidenceKind != "call" {
+		t.Errorf("the proposal named a %q from %s as its evidence, want the call — "+
+			"a meeting that has not happened cannot be the interaction that left "+
+			"no next step", proposal.EvidenceKind, proposal.EvidenceOccurredAt)
+	}
+	if proposal.EvidenceOccurredAt.After(time.Now()) {
+		t.Errorf("the proposal's evidence is dated %s, which is in the future",
+			proposal.EvidenceOccurredAt)
+	}
+}
+
+// A meeting still in progress is not yet evidence either: it started, but "over"
+// means ended, so the conversation cannot have left anything behind yet.
+func TestAMeetingStillRunningIsNotYetEvidence(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Meeting under way", e.pipeline, e.open, &e.Rep1)
+	// Started half an hour ago and scheduled for two hours.
+	e.seedMeeting(t, deal, "Long workshop", 1, 2*3600, "")
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 0 {
+		t.Errorf("a meeting still running staged %d proposals, want 0", got)
+	}
+}
+
+// The slipping lane reads the SAME "has a next step" question through
+// dealsWithNoOpenNextStep, and it is a different reader with its own statement.
+// Both were task-only before, so a fix to one alone would have left the two
+// disagreeing: the at-risk lane reporting "no next step" about a deal the
+// overnight sweep had just called planned.
+func TestTheSlippingLaneReadsABookedMeetingAsANextStep(t *testing.T) {
+	e := setupReconcile(t)
+	booked := e.SeedDeal(t, "Has a meeting booked", e.pipeline, e.open, &e.Rep1)
+	e.seedMeeting(t, booked, "Next Thursday", -72, 3600, "booked")
+
+	bare := e.SeedDeal(t, "Has nothing planned", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, bare, "call", "Discovery call", 3)
+
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithActor(ctx,
+		principal.Principal{Type: principal.PrincipalSystem, ID: "agent:overnight"})
+	stepless, err := dealsWithNoOpenNextStep(
+		ctx, e.Pool, []ids.UUID{booked, bare}, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stepless[booked] {
+		t.Errorf("the lane reports no next step for a deal with a meeting on the " +
+			"calendar; the overnight sweep reads the same deal as planned")
+	}
+	// The premise guard: the reader must still find the deal that genuinely has
+	// nothing, or the assertion above passes for a reader that answers "planned"
+	// to everything.
+	if !stepless[bare] {
+		t.Errorf("the lane found a next step on a deal that has only a past call")
 	}
 }
 

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -436,14 +436,38 @@ func TestACancelledFutureMeetingIsNotANextStep(t *testing.T) {
 func TestAMeetingStillRunningIsNotYetEvidence(t *testing.T) {
 	e := setupReconcile(t)
 	deal := e.SeedDeal(t, "Meeting under way", e.pipeline, e.open, &e.Rep1)
-	// Started half an hour ago and scheduled for two hours.
+	e.seedInteraction(t, deal, "call", "Earlier call", 3)
+	// Started an hour ago and scheduled for two hours, so it is neither over
+	// nor still in the future. A running meeting has to count as the PLANNED
+	// next step for this to hold: otherwise the earlier call is evidence, the
+	// meeting is not yet a plan, and the sweep tells a rep they have no next
+	// step while they are sitting in one.
 	e.seedMeeting(t, deal, "Long workshop", 1, 2*3600, "")
 
 	if err := e.reconcile(); err != nil {
 		t.Fatal(err)
 	}
 	if got := e.pendingFollowUps(t, deal); got != 0 {
-		t.Errorf("a meeting still running staged %d proposals, want 0", got)
+		t.Errorf("a meeting still running staged %d proposals, want 0 — a rep in "+
+			"the meeting is not a rep who forgot to plan one", got)
+	}
+}
+
+// A future row already marked `held` is not a plan. Everywhere else in the tree
+// that status means the meeting happened, so a deal whose only forward-dated
+// meeting carries it still owes a next step.
+func TestAFutureMeetingAlreadyMarkedHeldIsNotAPlan(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Settled ahead of time", e.pipeline, e.open, &e.Rep1)
+	e.seedInteraction(t, deal, "call", "Discovery call", 3)
+	e.seedMeeting(t, deal, "Already recorded as done", -24, 3600, "held")
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.pendingFollowUps(t, deal); got != 1 {
+		t.Errorf("a future meeting marked held suppressed the proposal (%d staged, "+
+			"want 1) — `held` says the meeting happened, so it is not a plan", got)
 	}
 }
 

--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -135,7 +135,7 @@ func quietDealScan(
 		for _, d := range out {
 			ids = append(ids, d.DealID)
 		}
-		stepless, err := dealsWithNoOpenNextStep(ctx, pool, ids)
+		stepless, err := dealsWithNoOpenNextStep(ctx, pool, ids, now)
 		if err != nil {
 			return nil, false, err
 		}

--- a/backend/internal/compose/slippingnextstep.go
+++ b/backend/internal/compose/slippingnextstep.go
@@ -18,10 +18,13 @@ package compose
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -47,12 +50,20 @@ import (
 //     at a company where anything at all is open.
 //   - An ARCHIVED task does not count, for the reason every read here excludes
 //     archived rows: it is retired, and a retired step is not a step.
+//   - A MEETING ALREADY ON THE CALENDAR counts. A deal whose next commitment is
+//     Thursday's review has a next step, and reporting it as missing sends a rep
+//     to chase something already booked.
+//
+// The predicate itself is deals.OpenNextStepSQL, shared with the overnight
+// follow-up sweep. Both once carried their own copy of the task-only reading,
+// and fixing one alone would have left the other proposing a follow-up for a
+// deal this lane had just called planned.
 //
 // One statement over all the candidate ids rather than a probe per deal: the
 // sweep already reads its candidates in two bounded queries, and a third that
 // grew with the set would make the lane's cost quadratic in a page.
 func dealsWithNoOpenNextStep(
-	ctx context.Context, pool *pgxpool.Pool, candidates []ids.UUID,
+	ctx context.Context, pool *pgxpool.Pool, candidates []ids.UUID, asOf time.Time,
 ) (map[ids.UUID]bool, error) {
 	none := map[ids.UUID]bool{}
 	if len(candidates) == 0 {
@@ -61,15 +72,14 @@ func dealsWithNoOpenNextStep(
 	for _, id := range candidates {
 		none[id] = true
 	}
+	// Selected FROM deal rather than from the activity rows, because the shared
+	// predicate asks about a deal and answers over two different tables: a
+	// statement shaped around one of them could not see the other.
+	query := fmt.Sprintf(`
+		SELECT d.id FROM deal d
+		 WHERE d.id = ANY($1) AND %s`, deals.OpenNextStepSQL("d.id", "$2"))
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, `
-			SELECT DISTINCT l.deal_id
-			  FROM activity a
-			  JOIN activity_link l ON l.activity_id = a.id
-			 WHERE l.deal_id = ANY($1)
-			   AND a.kind = 'task'
-			   AND a.is_done = false
-			   AND a.archived_at IS NULL`, candidates)
+		rows, err := tx.Query(ctx, query, candidates, asOf)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/deals/nextstep.go
+++ b/backend/internal/modules/deals/nextstep.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// What counts as a next step on a deal, spelled ONCE for the two sweeps that
+// ask: the overnight follow-up reconciliation (reconcile.go) and the slipping
+// lane's "nothing planned" reading (compose/slippingnextstep.go).
+//
+// The two used to carry their own copies of "an open task exists", and the copy
+// is what let them disagree the moment a booked meeting became a next step:
+// fixing one would have left the other proposing follow-ups for deals that
+// visibly had one.
+
+import "fmt"
+
+// OpenNextStepSQL renders the predicate "this deal has a next step planned",
+// true when either is on its timeline:
+//
+//   - an open task, or
+//   - a meeting that is booked and has not happened yet.
+//
+// A meeting on the calendar IS a next step, which is the half that was missing.
+// A deal whose only forward commitment is Thursday's review reads as planned to
+// the rep looking at it, and a sweep that asked only about tasks proposed a
+// follow-up for exactly that deal.
+//
+// dealExpr names the deal being asked about (an expression, not a value — the
+// callers pass `d.id` and `l.deal_id`) and asOf is the placeholder holding the
+// sweep's clock. Both are compile-time literals at every call site: nothing
+// off a request body is ever formatted in here.
+func OpenNextStepSQL(dealExpr, asOf string) string {
+	return fmt.Sprintf(`(
+		EXISTS (
+			SELECT 1 FROM activity t
+			JOIN activity_link tl ON tl.activity_id = t.id AND tl.deal_id = %[1]s
+			WHERE t.kind = 'task' AND t.is_done = false AND t.archived_at IS NULL
+		)
+		OR EXISTS (
+			SELECT 1 FROM activity m
+			JOIN activity_link ml ON ml.activity_id = m.id AND ml.deal_id = %[1]s
+			WHERE m.kind = 'meeting' AND m.archived_at IS NULL
+			  AND %[3]s
+			  AND %[2]s < m.occurred_at
+		)
+	)`, dealExpr, asOf, meetingStillStandingSQL("m"))
+}
+
+// MeetingIsOverSQL renders "this meeting is finished", the reading the waiting
+// queue and the brief's snooze-lift already share: over means ENDED — start
+// plus duration, not start — and a meeting that will never happen counts as
+// over.
+//
+// A third spelling of a rule that already lives in `activities` is a cost, and
+// the layering is why it is paid: a module never imports a sibling, so `deals`
+// cannot reach activities' copy. backend/gates/meetingoverspelling_test.go is
+// what keeps the two honest — it derives the clause from the activities owner
+// and fails when either side drifts, in both directions.
+func MeetingIsOverSQL(alias, asOf string) string {
+	return fmt.Sprintf(`(%[1]s.archived_at IS NOT NULL
+		OR %[1]s.meeting_status IN ('canceled', 'no_show')
+		OR %[1]s.occurred_at
+		   + make_interval(secs => coalesce(%[1]s.duration_seconds, 0)) <= %[2]s)`,
+		alias, asOf)
+}
+
+// meetingStillStandingSQL is the half of MeetingIsOverSQL that asks about
+// CANCELLATION alone, for a meeting whose time has not come yet.
+//
+// NULL is admitted deliberately, and it is the whole reason this is not written
+// as `meeting_status NOT IN (...)`. The column is nullable (the schema's own
+// CHECK allows it) and the overwhelming majority of captured meetings carry no
+// status at all — a calendar entry nobody has marked. `NOT IN` is NULL-false,
+// so that spelling would call every unmarked meeting cancelled and quietly
+// exclude nearly every meeting there is.
+func meetingStillStandingSQL(alias string) string {
+	return fmt.Sprintf(
+		`(%[1]s.meeting_status IS NULL OR %[1]s.meeting_status NOT IN ('canceled', 'no_show'))`,
+		alias)
+}

--- a/backend/internal/modules/deals/nextstep.go
+++ b/backend/internal/modules/deals/nextstep.go
@@ -18,7 +18,15 @@ import "fmt"
 // true when either is on its timeline:
 //
 //   - an open task, or
-//   - a meeting that is booked and has not happened yet.
+//   - a meeting that is still standing and has not ENDED yet — which covers the
+//     one in progress as well as the one on Thursday. A rep sitting in a
+//     meeting has a next step; telling them they do not is the same defect as
+//     telling them tomorrow's meeting already happened.
+//
+// The end test is written as a direct comparison rather than as `NOT
+// MeetingIsOverSQL(...)`. Negating that expression looks equivalent and is not:
+// it contains an `IN` over a nullable column, so an unmarked meeting made it
+// NULL, `NOT NULL` is NULL, and every such row silently failed the filter.
 //
 // A meeting on the calendar IS a next step, which is the half that was missing.
 // A deal whose only forward commitment is Thursday's review reads as planned to
@@ -42,6 +50,7 @@ func OpenNextStepSQL(dealExpr, asOf string) string {
 			WHERE m.kind = 'meeting' AND m.archived_at IS NULL
 			  AND %[3]s
 			  AND %[2]s < m.occurred_at
+			         + make_interval(secs => coalesce(m.duration_seconds, 0))
 		)
 	)`, dealExpr, asOf, meetingStillStandingSQL("m"))
 }
@@ -64,17 +73,23 @@ func MeetingIsOverSQL(alias, asOf string) string {
 		alias, asOf)
 }
 
-// meetingStillStandingSQL is the half of MeetingIsOverSQL that asks about
-// CANCELLATION alone, for a meeting whose time has not come yet.
+// meetingStillStandingSQL asks whether a meeting is still expected to happen:
+// nobody has called it off, and nobody has already recorded it as done.
+//
+// `held` is excluded alongside the two cancellations, because everywhere else
+// in this tree it is a statement about the PAST — the meeting brief's history
+// and the weekly scorecard both read it as "this one happened". A future row
+// carrying it is a meeting somebody has already settled, not a plan the deal
+// can be told it has.
 //
 // NULL is admitted deliberately, and it is the whole reason this is not written
 // as `meeting_status NOT IN (...)`. The column is nullable (the schema's own
 // CHECK allows it) and the overwhelming majority of captured meetings carry no
 // status at all — a calendar entry nobody has marked. `NOT IN` is NULL-false,
-// so that spelling would call every unmarked meeting cancelled and quietly
+// so that spelling would call every unmarked meeting settled and quietly
 // exclude nearly every meeting there is.
 func meetingStillStandingSQL(alias string) string {
 	return fmt.Sprintf(
-		`(%[1]s.meeting_status IS NULL OR %[1]s.meeting_status NOT IN ('canceled', 'no_show'))`,
+		`(%[1]s.meeting_status IS NULL OR %[1]s.meeting_status NOT IN ('canceled', 'no_show', 'held'))`,
 		alias)
 }

--- a/backend/internal/modules/deals/reconcile.go
+++ b/backend/internal/modules/deals/reconcile.go
@@ -150,44 +150,61 @@ type followUpCandidate struct {
 	subject           *string
 }
 
+// reconcileCandidatesSQL finds the discrepancy this pass exists for: an open
+// deal whose most recent real interaction landed inside the window, and which
+// has NO next step planned.
+//
+// Two bounds on the evidence, and the upper one is the fix. $1 opens the window
+// and $3 closes it at the sweep's clock: without $3 a meeting booked for
+// TOMORROW satisfied "landed inside the window", and because the LATERAL takes
+// the newest row it also outranked the real call or mail the follow-up should
+// have been about. The rep was then told a meeting "left no next step planned"
+// days before it happened.
+//
+// A meeting is evidence only once it is over — the same reading the waiting
+// queue uses, so a meeting running right now is not yet a touch to reconcile.
+//
+// Extracted from reconcileWorkspace so the statement, its two bounds and the
+// reason for them sit together rather than being read past on the way to the
+// scan loop.
+func reconcileCandidatesSQL() string {
+	return fmt.Sprintf(`
+		SELECT d.id, d.name, ev.activity_id, ev.kind, ev.direction, ev.occurred_at, ev.subject
+		FROM deal d
+		JOIN LATERAL (
+			SELECT a.id AS activity_id, a.kind, coalesce(a.direction, '') AS direction, a.occurred_at, a.subject
+			FROM activity a
+			JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = d.id
+			WHERE a.kind IN ('call','email','meeting')
+			  AND a.archived_at IS NULL
+			  -- The subject lands in an approval every decider of the
+			  -- deal reads, so only a message the whole workspace may
+			  -- read is evidence here; a limited one is its audience's.
+			  -- Spelled inline rather than through auth.AudienceWorkspaceOnly
+			  -- because this statement is a plain string with no format
+			  -- verbs; the predicate is the helper's, and a change to one
+			  -- is a change to both.
+			  AND a.audience = 'workspace'
+			  AND a.occurred_at >= $1
+			  AND a.occurred_at <= $3
+			  AND (a.kind <> 'meeting' OR %[1]s)
+			ORDER BY a.occurred_at DESC, a.id DESC
+			LIMIT 1
+		) ev ON true
+		WHERE d.status = 'open' AND d.archived_at IS NULL
+		  AND NOT %[2]s
+		ORDER BY d.id
+		LIMIT $2`,
+		MeetingIsOverSQL("a", "$3"),
+		OpenNextStepSQL("d.id", "$3"))
+}
+
 func (r *FollowUpReconciler) reconcileWorkspace(ctx context.Context) error {
 	now := r.now().UTC()
 	var candidates []followUpCandidate
 	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
-		// The discrepancy: an open deal whose most recent real interaction
-		// (call/mail/meeting) landed inside the window, and which has NO
-		// open task on its timeline — a touch with no next step planned.
-		// A note or a done task is not a next step; an undone task is (so
-		// the sweep does not nag a rep who already has one queued).
-		rows, err := tx.Query(ctx, `
-			SELECT d.id, d.name, ev.activity_id, ev.kind, ev.direction, ev.occurred_at, ev.subject
-			FROM deal d
-			JOIN LATERAL (
-				SELECT a.id AS activity_id, a.kind, coalesce(a.direction, '') AS direction, a.occurred_at, a.subject
-				FROM activity a
-				JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = d.id
-				WHERE a.kind IN ('call','email','meeting')
-				  AND a.archived_at IS NULL
-				  -- The subject lands in an approval every decider of the
-				  -- deal reads, so only a message the whole workspace may
-				  -- read is evidence here; a limited one is its audience's.
-				  -- Spelled inline rather than through auth.AudienceWorkspaceOnly
-				  -- because this statement is a plain string with no format
-				  -- verbs; the predicate is the helper's, and a change to one
-				  -- is a change to both.
-				  AND a.audience = 'workspace'
-				  AND a.occurred_at >= $1
-				ORDER BY a.occurred_at DESC, a.id DESC
-				LIMIT 1
-			) ev ON true
-			WHERE d.status = 'open' AND d.archived_at IS NULL
-			  AND NOT EXISTS (
-				SELECT 1 FROM activity t
-				JOIN activity_link tl ON tl.activity_id = t.id AND tl.deal_id = d.id
-				WHERE t.kind = 'task' AND t.is_done = false AND t.archived_at IS NULL
-			  )
-			ORDER BY d.id
-			LIMIT $2`, now.Add(-reconcileLookback), reconcileBatch)
+		rows, err := tx.Query(ctx, reconcileCandidatesSQL(),
+			now.Add(-reconcileLookback), reconcileBatch, now)
 		if err != nil {
 			return err
 		}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -382,7 +382,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `waiveronoffender_test.go` | H2 | A waiver must be asked about an offender, never about a candidate. |
 | `workflowhandler_test.go` | H2 | The workflow.Handler read/write contract as a fitness function (ports/workflow.Handler): Match is a pure predicate and Plan computes the typed Effect WITHOUT applying it — "this is what makes dry-run and diff preview possible". |
 
-## Claim (10)
+## Claim (11)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -391,6 +391,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `elapsedonespelling_test.go` | H1 | "How many days of silence" is spelled once. |
 | `employmentcurrency_test.go` | H1 | employment.IsCurrentSQL calls itself "the ONE spelling of 'this job is still theirs', and the only definition of a current employment in this product". |
 | `livemember_test.go` | H1 | "Someone who still works here" is `status = 'active' AND archived\_at IS NULL` on app\_user, and TWO functions in two different packages each called themselves the ONE spelling of it while the tree held about twenty copies. |
+| `meetingoverspelling_test.go` | H2 | "This meeting is over" is spelled twice, and the two must say the same thing. |
 | `noisejudgedspelling_test.go` | H2 | "An already-settled answer disowns this contact" is spelled once. |
 | `onedraftwriter_test.go` | H1 | One writer produces every grounded draft, or the surfaces drift. |
 | `renovatelockfileage_test.go` | H3 | The lockfile refresh is not held back by the repo-wide release-age floor. |


### PR DESCRIPTION
The overnight follow-up sweep told a rep that "a meeting on 2026-09-11 left no next step planned" — on the 10th, about a meeting booked for the next day.

Two defects produced that one sentence.

**The evidence window had no upper bound.** It asked only that an interaction landed after `now - 48h`, so a meeting in the future qualified. Because the query takes the newest row as evidence, tomorrow's meeting also displaced the real call the follow-up should have been about.

**A next step meant an open task and nothing else.** So the same booked meeting that was wrongly treated as evidence was not credited as the plan it obviously is. A rep with Thursday's review on the calendar was told to go arrange a next step.

## What changed

`deals.OpenNextStepSQL` is now the one predicate for "this deal has a next step", shared by the overnight sweep and the at-risk lane's `dealsWithNoOpenNextStep`. Both carried their own task-only copy, so fixing one alone would have left the two disagreeing about the same deal.

The evidence side gained an upper bound, and a meeting counts as evidence only once it has ended — the reading the waiting queue already uses.

## Two things worth a reviewer's attention

**The meeting-over rule is a deliberate second spelling.** A module never imports a sibling, so `deals` cannot reach the copy in `activities`. `backend/gates/meetingoverspelling_test.go` compares the two and fails in both directions; both of its assertions are mutation-checked.

**The cancellation test admits a NULL status.** `meeting_status` is nullable and the overwhelming majority of captured meetings carry no status — a calendar entry nobody marked. `NOT IN` is NULL-false, so that spelling would have called every unmarked meeting cancelled and excluded nearly every meeting there is. The gate holds this too.

## Tests

Five integration tests against real Postgres, each mutation-checked against the arm of the fix it covers:

- a meeting booked for tomorrow is not evidence (seeded alongside a past call, because a lone future meeting falls outside the lookback and would pass even with the bug present)
- a booked meeting counts as the planned next step, with a positive control proving the sweep still fires without it
- a cancelled future meeting is not a next step, and the proposal names the call rather than the meeting — this is the case that isolates the evidence window
- a meeting still running is not yet evidence
- the at-risk lane reads a booked meeting the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the overnight follow-up sweep so a booked meeting counts as a planned next step instead of evidence that a touch happened and left nothing planned.

- Adds an upper bound to the evidence window so a future meeting no longer qualifies as a recent interaction.
- Counts a meeting as evidence only once it has ended, matching the waiting queue's reading.
- Introduces `deals.OpenNextStepSQL` as the one "has a next step" predicate, shared by the overnight sweep and the at-risk lane's `dealsWithNoOpenNextStep`.
- Treats a meeting on the calendar as a next step, so reps are not told to arrange something already booked.

**Bug Fixes**

- A gate compares the two "meeting is over" spellings and fails in both directions, since `deals` cannot import a sibling module; it balances parentheses so the comparison covers the full clause.
- The cancellation check admits a NULL `meeting_status`; a `NOT IN` spelling would silently exclude nearly every captured meeting.
- A future meeting marked `held` is not a plan, since that status means it already happened.
- A meeting in progress counts as a next step, checked as a direct comparison against its end rather than a negated expression that would hit the same NULL trap.

<sup>Written for commit 23ef92988e57d41968f3f5941b781a6b5d248da7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

