### PR TITLE
A rep's morning work is decided by that rep

### DIFF
--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -140,7 +140,32 @@ func (s followUpStager) StageFollowUp(ctx context.Context, dealID ids.UUID, summ
 	if err != nil {
 		return fmt.Errorf("compose: marshal follow-up identity: %w", err)
 	}
-	_, _, err = s.svc.StageUnlessDeclined(ctx, approvals.StageInput{
+	// The task proposal records the deal's owner as the human it is FOR, the
+	// same as the drafted reply beside it.
+	//
+	// It is one rep's morning work: the follow-up it asks for lands on their
+	// deal, and approvals narrows a proposal to the seat it names. Staged under
+	// the sweep alone — as this path did — the row named nobody, so it appeared
+	// on every colleague's queue who held the grant, and a manager could answer
+	// a question the rep never saw.
+	//
+	// Only the owner's IDENTITY is needed here, not their authority: nothing in
+	// this staging reads under it. That is why this asks dealOwner rather than
+	// contextFor, which also resolves grants and would refuse a deal whose owner
+	// has since been suspended — a card that should still be filed for them.
+	staged := ctx
+	if s.owner.db != nil {
+		owner, err := s.owner.dealOwner(ctx, dealID)
+		if err != nil {
+			return err
+		}
+		// An unowned deal records nobody, which is what it honestly is: the
+		// proposal stays shared rather than being withheld from everyone.
+		if !owner.IsZero() {
+			staged = onBehalfOf(ctx, owner)
+		}
+	}
+	_, _, err = s.svc.StageUnlessDeclined(staged, approvals.StageInput{
 		Kind:           deals.FollowUpReconcileKind,
 		ProposedChange: canonical,
 		DiffHash:       hash,
@@ -248,11 +273,23 @@ func onBehalfOfOwner(sweepCtx, ownerCtx context.Context) context.Context {
 	if !ok || owner.UserID.IsZero() {
 		return sweepCtx
 	}
+	return onBehalfOf(sweepCtx, owner.UserID)
+}
+
+// onBehalfOf stamps one member as the human a staging acts for, leaving the
+// acting principal the sweep's own.
+//
+// Both halves are load-bearing, which is why this is one function rather than a
+// line at each call site. The actor stays the sweep, so the row remains a server
+// proposal with a NULL passport that the release executor may run, and its
+// provenance stays honest — no rep asked for this card. on_behalf_of names who
+// it is FOR, and that is what approvals narrows the decision to.
+func onBehalfOf(sweepCtx context.Context, owner ids.UUID) context.Context {
 	sweep, ok := principal.Actor(sweepCtx)
 	if !ok {
 		return sweepCtx
 	}
-	sweep.OnBehalfOf = owner.UserID
+	sweep.OnBehalfOf = owner
 	return principal.WithActor(sweepCtx, sweep)
 }
 

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -471,6 +471,67 @@ func TestAFutureMeetingAlreadyMarkedHeldIsNotAPlan(t *testing.T) {
 	}
 }
 
+// The task proposal records the deal's owner, driven through the REAL
+// reconciler rather than a hand-populated field: the writer is the half that
+// was missing, and a test that set on_behalf_of itself would have passed
+// against the bug it exists to catch.
+func TestATaskProposalRecordsTheDealOwnerItIsFor(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Owned by a rep", e.pipeline, e.open, &e.Rep1)
+	// A CALL, so the sweep takes the task-proposal path rather than drafting a
+	// reply — the drafted branch already recorded the owner.
+	e.seedInteraction(t, deal, "call", "Discovery call", 3)
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	var onBehalfOf *ids.UUID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT on_behalf_of FROM approval
+		  WHERE kind = 'deal_follow_up' AND target_entity_id = $1 AND status = 'pending'`,
+		deal).Scan(&onBehalfOf); err != nil {
+		t.Fatalf("reading the staged proposal: %v", err)
+	}
+	if onBehalfOf == nil {
+		t.Fatal("the proposal names nobody, so it sits on every colleague's queue " +
+			"and the rep whose deal it is has no claim on it")
+	}
+	if *onBehalfOf != e.Rep1 {
+		t.Errorf("the proposal is filed for %s, want the deal owner %s", *onBehalfOf, e.Rep1)
+	}
+}
+
+// A deal nobody owns records nobody, and that is the honest answer rather than a
+// gap: with no seat to name, withholding it would leave a proposal nobody at all
+// could act on.
+func TestAProposalOnAnUnownedDealRecordsNobody(t *testing.T) {
+	e := setupReconcile(t)
+	deal := e.SeedDeal(t, "Nobody owns this", e.pipeline, e.open, nil)
+	// CreateDeal falls back to the ACTING principal when handed no owner
+	// (storekit.OwnerOrActor), so a nil here seeds a deal owned by the admin.
+	// Clearing the column is the only way to reach the state this test is about
+	// — the one ON DELETE SET NULL leaves behind when a member is removed.
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE deal SET owner_id = NULL WHERE id = $1`, deal); err != nil {
+		t.Fatalf("clearing the deal owner: %v", err)
+	}
+	e.seedInteraction(t, deal, "call", "Discovery call", 3)
+
+	if err := e.reconcile(); err != nil {
+		t.Fatal(err)
+	}
+	var onBehalfOf *ids.UUID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT on_behalf_of FROM approval
+		  WHERE kind = 'deal_follow_up' AND target_entity_id = $1 AND status = 'pending'`,
+		deal).Scan(&onBehalfOf); err != nil {
+		t.Fatalf("reading the staged proposal: %v", err)
+	}
+	if onBehalfOf != nil {
+		t.Errorf("an unowned deal's proposal was filed for %s", *onBehalfOf)
+	}
+}
+
 // The slipping lane reads the SAME "has a next step" question through
 // dealsWithNoOpenNextStep, and it is a different reader with its own statement.
 // Both were task-only before, so a fix to one alone would have left the two

--- a/backend/internal/modules/approvals/authority.go
+++ b/backend/internal/modules/approvals/authority.go
@@ -17,7 +17,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/shared/apperrors"
-	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -63,6 +62,17 @@ const kindLinkedInMatch = "linkedin_match"
 // the release files the message under — and a typo across them would leave the
 // kind half-governed with nothing saying so.
 const kindHeldDraft = "held_draft"
+
+// kindDealFollowUp is the nightly reconciliation's "this conversation left no
+// next step" card, and kindTranscriptProposal the next step a transcript
+// recorded somebody committing to. Named rather than spelled: this module makes
+// three separate statements about each — the grants deciding it needs, that the
+// rep it was staged for decides it alone, and what filing it means — and a typo
+// across them would leave the kind half-governed with nothing saying so.
+const (
+	kindDealFollowUp       = "deal_follow_up"
+	kindTranscriptProposal = "transcript_proposal"
+)
 
 // KindScheduledSendHeld is the card a stopped scheduled message raises for the
 // rep who scheduled it (ADR-0104 §5). Exported because compose stages it and
@@ -248,14 +258,14 @@ var decisionGrants = map[string][]grantRequirement{
 	// the drafted task activity; the target deal's visibility gates who
 	// may see and decide it (targetVisible), the create grant gates the
 	// write the confirm performs.
-	"deal_follow_up": {{objectActivity, principal.ActionCreate}},
+	kindDealFollowUp: {{objectActivity, principal.ActionCreate}},
 	// Confirming a next step read out of a meeting transcript (S-E04.3)
 	// creates the task activity it proposed. The transcript activity it is
 	// filed against gates who may see and decide it (targetVisible); the
 	// create grant gates the write the confirm performs. Read is not enough:
 	// somebody who may read the transcript but not add to the timeline could
 	// otherwise release a task they could not have logged themselves.
-	"transcript_proposal": {{objectActivity, principal.ActionCreate}},
+	kindTranscriptProposal: {{objectActivity, principal.ActionCreate}},
 	// A proposed stage move is decided by whoever may MOVE the deal. Approving
 	// it performs the advance, so read is not enough: somebody who can see a
 	// deal but not steer it must not be able to release a move they could not
@@ -320,52 +330,6 @@ var targetResolvedGrants = map[string]principal.Action{
 	"create_record":  principal.ActionCreate,
 }
 
-// selfOnlyKinds are the staging kinds whose proposal is nobody's business but
-// the member it was staged for.
-//
-// The inbox is a SHARED surface by design — a manager triages what a rep
-// staged — and for almost every kind that is the point. It is wrong for one:
-// a LinkedIn match names a third party out of one member's imported address
-// book, people who never agreed to be in this CRM at all. The endpoints this
-// kind replaced were owner-only and said so; routing the same question through
-// a shared inbox would have handed every admin a readable copy of a
-// colleague's contact list, which is a bigger disclosure than the feature it
-// enables.
-//
-// So a self-only kind adds one predicate to the two below: the deciding human
-// must BE the member it was staged for. It is the inbox's mirror of the
-// webhooks module's selfOnlyEvents, which keeps the same three LinkedIn facts
-// off the workspace fan-out for the same reason.
-//
-// A step-up is the other: "may this agent keep reading" is a question about ONE
-// connection, and the only person who can answer it is the human whose authority
-// that connection borrows.
-// A held scheduled send is the third: the message is one rep's, the decision is
-// whether to retry it or abandon it, and nobody else has standing to answer.
-var selfOnlyKinds = map[string]bool{
-	kindLinkedInMatch:     true,
-	KindVolumeRelease:     true,
-	KindScheduledSendHeld: true,
-	// A vCard review is one member's own uploaded address book, exactly the
-	// LinkedIn-match shape: the staged card names a third party who never
-	// agreed to be in this CRM, and a shared inbox would hand every
-	// person:create holder a readable copy of a colleague's contacts.
-	"vcard_create": true,
-	// A held draft is the fourth, and it is about WHOSE MAILBOX the message
-	// leaves from rather than who may read it. Releasing one sends it, and the
-	// send stamps its identity from the approving human: comms.stagingUser
-	// takes the sending credential from the authenticated principal, and the
-	// display name and signature come from that same actor. So a colleague who
-	// approved a rep's draft did not authorise the rep's message — they sent
-	// their own, into a customer thread they were never part of, signed by
-	// themselves.
-	//
-	// The narrowing puts the decision back with the person the message would go
-	// out as. It is also what kindHeldDraft's own doc has always claimed ("held
-	// for the rep it was written for") and what nothing enforced.
-	kindHeldDraft: true,
-}
-
 // decidable is the ONE visibility-and-authority predicate for the inbox
 // and the decision: true when p holds every grant approving a would
 // require AND could read the staged target itself — the object-read grant
@@ -374,8 +338,9 @@ var selfOnlyKinds = map[string]bool{
 // gate can never drift apart — you see exactly what you could act on, and
 // what you cannot see you cannot decide (in either direction). Two shapes
 // narrow that to ONE seat, the member the row was staged for: a self-only
-// kind, and a staged create against a table whose rows belong to one human
-// each. An unknown kind (no mapping) or unknown target type is not
+// kind, a staged create against a table whose rows belong to one human
+// each, and a kind that is one rep's own morning work
+// (decidedByTheSeatStagedFor). An unknown kind (no mapping) or unknown target type is not
 // decidable: fail-closed.
 func decidable(ctx context.Context, tx pgx.Tx, p principal.Principal, a row) (bool, error) {
 	if requireDecisionGrants(p, a) != nil {
@@ -385,29 +350,6 @@ func decidable(ctx context.Context, tx pgx.Tx, p principal.Principal, a row) (bo
 		return false, nil
 	}
 	return targetDecidable(ctx, tx, a.TargetType, a.TargetID)
-}
-
-// withheldFromOtherSeats is the self-only narrowing of decidable, spelled once
-// because three reads apply it: the inbox scan through decidable, and the two
-// target-filtered reads (inbox.listForTarget, Service.PendingForTarget) which
-// settle target visibility for the record instead of per row and so cannot call
-// decidable itself. It reports the rows this caller must NOT see — true when the
-// staging is bound to one seat and p is not it.
-//
-// Two routes to the same predicate: a kind whose subject is one member's own
-// business, and a staged create against a table whose rows belong to one human
-// each — where no row exists yet for an ownership probe to ask. Fail-closed on a
-// missing stager: a proposal nobody is recorded for is one nobody may read, not
-// one everybody may.
-//
-// Held by: TestEveryApprovalsGrantFilterAlsoAppliesTheSelfOnlyNarrowing
-// (backend/gates/approvalselfonlyreaders_test.go) — it fails when a reader
-// filters rows with requireDecisionGrants and does not also call this.
-func withheldFromOtherSeats(p principal.Principal, a row) bool {
-	if !selfOnlyKinds[a.Kind] && !stagedForStagerOnly(a.TargetType, a.TargetID != nil) {
-		return false
-	}
-	return a.OnBehalfOf == nil || p.UserID == ids.Nil || a.OnBehalfOf.UUID != p.UserID
 }
 
 func requireDecisionGrants(p principal.Principal, a row) error {

--- a/backend/internal/modules/approvals/redeem.go
+++ b/backend/internal/modules/approvals/redeem.go
@@ -218,7 +218,7 @@ var contextTargetKinds = map[string]string{
 		"writes bump — and the same enrichment run that discovers the leads writes " +
 		"the company's profile fields, so the pin went stale before any human saw " +
 		"the lead and every accept failed for the row's lifetime.",
-	"deal_follow_up": "A reconciled follow-up is filed under the deal it is about, but the " +
+	kindDealFollowUp: "A reconciled follow-up is filed under the deal it is about, but the " +
 		"effect CREATES an activity and reads none of the deal's own fields. Its stager " +
 		"has always said it carries no pin, and stopped being right when the pin moved " +
 		"server-side: an overnight proposal waits until someone works their morning " +
@@ -231,7 +231,7 @@ var contextTargetKinds = map[string]string{
 		"disposition; it never writes the activity. Pinning bound the answer to a row " +
 		"that relinking, a participant correction or a subject fix bumps — every one of " +
 		"which is ordinary inbox work on the very message the question is about.",
-	"transcript_proposal": "A next step read out of a transcript is filed under the " +
+	kindTranscriptProposal: "A next step read out of a transcript is filed under the " +
 		"ACTIVITY carrying that transcript, because those lines are the evidence a human " +
 		"judges it on. The effect CREATES a task activity and never writes the transcript. " +
 		"Pinning would bind the answer to a row that relinking the meeting to a deal, or " +

--- a/backend/internal/modules/approvals/seatnarrowing.go
+++ b/backend/internal/modules/approvals/seatnarrowing.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Which staged proposals belong to ONE seat rather than to the shared inbox.
+//
+// The inbox is a shared surface by design — a manager triages what a rep staged
+// — so everything here is an exception to that, and each entry says which kind
+// of exception it is. Split out of authority.go because it is one concept with
+// one predicate, and because that file had grown past the length a reader can
+// hold at once.
+
+package approvals
+
+import (
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// selfOnlyKinds are the staging kinds whose proposal is nobody's business but
+// the member it was staged for.
+//
+// The inbox is a SHARED surface by design — a manager triages what a rep
+// staged — and for almost every kind that is the point. It is wrong for one:
+// a LinkedIn match names a third party out of one member's imported address
+// book, people who never agreed to be in this CRM at all. The endpoints this
+// kind replaced were owner-only and said so; routing the same question through
+// a shared inbox would have handed every admin a readable copy of a
+// colleague's contact list, which is a bigger disclosure than the feature it
+// enables.
+//
+// So a self-only kind adds one predicate to the two below: the deciding human
+// must BE the member it was staged for. It is the inbox's mirror of the
+// webhooks module's selfOnlyEvents, which keeps the same three LinkedIn facts
+// off the workspace fan-out for the same reason.
+//
+// A step-up is the other: "may this agent keep reading" is a question about ONE
+// connection, and the only person who can answer it is the human whose authority
+// that connection borrows.
+// A held scheduled send is the third: the message is one rep's, the decision is
+// whether to retry it or abandon it, and nobody else has standing to answer.
+var selfOnlyKinds = map[string]bool{
+	kindLinkedInMatch:     true,
+	KindVolumeRelease:     true,
+	KindScheduledSendHeld: true,
+	// A vCard review is one member's own uploaded address book, exactly the
+	// LinkedIn-match shape: the staged card names a third party who never
+	// agreed to be in this CRM, and a shared inbox would hand every
+	// person:create holder a readable copy of a colleague's contacts.
+	"vcard_create": true,
+	// A held draft is the fourth, and it is about WHOSE MAILBOX the message
+	// leaves from rather than who may read it. Releasing one sends it, and the
+	// send stamps its identity from the approving human: comms.stagingUser
+	// takes the sending credential from the authenticated principal, and the
+	// display name and signature come from that same actor. So a colleague who
+	// approved a rep's draft did not authorise the rep's message — they sent
+	// their own, into a customer thread they were never part of, signed by
+	// themselves.
+	//
+	// The narrowing puts the decision back with the person the message would go
+	// out as. It is also what kindHeldDraft's own doc has always claimed ("held
+	// for the rep it was written for") and what nothing enforced.
+	kindHeldDraft: true,
+}
+
+// decidedByTheSeatStagedFor is the WEAKER narrowing beside selfOnlyKinds: a
+// proposal that is one rep's morning work, decided by the rep it was staged
+// for.
+//
+// The difference from a self-only kind is what a missing stager means. These
+// carry no third party's data and no rep's mailbox, so a proposal recording
+// nobody is not a disclosure — it is a deal nobody owns, and it stays shared.
+//
+// Both entries are the overnight sweeps' output about ONE rep's deal. A manager
+// holding activity:create saw every rep's, which is not oversight: it is one
+// person's day appearing on somebody else's queue, where answering it takes the
+// question away from the rep who was going to act on it.
+var decidedByTheSeatStagedFor = map[string]bool{
+	// The nightly reconciliation's "this conversation left no next step" card,
+	// staged for the deal's owner.
+	kindDealFollowUp: true,
+	// A next step a transcript recorded somebody committing to, staged for the
+	// rep who asked for the recording to be read.
+	kindTranscriptProposal: true,
+}
+
+// withheldFromOtherSeats is the self-only narrowing of decidable, spelled once
+// because three reads apply it: the inbox scan through decidable, and the two
+// target-filtered reads (inbox.listForTarget, Service.PendingForTarget) which
+// settle target visibility for the record instead of per row and so cannot call
+// decidable itself. It reports the rows this caller must NOT see — true when the
+// staging is bound to one seat and p is not it.
+//
+// Two routes to the same predicate: a kind whose subject is one member's own
+// business, and a staged create against a table whose rows belong to one human
+// each — where no row exists yet for an ownership probe to ask. Fail-closed on a
+// missing stager: a proposal nobody is recorded for is one nobody may read, not
+// one everybody may.
+//
+// Held by: TestEveryApprovalsGrantFilterAlsoAppliesTheSelfOnlyNarrowing
+// (backend/gates/approvalselfonlyreaders_test.go) — it fails when a reader
+// filters rows with requireDecisionGrants and does not also call this.
+func withheldFromOtherSeats(p principal.Principal, a row) bool {
+	if selfOnlyKinds[a.Kind] || stagedForStagerOnly(a.TargetType, a.TargetID != nil) {
+		return a.OnBehalfOf == nil || p.UserID == ids.Nil || a.OnBehalfOf.UUID != p.UserID
+	}
+	if decidedByTheSeatStagedFor[a.Kind] {
+		// The nil case is the OPPOSITE of the arm above, and the difference is
+		// the point. A LinkedIn match with no stager recorded is one nobody may
+		// read: there is a third party in it and nothing says whose address
+		// book they came from, so absence fails closed. A follow-up on a deal
+		// nobody owns is honestly everybody's — no seat was skipped, because
+		// none exists — so absence leaves it shared.
+		return a.OnBehalfOf != nil && (p.UserID == ids.Nil || a.OnBehalfOf.UUID != p.UserID)
+	}
+	return false
+}

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -732,6 +732,47 @@ func TestEverySelfOnlyShapeIsWithheldFromEverySeatButTheOneItWasStagedFor(t *tes
 	}
 }
 
+// A rep's own morning work is decided by the rep, and the nil case is the
+// opposite of the self-only one above: a proposal recording nobody stays SHARED
+// rather than being withheld from everybody.
+//
+// Table-driven over the map so a kind enrolled tomorrow is covered without an
+// edit here — the enrolment is the decision, and a test that had to be updated
+// alongside it would be a second list to forget.
+func TestAProposalStagedForARepIsDecidedByThatRepAlone(t *testing.T) {
+	mine, theirs := ids.NewV7(), ids.NewV7()
+	subject := ids.From[ids.UserKind](mine)
+	rep := principal.Principal{UserID: mine, Permissions: principal.Permissions{RowScope: principal.RowScopeAll}}
+	manager := principal.Principal{UserID: theirs, Permissions: principal.Permissions{RowScope: principal.RowScopeAll}}
+
+	if len(decidedByTheSeatStagedFor) == 0 {
+		t.Fatal("no kind is enrolled at all — this walk covers nothing")
+	}
+	for kind := range decidedByTheSeatStagedFor {
+		t.Run(kind, func(t *testing.T) {
+			if selfOnlyKinds[kind] {
+				t.Fatal("this kind is ALSO self-only, so the arm under test never runs " +
+					"and the nil case below asserts the opposite rule")
+			}
+			forTheRep := row{Kind: kind, OnBehalfOf: &subject}
+			if !withheldFromOtherSeats(manager, forTheRep) {
+				t.Error("a colleague may decide a proposal staged for somebody else — " +
+					"answering it takes the question away from the rep who was going to act on it")
+			}
+			if withheldFromOtherSeats(rep, forTheRep) {
+				t.Error("the rep it was staged for cannot see their own proposal")
+			}
+			// An unowned deal records nobody. Nothing here is one person's
+			// private business, so it stays everybody's rather than nobody's.
+			unowned := row{Kind: kind}
+			if withheldFromOtherSeats(manager, unowned) {
+				t.Error("a proposal on a deal nobody owns was withheld from everyone, " +
+					"so nobody can act on it at all")
+			}
+		})
+	}
+}
+
 // DecisionGrantObjects is what the composition layer's satisfiability gate reads,
 // and it is load-bearing only if it names the SAME objects requireDecisionGrants
 // enforces. A gate certifying an object the decision does not demand — or blind to

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -773,6 +773,52 @@ func TestAProposalStagedForARepIsDecidedByThatRepAlone(t *testing.T) {
 	}
 }
 
+// The write side and the read side must narrow the SAME kinds.
+//
+// They run on opposite sides of one row — subjectScopedShape when it is staged,
+// withheldFromOtherSeats when it is read — and a kind narrowed on the read side
+// alone still matches across members on the write side. One seat's pending
+// proposal is then joined and handed to another, or superseded by it, or
+// suppressed by its rejection; each time the surviving row names a seat the
+// reader is not, so it is withheld from the person it was staged for.
+//
+// Derived from the maps rather than listed, so enrolling a kind in either one
+// carries the obligation with it.
+func TestEveryKindNarrowedOnReadIsAlsoNarrowedOnStaging(t *testing.T) {
+	seatNarrowed := map[string]bool{}
+	for kind := range selfOnlyKinds {
+		seatNarrowed[kind] = true
+	}
+	for kind := range decidedByTheSeatStagedFor {
+		seatNarrowed[kind] = true
+	}
+	if len(seatNarrowed) == 0 {
+		t.Fatal("no seat-narrowed kind found at all — this walk covers nothing")
+	}
+	for kind := range seatNarrowed {
+		t.Run(kind, func(t *testing.T) {
+			if !subjectScopedShape(StageInput{Kind: kind}) {
+				t.Error("this kind is decided by one seat but staged as if shared, so " +
+					"staging matches across members: a colleague's proposal is joined, " +
+					"superseded or suppressed by it, and the survivor names a seat the " +
+					"reader is not")
+			}
+		})
+	}
+
+	// The positive control. Without it this passes just as well if
+	// subjectScopedShape started answering true to everything, which would
+	// split every shared team proposal into one row per person.
+	shared := "merge_records"
+	if seatNarrowed[shared] {
+		t.Fatalf("the control kind %q is itself seat-narrowed, so it proves nothing", shared)
+	}
+	if subjectScopedShape(StageInput{Kind: shared}) {
+		t.Errorf("a SHARED kind was staged per-seat, which splits one team's proposal " +
+			"into a row for each member")
+	}
+}
+
 // DecisionGrantObjects is what the composition layer's satisfiability gate reads,
 // and it is load-bearing only if it names the SAME objects requireDecisionGrants
 // enforces. A gate certifying an object the decision does not demand — or blind to

--- a/backend/internal/modules/approvals/stagingsubject.go
+++ b/backend/internal/modules/approvals/stagingsubject.go
@@ -34,8 +34,18 @@ import (
 // Asked of the SHAPE rather than of a kind list at each statement, so a kind
 // added to selfOnlyKinds, or a table enrolled in probeOwnerOnly, inherits the
 // narrowing instead of quietly staying shared.
+//
+// It must answer for EVERY kind decidable narrows to a seat, not only the
+// self-only ones. The two run on opposite sides of one row — this when it is
+// written, decidable when it is read — so a kind narrowed on the read side
+// alone still MATCHES across members on the write side, and the mismatch has
+// three shapes, all silent: one seat's pending proposal is joined and handed
+// back to another, a second seat's differing payload supersedes the first's,
+// and one seat's rejection suppresses the other's. Each time, the row that
+// survives names a seat the reader is not, so it is withheld from the very
+// person it was staged for.
 func subjectScopedShape(in StageInput) bool {
-	if selfOnlyKinds[in.Kind] {
+	if selfOnlyKinds[in.Kind] || decidedByTheSeatStagedFor[in.Kind] {
 		return true
 	}
 	var targetType *string


### PR DESCRIPTION
Lars, reviewing his own Morning Brief, found Lena Fischer's work on it. The rows were overnight proposals staged on other reps' deals: a manager holding `activity:create` saw every one of them and could answer them first.

That is not oversight. Answering a rep's proposal takes the question away from the person who was going to act on it, and the rep never learns it was asked.

## Two changes, in order

**The task proposal never recorded who it was for.** Only the drafted-reply path called `onBehalfOfOwner`; the ordinary task path staged under the sweep alone and left `on_behalf_of` NULL. The database confirmed it — the pending `deal_follow_up` card named nobody. So a rule keyed on that field would have preserved exactly the card it was meant to move, and the writer had to be fixed first.

It reads `dealOwner` rather than `contextFor`: only the owner's identity is needed here, nothing stages under their authority. `contextFor` also resolves grants and would refuse a deal whose owner has since been suspended, which is a card that should still be filed for them.

**Then the narrowing.** `deal_follow_up` and `transcript_proposal` join a new `decidedByTheSeatStagedFor` map, decided by the seat they name.

## The nil case is the interesting half

This narrowing is deliberately weaker than the `selfOnlyKinds` one beside it, and they disagree about a missing stager on purpose:

- A LinkedIn match with no stager is one **nobody** may read. There is a third party in it and nothing says whose address book they came from, so absence fails closed.
- A follow-up on a deal nobody owns is honestly **everybody's**. No seat was skipped, because none exists. Withholding it would leave a proposal nobody at all could act on.

Both directions are asserted.

## Trade-off, stated per kind

A manager can no longer cover an absent rep. For `deal_follow_up` the nightly reconciler re-proposes after the 72h expiry. For `transcript_proposal` **nothing re-asks** — a rep asked for one recording to be read, and no sweep re-stages it — so an expired transcript step is gone until the rep re-runs the reading.

## Tests

Unit tests are table-driven over the map, so a kind enrolled tomorrow is covered without an edit. Both clauses are mutation-checked: reverting the narrowing fails the colleague assertion, and adopting the self-only nil rule fails the unowned-deal one.

The integration tests drive the **real reconciler** rather than setting `on_behalf_of` by hand — a hand-populated field would have passed against the bug this exists to catch. Note `CreateDeal` falls back to the acting principal, so the unowned case clears the column explicitly; passing nil seeds a deal owned by the admin, which is how the first version of that test failed and found its own premise wrong.

`authority.go` crossed the 500-line cap, so the seat-narrowing concept moved to its own file rather than taking a waiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overnight task proposals (deal follow-ups and transcript next steps) showing up on every colleague's queue. These are now decided by the rep they were staged for, so a manager can no longer answer a rep's question first.

**Changes**
- The task staging path now records the deal owner as the person the proposal is for; only the drafted-reply path did before.
- Approvals narrows these two kinds to the seat staged for, with a weaker nil rule than self-only kinds: a proposal on an unowned deal stays shared.
- The owner is read by identity only, not by grants, so a card for a suspended owner is still filed.
- Staging narrows by seat too, matching the read side, so a colleague's proposal can no longer be joined, superseded, or suppressed by another seat's.

**Trade-off**
- Managers can no longer cover for an absent rep.
- An expired transcript proposal is gone until the rep re-runs the reading; follow-ups re-propose after 72 hours.
- A reassigned deal leaves a pending proposal with the previous owner; this predates the change and is tracked as #5199.

<sup>Written for commit 2a5d2c2f27594560db4a34a0222278dc940b1b68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

