### PR TITLE
The export follows the identities a subject was merged from

### DIFF
--- a/backend/internal/modules/privacy/sar.go
+++ b/backend/internal/modules/privacy/sar.go
@@ -189,11 +189,11 @@ func AssembleSAR(ctx context.Context, db *database.DB, personID ids.PersonID) (S
 		// The subject's addresses and lead twins, read BEFORE the sections run:
 		// the staged-approvals section matches on them, and unlike erasure this
 		// path destroys nothing, so they are still there to read.
-		emails, leads, err := subjectReach(ctx, tx, personID)
+		emails, leads, identities, err := subjectReach(ctx, tx, personID)
 		if err != nil {
 			return err
 		}
-		sections := sarSections(&pkg, personID, emails, leads)
+		sections := sarSections(&pkg, personID, emails, leads, identities)
 
 		subject, err := rowMaps(ctx, tx, `
 			SELECT p.id, p.full_name, p.first_name, p.last_name, p.title,
@@ -327,26 +327,84 @@ func readableValue(value any) any {
 // Erasure cannot read them at that point — it has already destroyed them — so
 // the predicate takes them as arguments and each caller supplies them from
 // wherever it still can.
-func subjectReach(ctx context.Context, tx pgx.Tx, personID ids.PersonID) ([]string, []ids.UUID, error) {
+func subjectReach(ctx context.Context, tx pgx.Tx, personID ids.PersonID) ([]string, []ids.UUID, []ids.UUID, error) {
 	emails, err := subjectStrings(ctx, tx,
 		`SELECT email FROM person_email WHERE person_id = $1 AND email <> ''`, personID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("reading the subject's addresses for the export: %w", err)
+		return nil, nil, nil, fmt.Errorf("reading the subject's addresses for the export: %w", err)
 	}
-	rows, err := tx.Query(ctx, `SELECT id FROM lead WHERE promoted_person_id = $1`, personID.UUID)
+	// THE ADDRESSES OF EVERY IDENTITY THIS SUBJECT IS, not only the surviving
+	// row's. A merged-away predecessor keeps its own person_email rows, and the
+	// sections that match by address — the participant reach above, staged
+	// approvals — would otherwise miss a conversation held under the address
+	// the subject used before the cleanup.
+	priorEmails, err := subjectStrings(ctx, tx, `
+		SELECT email FROM person_email
+		 WHERE person_id IN (SELECT id FROM person WHERE merged_into_id = $1)
+		   AND email <> ''`, personID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("reading the subject's lead twins for the export: %w", err)
+		return nil, nil, nil, fmt.Errorf("reading the merged-away addresses for the export: %w", err)
+	}
+	emails = append(emails, priorEmails...)
+	// LEAD TWINS OF EVERY IDENTITY TOO. A lead promoted into a record that was
+	// later merged away points at the PREDECESSOR, so following only the
+	// survivor's promotions loses the lead-keyed proof A6 deliberately leaves
+	// on the lead.
+	rows, err := tx.Query(ctx, `
+		SELECT id FROM lead
+		 WHERE promoted_person_id = $1
+		    OR promoted_person_id IN (SELECT id FROM person WHERE merged_into_id = $1)`,
+		personID.UUID)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("reading the subject's lead twins for the export: %w", err)
 	}
 	defer rows.Close()
 	leads := []ids.UUID{}
 	for rows.Next() {
 		var id ids.UUID
 		if err := rows.Scan(&id); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		leads = append(leads, id)
 	}
-	return emails, leads, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, nil, nil, err
+	}
+	// EVERY PERSON ID THIS SUBJECT IS. The surviving row first, then each
+	// record merged into it — which keeps its own rows on purpose, because a
+	// predecessor's objection is evidence that THAT record's subject refused,
+	// and repointing it would make the history say somebody else objected.
+	//
+	// One hop, not a walk: a merge repoints the loser's own predecessors at the
+	// survivor as it goes, so the pointers are flat rather than a chain.
+	identities, err := subjectIdentities(ctx, tx, personID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return emails, leads, identities, nil
+}
+
+// subjectIdentities returns the survivor's own id plus the id of each record
+// merged into them, which together are the person rows an export must reach.
+func subjectIdentities(ctx context.Context, tx pgx.Tx, personID ids.PersonID) ([]ids.UUID, error) {
+	// The survivor's own id is carried in the WHERE rather than selected as a
+	// bare parameter: a lone `SELECT $1` in a UNION gives Postgres nothing to
+	// infer the type from, and it refuses to prepare the statement.
+	rows, err := tx.Query(ctx, `
+		SELECT id FROM person WHERE id = $1 OR merged_into_id = $1`, personID.UUID)
+	if err != nil {
+		return nil, fmt.Errorf("reading the identities this subject is, for the export: %w", err)
+	}
+	defer rows.Close()
+	out := []ids.UUID{}
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
 }
 
 // subjectStrings runs a one-column text query into a slice.

--- a/backend/internal/modules/privacy/sarmergelineage_integration_test.go
+++ b/backend/internal/modules/privacy/sarmergelineage_integration_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package privacy
+
+// What the Art. 15 export says about a subject whose duplicate was merged into
+// them.
+//
+// A merge retires one record and keeps the other. The consent module carries
+// the retiring subject's STOPS onto the survivor deliberately, and just as
+// deliberately leaves the originals where they are: the predecessor's row is
+// evidence that THAT record's subject objected, and rewriting its subject would
+// make the history say the objection was made about somebody else.
+//
+// So the data is split across two ids on purpose, and the export followed only
+// one of them. subjectReach walks promoted_person_id — the LEAD twin of a
+// promotion — and never merged_into_id, so a subject asking what is held about
+// them was answered from the surviving row alone. Everything on the predecessor
+// was omitted: the proof rows behind their consent, the bases their mail stood
+// on, and the objection they made before the cleanup that merged them.
+//
+// Art. 15 owes what is HELD. The installation holds all of it.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedMergedPredecessor retires one person into another the way a merge does:
+// the predecessor keeps its row and its data, and points at the survivor.
+func seedMergedPredecessor(ctx context.Context, t *testing.T, e *sarIdentifierEnv, survivor ids.PersonID) ids.PersonID {
+	t.Helper()
+	var predecessor ids.UUID
+	if err := e.owner.QueryRow(ctx, `
+		INSERT INTO person (full_name, source, captured_by, merged_into_id, archived_at)
+		VALUES ('Merged Duplicate', 'test', 'human:x', $1, now())
+		RETURNING id`, survivor).Scan(&predecessor); err != nil {
+		t.Fatalf("seeding the merged-away person: %v", err)
+	}
+	return ids.From[ids.PersonKind](predecessor)
+}
+
+// TestTheExportFollowsAPredecessorIdentity is the whole slice: a subject whose
+// duplicate was merged into them must be shown what is held under BOTH ids.
+func TestTheExportFollowsAPredecessorIdentity(t *testing.T) {
+	e := setupSARIdentifiers(t)
+	predecessor := seedMergedPredecessor(e.ctx, t, e, e.person)
+
+	// The objection the predecessor made. A6 carries a COPY onto the survivor
+	// and keeps this one as evidence, so the export that reads only the
+	// survivor shows the copy and never the act that produced it.
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO communication_suppression (person_id, kind, source, captured_by, decided_by_level)
+		VALUES ($1, 'marketing_objection', 'operator_ui', 'human:x', 'subject')`,
+		predecessor); err != nil {
+		t.Fatalf("seeding the predecessor's objection: %v", err)
+	}
+	// And the ground a message to them stood on, which stays where it was
+	// written: nothing copies a basis forward.
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO communication_basis (person_id, kind, valid_from, captured_by)
+		VALUES ($1, 'subject_initiated_correspondence', now() - interval '30 days', 'human:x')`,
+		predecessor); err != nil {
+		t.Fatalf("seeding the predecessor's basis: %v", err)
+	}
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	if len(pkg.CommunicationSuppression) == 0 {
+		t.Error("the export carries no stop at all, though the record merged into this subject " +
+			"holds an objection they made — a subject asking what is held is told the " +
+			"installation holds nothing about the refusal it is still acting on")
+	}
+	if len(pkg.CommunicationBases) == 0 {
+		t.Error("the export carries no communication basis, though the merged-away record holds " +
+			"one — the subject is shown neither the mail nor the ground it stood on")
+	}
+}
+
+// A LEAD PROMOTED INTO A RECORD THAT WAS LATER MERGED AWAY still belongs to the
+// subject who survives.
+//
+// The lead's own proof rows stay keyed by lead_id — a promotion carries the
+// consent forward and leaves the evidence where it was recorded — so the export
+// reaches them through the lead twin. That twin points at the PREDECESSOR, so
+// following only the survivor's promotions loses it.
+func TestTheExportReachesALeadPromotedIntoAMergedAwayRecord(t *testing.T) {
+	e := setupSARIdentifiers(t)
+	predecessor := seedMergedPredecessor(e.ctx, t, e, e.person)
+
+	var leadID ids.UUID
+	if err := e.owner.QueryRow(e.ctx, `
+		INSERT INTO lead (full_name, email, source, captured_by, promoted_person_id, promoted_at)
+		VALUES ('Promoted Then Merged', 'twin@sar.test', 'test', 'human:x', $1, now())
+		RETURNING id`, predecessor).Scan(&leadID); err != nil {
+		t.Fatalf("seeding the lead twin: %v", err)
+	}
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO communication_suppression (lead_id, kind, source, captured_by, decided_by_level)
+		VALUES ($1, 'marketing_objection', 'operator_ui', 'human:x', 'subject')`,
+		leadID); err != nil {
+		t.Fatalf("seeding the lead's objection: %v", err)
+	}
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	if len(pkg.CommunicationSuppression) == 0 {
+		t.Error("the export carries no stop, though a lead promoted into a record later merged " +
+			"into this subject holds an objection — two hops of ordinary cleanup and the " +
+			"refusal disappears from what the subject is told we hold")
+	}
+}
+
+// AND THE REACH DOES NOT WIDEN INTO A STRANGER. merged_into_id is followed in
+// one direction only: records merged INTO this subject are theirs, and the
+// record this subject was merged into belongs to somebody else.
+func TestTheExportDoesNotReachTheRecordThisSubjectWasMergedInto(t *testing.T) {
+	e := setupSARIdentifiers(t)
+
+	var survivor ids.UUID
+	if err := e.owner.QueryRow(e.ctx, `
+		INSERT INTO person (full_name, source, captured_by)
+		VALUES ('The Surviving Stranger', 'test', 'human:x') RETURNING id`).Scan(&survivor); err != nil {
+		t.Fatalf("seeding the survivor: %v", err)
+	}
+	// This subject was merged INTO them, which is the opposite direction.
+	if _, err := e.owner.Exec(e.ctx,
+		`UPDATE person SET merged_into_id = $1 WHERE id = $2`, survivor, e.person); err != nil {
+		t.Fatalf("retiring the subject: %v", err)
+	}
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO communication_suppression (person_id, kind, source, captured_by, decided_by_level)
+		VALUES ($1, 'marketing_objection', 'operator_ui', 'human:x', 'subject')`,
+		survivor); err != nil {
+		t.Fatalf("seeding the stranger's objection: %v", err)
+	}
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	if len(pkg.CommunicationSuppression) != 0 {
+		t.Errorf("the export carries %d stop(s) belonging to the record this subject was merged "+
+			"INTO — that is somebody else's data in this subject's package",
+			len(pkg.CommunicationSuppression))
+	}
+}

--- a/backend/internal/modules/privacy/sarmergelineage_integration_test.go
+++ b/backend/internal/modules/privacy/sarmergelineage_integration_test.go
@@ -68,6 +68,12 @@ func TestTheExportFollowsAPredecessorIdentity(t *testing.T) {
 		t.Fatalf("seeding the predecessor's basis: %v", err)
 	}
 
+	// And the decision that objection produced. Reading the survivor alone left
+	// the export contradicting itself: it would carry the predecessor's stop
+	// while withholding every refusal that stop caused, so the subject sees the
+	// rule and never the times it was applied to them.
+	seedRefusalAgainst(e.ctx, t, e, predecessor)
+
 	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
 	if err != nil {
 		t.Fatalf("AssembleSAR: %v", err)
@@ -81,6 +87,10 @@ func TestTheExportFollowsAPredecessorIdentity(t *testing.T) {
 	if len(pkg.CommunicationBases) == 0 {
 		t.Error("the export carries no communication basis, though the merged-away record holds " +
 			"one — the subject is shown neither the mail nor the ground it stood on")
+	}
+	if len(pkg.CommunicationDecisions) == 0 {
+		t.Error("the export carries no communication decision, though the merged-away record holds " +
+			"one — the package names the stop and withholds every refusal that stop produced")
 	}
 }
 
@@ -154,5 +164,43 @@ func TestTheExportDoesNotReachTheRecordThisSubjectWasMergedInto(t *testing.T) {
 		t.Errorf("the export carries %d stop(s) belonging to the record this subject was merged "+
 			"INTO — that is somebody else's data in this subject's package",
 			len(pkg.CommunicationSuppression))
+	}
+}
+
+// seedRefusalAgainst records one transmit refusal about the named subject. A
+// decision row hangs off a real delivery, so the mail it refused is seeded with
+// it: the foreign key is what keeps a decision from outliving the message it
+// was taken about.
+func seedRefusalAgainst(ctx context.Context, t *testing.T, e *sarIdentifierEnv, subject ids.PersonID) {
+	t.Helper()
+	var user ids.UUID
+	if err := e.owner.QueryRow(ctx, `SELECT id FROM app_user LIMIT 1`).Scan(&user); err != nil {
+		t.Fatalf("reading the fixture's user: %v", err)
+	}
+	activity, delivery := ids.NewV7(), ids.NewV7()
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO activity (id, kind, occurred_at, source, captured_by)
+		VALUES ($1, 'email', now(), 'manual', 'user:'||$2::text)`, activity, user); err != nil {
+		t.Fatalf("seeding the activity the refused mail hangs off: %v", err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO comms_outbound (id, activity_id, user_id, provider, message_id,
+		                            recipients, cc, subject, body, references_chain,
+		                            consent_purpose, status)
+		VALUES ($1, $2, $3, 'gmail', $4,
+		        jsonb_build_array('merged@sar.test'::text), '[]'::jsonb,
+		        'A marketing note', 'the message that was refused', '[]'::jsonb,
+		        'marketing', 'parked')`,
+		delivery, activity, user, delivery.String()+"@margince.test"); err != nil {
+		t.Fatalf("seeding the refused delivery: %v", err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO communication_decision
+		  (delivery_id, decision_set_id, recipient_address, subject_kind, subject_id,
+		   phase, requested_category, resolved_category, verdict, reason_code, mode, actor)
+		VALUES ($1, $2, 'merged@sar.test', 'person', $3,
+		        'transmit', 'marketing', 'marketing', 'deny', 'subject_request', 'enforce', 'user:'||$4::text)`,
+		delivery, ids.NewV7(), subject, user); err != nil {
+		t.Fatalf("seeding the refusal about the merged-away record: %v", err)
 	}
 }

--- a/backend/internal/modules/privacy/sarpreparable_integration_test.go
+++ b/backend/internal/modules/privacy/sarpreparable_integration_test.go
@@ -61,7 +61,7 @@ func TestEverySARSectionStatementResolvesAgainstTheSchema(t *testing.T) {
 	// added to any chapter is covered the day it is added, and one that stops
 	// being reachable stops being checked, which is correct in both directions.
 	var pkg SARPackage
-	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()})
+	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()}, []ids.UUID{ids.NewV7()})
 
 	// A floor, because a gather list that came back empty would report the same
 	// clean pass as one that resolved every statement. The number is the shape

--- a/backend/internal/modules/privacy/sarreachable_test.go
+++ b/backend/internal/modules/privacy/sarreachable_test.go
@@ -43,7 +43,7 @@ var fromJoin = regexp.MustCompile(`(?is)\b(?:from|join)\s+([a-z_][a-z0-9_]*)`)
 func tablesTheExportReaches(t *testing.T) map[string]bool {
 	t.Helper()
 	var pkg SARPackage
-	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()})
+	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()}, []ids.UUID{ids.NewV7()})
 
 	// A floor, for the reason the schema check beside this one carries one: an
 	// empty gather list reads exactly like a complete one, and every assertion
@@ -114,7 +114,7 @@ func TestEveryPromisedTableIsActuallyAssembled(t *testing.T) {
 // first and could fail this.
 func TestTheConfirmLinkSectionCarriesNoCredential(t *testing.T) {
 	var pkg SARPackage
-	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()})
+	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()}, []ids.UUID{ids.NewV7()})
 
 	var probed int
 	for _, section := range sections {

--- a/backend/internal/modules/privacy/sarsections.go
+++ b/backend/internal/modules/privacy/sarsections.go
@@ -18,13 +18,13 @@ import (
 // query set is compliance-critical — adding or dropping a source changes what
 // the export owes the data subject. It is assembled chapter by chapter, and the
 // order the chapters concatenate in is the order the export runs them in.
-func sarSections(pkg *SARPackage, personID ids.PersonID, emails []string, leads []ids.UUID) []sarSection {
+func sarSections(pkg *SARPackage, personID ids.PersonID, emails []string, leads, identities []ids.UUID) []sarSection {
 	sections := sarIdentitySections(pkg)
 	sections = append(sections, sarRecordSections(pkg)...)
 	sections = append(sections, sarMessagingSections(pkg, personID, emails, leads)...)
 	sections = append(sections, sarConsentSections(pkg)...)
 	sections = append(sections, sarConsentLinkSections(pkg)...)
-	sections = append(sections, sarCommunicationSections(pkg, personID, leads)...)
+	sections = append(sections, sarCommunicationSections(pkg, personID, leads, identities)...)
 	return append(sections, sarProvenanceSections(pkg)...)
 }
 
@@ -257,7 +257,7 @@ func sarConsentSections(pkg *SARPackage) []sarSection {
 // subject's own history. A person-keyed section would silently withhold the
 // earliest part of their record, which is the half they are least likely to
 // know about and most likely to be asking after.
-func sarCommunicationSections(pkg *SARPackage, personID ids.PersonID, leads []ids.UUID) []sarSection {
+func sarCommunicationSections(pkg *SARPackage, personID ids.PersonID, leads, identities []ids.UUID) []sarSection {
 	subjects := append([]any{}, personID)
 	return []sarSection{
 		{
@@ -267,14 +267,30 @@ func sarCommunicationSections(pkg *SARPackage, personID ids.PersonID, leads []id
 		   WHERE subject_id = $1 OR (subject_kind = 'lead' AND subject_id = ANY($2))`,
 			append(subjects, leads),
 		},
-		{&pkg.CommunicationBases, `SELECT kind, thread_key, valid_from, valid_until, note,
+		// EVERY IDENTITY, not the surviving row alone. A merge keeps the
+		// retiring subject's own basis and suppression rows where they are —
+		// the predecessor's objection is evidence that THAT record's subject
+		// refused — so an export reading only the survivor shows the copy the
+		// merge carried and never the act behind it.
+		//
+		// identities ALREADY CONTAINS the survivor, so these two take it in
+		// place of the bare person id rather than beside it: a parameter a
+		// statement never references is one Postgres cannot infer a type for,
+		// and it refuses to prepare the statement at all.
+		{
+			&pkg.CommunicationBases, `SELECT kind, thread_key, valid_from, valid_until, note,
 		          captured_at, revoked_at
 		   FROM communication_basis
-		   WHERE person_id = $1 OR lead_id = ANY($2)`, append(subjects, leads)},
-		{&pkg.CommunicationSuppression, `SELECT kind, source, address, recorded_at, revoked_at,
+		   WHERE person_id = ANY($1) OR lead_id = ANY($2)`,
+			[]any{identities, leads},
+		},
+		{
+			&pkg.CommunicationSuppression, `SELECT kind, source, address, recorded_at, revoked_at,
 		          decided_by_level
 		   FROM communication_suppression
-		   WHERE person_id = $1 OR lead_id = ANY($2)`, append(subjects, leads)},
+		   WHERE person_id = ANY($1) OR lead_id = ANY($2)`,
+			[]any{identities, leads},
+		},
 	}
 }
 

--- a/backend/internal/modules/privacy/sarsections.go
+++ b/backend/internal/modules/privacy/sarsections.go
@@ -24,7 +24,7 @@ func sarSections(pkg *SARPackage, personID ids.PersonID, emails []string, leads,
 	sections = append(sections, sarMessagingSections(pkg, personID, emails, leads)...)
 	sections = append(sections, sarConsentSections(pkg)...)
 	sections = append(sections, sarConsentLinkSections(pkg)...)
-	sections = append(sections, sarCommunicationSections(pkg, personID, leads, identities)...)
+	sections = append(sections, sarCommunicationSections(pkg, leads, identities)...)
 	return append(sections, sarProvenanceSections(pkg)...)
 }
 
@@ -257,15 +257,21 @@ func sarConsentSections(pkg *SARPackage) []sarSection {
 // subject's own history. A person-keyed section would silently withhold the
 // earliest part of their record, which is the half they are least likely to
 // know about and most likely to be asking after.
-func sarCommunicationSections(pkg *SARPackage, personID ids.PersonID, leads, identities []ids.UUID) []sarSection {
-	subjects := append([]any{}, personID)
+func sarCommunicationSections(pkg *SARPackage, leads, identities []ids.UUID) []sarSection {
 	return []sarSection{
+		// EVERY IDENTITY here too, for the reason the bases and suppressions
+		// below take it: a decision taken about a record that was later merged
+		// into this subject is a decision about this subject, and reading the
+		// survivor alone leaves the export contradicting itself — it would
+		// carry a predecessor's suppression while withholding the decisions
+		// that suppression produced.
 		{
 			&pkg.CommunicationDecisions, `SELECT phase, requested_category, resolved_category, verdict,
 		          reason_code, basis, suppression, mode, decided_at
 		   FROM communication_decision
-		   WHERE subject_id = $1 OR (subject_kind = 'lead' AND subject_id = ANY($2))`,
-			append(subjects, leads),
+		   WHERE (subject_kind IS DISTINCT FROM 'lead' AND subject_id = ANY($1))
+		      OR (subject_kind = 'lead' AND subject_id = ANY($2))`,
+			[]any{identities, leads},
 		},
 		// EVERY IDENTITY, not the surviving row alone. A merge keeps the
 		// retiring subject's own basis and suppression rows where they are —

--- a/backend/internal/modules/privacy/sarwithheld_integration_test.go
+++ b/backend/internal/modules/privacy/sarwithheld_integration_test.go
@@ -122,7 +122,7 @@ func TestNoWithheldColumnReachesTheAssembledExport(t *testing.T) {
 	}
 
 	var pkg SARPackage
-	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()})
+	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()}, []ids.UUID{ids.NewV7()})
 
 	var probed int
 	for _, section := range sections {


### PR DESCRIPTION
## What was wrong

A subject access request export read the surviving person row alone. When a duplicate had been merged into that subject, everything left on the predecessor was absent from the package: its consent proof rows, its addresses, the grounds its mail stood on, and the stop the predecessor's subject recorded.

The stop is the sharpest case. A merge copies live suppressions onto the survivor and deliberately keeps the originals where they are, because the original row is the evidence that record's subject objected. The export showed the copy and never the act behind it.

## What changed

`subjectReach` in `backend/internal/modules/privacy/sar.go` now also returns the person identities the subject is: their own id plus every row whose `merged_into_id` points at them. `subjectIdentities` reads them in one hop, which is enough because a merge repoints the loser's own predecessors at the survivor as it goes.

The communication bases and suppression sections in `sarsections.go` read by `ANY` over that set. The prior-email and lead-twin queries widen the same way, so a lead promoted into a record that was later merged away is now reachable.

## What deliberately did not change

The reach does not widen upward. A record merged into this subject is theirs. The record this subject was merged into belongs to somebody else, and pulling it in would put a stranger's data in the package. `TestTheExportDoesNotReachTheRecordThisSubjectWasMergedInto` holds that line.

## Proof

Three new tests in `sarmergelineage_integration_test.go`. The lineage test was mutation-verified: reverting `subjectIdentities` to read only the survivor's own id reproduces both failures verbatim.

Full `make check-backend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the subject access export so a subject whose duplicate was merged into them is answered from every record they are, not the surviving row alone — the predecessor's consent proofs, communication bases, the refusals its stop caused, and the objection itself were previously missing from the package.

- `subjectReach` now returns the subject's own id plus every row whose `merged_into_id` points at them, and the communication sections — including decisions — read over that set.
- The prior-email and lead-twin queries widen the same way, so a lead promoted into a record later merged away stays reachable.
- The reach does not widen upward: the record this subject was merged into belongs to somebody else and remains outside the package.
- Adds `sarmergelineage_integration_test.go` covering both directions, with the stranger boundary held by test.

<sup>Written for commit ae1f048d6eec2ea56fa6cddb947ea3908baccc13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

