### PR TITLE
claim: TestPreferenceCenterOptOutBlocksAgentSend is red on main

### DIFF
--- a/.claim-marker
+++ b/.claim-marker
@@ -1,0 +1,1 @@
+claiming TestPreferenceCenterOptOutBlocksAgentSend


### PR DESCRIPTION
## Tests I am taking

- `TestPreferenceCenterOptOutBlocksAgentSend` (`backend/internal/compose/preference_agent_integration_test.go:97`)

Nothing else. If your red is a different test in the integration lane, you are first for it — this claim does not cover you.

## What it says

```
preference_agent_integration_test.go:97:
  granted agent send → person.update: permission denied, want success
```

## It is main, not a PR

Reproduced on a clean detached worktree at `origin/main` (`14192f373`), outside any branch:

```
make test-it DIR=backend/internal/compose RUN=TestPreferenceCenterOptOutBlocksAgentSend
--- FAIL: TestPreferenceCenterOptOutBlocksAgentSend (0.28s)
```

It fails four of the six integration shards on every open PR that reruns, which is how I met it — #5188 reran twice with the same four shards red and no `--- FAIL` visible in the shard logs.

## Suspicion, not yet a diagnosis

`14192f373` "A withdrawal link outlives the mail that carried it" (#5196) is the most recent commit touching the preference centre. The assertion is about an agent grant on `person.update`, so the likely shape is an authorization or grant path that moved with it. I will confirm before changing anything.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Claims the failing integration test `TestPreferenceCenterOptOutBlocksAgentSend` so no one else duplicates the investigation.

The test fails on a clean checkout of `origin/main`, not from any PR, across four of six integration shards. The likely cause is the recent preference center change in #5196, but that's not confirmed yet.

<sup>Written for commit 5aa210c9e7069a0c2f339573c42fbbf1441c77f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

