### PR TITLE
test(perf-mobile): the benchmark says which reads were in flight during a slow open

### DIFF
--- a/frontend/e2e/perf-mobile.spec.ts
+++ b/frontend/e2e/perf-mobile.spec.ts
@@ -69,6 +69,24 @@ function nearestRank(samples: number[], quantile: number): number {
 }
 
 /**
+ * Every read the page issued, with the moment it was issued.
+ *
+ * `in_order` said the slow opens arrive on a CLOCK — indices 5, 11 and 17 of a
+ * 20-sample run, a period of six, which at that run's pace is ~33s against the
+ * 30s `STALE_TIME_MS` in src/app/queryclient.ts. What it cannot say is whether
+ * the stale refetch is what the slow sample was WAITING for, and that is the
+ * whole remaining question: a burst that fires beside a slow open and a burst
+ * that causes one look identical in a latency series.
+ *
+ * Recorded here rather than inferred from a laptop, because the two machines
+ * disagree and only the runner's answer counts. Locally the same bursts fire on
+ * the same clock and cost the open nothing, even with the renderer throttled 6x
+ * — but only the BROWSER is throttled there, while these route handlers keep a
+ * full-speed Node process to themselves. On a two-core runner they share.
+ */
+const reads: { path: string; at: number }[] = [];
+
+/**
  * Open one record from the list, and answer what the click cost.
  *
  * Extracted so the discarded first open below runs the SAME path as a measured
@@ -108,6 +126,13 @@ test("MOBILE-AC-2: record open holds the 300ms perceived budget on Fast-3G at 39
 }) => {
   await mockApi(page);
   await throttle(page);
+  // Paths only: a full URL adds the origin to every line and answers nothing
+  // this is asking. Non-API traffic is left out — the bundle and the fonts are
+  // shaped by CDP and settle long before the first sample.
+  page.on("request", (r) => {
+    const path = new URL(r.url()).pathname;
+    if (path.startsWith("/v1/")) reads.push({ path, at: Date.now() });
+  });
 
   // ONE DISCARDED OPEN FIRST, and it is not a kindness to the number.
   //
@@ -128,8 +153,15 @@ test("MOBILE-AC-2: record open holds the 300ms perceived budget on Fast-3G at 39
   await openOneRecord(page);
 
   const samples: number[] = [];
+  // One window per sample, so a read can be attributed to the open it landed
+  // inside rather than to the run as a whole.
+  const windows: { path: string; at: number }[][] = [];
   for (let i = 0; i < SAMPLES; i++) {
-    samples.push(await openOneRecord(page));
+    const before = reads.length;
+    const ms = await openOneRecord(page);
+    const end = Date.now();
+    samples.push(ms);
+    windows.push(reads.slice(before).filter((r) => r.at >= end - ms));
   }
 
   const measured = nearestRank(samples, 0.95);
@@ -160,6 +192,25 @@ test("MOBILE-AC-2: record open holds the 300ms perceived budget on Fast-3G at 39
     `perfbench [fast-3g/390px]: record_open_perceived ` +
       `in_order=${JSON.stringify(samples)}`,
   );
+  // The reads that were in flight during each open, aligned index-for-index with
+  // `in_order` above. This is the line that separates the two readings a clock
+  // allows: a slow open that carries reads is one waiting on them, and a slow
+  // open that carries none is a clock that only correlates.
+  console.log(
+    `perfbench [fast-3g/390px]: record_open_perceived ` +
+      `reads_in_window=${JSON.stringify(windows.map((w) => w.length))}`,
+  );
+  // And WHICH reads, for the windows that had any — the counts say a burst
+  // happened, the paths say what the app decided to re-read, and a fix has to
+  // name endpoints rather than a number.
+  windows.forEach((w, i) => {
+    if (w.length > 0) {
+      console.log(
+        `perfbench [fast-3g/390px]: record_open_perceived ` +
+          `sample=${i} ms=${samples[i]} reads=${JSON.stringify(w.map((r) => r.path))}`,
+      );
+    }
+  });
   // Written BEFORE the assertion, deliberately: a breach is the run whose
   // number a reader most wants to see, and recording afterwards would leave
   // the published page green while the run went red.

--- a/frontend/e2e/perf-mobile.spec.ts
+++ b/frontend/e2e/perf-mobile.spec.ts
@@ -93,7 +93,9 @@ const reads: { path: string; at: number }[] = [];
  * one. A warm-up that took a shortcut would leave whatever it skipped to be
  * paid by sample 1, which is the defect it exists to remove.
  */
-async function openOneRecord(page: Page): Promise<number> {
+async function openOneRecord(
+  page: Page,
+): Promise<{ startedAt: number; ms: number }> {
   await page.goto("/#/contacts");
   // Anchor on a settled screen before measuring, for the reason ac.spec.ts
   // records: a click during hydration lands on a row whose handler is not
@@ -118,7 +120,12 @@ async function openOneRecord(page: Page): Promise<number> {
   await expect(
     page.getByRole("heading", { level: 1, name: "Anna Weber", exact: true }),
   ).toBeVisible();
-  return Date.now() - start;
+  // The START is returned rather than left to be derived. A caller computing it
+  // as `end - ms` from its own clock reads LATER than this one did, because the
+  // await returns before that line runs — and the reads it would drop are the
+  // ones issued in the first milliseconds by the click, which are precisely the
+  // ones the window is being measured to catch.
+  return { startedAt: start, ms: Date.now() - start };
 }
 
 test("MOBILE-AC-2: record open holds the 300ms perceived budget on Fast-3G at 390px", async ({
@@ -158,10 +165,13 @@ test("MOBILE-AC-2: record open holds the 300ms perceived budget on Fast-3G at 39
   const windows: { path: string; at: number }[][] = [];
   for (let i = 0; i < SAMPLES; i++) {
     const before = reads.length;
-    const ms = await openOneRecord(page);
-    const end = Date.now();
+    const { startedAt, ms } = await openOneRecord(page);
     samples.push(ms);
-    windows.push(reads.slice(before).filter((r) => r.at >= end - ms));
+    windows.push(
+      reads
+        .slice(before)
+        .filter((r) => r.at >= startedAt && r.at <= startedAt + ms),
+    );
   }
 
   const measured = nearestRank(samples, 0.95);


### PR DESCRIPTION
Refs https://github.com/margince/margince/issues/4804. Instrumentation only — no product code, no budget change.

## What

MOBILE-AC-2 now reports, for each measured open, **which reads were in flight inside it** — aligned index-for-index with the `in_order` line, plus the paths for the windows that had any.

## Why

The previous increment on this benchmark added `in_order`, and the run it was written for finally happened: https://github.com/margince/margince/actions/runs/34428951313

```
p95=318ms (budget 300ms, 20 samples)     ← third breach: 307ms, 323ms, 318ms
p50=77ms p99=321ms min=68ms max=321ms
in_order=[70,70,85,68,76,321,87,79,74,77,79,316,73,318,76,107,77,312,76,72]
 index     0  1  2  3  4 [5]  6  7  8  9 10 [11] 12 [13] 14  15 16 [17] 18 19
```

That line does what it was built to do. Its author wrote the three readings it separates — *bunched at the front is something still warming, evenly spaced is something expiring on a clock, scattered is the runner* — and the answer is the middle one: **5, 11 and 17 are a period of exactly six**, and six iterations at that run's pace is about **33 seconds**, against `STALE_TIME_MS = 30_000` in `src/app/queryclient.ts`.

Measured directly rather than inferred from the period, by running the spec locally at the runner's cadence with per-request logging: the refetch bursts land 61s and 94s in — **33s apart** — and `/v1/connectors` recurs at +43s, +75s, +107s, **32s apart**.

**What `in_order` cannot say is whether the burst is what the slow sample was waiting for.** A burst that fires beside a slow open and a burst that causes one are the same picture in a latency series, and the difference decides whether the answer is in the data layer or somewhere else entirely. That is what this line answers.

## Why it has to be measured on the runner

The two machines disagree, and only the runner's answer counts.

| | shape |
|---|---|
| this laptop, runner's cadence | 38–72ms, **unimodal**, no gap — a seven-read burst measured 64ms against neighbours of 63 and 60 |
| this laptop, renderer throttled 6× | 463–600ms, **unimodal** — everything scaled together, and the burst at sample 5 measured 586ms against neighbours of 563 and 557 |
| CI | 68–107ms **and** 312–321ms, a clean gap |

CPU starvation scales a distribution; it does not open a gap in one. And the local throttle is not the runner's situation anyway: only the *browser* is slowed there, while these route handlers — which sleep 562ms per `/v1/**` call before falling back to the mock — keep a full-speed Node process to themselves. On a two-core runner the browser and those handlers share. That asymmetry is the leading explanation for why six concurrent intercepted reads cost 320ms there and nothing here, and it is **not yet evidence**, which is the point of this change.

Worth recording that my first hypothesis was wrong in a way the arithmetic hid: 115s at 30s per expiry predicts ~4 slow samples, and CI showed exactly 4. The count fit perfectly and the mechanism did not survive being tested. Only the *positions* `in_order` supplied made it a finding.

## How verified

An all-zero `reads_in_window` is the honest reading of a run too fast to cross a stale window — which is also what a broken filter looks like, so it was checked against a run that does cross one:

```
reads_in_window=[0,0,0,0,0,0,1,0,0,1,0,0,0,7,0,0,1,0,0,0]
sample=13 ms=64 reads=["/v1/people/p-anna","/v1/people","/v1/people/p-anna/consent",
                       "/v1/consent-purposes","/v1/people/p-anna/360",
                       "/v1/people/p-anna/brief","/v1/people/p-anna/consent/guard"]
```

Seven reads on one stale expiry: the people list, the record, its consent, the purposes, the 360, the brief and the consent guard. On this machine that window still measured 64ms — the reading the runner now has to confirm or contradict.

- [x] `make check` is green — `check-fe` `EXIT=0`; `tsc --noEmit` and `biome check` clean on the file. `check-backend` is untouched by this diff: no Go, no SQL, no script the backend gate reads
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — it touches neither
- [x] `make craft-static` reports no new blockers — it sweeps the Go trees, and this diff has none
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

The spec is not collected by `pnpm e2e` (`testIgnore` unless `MARGINCE_BENCH_MOBILE=1`), so this adds nothing to the acceptance lane's runtime. It was exercised end to end four times locally while producing the numbers above.

## AI involvement

Written by Claude Code, working #4804 under a decision to find the slow path before touching the budget. The judgement call is scope: this lands the instrumentation and no fix. If the runner confirms the mechanism, the fix is a product question — a six-read burst on a 30-second clock is a real cost to a phone, and widening the budget to 350ms would silence the only lane that noticed it.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced mobile performance testing to track API reads during each sample window.
  * Added timestamps, per-window read counts, and request paths to help diagnose slow page opens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->