### PR TITLE
feat(jobs): label queue depth and running gauges by kind

### DIFF
--- a/backend/internal/compose/jobdeclared_test.go
+++ b/backend/internal/compose/jobdeclared_test.go
@@ -214,7 +214,7 @@ func TestAnUndeclaredKindWithRowsIsReportedSeparately(t *testing.T) {
 	}
 	// Still counted where it is actually sitting: the depth gauge answers how
 	// much work a queue is holding, and work of a retired kind is work.
-	if !strings.Contains(out, `margince_job_queue_depth{queue="default",workspace_id=""} 4`) {
+	if !strings.Contains(out, `margince_job_queue_depth{kind="a_kind_no_longer_declared",queue="default",workspace_id=""} 4`) {
 		t.Errorf("the undeclared rows vanished from the queue they are actually in\ngot:\n%s", out)
 	}
 }
@@ -387,7 +387,7 @@ func TestAnExtensionKindThisBuildDoesNotComposeIsItsOwnFamily(t *testing.T) {
 	}
 	// Still counted where it is actually sitting, exactly as a retired core
 	// kind's rows are: the depth gauge answers what a queue is holding.
-	if !strings.Contains(out, `margince_job_queue_depth{queue="default"`) {
+	if !strings.Contains(out, `margince_job_queue_depth{kind="ext_absent_unit_refresh_ws",queue="default"`) {
 		t.Errorf("the ext_ rows vanished from the queue they are actually in\ngot:\n%s", out)
 	}
 }

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -45,8 +45,19 @@ var queueDepthStates = map[string]bool{
 	"pending":   true,
 }
 
-// queueKey identifies one series of the per-queue gauges.
+// queueKey identifies one series of the per-queue gauges: the age gauge,
+// which is legitimately per-queue rather than per-kind — "how long has the
+// oldest runnable job in this queue waited" does not split by which kind
+// that job is.
 type queueKey struct{ queue, workspace string }
+
+// queueKindKey identifies one series of the depth/running gauges. Kind is
+// on the wire alongside queue because most kinds share the "default" queue
+// (opts_owner: caller and every kind without its own pool), so a queue-only
+// breakdown collapses dozens of unrelated kinds into one series named
+// "default" — useless for "which kind is backed up" or "which kind is
+// actually running".
+type queueKindKey struct{ kind, queue, workspace string }
 
 // kindKey identifies one series of the per-kind gauges. Dead work is keyed
 // by kind rather than by queue because "which work will never run" is a
@@ -67,8 +78,8 @@ const (
 
 // jobSeries is one pass of the snapshot, bucketed per family.
 type jobSeries struct {
-	depth        map[queueKey]int64
-	running      map[queueKey]int64
+	depth        map[queueKindKey]int64
+	running      map[queueKindKey]int64
 	discarded    map[kindKey]int64
 	cancelled    map[kindKey]int64
 	oldest       map[queueKey]float64
@@ -80,8 +91,8 @@ type jobSeries struct {
 // seven writes.
 func aggregate(rows []jobs.StateRow) jobSeries {
 	a := jobSeries{
-		depth:        map[queueKey]int64{},
-		running:      map[queueKey]int64{},
+		depth:        map[queueKindKey]int64{},
+		running:      map[queueKindKey]int64{},
 		discarded:    map[kindKey]int64{},
 		cancelled:    map[kindKey]int64{},
 		oldest:       map[queueKey]float64{},
@@ -90,12 +101,13 @@ func aggregate(rows []jobs.StateRow) jobSeries {
 	for _, r := range rows {
 		ws := workspaceLabelFor(r)
 		qk := queueKey{queue: r.Queue, workspace: ws}
+		qkk := queueKindKey{kind: r.Kind, queue: r.Queue, workspace: ws}
 		kk := kindKey{kind: r.Kind, workspace: ws}
 		switch {
 		case queueDepthStates[r.State]:
-			a.depth[qk] += r.Count
+			a.depth[qkk] += r.Count
 		case r.State == stateRunning:
-			a.running[qk] += r.Count
+			a.running[qkk] += r.Count
 		case r.State == stateDiscarded:
 			a.discarded[kk] += r.Count
 		case r.State == stateCancelled:
@@ -204,13 +216,13 @@ func writeJobMetrics(w io.Writer, snap jobs.Snapshot) error {
 	if err := writeDeclaredInfo(w); err != nil {
 		return err
 	}
-	if err := writeQueueGauge(w, "margince_job_queue_depth",
-		"Jobs waiting to run (available + scheduled + retryable + pending) per queue and workspace. An empty workspace_id is a fleet-wide pass, which answers for the installation rather than for one tenant.",
+	if err := writeQueueKindGauge(w, "margince_job_queue_depth",
+		"Jobs waiting to run (available + scheduled + retryable + pending) per kind, queue and workspace. An empty workspace_id is a fleet-wide pass, which answers for the installation rather than for one tenant.",
 		depth); err != nil {
 		return err
 	}
-	if err := writeQueueGauge(w, "margince_job_running",
-		"Jobs currently executing per queue and workspace.",
+	if err := writeQueueKindGauge(w, "margince_job_running",
+		"Jobs currently executing per kind, queue and workspace.",
 		running); err != nil {
 		return err
 	}
@@ -239,13 +251,17 @@ func writeJobMetrics(w io.Writer, snap jobs.Snapshot) error {
 	return writeUnrecognisedKindGauge(w, snap.Rows)
 }
 
-func writeQueueGauge(w io.Writer, name, help string, series map[queueKey]int64) error {
+func writeQueueKindGauge(w io.Writer, name, help string, series map[queueKindKey]int64) error {
 	if err := writeFamilyHeader(w, name, help); err != nil {
 		return err
 	}
-	for _, k := range sortedQueueKeys(series) {
-		if _, err := fmt.Fprintf(w, "%s{queue=%s,workspace_id=%s} %d\n",
-			name, label(k.queue), label(k.workspace), series[k]); err != nil {
+	keys := sortedKeysOf(series, func(a, b queueKindKey) int {
+		return cmp.Or(cmp.Compare(a.kind, b.kind), cmp.Compare(a.queue, b.queue),
+			cmp.Compare(a.workspace, b.workspace))
+	})
+	for _, k := range keys {
+		if _, err := fmt.Fprintf(w, "%s{kind=%s,queue=%s,workspace_id=%s} %d\n",
+			name, label(k.kind), label(k.queue), label(k.workspace), series[k]); err != nil {
 			return err
 		}
 	}
@@ -277,83 +293,6 @@ func writeAgeGauge(w io.Writer, series map[queueKey]float64) error {
 	for _, k := range sortedQueueKeys(series) {
 		if _, err := fmt.Fprintf(w, "%s{queue=%s,workspace_id=%s} %.0f\n",
 			name, label(k.queue), label(k.workspace), series[k]); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// writeSweepGauges renders the pair that answers "are tenants being
-// missed". Both halves carry the same sweep label so an alert can compare
-// them; for a fan-out kind the label is the CHILD kind, which is what the
-// rows hold — mapping back to the dispatcher would be a hand-kept table.
-// For a Fleet kind that fans out to nothing (ADR-0103's collapsed pass) the
-// label is the kind's own name, and the reading is 1 (or 0, if the pass has
-// never run) rather than a true workspace count — there is no workspace
-// grain to read for it at all.
-func writeSweepGauges(w io.Writer, sweeps []jobs.SweepPass) error {
-	ordered := slices.SortedFunc(slices.Values(sweeps), func(a, b jobs.SweepPass) int {
-		return cmp.Compare(a.Kind, b.Kind)
-	})
-
-	if err := writeFamilyHeader(w, "margince_sweep_workspaces",
-		"Workspaces with a surviving child of this fleet pass. Counted per workspace rather than per pass: a child still active from an earlier fan-out is deduplicated out of the current one and writes no new row, so no batch can be identified. A workspace whose only child aged out of River's job retention is absent rather than reported as zero. For a kind that answers for the whole installation in one row rather than fanning out, this reads 1 when its latest tagged run exists — the closest reading to 'did the pass happen' when there is no workspace to count."); err != nil {
-		return err
-	}
-	for _, s := range ordered {
-		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces{sweep=%s} %d\n",
-			label(s.Kind), s.Workspaces); err != nil {
-			return err
-		}
-	}
-
-	if err := writeFamilyHeader(w, "margince_sweep_workspaces_failed",
-		"Workspaces whose MOST RECENT child of this fleet pass ended discarded or cancelled — tenants whose share of the pass did not happen. A workspace that failed and then succeeded is not counted. For a kind that answers for the whole installation in one row, this reads 1 when its latest tagged run ended that way."); err != nil {
-		return err
-	}
-	for _, s := range ordered {
-		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_failed{sweep=%s} %d\n",
-			label(s.Kind), s.Failed); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// writeSweepUnitGauges renders the pair that answers the same question one
-// grain down, for the dispatchers that fan out per connection or per build.
-// The workspace pair above is the coarser reading of the same passes and can
-// mask a failed unit behind a healthy sibling in the same workspace; these two
-// cannot, because each unit is counted in its own right.
-//
-// Present ONLY for kinds whose declared unit is finer than a workspace. For
-// every other fan-out kind the unit IS the workspace, so this pair would repeat
-// the one above value for value, and two published series for one number is a
-// worse surface than one series and a documented pairing. The unit rides as a
-// label so an alert can see which grain it is reading without a lookup.
-func writeSweepUnitGauges(w io.Writer, units []jobs.SweepUnit) error {
-	ordered := slices.SortedFunc(slices.Values(units), func(a, b jobs.SweepUnit) int {
-		return cmp.Compare(a.Kind, b.Kind)
-	})
-
-	if err := writeFamilyHeader(w, "margince_sweep_units",
-		"Fan-out units with a surviving child of this fleet pass, for the dispatchers that fan out per connection or per build rather than per workspace. The unit label names the grain. Kinds that fan out per workspace are absent here and reported by margince_sweep_workspaces, which is the same measurement for them."); err != nil {
-		return err
-	}
-	for _, u := range ordered {
-		if _, err := fmt.Fprintf(w, "margince_sweep_units{sweep=%s,unit=%s} %d\n",
-			label(u.Kind), label(fanOutUnitName(u.Unit)), u.Units); err != nil {
-			return err
-		}
-	}
-
-	if err := writeFamilyHeader(w, "margince_sweep_units_failed",
-		"Fan-out units whose MOST RECENT child of this fleet pass ended discarded or cancelled. Unlike the per-workspace pair, a failed connection is counted even when a sibling connection in the same workspace succeeded afterwards -- which is the masking this pair exists to remove."); err != nil {
-		return err
-	}
-	for _, u := range ordered {
-		if _, err := fmt.Fprintf(w, "margince_sweep_units_failed{sweep=%s,unit=%s} %d\n",
-			label(u.Kind), label(fanOutUnitName(u.Unit)), u.Failed); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -27,8 +27,8 @@ func TestJobMetricsNameTheWorkspaceThatOwnsTheWorkAndLeaveItEmptyForADispatcher(
 	}
 
 	want := []string{
-		`margince_job_queue_depth{queue="default",workspace_id="` + ws + `"} 2`,
-		`margince_job_queue_depth{queue="default",workspace_id=""} 1`,
+		`margince_job_queue_depth{kind="tenant_pass",queue="default",workspace_id="` + ws + `"} 2`,
+		`margince_job_queue_depth{kind="the_dispatcher",queue="default",workspace_id=""} 1`,
 	}
 	for _, line := range want {
 		if !strings.Contains(buf.String(), line) {
@@ -53,11 +53,37 @@ func TestQueueDepthSumsEveryStateAJobCanBeWaitingIn(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
-	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id=""} 23`) {
+	if !strings.Contains(buf.String(), `margince_job_queue_depth{kind="k",queue="default",workspace_id=""} 23`) {
 		t.Errorf("queue depth did not sum available+scheduled+retryable+pending\ngot:\n%s", buf.String())
 	}
-	if !strings.Contains(buf.String(), `margince_job_running{queue="default",workspace_id=""} 8`) {
+	if !strings.Contains(buf.String(), `margince_job_running{kind="k",queue="default",workspace_id=""} 8`) {
 		t.Errorf("running is its own gauge, not part of depth\ngot:\n%s", buf.String())
+	}
+}
+
+// TestQueueDepthAndRunningAreKeyedByKindToo — most kinds share the "default"
+// queue, so a queue-only breakdown collapses dozens of unrelated kinds into
+// one series named "default". An operator asking which kind is backed up,
+// or which kind is actually running, needs the kind on the wire too.
+func TestQueueDepthAndRunningAreKeyedByKindToo(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "default", Kind: "site_deep_read", Untenanted: true, State: "available", Count: 3},
+		{Queue: "default", Kind: "geocode_lookup", Untenanted: true, State: "available", Count: 5},
+		{Queue: "default", Kind: "site_deep_read", Untenanted: true, State: "running", Count: 1},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	got := buf.String()
+	for _, want := range []string{
+		`margince_job_queue_depth{kind="site_deep_read",queue="default",workspace_id=""} 3`,
+		`margince_job_queue_depth{kind="geocode_lookup",queue="default",workspace_id=""} 5`,
+		`margince_job_running{kind="site_deep_read",queue="default",workspace_id=""} 1`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("exposition missing %q — two kinds sharing one queue must not collapse "+
+				"into one series\ngot:\n%s", want, got)
+		}
 	}
 }
 
@@ -366,7 +392,7 @@ func TestAQueueHoldingOnlyRunningWorkReportsNoAgeEither(t *testing.T) {
 	if strings.Contains(buf.String(), `margince_job_oldest_queued_age_seconds{queue="busy"`) {
 		t.Errorf("a queue whose work is all claimed reported a waiting age\ngot:\n%s", buf.String())
 	}
-	if !strings.Contains(buf.String(), `margince_job_running{queue="busy",workspace_id=""} 4`) {
+	if !strings.Contains(buf.String(), `margince_job_running{kind="k",queue="busy",workspace_id=""} 4`) {
 		t.Errorf("the running work itself went missing\ngot:\n%s", buf.String())
 	}
 }
@@ -392,7 +418,7 @@ func TestAQueueOfFutureScheduledWorkReportsNoAgeSeries(t *testing.T) {
 	if strings.Contains(buf.String(), `margince_job_oldest_queued_age_seconds{queue="nightly"`) {
 		t.Errorf("a queue whose work is all future-scheduled reported an age\ngot:\n%s", buf.String())
 	}
-	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="nightly",workspace_id=""} 4`) {
+	if !strings.Contains(buf.String(), `margince_job_queue_depth{kind="k",queue="nightly",workspace_id=""} 4`) {
 		t.Errorf("the queued work itself went missing\ngot:\n%s", buf.String())
 	}
 }
@@ -411,14 +437,14 @@ func TestAPresentButEmptyWorkspaceIsNotCountedAsADispatcher(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
-	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id=""} 1`) {
+	if !strings.Contains(buf.String(), `margince_job_queue_depth{kind="k",queue="default",workspace_id=""} 1`) {
 		t.Errorf("the real dispatcher row was disturbed\ngot:\n%s", buf.String())
 	}
-	if strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id=""} 10`) {
+	if strings.Contains(buf.String(), `margince_job_queue_depth{kind="k",queue="default",workspace_id=""} 10`) {
 		t.Error("a malformed row was folded into the dispatcher series, which is the one " +
 			"invariant these gauges promise")
 	}
-	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id="malformed_workspace_id"} 9`) {
+	if !strings.Contains(buf.String(), `margince_job_queue_depth{kind="k",queue="default",workspace_id="malformed_workspace_id"} 9`) {
 		t.Errorf("the malformed row is invisible rather than flagged\ngot:\n%s", buf.String())
 	}
 }
@@ -475,7 +501,7 @@ func TestALiteralEscapeSequenceDoesNotCollideWithTheCharacterItEncodes(t *testin
 		t.Errorf("the real tab did not render as its escape\ngot:\n%s", got)
 	}
 	// The load-bearing assertion: two distinct ids, two distinct series.
-	if strings.Count(got, `margince_job_queue_depth{queue="q"`) != 2 {
+	if strings.Count(got, `margince_job_queue_depth{kind="k",queue="q"`) != 2 {
 		t.Errorf("two distinct workspace ids collapsed into one series; a duplicate label "+
 			"set makes Prometheus reject the entire scrape\ngot:\n%s", got)
 	}

--- a/backend/internal/compose/jobsweepmetrics.go
+++ b/backend/internal/compose/jobsweepmetrics.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The two sweep-pair families beside jobmetrics.go's per-job gauges: "are
+// tenants being missed" at the workspace grain and, where a kind's declared
+// unit is finer, at the unit grain too. Split out of jobmetrics.go because
+// the sweep passes answer a different question (did every tenant's share of
+// a pass run) from the job-runtime gauges next door (what is a queue
+// currently holding).
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"slices"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
+)
+
+// writeSweepGauges renders the pair that answers "are tenants being
+// missed". Both halves carry the same sweep label so an alert can compare
+// them; for a fan-out kind the label is the CHILD kind, which is what the
+// rows hold — mapping back to the dispatcher would be a hand-kept table.
+// For a Fleet kind that fans out to nothing (ADR-0103's collapsed pass) the
+// label is the kind's own name, and the reading is 1 (or 0, if the pass has
+// never run) rather than a true workspace count — there is no workspace
+// grain to read for it at all.
+func writeSweepGauges(w io.Writer, sweeps []jobs.SweepPass) error {
+	ordered := slices.SortedFunc(slices.Values(sweeps), func(a, b jobs.SweepPass) int {
+		return cmp.Compare(a.Kind, b.Kind)
+	})
+
+	if err := writeFamilyHeader(w, "margince_sweep_workspaces",
+		"Workspaces with a surviving child of this fleet pass. Counted per workspace rather than per pass: a child still active from an earlier fan-out is deduplicated out of the current one and writes no new row, so no batch can be identified. A workspace whose only child aged out of River's job retention is absent rather than reported as zero. For a kind that answers for the whole installation in one row rather than fanning out, this reads 1 when its latest tagged run exists — the closest reading to 'did the pass happen' when there is no workspace to count."); err != nil {
+		return err
+	}
+	for _, s := range ordered {
+		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces{sweep=%s} %d\n",
+			label(s.Kind), s.Workspaces); err != nil {
+			return err
+		}
+	}
+
+	if err := writeFamilyHeader(w, "margince_sweep_workspaces_failed",
+		"Workspaces whose MOST RECENT child of this fleet pass ended discarded or cancelled — tenants whose share of the pass did not happen. A workspace that failed and then succeeded is not counted. For a kind that answers for the whole installation in one row, this reads 1 when its latest tagged run ended that way."); err != nil {
+		return err
+	}
+	for _, s := range ordered {
+		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_failed{sweep=%s} %d\n",
+			label(s.Kind), s.Failed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeSweepUnitGauges renders the pair that answers the same question one
+// grain down, for the dispatchers that fan out per connection or per build.
+// The workspace pair above is the coarser reading of the same passes and can
+// mask a failed unit behind a healthy sibling in the same workspace; these two
+// cannot, because each unit is counted in its own right.
+//
+// Present ONLY for kinds whose declared unit is finer than a workspace. For
+// every other fan-out kind the unit IS the workspace, so this pair would repeat
+// the one above value for value, and two published series for one number is a
+// worse surface than one series and a documented pairing. The unit rides as a
+// label so an alert can see which grain it is reading without a lookup.
+func writeSweepUnitGauges(w io.Writer, units []jobs.SweepUnit) error {
+	ordered := slices.SortedFunc(slices.Values(units), func(a, b jobs.SweepUnit) int {
+		return cmp.Compare(a.Kind, b.Kind)
+	})
+
+	if err := writeFamilyHeader(w, "margince_sweep_units",
+		"Fan-out units with a surviving child of this fleet pass, for the dispatchers that fan out per connection or per build rather than per workspace. The unit label names the grain. Kinds that fan out per workspace are absent here and reported by margince_sweep_workspaces, which is the same measurement for them."); err != nil {
+		return err
+	}
+	for _, u := range ordered {
+		if _, err := fmt.Fprintf(w, "margince_sweep_units{sweep=%s,unit=%s} %d\n",
+			label(u.Kind), label(fanOutUnitName(u.Unit)), u.Units); err != nil {
+			return err
+		}
+	}
+
+	if err := writeFamilyHeader(w, "margince_sweep_units_failed",
+		"Fan-out units whose MOST RECENT child of this fleet pass ended discarded or cancelled. Unlike the per-workspace pair, a failed connection is counted even when a sibling connection in the same workspace succeeded afterwards -- which is the masking this pair exists to remove."); err != nil {
+		return err
+	}
+	for _, u := range ordered {
+		if _, err := fmt.Fprintf(w, "margince_sweep_units_failed{sweep=%s,unit=%s} %d\n",
+			label(u.Kind), label(fanOutUnitName(u.Unit)), u.Failed); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- `margince_job_queue_depth` and `margince_job_running` were keyed only by `queue` + `workspace_id`. 52 of ~65 declared kinds share the single `default` queue, so the Grafana "Queue size and jobs running over time" panel could only ever show `default · running` — no way to tell which job kind is actually queued or running.
- Adds `kind` to both gauges' label set (`kind`, `queue`, `workspace_id`), matching the pattern already used by the kind-keyed `margince_job_discarded`/`margince_job_cancelled` gauges.
- Existing `sum by (queue)` dashboard queries (the Queued/Running stat panels, the per-queue roster table) are unaffected — the extra label doesn't change what those aggregations report.
- The oldest-wait age gauge stays per-queue only; that question is legitimately about the queue, not the kind sitting in it.
- Split the two sweep-pair gauge writers out of `jobmetrics.go` into a new `jobsweepmetrics.go` to stay under the 500-line file cap after the change.

## Test plan
- [x] `TestQueueDepthAndRunningAreKeyedByKindToo` (new, TDD-first: watched it fail before implementing)
- [x] `go test ./internal/compose/...` — all green
- [x] `make check-go` — full backend lane green
- [x] `craft static --strict` (pre-push hook) — 0 blocker/major/minor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `kind` label to `margince_job_queue_depth` and `margince_job_running` so Grafana can tell which job kind is queued or running. Previously both gauges were keyed only by queue and workspace, but 52 of ~65 declared kinds share the single `default` queue, so the queue-only breakdown collapsed them into one indistinguishable series.

- Existing `sum by (queue)` dashboard queries are unaffected; the extra label doesn't change those aggregations.
- The oldest-wait age gauge stays per-queue only, since that question is about the queue, not the kind.
- Splits the sweep-pair gauge writers into a new `jobsweepmetrics.go` to stay under the 500-line file cap.
- Adds `TestQueueDepthAndRunningAreKeyedByKindToo` and updates existing tests for the new label.

<sup>Written for commit 240baf83825b606c633d98c524f247c1d7dafb55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue depth and running metrics now distinguish jobs by kind, in addition to queue and workspace.
  * Added Prometheus metrics for sweep workspace and unit totals, including failed counts and identifying labels.
* **Improvements**
  * Metric output is consistently ordered by job or sweep kind, improving readability and reliable comparison across reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->