### PR TITLE
fix(identity): an agent is not a Seat, and the meter stops counting one

### DIFF
--- a/backend/internal/compose/integration/license_entitlement_integration_test.go
+++ b/backend/internal/compose/integration/license_entitlement_integration_test.go
@@ -8,13 +8,13 @@ package integration
 // The seat count the entitlement surface reports, against a real database.
 //
 // Nothing else can prove it. The count is a SQL predicate over app_user — full
-// seats that are not deactivated, agents included — and the three decisions it
-// makes are the difference between a meter that bills honestly and one that
-// bills for access the installation already withdrew:
+// seats held by a person and not deactivated — and the three decisions it makes
+// are the difference between a meter that bills honestly and one that bills for
+// access the installation never had or already withdrew:
 //
 //   a read seat is never counted        A62/ADR-0047: they are unlimited
 //   a deactivated seat is not counted   the access is already gone
-//   an agent seat IS counted            it acts on the estate like a human
+//   an agent seat is not counted        LICENSE: a Seat is a natural person
 //
 // A unit test cannot see any of it: what is real here is the predicate running
 // against rows a real database holds, and the verdict the server reaches with
@@ -119,18 +119,25 @@ func TestLicenseEntitlementCountsTheSeatsThatAct(t *testing.T) {
 			"metered that no person uses", afterDemotion.SeatsUsed)
 	}
 
-	// THE THIRD RULE, and this is the only place that holds it: an agent seat IS
-	// counted. It used to be held by accident — bootstrap seeded an agent row, so
-	// the count after this demotion could not reach zero — and retiring that seed
-	// took the assertion with it.
+	// THE THIRD RULE, and this is the only place that holds it: an agent seat is
+	// NOT counted. LICENSE defines a Seat as "a single, identified natural
+	// person" and excludes automated agents acting under the authority of a
+	// counted Seat — and this meter is what that document is read against, so a
+	// customer reading the licence they signed and an operator reading
+	// seats_used must get the same number.
+	//
+	// It does not let an installation act without limit through agents, which is
+	// the reading the exclusion invites: the licence admits an agent only where
+	// it is ATTRIBUTABLE to a counted Seat, so an installation with none has no
+	// authority for one to act under.
 	//
 	// Written through the owner connection because nothing in the product creates
 	// an agent row any more, which is what TestBootstrapMintsNoAgentSeat asserts.
-	// A resident runner will land under this flag, and it must arrive metered:
-	// excluding agents is what would let an installation act without limit
-	// through them. `full` and `active` are spelled out because
-	// app_user_agent_is_full admits no other seat type for an agent — the same
-	// constraint that makes this row survive the demotion above.
+	// A resident runner will land under this flag, and it must arrive unmetered.
+	// `full` and `active` are spelled out because app_user_agent_is_full admits
+	// no other seat type for an agent — the same constraint that makes this row
+	// survive the demotion above, and what would have made it the one metered
+	// seat on an installation with no people left on it.
 	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO app_user (email, display_name, is_agent, seat_type, status)
 		 VALUES ('runner@example.com', 'A Runner', true, 'full', 'active')`); err != nil {
@@ -140,10 +147,10 @@ func TestLicenseEntitlementCountsTheSeatsThatAct(t *testing.T) {
 	if status := e.Call(t, "GET", "/v1/installation/license", nil, nil, &withAgent); status != http.StatusOK {
 		t.Fatalf("read the entitlement with an agent identity → %d", status)
 	}
-	if withAgent.SeatsUsed != 1 {
-		t.Errorf("seats in use = %d with one agent identity and every human demoted, want 1 — an "+
-			"agent that is not counted is an installation acting without limit through agents",
-			withAgent.SeatsUsed)
+	if withAgent.SeatsUsed != 0 {
+		t.Errorf("seats in use = %d with one agent identity and every human demoted, want 0 — "+
+			"LICENSE says an agent is not a Seat, and metering one caps an installation for "+
+			"something its licence gives away", withAgent.SeatsUsed)
 	}
 }
 

--- a/backend/internal/modules/identity/seatceiling_integration_test.go
+++ b/backend/internal/modules/identity/seatceiling_integration_test.go
@@ -210,6 +210,40 @@ func TestSeatCeilingDoesNotHoldAReadSeatToTheFullSeatGrant(t *testing.T) {
 	}
 }
 
+// An agent identity is not a Seat, so it is neither metered nor allowed to spend
+// somebody's licensed seat.
+//
+// LICENSE is the authority: a Seat is "a single, identified natural person", and
+// an automated agent acting under the authority of a counted Seat explicitly is
+// not one. A meter that counted them would cap an installation for something its
+// licence gives away — and the way a customer meets that is not the number on
+// the entitlement screen, it is being refused the last person they are entitled
+// to, which is what the second half asserts.
+func TestSeatCeilingDoesNotMeterAnAgentAgainstTheLicence(t *testing.T) {
+	e := setupRevocationEnv(t, "seat-ceiling-agent")
+	before := seatsInUse(t, e)
+
+	seedAgentIdentity(t, e.owner, "runner-"+e.slug+"@seatceiling.test")
+
+	if got := seatsInUse(t, e); got != before {
+		t.Fatalf("seats in use went %d → %d when an agent identity landed; want it unchanged — "+
+			"LICENSE says an agent is not a Seat, and this meter is what that document is read against",
+			before, got)
+	}
+	// The agent row is really there, so the assertion above is about the
+	// predicate rather than about an insert that silently did nothing.
+	if agents := readAgentSeats(t, e.owner); len(agents) != 1 {
+		t.Fatalf("found %d agent identities, want the 1 just seeded — the count above proved nothing", len(agents))
+	}
+
+	// And the seat it does not take is still there to give away. This is the
+	// harm: an installation licensed for its people gets refused one of them.
+	licenseFor(t, e, licensedSeats(before+1))
+	if err := inviteOneMore(t, e, "the-person-the-agent-displaced"); err != nil {
+		t.Errorf("inviting into a licensed seat alongside an agent: %v — the agent spent a seat the licence did not sell", err)
+	}
+}
+
 // What an unlicensed installation and an uncapped license have in common: no
 // number to hold anybody to. Both reach identity as the same answer, and a
 // service nobody wired is the third spelling of it.

--- a/backend/internal/modules/identity/seatusage.go
+++ b/backend/internal/modules/identity/seatusage.go
@@ -43,7 +43,7 @@ type SeatUsageStore struct {
 func NewSeatUsage(db *database.DB) *SeatUsageStore { return &SeatUsageStore{db: db} }
 
 // FullSeatsInUse counts the full seats this installation is using: every
-// non-deactivated one, agents included.
+// non-deactivated one held by a person.
 //
 // Three decisions the count makes, each of which the meter would be wrong
 // without:
@@ -55,9 +55,23 @@ func NewSeatUsage(db *database.DB) *SeatUsageStore { return &SeatUsageStore{db: 
 // acting without erasing them, so counting one would bill for access the
 // installation has already withdrawn.
 //
-// AN AGENT SEAT IS COUNTED. `app_user_agent_is_full` makes every agent a full
-// seat, and a first-party runner acts on the estate exactly as a human does.
-// Excluding them would let an installation act without limit through agents.
+// AN AGENT SEAT IS NOT COUNTED, because LICENSE says so: a Seat is "a single,
+// identified natural person", and automated agents that act under the authority
+// of a counted Seat explicitly do not count. That document is what a customer
+// relies on and what this meter is measured against, so the meter follows it —
+// counting agents would cap an installation for something its licence gives
+// away, and the first customer to read both carefully would find it.
+//
+// It does not let an installation act without limit through agents, which is the
+// reading the exclusion invites: the licence admits an agent only where it is
+// attributable to a counted Seat, so an installation with no seats has no
+// authority for one to act under.
+//
+// `is_agent` is the whole of it. The licence also excludes service accounts, and
+// app_user carries no second marker for one — the only service account in this
+// product is Google's Pub/Sub signer, which is an external identity and holds no
+// row here. A second exclusion would be inventing a distinction the schema does
+// not make.
 //
 // This is deliberately NOT the spec's "active" definition (signed in within 30
 // days, UC-ADMIN-03 precondition 3): the two meters therefore disagree, which is
@@ -105,10 +119,14 @@ func (s *SeatUsageStore) countFullSeats(ctx context.Context) (int, error) {
 // nobody can see are the same defect from two sides, and the only way the two
 // cannot drift is that there is one of them.
 //
-// The predicate is the three decisions above: full seats only, agents included,
-// and neither a suspended nor a deactivated seat — both are access the
-// installation has already withdrawn, and an admin who suspended somebody to
-// free a seat has to actually get it back.
+// The predicate is the three decisions above: full seats only, no agents, and
+// neither a suspended nor a deactivated seat — both are access the installation
+// has already withdrawn, and an admin who suspended somebody to free a seat has
+// to actually get it back.
+//
+// `NOT is_agent` is the licence's own exclusion and not a filter somebody added:
+// a Seat is a natural person there, so an agent row is not one of these however
+// much estate it touches. Removing it would meter what the licence gives away.
 //
 // It names the statuses that do NOT count rather than the one that does. A seat
 // exists until the installation withdraws it, so a status added later should
@@ -116,4 +134,5 @@ func (s *SeatUsageStore) countFullSeats(ctx context.Context) (int, error) {
 // stop metering a state nobody had thought about, and an installation would
 // issue seats its license never granted.
 const fullSeatsInUseQuery = `SELECT count(*) FROM app_user
-	 WHERE seat_type = 'full' AND status NOT IN ('suspended', 'deactivated')`
+	 WHERE seat_type = 'full' AND NOT is_agent
+	   AND status NOT IN ('suspended', 'deactivated')`


### PR DESCRIPTION
Closes #1791. Builds the ruling: add the exclusion to the one query; the licence
is the authority.

## The contradiction

`LICENSE` defines a Seat as *"a single, identified natural person"* and excludes
*"automated agents, AI systems, bots, and service accounts that act under the
authority of, and are attributable to, a counted Seat"*. The meter counted every
`full` seat, agents included — so the document a customer signed and the number
an operator reads disagreed about the same installation, and the gap runs
against us: we cap an installation for something the licence gives away.

## One clause, because there is one meter

`fullSeatsInUseQuery` is what the entitlement screen shows and what the seat
ceiling refuses by. Its own comment is why this is a one-line fix: *"A meter
nobody is held to and a ceiling nobody can see are the same defect from two
sides, and the only way the two cannot drift is that there is one of them."* The
number and the refusal move together by construction.

## The reason that was there, and why it does not hold

The doc block said `AN AGENT SEAT IS COUNTED` and gave a reason — excluding them
*"would let an installation act without limit through agents"*. The licence
already answers that: it admits an agent only where it is **attributable to a
counted Seat**, so an installation with no seats has no authority for one to act
under. The comment is rewritten to say what the exclusion is, so the next author
does not read `NOT is_agent` as a filter somebody added and wonder whether it is
safe to remove.

## Service accounts: checked, not assumed

The ruling asked. `app_user` carries `is_agent` and no second marker — the only
service account in this product is Google's Pub/Sub signer, which is an external
identity and holds no row here. A second predicate would invent a distinction the
schema does not make.

## One thing in the ticket is stale

The ticket's headline case is a fresh install reading two seats — the admin plus
the agent runner. **Bootstrap no longer seeds a runner seat**
(`TestBootstrapMintsNoAgentSeat` holds that), so there is no fresh-install gap
left to close. The rule still binds: `is_agent` is a live column, a resident
runner will land under it, and any agent row that exists today is metered against
a licence that says it should not be. The fix is the same; the harm is future
rather than current, and the PR says so rather than repeating a case that no
longer happens.

## The test

`TestSeatCeilingDoesNotMeterAnAgentAgainstTheLicence` asserts both halves,
because the number is not how a customer meets this:

1. the meter does not move when an agent identity lands — and the agent row is
   asserted present afterwards, so a seeding no-op cannot pass as an exclusion;
2. **the seat it does not take is still there to give to a person** — licensed
   for `before+1`, an invite alongside the agent succeeds. That is the harm: an
   installation licensed for its people refused one of them.

Mutation-checked: `AND (NOT is_agent OR true)` fails it with "seats in use went
2 → 3".

## Checks

- `make check-backend` green.
- `craft static --strict` over the diff: 0/0/0.
- Integration: `identity` in full, plus the seat and licence cases in
  `compose/integration`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Agent identities are no longer counted toward licensed full-seat usage.
  - Installations containing only agent identities now report zero seats used.
  - Available licensed seats remain available for inviting human users when agent identities are present.

- **Tests**
  - Added coverage confirming agent identities are excluded from seat metering and do not prevent additional human-seat invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->