### PR TITLE
fix(lists): a sort a list offers is a sort its resource accepts

### DIFF
--- a/backend/gates/listsortvocabulary_test.go
+++ b/backend/gates/listsortvocabulary_test.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// A sort the list OFFERS is a sort the server ACCEPTS.
+//
+// A column header carries the field name it will ask for. The server keeps a
+// per-resource vocabulary and refuses anything outside it, so the two are one
+// invariant spelled on both sides of a wire — and the drift is silent until a
+// reader clicks, because nothing renders differently until the request is made.
+//
+// This is #2090's own last ask: "a column that declares a sort the server does
+// not accept should fail a test, not silently render a dead header." What that
+// issue found was the other direction — columns with no sort at all — and the
+// ruling behind it (any column shown is sortable) is answered column by column
+// as the sort model grows. THIS direction needs no ruling and no waiver: a
+// header offering a field the resource does not have is a refusal in front of a
+// user, whatever anybody decides about the columns that offer nothing.
+//
+// The Go side is read with its CONSTANTS RESOLVED. Several vocabularies spell
+// their keys as package constants (`ownerIDColumn`, `personNameColumn`), so a
+// scan reading string literals finds an EMPTY vocabulary and agrees with every
+// sort a screen could possibly offer. That is the failure direction a census
+// must not have, and this one had it until the constants were followed.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// listSurface pairs a screen with the resource it lists.
+//
+// Declared because nothing in either tree names the other: a screen fetches a
+// path and the vocabulary belongs to a store, and no import, type or route
+// connects the two. Every entry is checked to resolve on both sides, so a
+// renamed file or a retired vocabulary fails here rather than dropping a
+// surface out of the census quietly.
+var listSurfaces = map[string]struct{ vocabulary, source string }{
+	"deals.tsx":          {"dealListFields", "internal/modules/deals/deal_read.go"},
+	"contacts.tsx":       {"personListFields", "internal/modules/people/person_list.go"},
+	"leads.list.tsx":     {"leadListFields", "internal/modules/people/lead_list.go"},
+	"organizations.tsx":  {"organizationListFields", "internal/modules/people/organization_list.go"},
+	"projects.tsx":       {"projectListFields", "internal/modules/projects/read.go"},
+	"products.tsx":       {"productListFields", "internal/modules/deals/product.go"},
+	"offertemplates.tsx": {"offerTemplateListFields", "internal/modules/deals/offer_template.go"},
+}
+
+const screenDir = "../frontend/src/screens/"
+
+// sharedColumnSource holds the column helpers several screens draw from. A sort
+// one of them offers is offered by every screen that calls it, so it is read
+// per screen rather than once.
+const sharedColumnSource = screenDir + "recordlist.tsx"
+
+var (
+	// tsSortLiteral reads one `sort: "field"` off a column.
+	tsSortLiteral = regexp.MustCompile(`\bsort:\s*"([a-z_0-9]+)"`)
+	// tsColumnHelper reads one exported column helper's name.
+	tsColumnHelper = regexp.MustCompile(`export function ([a-zA-Z]+Column)<`)
+)
+
+func TestEverySortAListOffersIsOneItsResourceAccepts(t *testing.T) {
+	t.Parallel()
+
+	helpers := sharedColumnSorts(t)
+	if len(helpers) == 0 {
+		t.Fatal("read no shared column helpers at all — every screen's borrowed sorts would then go unchecked")
+	}
+
+	screens := make([]string, 0, len(listSurfaces))
+	for name := range listSurfaces {
+		screens = append(screens, name)
+	}
+	sort.Strings(screens)
+
+	for _, name := range screens {
+		surface := listSurfaces[name]
+		accepted := goSortVocabulary(t, surface.source, surface.vocabulary)
+		if len(accepted) == 0 {
+			t.Errorf("%s resolves to an EMPTY vocabulary — an empty one accepts nothing and this gate would agree with everything; the keys are probably constants this scan did not follow",
+				surface.vocabulary)
+			continue
+		}
+		screen := readSource(t, screenDir+name)
+
+		offered := map[string]string{}
+		for _, m := range tsSortLiteral.FindAllStringSubmatch(screen, -1) {
+			offered[m[1]] = "its own column"
+		}
+		// The sorts this screen borrows. A helper's header is this screen's
+		// header once it is drawn here, so its field is this resource's to
+		// accept.
+		for helper, field := range helpers {
+			if strings.Contains(screen, helper+"<") {
+				offered[field] = helper + "()"
+			}
+		}
+
+		fields := make([]string, 0, len(offered))
+		for field := range offered {
+			fields = append(fields, field)
+		}
+		sort.Strings(fields)
+		for _, field := range fields {
+			if !slices.Contains(accepted, field) {
+				t.Errorf("%s offers sort %q (from %s) and %s does not accept it — the header renders, the reader clicks, and the request is refused",
+					name, field, offered[field], surface.vocabulary)
+			}
+		}
+	}
+}
+
+// sharedColumnSorts maps each shared helper to the sort it offers, skipping the
+// ones that offer none.
+func sharedColumnSorts(t *testing.T) map[string]string {
+	t.Helper()
+	body := readSource(t, sharedColumnSource)
+	names := tsColumnHelper.FindAllStringSubmatchIndex(body, -1)
+	out := map[string]string{}
+	for i, at := range names {
+		end := len(body)
+		if i+1 < len(names) {
+			end = names[i+1][0]
+		}
+		helper, definition := body[at[2]:at[3]], body[at[0]:end]
+		if m := tsSortLiteral.FindStringSubmatch(definition); m != nil {
+			out[helper] = m[1]
+			continue
+		}
+		// A helper that MENTIONS a sort this scan cannot read is the failure
+		// direction that matters: the field goes unattributed, every screen
+		// drawing it goes unchecked, and the gate reports PASS over exactly the
+		// header it exists to catch. A `sort:` computed from a flag did this
+		// once already — the mutation that should have failed came back green.
+		if strings.Contains(definition, "sort:") {
+			t.Fatalf("%s writes a sort this gate cannot read as a literal — a computed one leaves every screen that draws it unchecked, which reads as agreement. Give the column a plain `sort: \"field\"`, or split the cell out for the caller that must not offer one",
+				helper)
+		}
+	}
+	return out
+}
+
+// goSortVocabulary reads a vocabulary map's keys, resolving a key spelled as a
+// package constant to the string it holds.
+func goSortVocabulary(t *testing.T, source, name string) []string {
+	t.Helper()
+	constants := packageStringConstants(t, filepath.Dir(source))
+	file, err := parser.ParseFile(token.NewFileSet(), source, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", source, err)
+	}
+	var out []string
+	for _, spec := range valueSpecsNamed(file, name) {
+		lit, ok := spec.Values[0].(*ast.CompositeLit)
+		if !ok {
+			t.Fatalf("%s is not a composite literal; this gate can only read one", name)
+		}
+		for _, entry := range lit.Elts {
+			kv, ok := entry.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			switch key := kv.Key.(type) {
+			case *ast.BasicLit:
+				unquoted, err := strconv.Unquote(key.Value)
+				if err != nil {
+					t.Fatalf("unquoting %s in %s: %v", key.Value, source, err)
+				}
+				out = append(out, unquoted)
+			case *ast.Ident:
+				value, declared := constants[key.Name]
+				if !declared {
+					t.Fatalf("%s names %s, which its package declares no string constant for — an unresolved key is a field this gate cannot see, and it would then agree with a screen offering it",
+						name, key.Name)
+				}
+				out = append(out, value)
+			default:
+				t.Fatalf("%s has a key this gate cannot read (%T)", name, kv.Key)
+			}
+		}
+	}
+	return out
+}
+
+// packageStringConstants reads every string constant one package declares.
+func packageStringConstants(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	sources, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("listing %s: %v", dir, err)
+	}
+	out := map[string]string{}
+	for _, source := range sources {
+		if strings.HasSuffix(source, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), source, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", source, err)
+		}
+		for _, decl := range file.Decls {
+			general, ok := decl.(*ast.GenDecl)
+			if !ok || general.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range general.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok || len(value.Names) != 1 || len(value.Values) != 1 {
+					continue
+				}
+				if lit, ok := value.Values[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					unquoted, err := strconv.Unquote(lit.Value)
+					if err != nil {
+						t.Fatalf("unquoting %s in %s: %v", lit.Value, source, err)
+					}
+					out[value.Names[0].Name] = unquoted
+				}
+			}
+		}
+	}
+	return out
+}

--- a/backend/gates/listsortvocabulary_test.go
+++ b/backend/gates/listsortvocabulary_test.go
@@ -3,6 +3,11 @@
 
 //gate:kind parity H3
 
+// The AST helpers this shares with the sibling reference census are declared
+// under the same tag, so it carries it too rather than reaching for them from a
+// build they are not in.
+//go:build !integration
+
 package gates
 
 // A sort the list OFFERS is a sort the server ACCEPTS.

--- a/backend/gates/listsortvocabulary_test.go
+++ b/backend/gates/listsortvocabulary_test.go
@@ -3,14 +3,15 @@
 
 //gate:kind parity H3
 
-// The AST helpers this shares with the sibling reference census are declared
-// under the same tag, so it carries it too rather than reaching for them from a
-// build they are not in.
 //go:build !integration
 
 package gates
 
 // A sort the list OFFERS is a sort the server ACCEPTS.
+//
+// Tagged `!integration` with the sibling reference census, whose AST helpers it
+// shares: reaching for them from a build they are not in is a typecheck failure
+// the merge gate finds and the default `go test` does not.
 //
 // A column header carries the field name it will ask for. The server keeps a
 // per-resource vocabulary and refuses anything outside it, so the two are one

--- a/backend/internal/modules/people/lead_list.go
+++ b/backend/internal/modules/people/lead_list.go
@@ -40,9 +40,15 @@ const (
 	lastActivityColumn = "last_activity_at"
 )
 
-// leadListFields is the lead list's core sortable vocabulary. Every column
-// the list surface shows is here, so a header the reader can click is a
-// header the server can answer; active cf_ columns join it per request.
+// leadListFields is the lead list's core sortable vocabulary; active cf_
+// columns join it per request.
+//
+// It used to say every column the list shows is here, which was not true and
+// nothing held: the list draws Last activity, and a lead's is DERIVED from
+// activity_link rather than stored, so it is not a column this vocabulary can
+// name. That header no longer offers a sort, and
+// TestEverySortAListOffersIsOneItsResourceAccepts is what keeps the two
+// answering together.
 var leadListFields = map[string]string{
 	createdAtColumn:   storekit.KindTimestamp,
 	updatedAtColumn:   storekit.KindTimestamp,

--- a/backend/internal/modules/projects/read.go
+++ b/backend/internal/modules/projects/read.go
@@ -117,6 +117,11 @@ var projectListFields = map[string]string{
 	"last_activity_at": storekit.KindTimestamp,
 	projectNameField:   fieldcatalog.TypeText,
 	"target_end_date":  fieldcatalog.TypeDate,
+	// The Owner header has offered this sort for as long as the list has drawn
+	// the column, and the server refused it: `project.owner_id` is a column of
+	// the row like any other, so the refusal was the vocabulary's omission
+	// rather than anything about the field.
+	filterOwnerID: storekit.KindUUID,
 }
 
 // ListProjects answers one page under the caller's row scope.

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (106)
+## Parity (107)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -85,6 +85,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `issuelabels_test.go` | H3 | The label taxonomy is written down once and read from there. |
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |
 | `linkceilingparity_test.go` | H2 | The per-activity link ceiling is one number, wherever it is spelled. |
+| `listsortvocabulary_test.go` | H3 | The AST helpers this shares with the sibling reference census are declared under the same tag, so it carries it too rather than reaching for them from a build they are not in. |
 | `lockspelling_test.go` | H2 | One lock, two modules, and no import between them. |
 | `mailbrieflink_test.go` | H1 | The Brief's address is spelled twice: the frontend routes it (frontend/src/screens/brief.view.ts) and outbound mail links to it (internal/platform/mailcopy/link.go), because a message has to name a view before the app it opens is running. |
 | `mailcopy_test.go` | H2 | The weekly message's labels are the weekly PANEL's labels. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -85,7 +85,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `issuelabels_test.go` | H3 | The label taxonomy is written down once and read from there. |
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |
 | `linkceilingparity_test.go` | H2 | The per-activity link ceiling is one number, wherever it is spelled. |
-| `listsortvocabulary_test.go` | H3 | The AST helpers this shares with the sibling reference census are declared under the same tag, so it carries it too rather than reaching for them from a build they are not in. |
+| `listsortvocabulary_test.go` | H3 | A sort the list OFFERS is a sort the server ACCEPTS. |
 | `lockspelling_test.go` | H2 | One lock, two modules, and no import between them. |
 | `mailbrieflink_test.go` | H1 | The Brief's address is spelled twice: the frontend routes it (frontend/src/screens/brief.view.ts) and outbound mail links to it (internal/platform/mailcopy/link.go), because a message has to name a view before the app it opens is running. |
 | `mailcopy_test.go` | H2 | The weekly message's labels are the weekly PANEL's labels. |

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -52,7 +52,7 @@ import {
 } from "./listquery";
 import {
   createdColumn,
-  lastActivityColumn,
+  lastActivityCell,
   mineEmptyNote,
   ownerColumn,
   standardViews,
@@ -447,7 +447,13 @@ function LeadsWorkbench({
               </span>
             ),
           },
-          lastActivityColumn<Lead>(t, locale, recordZone),
+          {
+            // The CELL, not the shared column: a lead's last activity is
+            // DERIVED (see lastActivityCell), so this header offers no sort.
+            key: "lastActivity",
+            header: t("list.lastActivity"),
+            cell: lastActivityCell<Lead>(locale, recordZone),
+          },
           {
             key: "source",
             header: t("lead.source"),

--- a/frontend/src/screens/recordlist.tsx
+++ b/frontend/src/screens/recordlist.tsx
@@ -93,6 +93,28 @@ export function createdColumn<Row extends OwnedRecord>(
  * The Last activity column: the timeline's clock, maintained in the schema so
  * the server can sort on it; empty until something has happened.
  */
+/**
+ * The Last activity CELL, without a column around it.
+ *
+ * Split out for the one record whose last activity is DERIVED rather than
+ * stored: a lead's comes from activity_link, and the list machinery orders by a
+ * column of the row's own table, so that header must not offer a sort. It draws
+ * the same cell as everyone else, and taking the cell rather than the column is
+ * how it says so without a second renderer.
+ */
+export function lastActivityCell<Row extends OwnedRecord>(
+  locale: Locale,
+  recordZone: string,
+): (row: Row) => ReactNode {
+  return (row) => (
+    <span className="t-caption">
+      {row.last_activity_at
+        ? formatDateAbbrev(row.last_activity_at, locale, recordZone)
+        : ""}
+    </span>
+  );
+}
+
 export function lastActivityColumn<Row extends OwnedRecord>(
   t: Translate,
   locale: Locale,
@@ -101,13 +123,7 @@ export function lastActivityColumn<Row extends OwnedRecord>(
   return {
     key: "lastActivity",
     header: t("list.lastActivity"),
-    cell: (row) => (
-      <span className="t-caption">
-        {row.last_activity_at
-          ? formatDateAbbrev(row.last_activity_at, locale, recordZone)
-          : ""}
-      </span>
-    ),
+    cell: lastActivityCell<Row>(locale, recordZone),
     sort: "last_activity_at",
   };
 }


### PR DESCRIPTION
Part of #2090 — its own last ask, and two live instances of its complaint.

> Whatever replaces the allowlist should make the failure loud: a column that declares a sort the server does not accept should fail a test, not silently render a dead header.

Nothing did. The gate found two on its first run, in lists the issue never named — it was filed about deals:

```
projects.tsx   offers sort "owner_id"          (from ownerColumn())        projectListFields does not accept it
leads.list.tsx offers sort "last_activity_at"  (from lastActivityColumn()) leadListFields  does not accept it
```

Each is the issue's complaint exactly: the header renders, the reader clicks, the request is refused.

## They are not the same fix

**`project.owner_id` is a column of the row** like any other. The header has offered that sort for as long as the list has drawn the column, and the refusal was the vocabulary's omission — one entry.

**A lead's `last_activity_at` is derived.** The contract says so outright: *"Derived from activity_link, not stored on the lead."* The list machinery orders by a column of the row's own table, so that header cannot be answered until the sort model takes an expression — the same blocker `dealListFields` already records for company, partner and stage.

So leads draws the shared **cell** instead of the shared **column**. Same rendering, no offer nobody can serve, and no second renderer.

## A comment that claimed what nothing held

```go
// leadListFields is the lead list's core sortable vocabulary. Every column
// the list surface shows is here, so a header the reader can click is a
// header the server can answer;
```

It was not true — the list draws Last activity and the vocabulary cannot name it. The comment now says which column is missing and why, and the gate is what keeps the two answering together.

## Two things about the gate itself

**The Go side is read with its constants resolved.** Several vocabularies spell keys as package constants (`ownerIDColumn`, `personNameColumn`), so a scan reading string literals finds an **empty** vocabulary and agrees with every sort a screen could possibly offer. My own first pass at this was a grep for `"owner_id"` and reported it missing from all five — it is there, as `ownerIDColumn`.

**It refuses to read a computed sort.** The first version matched `sort: "field"`. I then wrote `sort: sortable ? "last_activity_at" : undefined` in the shared helper, and the mutation that should have failed came back **green** — the field went unattributed and every screen drawing it went unchecked. That is the failure direction a census must not have, so a `sort:` this scan cannot read as a literal now fails loudly.

## Mutation-verified

| mutation | findings |
|---|---|
| `projectListFields` loses `owner_id` again | 1 |
| leads re-offers the dead sort | 1 |
| the shared helper's sort made computed again | 1 |
| unmutated | 0 |

## Scope

This is the direction that needs no ruling: a header offering a field the resource does not have is a refusal in front of a user, whatever is decided about the columns that offer nothing. The other direction — #2090's ruling that every shown column *is* sortable — is answered column by column as the sort model grows, and the three joined deal columns plus this lead column are what remain.

## Verification

`make check-go`, `make check-fe`, `make craft-static` green. Gate inventory regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Project lists now support sorting by Owner as expected.
  - The Leads list no longer offers sorting for Last activity, which is derived data and cannot be reliably sorted.
  - Improved consistency between sorting options shown in lists and the sorting supported by the corresponding records.

- **Documentation**
  - Updated internal reference documentation for list-sort compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->