### PR TITLE
fix(e2e): a 404 on the read is the withdraw-only state, and the spec says so

### DIFF
--- a/frontend/e2e/public-preferences.spec.ts
+++ b/frontend/e2e/public-preferences.spec.ts
@@ -141,19 +141,43 @@ test.describe("the pages a message links to", () => {
     ).toBeVisible();
   });
 
-  test("a dead link says so once, and offers no button", async ({ page }) => {
-    await page.route("**/v1/public/preferences/**", (route) =>
-      route.fulfill({
-        status: 404,
-        json: { title: "Not Found", status: 404, code: "not_found" },
-      }),
-    );
+  // A 404 ON THE READ IS THE WITHDRAW-ONLY STATE, not a dead link. A
+  // withdrawal credential outlives the preference token it rode with and
+  // carries no authority to READ a consent state, so this page's opening fetch
+  // 404s for exactly the links that still work — the ones in old mail, which
+  // is the case one-click unsubscribe exists for. The page keeps the button and
+  // drops everything that needed the read.
+  //
+  // The mock needs no extra routing to produce that: it answers any token but
+  // TOKEN with a 404 on the read, and answers the POST regardless, which is the
+  // shape the server has for a credential that outlived its read authority.
+  test("a link that may only withdraw keeps its button, and the press still stops the purpose", async ({
+    page,
+  }) => {
+    const sent: Sent[] = [];
+    await mockPublicEdge(page, sent);
 
     await page.goto(`/#/unsubscribe/pref_gone/${PURPOSE}`);
-    await expect(page.getByText(de["prefs.invalidLink"])).toBeVisible();
+    const confirm = page.getByRole("button", {
+      name: de["prefs.unsub.confirm"],
+    });
+    await expect(confirm).toBeVisible();
+    // And no retry, which would invite the reader to hammer a read that will
+    // never succeed for this credential.
     await expect(
-      page.getByRole("button", { name: de["prefs.unsub.confirm"] }),
+      page.getByRole("button", { name: de["prefs.unsub.retry"] }),
     ).toHaveCount(0);
+
+    // The PRESS is the authority, so it has to work from this state — a button
+    // that survived the read only to refuse the withdrawal would be worse than
+    // the dead-link sentence it replaced.
+    await confirm.click();
+    await expect(
+      page.getByRole("heading", { name: de["prefs.unsub.doneTitle"] }),
+    ).toBeVisible();
+    expect(sent.find((r) => r.method === "POST")?.url).toContain(
+      `purpose=${PURPOSE}`,
+    );
   });
 
   // A locked purpose carries no control at all: one that always failed


### PR DESCRIPTION
**`main` is red on the screen-acceptance lane.** Claimed at https://github.com/margince/margince/pull/5214 (this PR), now carrying the fix.

## What was failing

```
e2e/public-preferences.spec.ts:144 › a dead link says so once, and offers no button
  Error: expect(locator).toBeVisible() failed — element(s) not found
  > 153 |  await expect(page.getByText(de["prefs.invalidLink"])).toBeVisible();
```

## The cause, in its author's own words

`14192f373` (https://github.com/margince/margince/pull/5196, *A withdrawal link outlives the mail that carried it*) changed what a 404 means, deliberately. From that commit:

> A 404 on the read is now the **WITHDRAW-ONLY** state, not a dead link.
>
> An existing test asserted a 404 read means a dead link with nothing to retry.

A withdrawal credential outlives the preference token it rode with and carries no authority to *read* a consent state, so the page's opening fetch 404s for exactly the links that **still work** — the ones sitting in old mail, which is the case one-click unsubscribe exists for.

That change updated `unsubscribe.test.tsx`, which asserts the same rule at the unit level. It missed this spec. **One invariant spelled on both sides, and only one side moved** — the e2e was left asserting the behaviour the change had just removed.

## What the case asserts now

The behaviour the page has, mirroring the unit test that was updated:

- the confirm button **survives** the failed read,
- **no retry** is offered — a read that will never succeed for this credential is not something to invite a reader to hammer,
- and **the press still stops the purpose**.

That last one is the part a visibility check alone would not catch, and it is the whole point of the credential outliving the mail. A button that survived the read only to refuse the withdrawal would be worse than the dead-link sentence it replaced.

No new mocking was needed: the existing edge stub already answers any token but `TOKEN` with a 404 on the read and answers the POST regardless, which is exactly the server's shape for a credential that outlived its read authority.

`prefs.invalidLink` is **not** dead — `preferences.tsx` still shows it for the preference centre, a different surface with a different rule. Only the unsubscribe page stopped meaning it.

## How verified

- `make frontend-e2e` — **381 passed**, the whole lane, the way CI runs it.
- Reproduced the red first on a clean, freshly built `origin/main` (`ca5b2d991`): 7 passed, 1 failed, the same case.

**A correction worth recording, because it nearly sent me the wrong way.** My first local run of this spec passed 8/8 and I said so. That run was served by `vite preview` off a `dist/` built *before* I rebased onto current `main` — a stale artifact. `make frontend-e2e` builds first; `playwright test` by hand does not. The pass was of yesterday's code, and the honest reading only appeared after a rebuild.

- [x] `make check` is green — this diff is one e2e spec; the lane that governs it is run in full above. `biome check` clean
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — it touches neither; no Go, no SQL
- [x] `make craft-static` reports no new blockers — it sweeps the Go trees, and this diff has none
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## Suspect range, for the record

`main-health`'s last green `uat` was `7a246a72` at 00:14Z; six commits landed after it. `14192f373` is the one, confirmed by reading its diff rather than guessed from its subject.

## AI involvement

Written by Claude Code. Found while driving https://github.com/margince/margince/pull/5205 (an unrelated benchmark-instrumentation change) to green: that PR's `uat` failed twice on a spec its diff cannot collect, which is what said the failure was `main`'s.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
