### PR TITLE
fix(contract-api): retention.applied publishes a closed action set

### DIFF
--- a/backend/api/public-events.yaml
+++ b/backend/api/public-events.yaml
@@ -2892,7 +2892,24 @@ components:
       properties:
         action:
           type: string
-          description: The action that ran (archive | anonymize | erase).
+          enum: [archive, anonymize, erase]
+          # Named explicitly: these three generate `Archive`, `Anonymize` and
+          # `Erase`, which crm.yaml's RetentionAction already holds — and a
+          # collision there silently renames THAT enum's constants and breaks
+          # modules with no connection to this one.
+          x-enum-varnames:
+            - RetentionAppliedArchive
+            - RetentionAppliedAnonymize
+            - RetentionAppliedErase
+          description: >-
+            The action that ran. A CLOSED set, so a subscriber can switch on it
+            exhaustively — which is the whole reason for closing it: an open
+            field leaves a consumer to either branch on values nobody has
+            defined or drop what it does not recognise, and a silent drop looks
+            exactly like no event. `retention_policy.action` carries the same
+            three under a CHECK, and a gate holds the two spellings together.
+            Restriction is NOT a fourth action here: it emits
+            retention.restricted, whose own action is a different closed set.
         policy:
           type: string
           format: uuid

--- a/backend/gates/corepicklistcontract_test.go
+++ b/backend/gates/corepicklistcontract_test.go
@@ -226,13 +226,22 @@ func descendContract(t *testing.T, doc map[string]any, path ...string) map[strin
 
 func loadContractDocument(t *testing.T) map[string]any {
 	t.Helper()
-	raw, err := os.ReadFile(contractDocument)
+	return loadOpenAPIDocument(t, contractDocument)
+}
+
+// loadOpenAPIDocument reads one OpenAPI document as untyped nodes, for the
+// readers above. The path is a parameter because the product publishes two —
+// crm.yaml to callers and public-events.yaml to subscribers — and a set spelled
+// in both is read here twice rather than by two readers.
+func loadOpenAPIDocument(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("reading %s: %v", contractDocument, err)
+		t.Fatalf("reading %s: %v", path, err)
 	}
 	var doc map[string]any
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		t.Fatalf("parsing %s: %v", contractDocument, err)
+		t.Fatalf("parsing %s: %v", path, err)
 	}
 	return doc
 }

--- a/backend/gates/retentionactionset_test.go
+++ b/backend/gates/retentionactionset_test.go
@@ -59,7 +59,19 @@ func retentionActionCheck(t *testing.T) []string {
 		}
 		out := make([]string, 0, len(values))
 		for _, value := range values {
-			out = append(out, value[1])
+			// SQL doubles a quote to escape it; the stored value has one.
+			out = append(out, strings.ReplaceAll(value[1], "''", "'"))
+		}
+		// EVERY literal, or none of them. A value the pattern cannot read is
+		// dropped from the set and the remaining ones still match the
+		// contract's — so the gate would pass while the two had diverged by
+		// exactly the value nobody could parse, which is the failure a census
+		// must not have. Removing what was read must leave no quote behind.
+		if rest := quotedSQLText.ReplaceAllString(line, ""); strings.Contains(rest, "'") {
+			t.Fatalf("the retention action CHECK carries a quoted value this reader cannot parse:\n\t%s\n"+
+				"It read %v and left %q. A value it cannot see is one it cannot compare, and the values "+
+				"it CAN see would still match the contract — so this gate would report agreement over a divergence",
+				line, out, rest)
 		}
 		sort.Strings(out)
 		return out
@@ -70,7 +82,11 @@ func retentionActionCheck(t *testing.T) []string {
 
 // quotedSQLText pulls the literals out of a rendered CHECK, which the catalog
 // writes as `ARRAY['archive'::text, …]`.
-var quotedSQLText = regexp.MustCompile(`'([a-z_]+)'::text`)
+// quotedSQLText matches one SQL string literal and its cast, doubled quotes
+// included. Deliberately not `[a-z_]+`: a value carrying a hyphen, a capital or
+// a space is one this reader would silently skip, and skipping is the direction
+// that reports agreement over a divergence.
+var quotedSQLText = regexp.MustCompile(`'((?:''|[^'])*)'::text`)
 
 // TestTheRetentionActionSetIsOneSet holds the three spellings together.
 func TestTheRetentionActionSetIsOneSet(t *testing.T) {

--- a/backend/gates/retentionactionset_test.go
+++ b/backend/gates/retentionactionset_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// One set of retention actions, spelled in three places.
+//
+// `retention_policy.action` carries a CHECK; `crm.yaml` publishes
+// RetentionAction to the API; `public-events.yaml` publishes the same values on
+// retention.applied to subscribers. All three are hand-written, and each is the
+// authority for a different reader — the database refuses a row, the API refuses
+// a request, and the event contract is what lets a subscriber switch on the
+// value exhaustively.
+//
+// They fail differently in each direction, which is why this asserts EQUALITY
+// rather than containment:
+//
+//   - a value in the database and not on the event is one an emit site can ship
+//     and every subscriber drops in silence, which reads exactly like no event
+//     having been emitted;
+//   - a value on the event and not in the database is a promise to subscribers
+//     that nothing can produce, so a consumer writes a branch that never runs;
+//   - a value in the API and not the database is a request accepted and then
+//     refused by a constraint, with the caller told nothing useful.
+//
+// The gate is what makes the third copy safe to have. Deriving one from another
+// was the alternative, and there is nowhere to derive from: the CHECK is SQL in
+// a shipped migration, and the two contracts are read by generators that resolve
+// no cross-document reference.
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// retentionActionCheck reads the values the database admits, out of the schema
+// head rather than any one migration: a later migration may have widened or
+// narrowed the CHECK, and the head is what a running installation has.
+func retentionActionCheck(t *testing.T) []string {
+	t.Helper()
+	const catalog = "migrations/testdata/head_catalog.txt"
+	const constraint = "public.retention_policy.retention_policy_action_check "
+	raw, err := os.ReadFile(catalog)
+	if err != nil {
+		t.Fatalf("reading the schema head: %v", err)
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		if !strings.HasPrefix(line, constraint) {
+			continue
+		}
+		values := quotedSQLText.FindAllStringSubmatch(line, -1)
+		if len(values) == 0 {
+			t.Fatalf("the retention action CHECK reads %q and names no value — this gate would compare against nothing", line)
+		}
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			out = append(out, value[1])
+		}
+		sort.Strings(out)
+		return out
+	}
+	t.Fatalf("no retention_policy action CHECK at schema head — either the column stopped being constrained, which is its own defect, or this reader stopped finding it")
+	return nil
+}
+
+// quotedSQLText pulls the literals out of a rendered CHECK, which the catalog
+// writes as `ARRAY['archive'::text, …]`.
+var quotedSQLText = regexp.MustCompile(`'([a-z_]+)'::text`)
+
+// TestTheRetentionActionSetIsOneSet holds the three spellings together.
+func TestTheRetentionActionSetIsOneSet(t *testing.T) {
+	t.Parallel()
+	database := retentionActionCheck(t)
+	for _, spelling := range []struct {
+		what     string
+		path     string
+		schema   string
+		property string
+	}{
+		{"the API's RetentionAction", "api/crm.yaml", "RetentionAction", ""},
+		{"retention.applied's action", "api/public-events.yaml", "PublicEventRetentionApplied", "action"},
+	} {
+		doc := loadOpenAPIDocument(t, spelling.path)
+		published := contractEnum(t, doc, spelling.schema, spelling.property)
+		if len(published) == 0 {
+			t.Errorf("%s declares no enum — an open field is what this gate exists to find", spelling.what)
+			continue
+		}
+		names := make([]string, 0, len(published))
+		for value := range published {
+			names = append(names, value)
+		}
+		sort.Strings(names)
+		if strings.Join(names, ",") != strings.Join(database, ",") {
+			t.Errorf("%s publishes %v and retention_policy.action admits %v — one set, and the two ends of it disagree",
+				spelling.what, names, database)
+		}
+	}
+}

--- a/backend/internal/contracts/publicevents_gen.go
+++ b/backend/internal/contracts/publicevents_gen.go
@@ -357,6 +357,27 @@ func (e PublicEventRelationshipNudgeDecidedAction) Valid() bool {
 	}
 }
 
+// Defines values for PublicEventRetentionAppliedAction.
+const (
+	RetentionAppliedAnonymize PublicEventRetentionAppliedAction = "anonymize"
+	RetentionAppliedArchive   PublicEventRetentionAppliedAction = "archive"
+	RetentionAppliedErase     PublicEventRetentionAppliedAction = "erase"
+)
+
+// Valid indicates whether the value is a known member of the PublicEventRetentionAppliedAction enum.
+func (e PublicEventRetentionAppliedAction) Valid() bool {
+	switch e {
+	case RetentionAppliedAnonymize:
+		return true
+	case RetentionAppliedArchive:
+		return true
+	case RetentionAppliedErase:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PublicEventRetentionRestrictedAction.
 const (
 	Pin      PublicEventRetentionRestrictedAction = "pin"
@@ -2002,8 +2023,8 @@ type PublicEventRelationshipNudgeDecidedAction string
 
 // PublicEventRetentionApplied Payload for retention.applied — a retention/erasure action ran against one record. Four emit sites, four different runtime subjects: the embed-call sweep (ai_call), the voice-learning-signal content sweep (voice_learning_signal), a workspace's configured retention policy's object type (activity | deal | lead | person | ai_call_payload), and Art. 17 erasure (person) — none fixed enough for this schema to name, so this is dynamic-entity (contract `x-entity-type: dynamic`): the generated EntityType() is unused, and each emit site supplies its own runtime entity type through storekit.EmitEventForEntity. policy/reason are a union across the sites — both telemetry sweeps set neither, the policy-driven sweep sets policy only, Art. 17 erasure sets reason only.
 type PublicEventRetentionApplied struct {
-	// Action The action that ran (archive | anonymize | erase).
-	Action string `json:"action"`
+	// Action The action that ran. A CLOSED set, so a subscriber can switch on it exhaustively — which is the whole reason for closing it: an open field leaves a consumer to either branch on values nobody has defined or drop what it does not recognise, and a silent drop looks exactly like no event. `retention_policy.action` carries the same three under a CHECK, and a gate holds the two spellings together. Restriction is NOT a fourth action here: it emits retention.restricted, whose own action is a different closed set.
+	Action PublicEventRetentionAppliedAction `json:"action"`
 
 	// Policy The retention policy that drove this action (absent for the fixed embed-call sweep and for Art. 17 erasure, neither of which is policy-configured).
 	Policy *openapi_types.UUID `json:"policy,omitempty"`
@@ -2011,6 +2032,9 @@ type PublicEventRetentionApplied struct {
 	// Reason Why this action ran (Art. 17 erasure only — e.g. dsr_request; absent for both retention-sweep sites).
 	Reason *string `json:"reason,omitempty"`
 }
+
+// PublicEventRetentionAppliedAction The action that ran. A CLOSED set, so a subscriber can switch on it exhaustively — which is the whole reason for closing it: an open field leaves a consumer to either branch on values nobody has defined or drop what it does not recognise, and a silent drop looks exactly like no event. `retention_policy.action` carries the same three under a CHECK, and a gate holds the two spellings together. Restriction is NOT a fourth action here: it emits retention.restricted, whose own action is a different closed set.
+type PublicEventRetentionAppliedAction string
 
 // PublicEventRetentionRestricted Payload for retention.restricted — a statutory retention obligation changed what may be done with one record (A165/ADR-0114). Its own event type rather than a widening of retention.applied, because `restrict` carries an obligation on the SUBSCRIBER that no existing action does: the record survives in storage and must not survive in a projection. Adding it to retention.applied would have changed the meaning of a field subscribers already parse, which the versioning rule forbids within a major.
 type PublicEventRetentionRestricted struct {

--- a/backend/internal/modules/privacy/erasure_tombstone.go
+++ b/backend/internal/modules/privacy/erasure_tombstone.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -41,5 +42,5 @@ func tombstonePersonErasure(ctx context.Context, tx pgx.Tx, subject ids.PersonID
 	if err != nil {
 		return err
 	}
-	return storekit.EmitEventForEntity(ctx, tx, auditID, "person", subject.UUID, retentionAppliedPayload(actionErase, nil, &reason))
+	return storekit.EmitEventForEntity(ctx, tx, auditID, "person", subject.UUID, retentionAppliedPayload(crmcontracts.RetentionAppliedErase, nil, &reason))
 }

--- a/backend/internal/modules/privacy/purge.go
+++ b/backend/internal/modules/privacy/purge.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -128,7 +129,7 @@ func (s *RetentionService) purgeOneActivity(ctx context.Context, id ids.UUID, re
 			return err
 		}
 		return storekit.EmitEventForEntity(ctx, tx, auditID, "activity", id,
-			retentionAppliedPayload(actionErase, nil, nil))
+			retentionAppliedPayload(crmcontracts.RetentionAppliedErase, nil, nil))
 	})
 }
 
@@ -180,7 +181,7 @@ func (s *RetentionService) anonymiseOnePerson(ctx context.Context, id ids.UUID, 
 			return err
 		}
 		return storekit.EmitEventForEntity(ctx, tx, auditID, "person", id,
-			retentionAppliedPayload(actionAnonymize, nil, nil))
+			retentionAppliedPayload(crmcontracts.RetentionAppliedAnonymize, nil, nil))
 	})
 }
 

--- a/backend/internal/modules/privacy/retention.go
+++ b/backend/internal/modules/privacy/retention.go
@@ -38,7 +38,16 @@ import (
 // per site). policyID/reason are each nil where that site's
 // action carries no such value — the union this schema's optional
 // policy/reason fields exist for.
-func retentionAppliedPayload(action string, policyID *ids.UUID, reason *string) crmcontracts.PublicEventRetentionApplied {
+//
+// The action is the contract's own type rather than a string, so a fourth one
+// cannot reach a subscriber by being spelled at an emit site: the set is closed
+// in the schema, and the compiler is what holds the sites to it. A subscriber
+// switching on the three exhaustively is the whole reason the set is closed, and
+// a value it does not know is dropped in silence that reads exactly like no
+// event.
+func retentionAppliedPayload(
+	action crmcontracts.PublicEventRetentionAppliedAction, policyID *ids.UUID, reason *string,
+) crmcontracts.PublicEventRetentionApplied {
 	payload := crmcontracts.PublicEventRetentionApplied{Action: action}
 	if policyID != nil {
 		policy := openapi_types.UUID(*policyID)

--- a/backend/internal/modules/privacy/retention.go
+++ b/backend/internal/modules/privacy/retention.go
@@ -31,6 +31,26 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
 )
 
+// publishedRetentionAction is the check the one emit site whose action comes off
+// a ROW rather than out of the code has to make.
+//
+// Every other site passes a contract constant, so the compiler holds them.
+// retention_policy.action carries the same closed set under a CHECK, but a row
+// written before a value was retired — or by a migration that widened the CHECK
+// without the contract — would otherwise ship an event every subscriber drops in
+// silence, which is the shape this event's closed set exists to stop.
+func publishedRetentionAction(
+	stored string, policyID ids.UUID,
+) (crmcontracts.PublicEventRetentionAppliedAction, error) {
+	action := crmcontracts.PublicEventRetentionAppliedAction(stored)
+	if !action.Valid() {
+		return "", fmt.Errorf(
+			"privacy: retention policy %s names the action %q, which retention.applied does not publish",
+			policyID, stored)
+	}
+	return action, nil
+}
+
 // retentionAppliedPayload builds the retention.applied wire payload — the
 // subject travels separately (the caller's own entityType, passed to
 // storekit.EmitEventForEntity), since this event's entity is dynamic

--- a/backend/internal/modules/privacy/retention_payload_test.go
+++ b/backend/internal/modules/privacy/retention_payload_test.go
@@ -227,3 +227,47 @@ func TestRetentionAppliedEmitUsesRuntimeEntityType(t *testing.T) {
 		})
 	}
 }
+
+// The row-sourced action is checked against what the contract publishes.
+//
+// Every other emit site passes a contract constant and is held by the compiler.
+// This one takes retention_policy.action off the row, and the CHECK there
+// currently admits exactly the three the contract does — held by
+// TestTheRetentionActionSetIsOneSet, which is what makes the two agree today.
+//
+// So this guard is for the day they DO NOT: a migration that widens the CHECK
+// without the contract, or an installation whose schema drifted. It fails at a
+// different moment than the gate does — the gate on a diff, this on a database
+// — and the failure it prevents is an event every subscriber drops in silence,
+// which reads exactly like no event having been emitted.
+//
+// Asserted as a function rather than through a row, because the CHECK means no
+// row can carry the value that exercises it; a case that went through Postgres
+// could only test the arm the constraint already forbids.
+func TestARowsRetentionActionIsCheckedAgainstWhatIsPublished(t *testing.T) {
+	policy := ids.NewV7()
+
+	for _, published := range []string{"archive", "anonymize", "erase"} {
+		action, err := publishedRetentionAction(published, policy)
+		if err != nil {
+			t.Errorf("the contract publishes %q and the check refused it: %v", published, err)
+		}
+		if string(action) != published {
+			t.Errorf("checking %q answered %q — the value a subscriber switches on must be the one stored",
+				published, action)
+		}
+	}
+
+	action, err := publishedRetentionAction("redact", policy)
+	if err == nil {
+		t.Fatalf("an action retention.applied does not publish was accepted as %q — the event would "+
+			"ship and every subscriber switching on the three known values would drop it", action)
+	}
+	// The VALUE and the POLICY, both. An operator meeting this has to find the
+	// row, and a message naming neither sends them to grep the whole table.
+	for _, want := range []string{"redact", policy.String()} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal %q does not name %q", err, want)
+		}
+	}
+}

--- a/backend/internal/modules/privacy/retention_payload_test.go
+++ b/backend/internal/modules/privacy/retention_payload_test.go
@@ -47,7 +47,7 @@ import (
 // TestRetentionAppliedPayload_ActionOnly proves the embed-call sweep's
 // subset (retention.go's eraseEmbedCall): action only, no policy or reason.
 func TestRetentionAppliedPayload_ActionOnly(t *testing.T) {
-	payload := retentionAppliedPayload(actionErase, nil, nil)
+	payload := retentionAppliedPayload(crmcontracts.RetentionAppliedErase, nil, nil)
 
 	if !reflect.DeepEqual(payload.EventType(), "retention.applied") {
 		t.Errorf("got %v, want %v", payload.EventType(), "retention.applied")
@@ -55,8 +55,8 @@ func TestRetentionAppliedPayload_ActionOnly(t *testing.T) {
 	if !reflect.DeepEqual(payload.EntityType(), "dynamic") {
 		t.Errorf("retention.applied is a dynamic-entity type — its static EntityType() is unused; the real subject comes from EmitEventForEntity's caller-supplied entityType: got %v, want %v", payload.EntityType(), "dynamic")
 	}
-	if !reflect.DeepEqual(payload.Action, actionErase) {
-		t.Errorf("got %v, want %v", payload.Action, actionErase)
+	if !reflect.DeepEqual(payload.Action, crmcontracts.RetentionAppliedErase) {
+		t.Errorf("got %v, want %v", payload.Action, crmcontracts.RetentionAppliedErase)
 	}
 	if payload.Policy != nil {
 		t.Errorf("expected nil, got %v", payload.Policy)
@@ -89,10 +89,10 @@ func TestRetentionAppliedPayload_ActionOnly(t *testing.T) {
 func TestRetentionAppliedPayload_WithPolicy(t *testing.T) {
 	policyID := ids.NewV7()
 
-	payload := retentionAppliedPayload("archive", &policyID, nil)
+	payload := retentionAppliedPayload(crmcontracts.RetentionAppliedArchive, &policyID, nil)
 
-	if !reflect.DeepEqual(payload.Action, "archive") {
-		t.Errorf("got %v, want %v", payload.Action, "archive")
+	if !reflect.DeepEqual(payload.Action, crmcontracts.RetentionAppliedArchive) {
+		t.Errorf("got %v, want %v", payload.Action, crmcontracts.RetentionAppliedArchive)
 	}
 	if payload.Policy == nil {
 		t.Fatalf("expected non-nil value")
@@ -110,10 +110,10 @@ func TestRetentionAppliedPayload_WithPolicy(t *testing.T) {
 func TestRetentionAppliedPayload_WithReason(t *testing.T) {
 	reason := "dsr_request"
 
-	payload := retentionAppliedPayload(actionErase, nil, &reason)
+	payload := retentionAppliedPayload(crmcontracts.RetentionAppliedErase, nil, &reason)
 
-	if !reflect.DeepEqual(payload.Action, actionErase) {
-		t.Errorf("got %v, want %v", payload.Action, actionErase)
+	if !reflect.DeepEqual(payload.Action, crmcontracts.RetentionAppliedErase) {
+		t.Errorf("got %v, want %v", payload.Action, crmcontracts.RetentionAppliedErase)
 	}
 	if payload.Policy != nil {
 		t.Errorf("expected nil, got %v", payload.Policy)
@@ -208,7 +208,7 @@ func decodedOutboxEntityType(t *testing.T, tx *fakeTx) string {
 // wire entity_type tracks the caller-supplied subject, not the payload's
 // static type.
 func TestRetentionAppliedEmitUsesRuntimeEntityType(t *testing.T) {
-	payload := retentionAppliedPayload(actionErase, nil, nil)
+	payload := retentionAppliedPayload(crmcontracts.RetentionAppliedErase, nil, nil)
 
 	for _, entityType := range []string{"ai_call", "activity", "deal", "person"} {
 		t.Run(entityType, func(t *testing.T) {

--- a/backend/internal/modules/privacy/retentionactions.go
+++ b/backend/internal/modules/privacy/retentionactions.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -141,15 +140,9 @@ func (s *RetentionService) apply(ctx context.Context, pol retentionPolicy, id id
 			return err
 		}
 		policyID := pol.ID
-		// The one site whose action comes off a ROW rather than out of the
-		// code, so it is the one that has to check. retention_policy.action
-		// carries the same closed set under a CHECK, but a row written before a
-		// value was retired — or by a migration that widened the CHECK without
-		// the contract — would otherwise ship an event every subscriber drops
-		// in silence, which is the shape this event's closed set exists to stop.
-		action := crmcontracts.PublicEventRetentionAppliedAction(pol.Action)
-		if !action.Valid() {
-			return fmt.Errorf("privacy: retention policy %s names the action %q, which retention.applied does not publish", pol.ID, pol.Action)
+		action, err := publishedRetentionAction(pol.Action, pol.ID)
+		if err != nil {
+			return err
 		}
 		return storekit.EmitEventForEntity(ctx, tx, auditID, pol.ObjectType, id, retentionAppliedPayload(action, &policyID, nil))
 	})

--- a/backend/internal/modules/privacy/retentionactions.go
+++ b/backend/internal/modules/privacy/retentionactions.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -140,7 +141,17 @@ func (s *RetentionService) apply(ctx context.Context, pol retentionPolicy, id id
 			return err
 		}
 		policyID := pol.ID
-		return storekit.EmitEventForEntity(ctx, tx, auditID, pol.ObjectType, id, retentionAppliedPayload(pol.Action, &policyID, nil))
+		// The one site whose action comes off a ROW rather than out of the
+		// code, so it is the one that has to check. retention_policy.action
+		// carries the same closed set under a CHECK, but a row written before a
+		// value was retired — or by a migration that widened the CHECK without
+		// the contract — would otherwise ship an event every subscriber drops
+		// in silence, which is the shape this event's closed set exists to stop.
+		action := crmcontracts.PublicEventRetentionAppliedAction(pol.Action)
+		if !action.Valid() {
+			return fmt.Errorf("privacy: retention policy %s names the action %q, which retention.applied does not publish", pol.ID, pol.Action)
+		}
+		return storekit.EmitEventForEntity(ctx, tx, auditID, pol.ObjectType, id, retentionAppliedPayload(action, &policyID, nil))
 	})
 }
 

--- a/backend/internal/modules/privacy/retentionai.go
+++ b/backend/internal/modules/privacy/retentionai.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -75,7 +76,7 @@ func (s *RetentionService) eraseVoiceSignalContent(ctx context.Context, id ids.U
 		if err != nil {
 			return err
 		}
-		return storekit.EmitEventForEntity(ctx, tx, auditID, "voice_learning_signal", id, retentionAppliedPayload(actionErase, nil, nil))
+		return storekit.EmitEventForEntity(ctx, tx, auditID, "voice_learning_signal", id, retentionAppliedPayload(crmcontracts.RetentionAppliedErase, nil, nil))
 	})
 }
 
@@ -147,6 +148,6 @@ func (s *RetentionService) eraseEmbedCall(ctx context.Context, id ids.UUID) erro
 		if err != nil {
 			return err
 		}
-		return storekit.EmitEventForEntity(ctx, tx, auditID, "ai_call", id, retentionAppliedPayload(actionErase, nil, nil))
+		return storekit.EmitEventForEntity(ctx, tx, auditID, "ai_call", id, retentionAppliedPayload(crmcontracts.RetentionAppliedErase, nil, nil))
 	})
 }

--- a/backend/internal/modules/privacy/retentionrestricted.go
+++ b/backend/internal/modules/privacy/retentionrestricted.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -110,7 +111,7 @@ func (s *RetentionService) expireRestriction(ctx context.Context, id ids.UUID) e
 			return err
 		}
 		reason := restrictionExpiredCause
-		return storekit.EmitEventForEntity(ctx, tx, auditID, "activity", id, retentionAppliedPayload(actionErase, nil, &reason))
+		return storekit.EmitEventForEntity(ctx, tx, auditID, "activity", id, retentionAppliedPayload(crmcontracts.RetentionAppliedErase, nil, &reason))
 	})
 }
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (106)
+## Parity (105)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -85,7 +85,6 @@ The eight shapes, what each is for, and how each one silently passes:
 | `issuelabels_test.go` | H3 | The label taxonomy is written down once and read from there. |
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |
 | `linkceilingparity_test.go` | H2 | The per-activity link ceiling is one number, wherever it is spelled. |
-| `lockspelling_test.go` | H2 | One lock, two modules, and no import between them. |
 | `mailbrieflink_test.go` | H1 | The Brief's address is spelled twice: the frontend routes it (frontend/src/screens/brief.view.ts) and outbound mail links to it (internal/platform/mailcopy/link.go), because a message has to name a view before the app it opens is running. |
 | `mailcopy_test.go` | H2 | The weekly message's labels are the weekly PANEL's labels. |
 | `meetinghorizonparity_test.go` | H2 | How far into the diary a meeting still says a relationship is live, spelled twice in two modules that may not import each other, and held equal here. |
@@ -244,7 +243,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `reportasof_test.go` | H2 | A report's answer is labelled with the instant it was COMPUTED at. |
 | `requiredbodyids_test.go` | H3 | Every contract request body that declares a required id must be accounted for. |
 | `restrictedreaders_test.go` | H2 | A record held under a statutory retention obligation is unavailable in EVERY ordinary read path (A165/ADR-0114 §2): lists, timelines, search, exports, embeddings, agent grounding. |
-| `rightscasewriters_test.go` | H2 | EVERY PROPOSAL A DATA SUBJECT SENDS OPENS A CASE SOMEBODY OWES AN ANSWER TO. |
+| `retentionactionset_test.go` | H2 | One set of retention actions, spelled in three places. |
 | `rlsclaimsprose_test.go` | H2 | The prose says what bounds a read, and it is not row-level security. |
 | `rulebookdelegation_test.go` | H3 | AGENTS.md is the rulebook — at the root, and in any directory that needs one of its own. |
 | `safetydefects_test.go` | H2 | Every declared stage-automation safety defect can actually stop a rule. |
@@ -384,7 +383,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `waiveronoffender_test.go` | H2 | A waiver must be asked about an offender, never about a candidate. |
 | `workflowhandler_test.go` | H2 | The workflow.Handler read/write contract as a fitness function (ports/workflow.Handler): Match is a pure predicate and Plan computes the typed Effect WITHOUT applying it — "this is what makes dry-run and diff preview possible". |
 
-## Claim (11)
+## Claim (10)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -393,7 +392,6 @@ The eight shapes, what each is for, and how each one silently passes:
 | `elapsedonespelling_test.go` | H1 | "How many days of silence" is spelled once. |
 | `employmentcurrency_test.go` | H1 | employment.IsCurrentSQL calls itself "the ONE spelling of 'this job is still theirs', and the only definition of a current employment in this product". |
 | `livemember_test.go` | H1 | "Someone who still works here" is `status = 'active' AND archived\_at IS NULL` on app\_user, and TWO functions in two different packages each called themselves the ONE spelling of it while the tree held about twenty copies. |
-| `meetingoverspelling_test.go` | H2 | "This meeting is over" is spelled twice, and the two must say the same thing. |
 | `noisejudgedspelling_test.go` | H2 | "An already-settled answer disowns this contact" is spelled once. |
 | `onedraftwriter_test.go` | H1 | One writer produces every grounded draft, or the surfaces drift. |
 | `renovatelockfileage_test.go` | H3 | The lockfile refresh is not held back by the repo-wide release-age floor. |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (105)
+## Parity (106)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -85,6 +85,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `issuelabels_test.go` | H3 | The label taxonomy is written down once and read from there. |
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |
 | `linkceilingparity_test.go` | H2 | The per-activity link ceiling is one number, wherever it is spelled. |
+| `lockspelling_test.go` | H2 | One lock, two modules, and no import between them. |
 | `mailbrieflink_test.go` | H1 | The Brief's address is spelled twice: the frontend routes it (frontend/src/screens/brief.view.ts) and outbound mail links to it (internal/platform/mailcopy/link.go), because a message has to name a view before the app it opens is running. |
 | `mailcopy_test.go` | H2 | The weekly message's labels are the weekly PANEL's labels. |
 | `meetinghorizonparity_test.go` | H2 | How far into the diary a meeting still says a relationship is live, spelled twice in two modules that may not import each other, and held equal here. |
@@ -125,7 +126,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (141)
+## Census (142)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -244,6 +245,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `requiredbodyids_test.go` | H3 | Every contract request body that declares a required id must be accounted for. |
 | `restrictedreaders_test.go` | H2 | A record held under a statutory retention obligation is unavailable in EVERY ordinary read path (A165/ADR-0114 §2): lists, timelines, search, exports, embeddings, agent grounding. |
 | `retentionactionset_test.go` | H2 | One set of retention actions, spelled in three places. |
+| `rightscasewriters_test.go` | H2 | EVERY PROPOSAL A DATA SUBJECT SENDS OPENS A CASE SOMEBODY OWES AN ANSWER TO. |
 | `rlsclaimsprose_test.go` | H2 | The prose says what bounds a read, and it is not row-level security. |
 | `rulebookdelegation_test.go` | H3 | AGENTS.md is the rulebook — at the root, and in any directory that needs one of its own. |
 | `safetydefects_test.go` | H2 | Every declared stage-automation safety defect can actually stop a rule. |
@@ -383,7 +385,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `waiveronoffender_test.go` | H2 | A waiver must be asked about an offender, never about a candidate. |
 | `workflowhandler_test.go` | H2 | The workflow.Handler read/write contract as a fitness function (ports/workflow.Handler): Match is a pure predicate and Plan computes the typed Effect WITHOUT applying it — "this is what makes dry-run and diff preview possible". |
 
-## Claim (10)
+## Claim (11)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -392,6 +394,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `elapsedonespelling_test.go` | H1 | "How many days of silence" is spelled once. |
 | `employmentcurrency_test.go` | H1 | employment.IsCurrentSQL calls itself "the ONE spelling of 'this job is still theirs', and the only definition of a current employment in this product". |
 | `livemember_test.go` | H1 | "Someone who still works here" is `status = 'active' AND archived\_at IS NULL` on app\_user, and TWO functions in two different packages each called themselves the ONE spelling of it while the tree held about twenty copies. |
+| `meetingoverspelling_test.go` | H2 | "This meeting is over" is spelled twice, and the two must say the same thing. |
 | `noisejudgedspelling_test.go` | H2 | "An already-settled answer disowns this contact" is spelled once. |
 | `onedraftwriter_test.go` | H1 | One writer produces every grounded draft, or the surfaces drift. |
 | `renovatelockfileage_test.go` | H3 | The lockfile refresh is not held back by the repo-wide release-age floor. |

--- a/frontend/src/api/public-events.ts
+++ b/frontend/src/api/public-events.ts
@@ -1212,8 +1212,11 @@ export interface components {
         };
         /** @description Payload for retention.applied — a retention/erasure action ran against one record. Four emit sites, four different runtime subjects: the embed-call sweep (ai_call), the voice-learning-signal content sweep (voice_learning_signal), a workspace's configured retention policy's object type (activity | deal | lead | person | ai_call_payload), and Art. 17 erasure (person) — none fixed enough for this schema to name, so this is dynamic-entity (contract `x-entity-type: dynamic`): the generated EntityType() is unused, and each emit site supplies its own runtime entity type through storekit.EmitEventForEntity. policy/reason are a union across the sites — both telemetry sweeps set neither, the policy-driven sweep sets policy only, Art. 17 erasure sets reason only. */
         PublicEventRetentionApplied: {
-            /** @description The action that ran (archive | anonymize | erase). */
-            action: string;
+            /**
+             * @description The action that ran. A CLOSED set, so a subscriber can switch on it exhaustively — which is the whole reason for closing it: an open field leaves a consumer to either branch on values nobody has defined or drop what it does not recognise, and a silent drop looks exactly like no event. `retention_policy.action` carries the same three under a CHECK, and a gate holds the two spellings together. Restriction is NOT a fourth action here: it emits retention.restricted, whose own action is a different closed set.
+             * @enum {string}
+             */
+            action: "archive" | "anonymize" | "erase";
             /**
              * Format: uuid
              * @description The retention policy that drove this action (absent for the fixed embed-call sweep and for Art. 17 erasure, neither of which is policy-configured).
@@ -1738,6 +1741,7 @@ export const publicEventIntroRequestCompletedOutcomeValues: ReadonlyArray<Flatte
 export const publicEventIntroRequestClosedReasonValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["PublicEventIntroRequestClosed"]["reason"]> = ["cancelled", "expired"];
 export const publicEventCommsDeliveryBouncedKindValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["PublicEventCommsDeliveryBounced"]["kind"]> = ["hard", "soft"];
 export const publicEventRetentionRestrictedActionValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["PublicEventRetentionRestricted"]["action"]> = ["restrict", "release", "pin"];
+export const publicEventRetentionAppliedActionValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["PublicEventRetentionApplied"]["action"]> = ["archive", "anonymize", "erase"];
 export const userReactivatedStatusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["UserReactivatedStatus"]> = ["invited", "active"];
 export const publicEventTeamChangedChangeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["PublicEventTeamChanged"]["change"]> = ["created", "renamed", "archived", "restored", "member_added", "member_removed"];
 export const publicEventApprovalDecidedVerdictValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["PublicEventApprovalDecided"]["verdict"]> = ["approved", "rejected", "expired"];


### PR DESCRIPTION
Closes #1769. Both halves: the enum, and a gate holding it against the CHECK.

## The gap

ADR-0117 closed `retention.applied`'s `action` to `archive | anonymize | erase`.
The contract carried the three **in prose** and the schema admitted any string,
so the generated Go and TypeScript followed the schema and nothing refused a
fourth value. A subscriber reading that sees an open field, which leaves two bad
choices: branch on values nobody has defined, or drop what it does not recognise
— and a silent drop reads exactly like no event having been emitted.

`retention.restricted.action`, right beside it in the same file, was already a
proper enum. This was an oversight rather than a design choice.

## Named constants, deliberately

`archive`/`anonymize`/`erase` generate `Archive`/`Anonymize`/`Erase`, and
crm.yaml's `RetentionAction` already holds those three names in the same package.
A collision there **silently renames that enum's constants** and breaks modules
with no connection to this one, so the values take `x-enum-varnames` — the idiom
this contract already uses for `meeting_status`, with the same reason recorded
beside it.

## The compiler holds the emit sites now

`retentionAppliedPayload` takes `PublicEventRetentionAppliedAction` rather than a
string, so a fourth action cannot reach a subscriber by being spelled at an emit
site — which is the ticket's failure scenario: *"an emit site that passes the
value straight into the event payload bypasses [the CHECK]"*.

Five of the six sites pass a constant. The sixth takes its action off a **row**
(`retentionactions.go`, the policy-driven sweep) and cannot be held by the
compiler, so it checks `Valid()` and refuses with the value named. The CHECK
bounds what can be written today; a row written before a value was retired, or a
migration that widened the CHECK without the contract, is what that guard is for.

## The gate — the issue's second half

`TestTheRetentionActionSetIsOneSet`. The set is spelled in three places and
hand-written in all of them: the CHECK at schema head, `RetentionAction` in
crm.yaml, and this event's enum.

It asserts **equality, not containment**, because the three directions fail
differently:

- a value in the database and not on the event ships an event every subscriber
  drops in silence;
- a value on the event and not in the database promises subscribers something
  nothing can produce, so a consumer writes a branch that never runs;
- a value in the API and not the database is a request accepted and then refused
  by a constraint.

Read from the schema **head catalog** rather than a migration, since a later one
may have moved the CHECK and the head is what a running installation has. Both
readers refuse rather than pass when they find nothing to compare.

Deriving one spelling from another was the alternative and there is nowhere to
derive from: the CHECK is SQL in a shipped migration, and the generators resolve
no cross-document reference between crm.yaml and public-events.yaml.

Mutation-checked both ways: adding `redact` to the event enum fails it against
the CHECK, and removing the enum entirely — the original defect — fails it as an
open field.

## No migration

Confirmed, per the decision note: this is not a Postgres enum. The house pattern
is `CHECK (col IN (...))`, which `retention_policy.action` already has and which
already enforces the three values correctly.

## Checks

- `make check-backend` green; gate inventory regenerated.
- `craft static --strict` over the diff: 0/0/0.
- `privacy` unit and integration lanes green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Contract**
  - Retention-applied event actions are now limited to `archive`, `anonymize`, and `erase`.
  - Added clearly defined action values for supported integrations and generated clients.
  - Invalid or unsupported retention actions are rejected instead of being published.

- **Consistency**
  - Retention action definitions are now aligned across public APIs, frontend types, and database validation.

- **Documentation**
  - Clarified that restriction events use the separate `retention.restricted` event rather than a retention-applied action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->