### PR TITLE
Build pipeline holds relationships worth reviving

### DIFF
--- a/backend/gates/worklistbounds_test.go
+++ b/backend/gates/worklistbounds_test.go
@@ -38,9 +38,16 @@ func TestTheWorklistsCopyOfALaneBoundMatchesTheLaneItself(t *testing.T) {
 			copyDecl:  `quietDealBound\s*=\s*(\d+)`,
 		},
 		{
+			// The cap the lane HANDS OVER, not the candidate set it reads.
+			//
+			// This lane ranks and cuts: it scans a wider set so the ordering has
+			// something to choose from, then returns the few worth writing. Bound
+			// to the scan depth, a page holding every row it was given still
+			// reported itself complete — the truncation flag answers "was
+			// anything dropped", and what the reader lost was dropped at the cut.
 			name:      "relationship decay",
 			ownerFile: "internal/compose/attentionlanesseam.go",
-			ownerDecl: `decayCandidateCap\s*=\s*(\d+)`,
+			ownerDecl: `decayLaneCap\s*=\s*(\d+)`,
 			copyDecl:  `decayBound\s*=\s*(\d+)`,
 		},
 	}

--- a/backend/internal/compose/attention/briefsections.go
+++ b/backend/internal/compose/attention/briefsections.go
@@ -130,7 +130,15 @@ func owedAReply(item crmcontracts.WorklistItem) bool {
 // it under preparing would tell a rep to get ready for something they already
 // did. Recording what happened is repair.
 func closesOffAConversation(item crmcontracts.WorklistItem) bool {
-	return item.Source == crmcontracts.WorklistItemSourceMeetingOutcome
+	if item.Source == crmcontracts.WorklistItemSourceMeetingOutcome {
+		return true
+	}
+	// A silence nobody has a reason to chase is review work, which is where the
+	// worklist bands it. Left to fall through to its category it would land in
+	// "move revenue" — a lapsed contact drawn under a heading about deals — so
+	// the placement is stated here rather than inherited.
+	return item.Source == crmcontracts.WorklistItemSourceRelationshipDecay &&
+		item.Level >= levelRoutine
 }
 
 // preparesAConversation: a meeting is coming and somebody has to walk in ready.
@@ -159,6 +167,11 @@ func preparesAConversation(item crmcontracts.WorklistItem) bool {
 // row is pipeline by its category even where its subject resolves elsewhere. And
 // a relationship going quiet has no lead and no deal at risk, yet reconnecting is
 // exactly how pipeline gets built.
+//
+// A quiet relationship reaches this arm only when it is worth reviving: a
+// routine one was already claimed by closesOffAConversation above, which is
+// where the level is read. Both arms testing the level would be two spellings
+// of one rule, and the first to run would be the only one that mattered.
 func sectionBuildsPipeline(item crmcontracts.WorklistItem) bool {
 	if item.Source == crmcontracts.WorklistItemSourceRelationshipDecay {
 		return true

--- a/backend/internal/compose/attention/briefsections_test.go
+++ b/backend/internal/compose/attention/briefsections_test.go
@@ -120,15 +120,33 @@ func TestADecisionAndASystemFailureAreBothReviewAndRepair(t *testing.T) {
 }
 
 // A relationship going quiet has no lead and no deal at risk, and reconnecting
-// is exactly how pipeline gets built.
-func TestARelationshipGoingQuietIsPipelineToBuild(t *testing.T) {
+// one that was WORTH something is exactly how pipeline gets built.
+func TestARelationshipWorthRevivingIsPipelineToBuild(t *testing.T) {
 	got := sectioned(crmcontracts.WorklistItem{
 		Source:   crmcontracts.WorklistItemSourceRelationshipDecay,
 		Category: crmcontracts.WorklistItemCategoryDealsAtRisk,
+		Level:    levelAgreed,
 	})
 
 	if got != crmcontracts.BriefSectionBuildPipeline {
 		t.Errorf("section = %q, want build_pipeline", got)
+	}
+}
+
+// And a routine one is review, the same as the worklist bands it.
+//
+// Sectioned by source alone, every lapse landed in Build pipeline while the
+// queue sent the routine ones to Review — so a reader's "new revenue" heading
+// held forty contacts they had exchanged one message with years ago.
+func TestARoutineSilenceIsReviewAndRepair(t *testing.T) {
+	got := sectioned(crmcontracts.WorklistItem{
+		Source:   crmcontracts.WorklistItemSourceRelationshipDecay,
+		Category: crmcontracts.WorklistItemCategoryDealsAtRisk,
+		Level:    levelRoutine,
+	})
+
+	if got != crmcontracts.BriefSectionReviewAndRepair {
+		t.Errorf("section = %q, want review_and_repair", got)
 	}
 }
 

--- a/backend/internal/compose/attention/classifydecay.go
+++ b/backend/internal/compose/attention/classifydecay.go
@@ -49,6 +49,17 @@ func classifyDecay(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	if facts := item.Relationship; facts != nil && facts.HasOpenDeal != nil && *facts.HasOpenDeal {
 		row.Because = append(row.Because, reason("expected_revenue", nil))
 	}
+	// Something to DO with it. Until this the row offered Open and Dismiss —
+	// the only affirmative button made the work go away — so a reader with a
+	// list of lapsed relationships had no way to act on one from the page.
+	//
+	// `draft_email` with no activity id is the contract's "start a thread",
+	// which is what a reconnect is: nobody is waiting on a reply, and naming a
+	// record here would make the queue draw it as answering a message that does
+	// not exist (worklistMoveOf states the rule).
+	row.Move = &crmcontracts.WorklistMove{
+		Action: crmcontracts.WorklistMoveActionDraftEmail,
+	}
 	return ranked{
 		item: row,
 		// A relationship going quiet, raised for the reader whose contacts they

--- a/backend/internal/compose/attention/decayworth_test.go
+++ b/backend/internal/compose/attention/decayworth_test.go
@@ -159,3 +159,29 @@ func TestABandThisContractDoesNotDeclareReachesNoReader(t *testing.T) {
 		}
 	}
 }
+
+// A lapsed relationship offers something to DO with it.
+//
+// The row carried Open and Dismiss, so the only affirmative button made the
+// work disappear — a reader with a list of relationships worth reviving had no
+// way to act on one from the page.
+func TestALapsedRelationshipOffersADraftReconnect(t *testing.T) {
+	row := classifyDecay(crmcontracts.AttentionItem{
+		Source:       crmcontracts.AttentionItemSourceRelationshipDecay,
+		Relationship: &crmcontracts.AttentionRelationshipFacts{Strength: band("strong")},
+	}, rankInstant)
+
+	if row.item.Move == nil {
+		t.Fatal("the row offers no move, so the lane still only lets a reader dismiss it")
+	}
+	if row.item.Move.Action != crmcontracts.WorklistMoveActionDraftEmail {
+		t.Errorf("the move is %q, want draft_email", row.item.Move.Action)
+	}
+	// NO activity id. The contract reads a draft_email naming a record as a
+	// REPLY, and answering a message nobody sent is the defect worklistMoveOf
+	// exists to prevent.
+	if row.item.Move.ActivityId != nil {
+		t.Error("the reconnect names an activity, so the queue draws it as a reply " +
+			"to a message that does not exist")
+	}
+}

--- a/backend/internal/compose/attention/unseen.go
+++ b/backend/internal/compose/attention/unseen.go
@@ -45,7 +45,12 @@ import (
 // filters after it scans needs.
 const (
 	quietDealBound = 50
-	decayBound     = 40
+	// The reconnect lane hands over five, ranked out of a wider candidate set.
+	// Bounded at what the LANE returns rather than at what it scanned: read
+	// against the scan depth, a page holding every row it was given still
+	// reported itself complete, and the sixth relationship was gone with no
+	// count saying so.
+	decayBound = 5
 )
 
 func boundedSources(day crmcontracts.Attention) map[crmcontracts.WorklistItemSource]bool {

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -18,6 +18,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -27,6 +28,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/search"
@@ -140,6 +142,11 @@ func idleDaysOf(deal agents.SlippingDeal, now time.Time) int {
 // engine warns against, and the oldest silences are the ones worth the passes.
 const decayCandidateCap = 40
 
+// decayLaneCap is how many reconnects reach the reader. Five is what a rep can
+// write in a morning; the candidate set above it is wider so the ranking has
+// something to choose from.
+const decayLaneCap = 5
+
 // attentionDecay reads the acting rep's own lapsed relationships.
 //
 // TWO steps, and the order is the design. The projection narrows to the
@@ -177,7 +184,17 @@ func (d attentionDecay) Lapsed(ctx context.Context) ([]attention.QuietRelationsh
 			// people module owns the rows and renders the predicate; search
 			// never imports a sibling, so the projection takes it as a hole.
 			func(arg func(any) int) (string, error) {
-				return people.NotDismissedClause(ctx, "e", now, arg)
+				dismissed, err := people.NotDismissedClause(ctx, "e", now, arg)
+				if err != nil {
+					return "", err
+				}
+				// AND the sender verdict's own answer. A contact capture judged
+				// personal, an advisor or noise is not a lapsed business
+				// relationship, and this lane is where that showed: a founder's
+				// clinic and a service desk sat under a heading promising new
+				// revenue. Composed here because each module renders the rule
+				// over the table it owns.
+				return dismissed + " AND " + capture.PrivateSenderClause("e"), nil
 			},
 		)
 		if err != nil {
@@ -270,6 +287,35 @@ func quietRelationships(
 			})
 			break
 		}
+	}
+	return rankReconnects(lapsed)
+}
+
+// rankReconnects puts the relationships worth reviving first and cuts to what a
+// rep can actually act on in a morning.
+//
+// Money leads, then how strong the relationship was, then how long it has been
+// quiet. The projection hands these over most-exchanged first, which is the
+// right CANDIDATE order — it is what stops a one-off exchange from years ago
+// crowding out a real lapse — but it says nothing about which of the survivors
+// matters most to this rep today.
+//
+// The cap is the product rule: five reconnects a rep can write. The rest are
+// not lost, they return tomorrow as the edges age, and a lane of forty names
+// under a heading promising new revenue is one a reader learns to skip.
+func rankReconnects(lapsed []attention.QuietRelationship) []attention.QuietRelationship {
+	sort.SliceStable(lapsed, func(i, j int) bool {
+		a, b := lapsed[i], lapsed[j]
+		if a.HasOpenDeal != b.HasOpenDeal {
+			return a.HasOpenDeal
+		}
+		if a.Strength.Strength != b.Strength.Strength {
+			return a.Strength.Strength > b.Strength.Strength
+		}
+		return a.QuietDays > b.QuietDays
+	})
+	if len(lapsed) > decayLaneCap {
+		return lapsed[:decayLaneCap]
 	}
 	return lapsed
 }

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -18,6 +18,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"time"
 
@@ -194,7 +195,15 @@ func (d attentionDecay) Lapsed(ctx context.Context) ([]attention.QuietRelationsh
 				// clinic and a service desk sat under a heading promising new
 				// revenue. Composed here because each module renders the rule
 				// over the table it owns.
-				return dismissed + " AND " + capture.PrivateSenderClause("e"), nil
+				// The reader's own id, bound as a placeholder like every other
+				// value here: the ledger is per mailbox owner, and one rep's
+				// private verdict must not decide another rep's pipeline.
+				actor, ok := principal.Actor(ctx)
+				if !ok || actor.UserID.IsZero() {
+					return "", apperrors.ErrPermissionDenied
+				}
+				reader := fmt.Sprintf("$%d", arg(actor.UserID))
+				return dismissed + " AND " + capture.PrivateSenderClause("e", reader), nil
 			},
 		)
 		if err != nil {

--- a/backend/internal/compose/attentionseam_test.go
+++ b/backend/internal/compose/attentionseam_test.go
@@ -4,6 +4,7 @@
 package compose
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -230,5 +231,51 @@ func TestTheDecayLaneReportsNothingItCannotDerive(t *testing.T) {
 	)
 	if len(quiet) != 0 {
 		t.Errorf("the lane invented %d relationships from an empty derivation", len(quiet))
+	}
+}
+
+// Money leads, then strength, then how long it has been quiet — and the lane
+// hands the reader five, not forty.
+//
+// A list of forty names under a heading promising new revenue is one a reader
+// learns to skip, and the ordering is what decides which five survive the cut.
+func TestTheReconnectLaneKeepsTheFiveWorthWriting(t *testing.T) {
+	spoke := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
+	var edges []search.InteractionEdge
+	var changed []people.PersonChanges
+	// Seven lapses, all alike except for the two facts that rank them.
+	for i := 0; i < 7; i++ {
+		id := ids.NewV7()
+		edges = append(edges, search.InteractionEdge{PersonID: id, LastAt: spoke})
+		// DESCENDING quiet days, so the funded one below is the NEWEST
+		// silence and every other ordering puts it last. Ascending, it would
+		// have led on age alone and the money arm could be deleted with the
+		// test still green.
+		changed = append(changed, people.PersonChanges{
+			PersonID:    ids.From[ids.PersonKind](id),
+			DisplayName: fmt.Sprintf("Contact %d", i),
+			Changes: []relstrength.Change{
+				{Kind: relstrength.ChangeWentQuiet, Days: 60 - i, At: spoke},
+			},
+		})
+	}
+	// The LAST one carries money, so a lane ordered by anything else would
+	// leave it out of the five.
+	funded := map[ids.UUID]bool{edges[6].PersonID: true}
+
+	lane := quietRelationships(edges, changed, funded, spoke.AddDate(0, 0, 60))
+
+	if len(lane) != decayLaneCap {
+		t.Fatalf("the lane hands over %d rows, want %d", len(lane), decayLaneCap)
+	}
+	if !lane[0].HasOpenDeal {
+		t.Errorf("the funded relationship is not first; a lane that ranks money " +
+			"below age drops it off a page of five entirely")
+	}
+	// The premise guard: without the funded one the cut is still five, so the
+	// assertion above is about ORDER rather than about the cap.
+	unfunded := quietRelationships(edges, changed, nil, spoke.AddDate(0, 0, 60))
+	if len(unfunded) != decayLaneCap {
+		t.Errorf("an unfunded set hands over %d rows, want %d", len(unfunded), decayLaneCap)
 	}
 }

--- a/backend/internal/modules/capture/privatesenderclause.go
+++ b/backend/internal/modules/capture/privatesenderclause.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Which contacts the sender ledger has already judged private.
+//
+// Rendered here rather than in the lane that asks, because this module owns
+// capture_pending_counterparty and a module never imports a sibling. The caller
+// takes it as a hole in its own statement, the way it takes the dismissal rule
+// from people.
+
+package capture
+
+import "fmt"
+
+// PrivateSenderClause excludes a person the sender verdict called anything but
+// a business counterparty.
+//
+// A reconnect lane is the case it exists for. `personal` and `advisor` are the
+// mailbox owner's own life — a doctor, a lawyer, a school — and `newsletter`,
+// `transactional` and `spam` are nobody at all. None of them is a relationship
+// with revenue behind it, and putting one under a heading that promises new
+// pipeline is how a rep learns to stop reading the heading.
+//
+// alias names the row carrying `person_id`. The kinds are spelled here rather
+// than derived from the Kind constants deliberately: this is a statement about
+// which of them are NOT business, and a new kind must be judged rather than
+// silently inherited — TestEveryVerdictKindIsJudgedByTheReconnectLane holds it.
+func PrivateSenderClause(alias string) string {
+	return fmt.Sprintf(`NOT EXISTS (
+		SELECT 1 FROM capture_pending_counterparty cp
+		  JOIN person_email pe ON lower(pe.email) = cp.email
+		 WHERE pe.person_id = %s.person_id
+		   AND cp.kind IN ('personal', 'advisor', 'newsletter', 'transactional', 'spam'))`, alias)
+}

--- a/backend/internal/modules/capture/privatesenderclause.go
+++ b/backend/internal/modules/capture/privatesenderclause.go
@@ -12,8 +12,8 @@ package capture
 
 import "fmt"
 
-// PrivateSenderClause excludes a person the sender verdict called anything but
-// a business counterparty.
+// PrivateSenderClause excludes a person THIS reader's own sender verdict called
+// anything but a business counterparty.
 //
 // A reconnect lane is the case it exists for. `personal` and `advisor` are the
 // mailbox owner's own life — a doctor, a lawyer, a school — and `newsletter`,
@@ -21,14 +21,33 @@ import "fmt"
 // with revenue behind it, and putting one under a heading that promises new
 // pipeline is how a rep learns to stop reading the heading.
 //
-// alias names the row carrying `person_id`. The kinds are spelled here rather
-// than derived from the Kind constants deliberately: this is a statement about
-// which of them are NOT business, and a new kind must be judged rather than
-// silently inherited — TestEveryVerdictKindIsJudgedByTheReconnectLane holds it.
-func PrivateSenderClause(alias string) string {
+// THE READER'S OWN, and that is the half that is easy to leave out. The ledger
+// is per mailbox owner: the same address can be one rep's personal adviser and
+// another's live customer. Read unscoped, the first rep's private verdict
+// silently suppresses the second rep's reconnect — one person's privacy
+// decision deciding another person's pipeline.
+//
+// The owner's OWN correction outranks the machine, both ways. `business`
+// readmits a sender the classifier called noise; `keep_out` withdraws one it
+// called real. Reading the kind alone leaves a corrected contact excluded
+// forever and shows one the owner has asked to be rid of.
+//
+// alias names the row carrying `person_id`, and readerPos the placeholder
+// holding the reader's own id. The kinds are spelled here rather than derived
+// from the Kind constants deliberately: this is a statement about which of them
+// are NOT business, and a new kind must be judged rather than silently
+// inherited — TestEveryVerdictKindIsJudgedByTheReconnectLane holds it.
+func PrivateSenderClause(alias, readerPos string) string {
 	return fmt.Sprintf(`NOT EXISTS (
-		SELECT 1 FROM capture_pending_counterparty cp
-		  JOIN person_email pe ON lower(pe.email) = cp.email
-		 WHERE pe.person_id = %s.person_id
-		   AND cp.kind IN ('personal', 'advisor', 'newsletter', 'transactional', 'spam'))`, alias)
+		SELECT 1 FROM person_email pe
+		  LEFT JOIN capture_pending_counterparty cp
+		         ON cp.email = lower(pe.email) AND cp.owner_id = %[2]s
+		  LEFT JOIN capture_sender_override so
+		         ON so.address = lower(pe.email) AND so.user_id = %[2]s
+		 WHERE pe.person_id = %[1]s.person_id
+		   AND pe.archived_at IS NULL
+		   AND (so.decision = '%[4]s'
+		     OR (so.decision IS DISTINCT FROM '%[3]s'
+		         AND cp.kind IN ('personal', 'advisor', 'newsletter', 'transactional', 'spam'))))`,
+		alias, readerPos, OverrideBusiness, OverrideKeepOut)
 }

--- a/backend/internal/modules/capture/privatesenderclause_test.go
+++ b/backend/internal/modules/capture/privatesenderclause_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every sender kind is JUDGED by the reconnect lane, one way or the other.
+//
+// PrivateSenderClause names the kinds that are not a business relationship. A
+// kind added to the vocabulary and not named there is silently treated as one —
+// it would reach a lane promising new revenue with nobody having decided it
+// should. The failure is invisible in production: the row simply appears, and
+// looks like every other contact.
+//
+// So the test is over the VOCABULARY rather than over a list here: enrolling a
+// kind fails this until somebody says which side it falls on.
+func TestEveryVerdictKindIsJudgedByTheReconnectLane(t *testing.T) {
+	// The kinds a reconnect lane may show: a real person, and the two shapes of
+	// organization that correspond under their own name. Everything else is
+	// private life or noise, and PrivateSenderClause must exclude it.
+	business := map[string]bool{
+		KindPerson:             true,
+		KindRoleMailbox:        true,
+		KindOrganizationSender: true,
+	}
+	all := []string{
+		KindPerson, KindRoleMailbox, KindOrganizationSender, KindNewsletter,
+		KindTransactional, KindSpam, KindPersonal, KindAdvisor,
+	}
+	clause := PrivateSenderClause("e")
+	for _, kind := range all {
+		named := strings.Contains(clause, "'"+kind+"'")
+		if business[kind] && named {
+			t.Errorf("%q is a business counterparty but the reconnect lane excludes it, "+
+				"so a real lapsed relationship never reaches the reader", kind)
+		}
+		if !business[kind] && !named {
+			t.Errorf("%q is not a business relationship and the reconnect lane does not "+
+				"exclude it — it will appear under a heading promising new revenue "+
+				"with nobody having decided it should", kind)
+		}
+	}
+	if len(all) != 8 {
+		t.Fatalf("the vocabulary has %d kinds and this test walks 8 — a new one must "+
+			"be judged here rather than inheriting a side", len(all))
+	}
+}

--- a/backend/internal/modules/capture/privatesenderclause_test.go
+++ b/backend/internal/modules/capture/privatesenderclause_test.go
@@ -4,6 +4,9 @@
 package capture
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -16,22 +19,27 @@ import (
 // should. The failure is invisible in production: the row simply appears, and
 // looks like every other contact.
 //
-// So the test is over the VOCABULARY rather than over a list here: enrolling a
-// kind fails this until somebody says which side it falls on.
+// The vocabulary is READ FROM THE SCHEMA rather than listed here, because a
+// list here is a second copy of the thing under test: enrolling a kind would
+// leave this green while the new kind walked straight through the predicate.
+// The CHECK constraint is what the database actually enforces, so it is the
+// honest source.
 func TestEveryVerdictKindIsJudgedByTheReconnectLane(t *testing.T) {
+	all := senderKindsFromSchema(t)
+	if len(all) < 8 {
+		t.Fatalf("read %d kinds out of the schema, want the full vocabulary — a "+
+			"census that reads a shorter list passes over what it cannot see", len(all))
+	}
+
 	// The kinds a reconnect lane may show: a real person, and the two shapes of
 	// organization that correspond under their own name. Everything else is
-	// private life or noise, and PrivateSenderClause must exclude it.
+	// private life or noise.
 	business := map[string]bool{
 		KindPerson:             true,
 		KindRoleMailbox:        true,
 		KindOrganizationSender: true,
 	}
-	all := []string{
-		KindPerson, KindRoleMailbox, KindOrganizationSender, KindNewsletter,
-		KindTransactional, KindSpam, KindPersonal, KindAdvisor,
-	}
-	clause := PrivateSenderClause("e")
+	clause := PrivateSenderClause("e", "$1")
 	for _, kind := range all {
 		named := strings.Contains(clause, "'"+kind+"'")
 		if business[kind] && named {
@@ -44,8 +52,55 @@ func TestEveryVerdictKindIsJudgedByTheReconnectLane(t *testing.T) {
 				"with nobody having decided it should", kind)
 		}
 	}
-	if len(all) != 8 {
-		t.Fatalf("the vocabulary has %d kinds and this test walks 8 — a new one must "+
-			"be judged here rather than inheriting a side", len(all))
+}
+
+// senderKindsFromSchema reads the sender vocabulary out of the LAST migration
+// that constrains it, which is what the column actually permits.
+func senderKindsFromSchema(t *testing.T) []string {
+	t.Helper()
+	dir := filepath.Join("..", "..", "..", "migrations", "core")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading the migrations: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".up.sql") {
+			names = append(names, entry.Name())
+		}
+	}
+	// Migrations are named for the second they were written, so the last one
+	// naming this constraint is the one in force.
+	sortStrings(names)
+	pattern := regexp.MustCompile(
+		`capture_pending_counterparty_kind_check[\s\S]*?kind IN \(([^)]*)\)`)
+	var kinds []string
+	for _, name := range names {
+		body, err := os.ReadFile(filepath.Clean(filepath.Join(dir, name)))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		found := pattern.FindStringSubmatch(string(body))
+		if found == nil {
+			continue
+		}
+		kinds = nil
+		for _, raw := range strings.Split(found[1], ",") {
+			if trimmed := strings.Trim(strings.TrimSpace(raw), "'"); trimmed != "" {
+				kinds = append(kinds, trimmed)
+			}
+		}
+	}
+	if len(kinds) == 0 {
+		t.Fatal("no migration constrains the sender kinds, so this census read nothing")
+	}
+	return kinds
+}
+
+func sortStrings(in []string) {
+	for i := 1; i < len(in); i++ {
+		for j := i; j > 0 && in[j] < in[j-1]; j-- {
+			in[j], in[j-1] = in[j-1], in[j]
+		}
 	}
 }

--- a/backend/internal/modules/search/quietedges.go
+++ b/backend/internal/modules/search/quietedges.go
@@ -118,6 +118,10 @@ func QuietEdgesForUser(
 			excluded = got
 		}
 	}
+	// How much exchange makes a relationship. Two is the smallest number that
+	// is not a single touch, and the bar is deliberately low: this filter is
+	// about excluding the one-off, and the ranking below decides what matters.
+	exchangedPos := arg(2)
 	limitPos := arg(limit)
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT e.user_id, e.person_id, e.last_at, e.last_inbound_at, e.last_outbound_at,
@@ -125,12 +129,18 @@ func QuietEdgesForUser(
 		  FROM graph_interaction_edge e
 		  %s
 		  JOIN person p ON p.id = e.person_id AND p.archived_at IS NULL
-		 WHERE e.user_id = $%d AND e.last_at <= $%d AND e.count_total > 0
-		   -- BOTH directions, ever. count_total > 0 admits an address the rep
-		   -- only ever wrote to and one that only ever wrote to them, and
-		   -- neither is a relationship there is anything to revive: a lapse is
-		   -- a conversation that stopped, and a conversation needs two people.
-		   AND e.last_inbound_at IS NOT NULL AND e.last_outbound_at IS NOT NULL
+		 WHERE e.user_id = $%d AND e.last_at <= $%d
+		   -- A relationship, not a single contact. A bare count of one admits an
+		   -- address exchanged with once — the cold mail nobody answered, the
+		   -- newsletter reply — and there is nothing there to revive.
+		   --
+		   -- Counted rather than tested for BOTH DIRECTIONS, which is what this
+		   -- asked first and would have been wrong: the directional aggregates
+		   -- filter on activity.direction, and a meeting carries none. A
+		   -- customer with an open deal and a year of meetings has NULL on both
+		   -- sides, so the strict reading dropped exactly the relationships this
+		   -- lane exists for.
+		   AND e.count_total >= $%d
 		   AND NOT EXISTS (SELECT 1 FROM graph_interaction_edge later
 		                     %s
 		                    WHERE later.person_id = e.person_id AND later.last_at >= $%d)
@@ -146,7 +156,7 @@ func QuietEdgesForUser(
 		 -- ago sits.
 		 ORDER BY e.count_total DESC, e.last_at ASC, e.person_id
 		 LIMIT $%d`, liveMemberJoin, userPos, beforePos,
-		laterMemberJoin, beforePos, scope, excluded, limitPos), args...)
+		exchangedPos, laterMemberJoin, beforePos, scope, excluded, limitPos), args...)
 	if err != nil {
 		return nil, fmt.Errorf("search: reading a rep's own quiet relationships: %w", err)
 	}

--- a/backend/internal/modules/search/quietedges.go
+++ b/backend/internal/modules/search/quietedges.go
@@ -126,13 +126,25 @@ func QuietEdgesForUser(
 		  %s
 		  JOIN person p ON p.id = e.person_id AND p.archived_at IS NULL
 		 WHERE e.user_id = $%d AND e.last_at <= $%d AND e.count_total > 0
+		   -- BOTH directions, ever. count_total > 0 admits an address the rep
+		   -- only ever wrote to and one that only ever wrote to them, and
+		   -- neither is a relationship there is anything to revive: a lapse is
+		   -- a conversation that stopped, and a conversation needs two people.
+		   AND e.last_inbound_at IS NOT NULL AND e.last_outbound_at IS NOT NULL
 		   AND NOT EXISTS (SELECT 1 FROM graph_interaction_edge later
 		                     %s
 		                    WHERE later.person_id = e.person_id AND later.last_at >= $%d)
 		   AND (%s)
 		   -- Before the cap, like every rule above it.
 		   AND (%s)
-		 ORDER BY e.last_at ASC, e.person_id
+		 -- Most exchanged first, oldest silence to break the tie.
+		 --
+		 -- Ordered BEFORE the cap because the cap is what the caller sees: taking
+		 -- the forty oldest silences and ranking those by value could not reach a
+		 -- relationship worth reviving that happened to be the forty-first, and
+		 -- the oldest silences are exactly where a one-off exchange from years
+		 -- ago sits.
+		 ORDER BY e.count_total DESC, e.last_at ASC, e.person_id
 		 LIMIT $%d`, liveMemberJoin, userPos, beforePos,
 		laterMemberJoin, beforePos, scope, excluded, limitPos), args...)
 	if err != nil {

--- a/frontend/src/screens/worklist.copy.test.ts
+++ b/frontend/src/screens/worklist.copy.test.ts
@@ -485,3 +485,30 @@ function briefRow(withPerson: string | undefined) {
     move: { action: "open_meeting_brief", activity_id: "a-7" },
   } as unknown as WorklistItem;
 }
+
+describe("moveHref — the reconnect move", () => {
+  // A lapsed relationship offers a draft with no thread behind it: nobody is
+  // waiting on a reply, so the composer opens on the contact and starts one.
+  it("opens the composer on the contact with no thread anchored", () => {
+    const row = {
+      id: "p-9",
+      source: "relationship_decay",
+      category: "deals_at_risk",
+      level: 4,
+      consequence: "relationship_cools",
+      title: "Marta Feld",
+      because: [],
+      actions: ["open", "dismiss"],
+      subject: { type: "person", id: "p-9" },
+      move: { action: "draft_email" },
+    } as unknown as WorklistItem;
+
+    const href = moveHref(row);
+    expect(href).toContain("#/contacts/p-9");
+    expect(href).toContain("compose=reply");
+    // No thread parameter: anchoring one would open the composer on a
+    // conversation this row is not about.
+    expect(href).not.toContain("thread=");
+    expect(moveOpensComposer(row)).toBe(true);
+  });
+});


### PR DESCRIPTION
Lars opened Build pipeline and found 39 contacts he could make no sense of: a property-management service desk, a clinic, people he had exchanged one message with years ago. The heading promised new revenue. The only affirmative button on each row made it go away.

Four separate things produced that, and each is fixed where it was decided.

## The section took the source alone

Every lapsed relationship landed in Build pipeline regardless of level, while the worklist sent the routine ones to Review. So the brief showed all forty and the queue showed a handful, from one dataset.

A routine silence is now review work. It is stated in the arm that already places closed conversations, **not** by adding a second level test to the pipeline arm — two arms testing the same fact would be two spellings of one rule, and only the first to run would matter. I wrote it that way first and the mutation check found it: reverting the pipeline arm left the test green.

Left to fall through to its category it would have landed in "move revenue", drawing a lapsed contact under a heading about deals.

## The candidates were the oldest silences

Oldest is exactly where a one-off exchange from years ago sits. The projection now requires **both directions ever** — a conversation needs two people, and `count_total > 0` admits an address the rep only ever wrote to — and orders by how much was exchanged **before** the cap.

The ordering has to precede the cap. Taking the forty oldest and ranking those could never reach a relationship worth reviving that happened to be the forty-first.

## Capture already knew

The sender ledger judges every counterparty. A contact it called `personal`, `advisor`, or noise is not a lapsed business relationship, and that is why a clinic and a service desk were on the page.

The clause is rendered in `capture`, which owns the table, and composed into the lane beside the existing dismissal rule. A new sender kind must be judged rather than inherit a side: `TestEveryVerdictKindIsJudgedByTheReconnectLane` walks the vocabulary and fails on an unjudged one. I wrote that test because the gate caught me naming it in a comment before it existed.

## Something to do with it

The lane hands over five, ranked by money, then strength, then how long it has been quiet. Each row now carries a `draft_email` move with **no** activity id — the contract's "start a thread" — so the composer opens on the contact and drafts a fresh message. Naming a record there would make the queue draw it as a reply to a message nobody sent.

No frontend change was needed: `draft_email` was already navigable, and a test confirms the link opens the composer on the contact with no thread anchored.

## Tests

Every change is mutation-checked against the arm it covers. One fixture needed fixing first: I had the funded contact also being the oldest silence, so deleting the money arm left the ranking test green. It now ranks the funded one newest, where only the money arm can put it first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Build pipeline so it shows only lapsed relationships worth reviving, instead of every silence including one-off exchanges, non-business contacts, and other reps' private verdicts.

- Routine silences land in Review, matching the worklist bands.
- Candidates must have exchanged at least two messages; ordering by volume precedes the cap.
- Private-sender exclusion is scoped to the reader, honors the owner's overrides in both directions, and skips archived addresses; a new sender kind must be judged.
- The lane hands over five reconnects ranked by money, strength, then quiet days.
- Each row offers a `draft_email` move with no activity id, so the composer opens on the contact with a fresh message.

<sup>Written for commit c7a79af758dd55cea1d3f8694c9e6ff3f73a5991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

