### PR TITLE
fix(leads): a lead nobody owns breaches again, unless nobody asked us for it

### DIFF
--- a/backend/internal/modules/people/lead_update.go
+++ b/backend/internal/modules/people/lead_update.go
@@ -391,6 +391,11 @@ func buildLeadPatch(current crmcontracts.Lead, in UpdateLeadInput) (*storekit.Pa
 		// condition: no owner yet, and no clock yet.
 		if current.RoutedAt == nil && current.OwnerId == nil {
 			p.Set("routed_at", nil, leadSLAClock().UTC())
+			// And the breach stamp goes with it, for the reason
+			// startLeadResponseClockTx clears it on the claim path: a row that
+			// breached while it was nobody's is already escalated, and leaving
+			// the stamp would keep this owner's lead out of the scan for good.
+			p.Set("sla_breached_at", nil, nil)
 		}
 	}
 	return p, resumeRecompute, nil

--- a/backend/internal/modules/people/leadresponseclock.go
+++ b/backend/internal/modules/people/leadresponseclock.go
@@ -76,7 +76,11 @@ func startLeadResponseClockTx(ctx context.Context, tx pgx.Tx, id ids.UUID) error
 		return err
 	}
 	if _, err := tx.Exec(ctx,
-		`UPDATE lead SET routed_at = $2
+		// The breach stamp goes with the clock. A lead that breached while it
+		// was nobody's has been escalated to the intake seat already; starting
+		// this owner's clock without clearing it would leave a row that can
+		// never breach again, because the scan skips anything already stamped.
+		`UPDATE lead SET routed_at = $2, sla_breached_at = NULL
 		  WHERE id = $1 AND routed_at IS NULL AND archived_at IS NULL`,
 		id, leadSLAClock().UTC()); err != nil {
 		return fmt.Errorf("people: starting the lead response clock: %w", err)

--- a/backend/internal/modules/people/leadsla.go
+++ b/backend/internal/modules/people/leadsla.go
@@ -14,13 +14,11 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/settings"
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -135,161 +133,6 @@ type SLABreach struct {
 	OwnerID  *ids.UserID
 	Deadline time.Time
 	Name     string
-}
-
-// ScanLeadSLA marks every open lead whose first-response deadline has passed
-// unanswered and not yet been escalated (formulas §18.2), once per breach:
-// sla_breached_at is the at-most-once mark, and the row lock with SKIP
-// LOCKED lets two scans share the work without escalating a lead twice.
-// Each breach lands one audit row and lead.sla_breached; the escalation
-// task hangs off that event.
-//
-// With the target switched off the scan is a no-op: no deadline exists to
-// breach, and a breach row the installation never asked for would page an
-// owner about a rule they did not set.
-func (s *Store) ScanLeadSLA(ctx context.Context, now time.Time) ([]SLABreach, error) {
-	if err := auth.Require(ctx, "lead", principal.ActionUpdate); err != nil {
-		return nil, err
-	}
-	var breaches []SLABreach
-	err := s.tx(ctx, func(tx pgx.Tx) error {
-		policy, err := loadLeadSLAPolicy(ctx, tx)
-		if err != nil {
-			return err
-		}
-		if !policy.enabled {
-			return nil
-		}
-		rows, err := tx.Query(ctx, `
-			SELECT id, owner_id, COALESCE(routed_at, created_at) + $1 * interval '1 minute',
-			       COALESCE(NULLIF(btrim(full_name), ''), email::text, '')
-			FROM lead
-			WHERE `+leadOwesAReplySQL+` AND sla_breached_at IS NULL
-			  -- Only a lead somebody is answerable for. An unowned row's
-			  -- deadline is measured from created_at against nobody, and
-			  -- escalating it stamps sla_breached_at — which then suppresses
-			  -- the real escalation once a human takes the lead on.
-			  AND owner_id IS NOT NULL
-			  AND COALESCE(routed_at, created_at) + $1 * interval '1 minute' < $2
-			ORDER BY created_at
-			FOR UPDATE SKIP LOCKED`,
-			policy.targetMinutes(), now)
-		if err != nil {
-			return fmt.Errorf("select breached leads: %w", err)
-		}
-		candidates, err := collectBreaches(rows)
-		if err != nil {
-			return err
-		}
-		// Each candidate is re-checked against the ACTIVITIES before it is
-		// marked. first_response_at is projected by an event subscriber
-		// reacting to activity.captured, so it lags the activity's own commit
-		// by the bus's latency: a reply committed at 11:59 against a 12:00
-		// deadline can still be unprojected when a 12:01 scan runs, and the
-		// lead reads as unanswered because the projection has not caught up
-		// rather than because nobody answered.
-		//
-		// The scan owns the consequence — a breach event, an escalation task,
-		// and a number on somebody's review — so it reads the ground truth
-		// rather than the projection. Where it finds one, it stamps the column
-		// itself: the subscriber's later write is then the replay
-		// recordFirstResponseTx already answers as a no-op.
-		breaches = breaches[:0]
-		for _, b := range candidates {
-			answered, err := answeredBy(ctx, tx, b.LeadID, b.Deadline)
-			if err != nil {
-				return err
-			}
-			if answered != nil {
-				if _, err := recordFirstResponseTx(ctx, tx, b.LeadID, *answered); err != nil {
-					return err
-				}
-				continue
-			}
-			if err := markBreach(ctx, tx, b, now); err != nil {
-				return err
-			}
-			breaches = append(breaches, b)
-		}
-		return nil
-	})
-	return breaches, err
-}
-
-func collectBreaches(rows pgx.Rows) ([]SLABreach, error) {
-	defer rows.Close()
-	var out []SLABreach
-	for rows.Next() {
-		var b SLABreach
-		if err := rows.Scan(&b.LeadID, &b.OwnerID, &b.Deadline, &b.Name); err != nil {
-			return nil, err
-		}
-		out = append(out, b)
-	}
-	return out, rows.Err()
-}
-
-func markBreach(ctx context.Context, tx pgx.Tx, b SLABreach, now time.Time) error {
-	// The SLA sweep runs as an unbounded system principal, for whom this probe
-	// returns nil without a query. It is here so that the day a human-facing
-	// caller reaches this write — an operator forcing a breach, a retry surface —
-	// it arrives already scoped rather than silently unguarded.
-	if err := auth.EnsureWritableLive(ctx, tx, "lead", b.LeadID.UUID); err != nil {
-		return err
-	}
-	// The row is already locked by the scan's SELECT ... FOR UPDATE; the
-	// predicate is the CAS that keeps the mark at-most-once regardless.
-	tag, err := tx.Exec(ctx,
-		`UPDATE lead SET sla_breached_at = $2 WHERE id = $1 AND sla_breached_at IS NULL`, b.LeadID, now)
-	if err != nil {
-		return fmt.Errorf("mark sla breach: %w", err)
-	}
-	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("mark sla breach on %s: %w", b.LeadID, apperrors.ErrConflict)
-	}
-	// sla_breached_at is the lead's own column and it is the whole change; the
-	// deadline that was missed is context ABOUT the breach and rides evidence,
-	// because a lead has no `deadline` column and field history would project
-	// one as a field of the record that nobody can find.
-	//
-	// The before-image is exact rather than read: the UPDATE above is the
-	// at-most-once CAS, so the single row it affected held nothing here.
-	auditID, err := storekit.AuditWithEvidence(ctx, tx, "update", "lead", b.LeadID.UUID,
-		map[string]any{slaBreachedColumn: nil}, map[string]any{slaBreachedColumn: now},
-		map[string]any{"deadline": b.Deadline})
-	if err != nil {
-		return fmt.Errorf("audit sla breach: %w", err)
-	}
-	payload := crmcontracts.PublicEventLeadSlaBreached{Deadline: b.Deadline}
-	switch {
-	case b.OwnerID != nil:
-		owner := openapi_types.UUID(b.OwnerID.UUID)
-		payload.OwnerId = &owner
-		// An owned lead escalates to its OWNER: the desk that owes the answer
-		// is the desk that hears about the miss.
-		payload.EscalationTarget = &owner
-	default:
-		// A lead NOBODY owns is the queue's worst case — past its response
-		// target with no one who has picked it up — and it was the one case
-		// that reached nobody at all: an unassigned task and no notice.
-		//
-		// The configured intake seat answers for it. Unset means the
-		// installation has not said who runs the queue, and the breach stays
-		// where it was rather than being addressed to somebody who did not
-		// agree to it; the unassigned view is what surfaces those.
-		target, configured, err := unassignedEscalationTarget(ctx, tx)
-		if err != nil {
-			return err
-		}
-		if configured {
-			addressed := openapi_types.UUID(target)
-			payload.EscalationTarget = &addressed
-		}
-	}
-	if err := storekit.EmitEvent(ctx, tx, auditID, b.LeadID.UUID, payload); err != nil {
-		return fmt.Errorf("emit lead.sla_breached: %w", err)
-	}
-	return nil
 }
 
 // RecordLeadFirstResponse stamps the lead's first genuine response from an

--- a/backend/internal/modules/people/leadsla_integration_test.go
+++ b/backend/internal/modules/people/leadsla_integration_test.go
@@ -715,3 +715,49 @@ func TestAnIntakeSeatMustBeAbleToReadTheLeadsItAnswersFor(t *testing.T) {
 		t.Errorf("the refused nomination was stored anyway")
 	}
 }
+
+// Taking on a lead that already breached clears the stamp with the clock.
+//
+// The two have to move together. COALESCE(routed_at, created_at) restarts the
+// deadline when somebody picks the lead up, and sla_breached_at keeps a row out
+// of the scan for good — so a stamp left behind by the ownerless escalation
+// would mean the new owner could never breach, on a clock that had just been
+// restarted for them. That is the suppression the breach scan used to avoid by
+// refusing to escalate unowned rows at all, which cost the intake seat its
+// escalation.
+func TestTakingOnABreachedLeadClearsTheStampWithTheClock(t *testing.T) {
+	e := setupPromoteConsent(t)
+	e.enableFirstResponseSLA(t)
+	e.nameIntakeSeat(t, e.user)
+	now := time.Now().UTC()
+
+	// An inbound nobody picked up, past its target: the ownerless case that
+	// escalates to the intake seat.
+	lead := e.seedOwnerlessLeadCreatedAt(t, "waiting@example.test", now.Add(-DefaultFirstResponseTarget-time.Hour))
+	if _, err := e.store.ScanLeadSLA(e.ctx, now); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if target := e.breachTargetOf(t, lead); target == nil || *target != e.user.String() {
+		t.Fatalf("escalation target = %v, want the intake seat %s — the rest of this case rests on it having breached", target, e.user)
+	}
+
+	owner := ids.From[ids.UserKind](e.user)
+	if _, err := e.store.UpdateLead(e.ctx, lead, UpdateLeadInput{OwnerID: &owner}); err != nil {
+		t.Fatalf("taking the lead on: %v", err)
+	}
+
+	var breachedAt *time.Time
+	var routedAt *time.Time
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT sla_breached_at, routed_at FROM lead WHERE id = $1`, lead.UUID).
+		Scan(&breachedAt, &routedAt); err != nil {
+		t.Fatal(err)
+	}
+	if routedAt == nil {
+		t.Fatal("taking the lead on started no clock, so this case cannot say anything about the stamp beside it")
+	}
+	if breachedAt != nil {
+		t.Errorf("the breach stamp survived the take-on (%v) — the new owner's clock restarted and the scan will skip this row for good, so they can never breach on it",
+			breachedAt)
+	}
+}

--- a/backend/internal/modules/people/leadslascan.go
+++ b/backend/internal/modules/people/leadslascan.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The breach sweep: which overdue leads escalate, and to whom.
+//
+// Split from leadsla.go, which holds what an SLA state IS — the policy, the
+// clock, and the clauses the list reads it with. This is the pass that acts on
+// them, and it is the half with the judgement in it: whether an unowned row is
+// a person waiting or a name nobody asked for, and whether a deadline the
+// projection has not caught up with is really a breach.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// ScanLeadSLA marks every open lead whose first-response deadline has passed
+// unanswered and not yet been escalated (formulas §18.2), once per breach:
+// sla_breached_at is the at-most-once mark, and the row lock with SKIP
+// LOCKED lets two scans share the work without escalating a lead twice.
+// Each breach lands one audit row and lead.sla_breached; the escalation
+// task hangs off that event.
+//
+// With the target switched off the scan is a no-op: no deadline exists to
+// breach, and a breach row the installation never asked for would page an
+// owner about a rule they did not set.
+func (s *Store) ScanLeadSLA(ctx context.Context, now time.Time) ([]SLABreach, error) {
+	if err := auth.Require(ctx, "lead", principal.ActionUpdate); err != nil {
+		return nil, err
+	}
+	var breaches []SLABreach
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		policy, err := loadLeadSLAPolicy(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if !policy.enabled {
+			return nil
+		}
+		rows, err := tx.Query(ctx, `
+			SELECT id, owner_id, COALESCE(routed_at, created_at) + $1 * interval '1 minute',
+			       COALESCE(NULLIF(btrim(full_name), ''), email::text, '')
+			FROM lead
+			WHERE `+leadOwesAReplySQL+` AND sla_breached_at IS NULL
+			  -- An UNOWNED lead breaches, unless NOBODY ASKED US for it: an
+			  -- inbound nobody picked up is the queue's worst case and escalates
+			  -- to the intake seat, while a name a pass read off a website is
+			  -- not somebody's work and a clock nobody started is not a breach.
+			  -- lead_source.intent already draws that line — siteread and crawl
+			  -- are low "for crawl's reason: nobody asked us for anything" — so
+			  -- reading it keeps one answer, and a prospecting source an
+			  -- operator adds gets the rule with it. Owned rows are
+			  -- unconditional: the clock is theirs however it arrived.
+			  --
+			  -- A subquery, not a join: leadOwesAReplySQL is shared and names
+			  -- its columns unqualified, so a second table makes "id" ambiguous
+			  -- for every reader of it. COALESCE so an unnamed source still
+			  -- breaches — an unknown arrival is likelier to be a person
+			  -- waiting, which is the direction to be wrong in.
+			  AND (owner_id IS NOT NULL
+			       OR COALESCE((SELECT intent FROM lead_source WHERE key = lead.source), '') <> 'low')
+			  AND COALESCE(routed_at, created_at) + $1 * interval '1 minute' < $2
+			ORDER BY created_at
+			FOR UPDATE SKIP LOCKED`,
+			policy.targetMinutes(), now)
+		if err != nil {
+			return fmt.Errorf("select breached leads: %w", err)
+		}
+		candidates, err := collectBreaches(rows)
+		if err != nil {
+			return err
+		}
+		// Each candidate is re-checked against the ACTIVITIES before it is
+		// marked. first_response_at is projected by an event subscriber
+		// reacting to activity.captured, so it lags the activity's own commit
+		// by the bus's latency: a reply committed at 11:59 against a 12:00
+		// deadline can still be unprojected when a 12:01 scan runs, and the
+		// lead reads as unanswered because the projection has not caught up
+		// rather than because nobody answered.
+		//
+		// The scan owns the consequence — a breach event, an escalation task,
+		// and a number on somebody's review — so it reads the ground truth
+		// rather than the projection. Where it finds one, it stamps the column
+		// itself: the subscriber's later write is then the replay
+		// recordFirstResponseTx already answers as a no-op.
+		breaches = breaches[:0]
+		for _, b := range candidates {
+			answered, err := answeredBy(ctx, tx, b.LeadID, b.Deadline)
+			if err != nil {
+				return err
+			}
+			if answered != nil {
+				if _, err := recordFirstResponseTx(ctx, tx, b.LeadID, *answered); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := markBreach(ctx, tx, b, now); err != nil {
+				return err
+			}
+			breaches = append(breaches, b)
+		}
+		return nil
+	})
+	return breaches, err
+}
+
+func collectBreaches(rows pgx.Rows) ([]SLABreach, error) {
+	defer rows.Close()
+	var out []SLABreach
+	for rows.Next() {
+		var b SLABreach
+		if err := rows.Scan(&b.LeadID, &b.OwnerID, &b.Deadline, &b.Name); err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+func markBreach(ctx context.Context, tx pgx.Tx, b SLABreach, now time.Time) error {
+	// The SLA sweep runs as an unbounded system principal, for whom this probe
+	// returns nil without a query. It is here so that the day a human-facing
+	// caller reaches this write — an operator forcing a breach, a retry surface —
+	// it arrives already scoped rather than silently unguarded.
+	if err := auth.EnsureWritableLive(ctx, tx, "lead", b.LeadID.UUID); err != nil {
+		return err
+	}
+	// The row is already locked by the scan's SELECT ... FOR UPDATE; the
+	// predicate is the CAS that keeps the mark at-most-once regardless.
+	tag, err := tx.Exec(ctx,
+		`UPDATE lead SET sla_breached_at = $2 WHERE id = $1 AND sla_breached_at IS NULL`, b.LeadID, now)
+	if err != nil {
+		return fmt.Errorf("mark sla breach: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("mark sla breach on %s: %w", b.LeadID, apperrors.ErrConflict)
+	}
+	// sla_breached_at is the lead's own column and it is the whole change; the
+	// deadline that was missed is context ABOUT the breach and rides evidence,
+	// because a lead has no `deadline` column and field history would project
+	// one as a field of the record that nobody can find.
+	//
+	// The before-image is exact rather than read: the UPDATE above is the
+	// at-most-once CAS, so the single row it affected held nothing here.
+	auditID, err := storekit.AuditWithEvidence(ctx, tx, "update", "lead", b.LeadID.UUID,
+		map[string]any{slaBreachedColumn: nil}, map[string]any{slaBreachedColumn: now},
+		map[string]any{"deadline": b.Deadline})
+	if err != nil {
+		return fmt.Errorf("audit sla breach: %w", err)
+	}
+	payload := crmcontracts.PublicEventLeadSlaBreached{Deadline: b.Deadline}
+	switch {
+	case b.OwnerID != nil:
+		owner := openapi_types.UUID(b.OwnerID.UUID)
+		payload.OwnerId = &owner
+		// An owned lead escalates to its OWNER: the desk that owes the answer
+		// is the desk that hears about the miss.
+		payload.EscalationTarget = &owner
+	default:
+		// A lead NOBODY owns is the queue's worst case — past its response
+		// target with no one who has picked it up — and it was the one case
+		// that reached nobody at all: an unassigned task and no notice.
+		//
+		// The configured intake seat answers for it. Unset means the
+		// installation has not said who runs the queue, and the breach stays
+		// where it was rather than being addressed to somebody who did not
+		// agree to it; the unassigned view is what surfaces those.
+		target, configured, err := unassignedEscalationTarget(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if configured {
+			addressed := openapi_types.UUID(target)
+			payload.EscalationTarget = &addressed
+		}
+	}
+	if err := storekit.EmitEvent(ctx, tx, auditID, b.LeadID.UUID, payload); err != nil {
+		return fmt.Errorf("emit lead.sla_breached: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
**`main` is red.** Two integration tests fail on tip, and `main-health` has not run since `7a246a72`:

```
--- FAIL: TestAnOwnerlessBreachReachesTheConfiguredIntakeSeat
    leadsla_integration_test.go:613: reading the breach's escalation target: no rows in result set
--- FAIL: TestAnIntakeSeatThatCannotWorkIsTreatedAsUnset
```

## What happened

- **#5015** — *"A breach on a lead nobody owns reaches somebody"* — made an ownerless breach escalate to the configured intake seat, with those two tests.
- **#5201** — *"A name read off a website is a record, not somebody's work"* — added `AND owner_id IS NOT NULL` to the breach scan, and did not touch either test. They have been red since.

## Both changes are right about their own case

The fixtures say it plainly:

| | source | what it is |
|---|---|---|
| #5015 | `inbound`, `human:x` | a person who wrote to us and nobody has picked up |
| #5201 | `siteread`, `agent:siteread` | a name a pass read off a company's website |

The first is the queue's worst case and must escalate. The second is not somebody's work and its clock was never started. **Ownership does not tell those apart** — it excludes both, which is why one PR's fix broke the other's tests.

## The discriminator the product already has

`lead_source.intent`, and it says so in its own words:

```go
// A name published on a company's own website, read by the deep-read pass.
// Low for crawl's reason: nobody asked us for anything.
"siteread": SourceIntentLow,
```

So: an unowned lead breaches unless its source intent is `low`. Read from the catalog rather than naming `siteread` and `crawl`, so a prospecting source an operator adds gets the rule with it. An **owned** lead is unconditional — somebody took it on, so the clock is theirs however it arrived.

Each half of the condition is required by a different PR's test:

```
as written                          all three pass
intent check removed                #5201's test fails
back to owner-only (main today)     both of #5015's fail
```

## The thing that made the exclusion look necessary is closed, not argued away

#5201's comment was **right**:

> escalating a row nobody has taken on stamps `sla_breached_at` — which then suppresses the real escalation once a human takes the lead on.

Because the take-on restarts the clock through `COALESCE(routed_at, created_at)` while the stamp keeps the row out of the scan **for good**. So the take-on now clears the stamp with the same condition that starts the clock, on both the claim and the update path, and the two move together.

`TestTakingOnABreachedLeadClearsTheStampWithTheClock` pins it; removing the clear fails it with *"the new owner's clock restarted and the scan will skip this row for good, so they can never breach on it."*

## Also

`leadsla.go` was at 498 of its 500-line ceiling, so the sweep moves to `leadslascan.go` — what an SLA state **is** on one side, and the pass that acts on it (the half with the judgement in it) on the other.

## Verification

`internal/modules/people` fully green (36s), `make check-go` green.

`make craft-static` reports two BLOCKERs in `internal/modules/consent/rightscase.go` — **not this diff**, and already on `main` from #5211. Flagged separately; the pre-push hook is diff-scoped so they do not gate this.

Found by @target-ce, who flagged it rather than racing a fix. Their calendar hypothesis was worth checking and does not hold — the target is a plain 240 minutes with no business-day logic, and today is a Thursday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC