### PR TITLE
fix(consent): the rights case does not discard its rollback's failure

### DIFF
--- a/backend/internal/modules/consent/rightscase.go
+++ b/backend/internal/modules/consent/rightscase.go
@@ -199,7 +199,15 @@ func attemptRightsCase(ctx context.Context, tx pgx.Tx, kind string, personID ids
 		oneCalendarMonthAfter(receivedAt), submissionID, receipt,
 	).Scan(&caseID, &stored, &created)
 	if err != nil {
-		_ = nested.Rollback(ctx)
+		// The insert's failure is what the caller needs, and the savepoint's
+		// rollback rides with it rather than being dropped: a rollback that
+		// fails usually means the connection is already gone, which turns a
+		// legible constraint violation into a confusing one further up. Joined
+		// rather than logged because this store carries no logger, and errors.Is
+		// still reaches the insert's own sentinel through the join.
+		if rbErr := nested.Rollback(ctx); rbErr != nil {
+			err = errors.Join(err, fmt.Errorf("rolling the savepoint back: %w", rbErr))
+		}
 		return ids.UUID{}, "", false, fmt.Errorf(
 			"consent: opening the rights case this request owes an answer to: %w", err)
 	}

--- a/backend/internal/modules/consent/rightscase_integration_test.go
+++ b/backend/internal/modules/consent/rightscase_integration_test.go
@@ -267,7 +267,14 @@ func TestAReplayedProposalOpensNoSecondCase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("opening a transaction: %v", err)
 	}
-	defer func() { _ = tx.Rollback(context.Background()) }()
+	// This transaction is never committed — the case it opens is the subject and
+	// is read back inside it — so the rollback IS the cleanup and a failure to
+	// roll back is a leaked connection the next case would wait on.
+	defer func() {
+		if err := tx.Rollback(context.Background()); err != nil {
+			t.Errorf("rolling back the probe transaction: %v", err)
+		}
+	}()
 
 	replayed, err := openRightsCaseTx(context.Background(), tx, e.person, submissionID,
 		submissionErasure, time.Now())


### PR DESCRIPTION
**`make craft-static` is red on `main`**, so the craftsmanship job fails on **every open pull request** — mine included. Two BLOCKERs, both from #5211:

```
backend/internal/modules/consent/rightscase.go:202
backend/internal/modules/consent/rightscase_integration_test.go:270
  [BLOCKER] swallowed-errors — blank-assigning a call result discards a possible error
```

## Why it reached main

CI's craftsmanship job runs `make craft-static` **whole-tree**; the pre-push hook runs `craft static --strict` **diff-scoped**. A file this change added is judged against what it added, and the two disagreed here. (I told #5211 the hook shape meant it would not gate anyone — that was wrong, and this is the correction: it gates everyone.)

## The store

```go
if rbErr := nested.Rollback(ctx); rbErr != nil {
    err = errors.Join(err, fmt.Errorf("rolling the savepoint back: %w", rbErr))
}
```

The insert's failure is what the caller needs; the rollback's rides with it rather than being dropped. A rollback that fails usually means the connection is already gone, which turns a legible constraint violation into a confusing one further up. Joined rather than logged because this store carries no logger — and `errors.Is` still reaches the insert's own sentinel through the join, which `isReceiptCollision` next door depends on.

## The test, which is the sharper of the two

```go
defer func() { _ = tx.Rollback(context.Background()) }()
```

That transaction is **never committed** — the case it opens is the subject and is read back inside it — so the rollback *is* the cleanup. A failure to roll back is a leaked connection the next case in the lane would wait on, discarded in a defer where nothing would ever say so. It fails the test now.

## Verification

`make craft-static` — 0 blocker, 0 major, 0 minor, whole tree. `make check-go` green. `internal/modules/consent` integration lane green.

Found while fixing an unrelated main-red (#5225). Both are `main` restorations rather than feature work, and either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when a consent case cannot be saved, including failures that occur while rolling back the transaction.
  - Test cleanup now reports transaction rollback failures instead of silently ignoring them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->