### PR TITLE
fix(consent): a failed savepoint rollback says so

### DIFF
--- a/backend/internal/modules/consent/rightscase.go
+++ b/backend/internal/modules/consent/rightscase.go
@@ -199,9 +199,18 @@ func attemptRightsCase(ctx context.Context, tx pgx.Tx, kind string, personID ids
 		oneCalendarMonthAfter(receivedAt), submissionID, receipt,
 	).Scan(&caseID, &stored, &created)
 	if err != nil {
-		_ = nested.Rollback(ctx)
-		return ids.UUID{}, "", false, fmt.Errorf(
-			"consent: opening the rights case this request owes an answer to: %w", err)
+		opening := fmt.Errorf("consent: opening the rights case this request owes an answer to: %w", err)
+		// The rollback's own failure travels with the fault it was undoing.
+		// This savepoint exists so a collision can be retried against a
+		// transaction Postgres has not given up on — so a rollback that did NOT
+		// take is the one condition under which the retry above cannot work,
+		// and every remaining attempt fails identically with the first
+		// attempt's message. Discarding it turns that into three mystery
+		// failures with the right words and the wrong cause.
+		if rbErr := nested.Rollback(ctx); rbErr != nil {
+			return ids.UUID{}, "", false, errors.Join(opening, rbErr)
+		}
+		return ids.UUID{}, "", false, opening
 	}
 	if err := nested.Commit(ctx); err != nil {
 		return ids.UUID{}, "", false, fmt.Errorf("consent: opening the rights case: %w", err)

--- a/backend/internal/modules/consent/rightscase_integration_test.go
+++ b/backend/internal/modules/consent/rightscase_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -267,7 +268,14 @@ func TestAReplayedProposalOpensNoSecondCase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("opening a transaction: %v", err)
 	}
-	defer func() { _ = tx.Rollback(context.Background()) }()
+	// The rollback IS this case's cleanup — nothing here commits — so a failure
+	// is the test's own connection in trouble and worth saying. ErrTxClosed is
+	// the exception: a transaction already finished is what a clean run leaves.
+	t.Cleanup(func() {
+		if err := tx.Rollback(context.Background()); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("releasing the replay transaction: %v", err)
+		}
+	})
 
 	replayed, err := openRightsCaseTx(context.Background(), tx, e.person, submissionID,
 		submissionErasure, time.Now())


### PR DESCRIPTION
`make craft-static` is red on `main` with two BLOCKERs, both in
`internal/modules/consent`, landed by #5211. The `craftsmanship` CI job runs the
whole-tree sweep, so **every open PR fails it** whether or not it touched
consent; the pre-push hook is diff-scoped and does not catch it.

Neither finding is a lint technicality.

## The savepoint rollback

`attemptRightsCase` discarded the result of rolling its savepoint back:

```go
if err != nil {
    _ = nested.Rollback(ctx)
    return …, fmt.Errorf("consent: opening the rights case …: %w", err)
}
```

That savepoint exists for exactly one reason, and the retry loop above it says
so: a receipt collision has to be retried *"against a transaction Postgres has
already given up on"* otherwise. So **a rollback that did not take is the single
condition under which the retry cannot work** — the outer transaction stays
poisoned and every remaining attempt fails identically, with the first attempt's
message. Discarding it turns that into three mystery failures carrying the right
words and the wrong cause.

It now travels with the fault it was undoing, through `errors.Join` — the same
shape `capture/sinkensure.go` and `projects/keymint.go` already use for a
savepoint whose failed rollback poisons its parent.

## The test's deferred rollback

`defer func() { _ = tx.Rollback(...) }()` in `rightscase_integration_test.go`.
Nothing in that case commits, so the rollback IS its cleanup and a failure is the
test's own connection in trouble. Moved to `t.Cleanup` with the `ErrTxClosed`
exception — a transaction already finished is what a clean run leaves — which is
the spelling this suite already uses elsewhere.

The alternative for both was `//craft:ignore swallowed-errors <reason>`, as
`platform/database/database.go` correctly does for a rollback that is a **designed
no-op after commit**. Neither of these is that: one is the failure the retry
cannot survive, and the other is a cleanup with nothing after it.

## Why this and not the other red thing

Two separate failures on main today. The lead-SLA cluster is #5225, from the
session that holds main. This one was flagged to me and claimed by nobody, and no
PR existed when I picked it up.

## Checks

- `make craft-static` over the whole tree: **PASS — 0 blocker, 0 major, 0 minor**
  (was 2 blockers).
- `make check-backend` green.
- `consent` integration lane green.