### PR TITLE
A newsletter question that cannot be asked costs the newsletter

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -6790,15 +6790,32 @@ paths:
                 consent: { $ref: '#/components/schemas/CaptureConsent' }
       responses:
         '201':
-          description: Booked; a minimal confirmation (no CRM record data disclosed).
+          description: |
+            Booked; a minimal confirmation (no CRM record data disclosed). `marketing` reports what
+            became of the newsletter tick, separately from the booking itself: a question this
+            installation could not put — no live mailbox on the record, a purpose archived since the
+            form was published, a mail lane that refused it — leaves the meeting standing and says
+            `not_asked`, so a booker who ticked the box is not left waiting for a mail that is not
+            coming.
           content:
             application/json:
               schema:
                 type: object
-                required: [start, end]
+                required: [start, end, booking, marketing]
                 properties:
                   start: { type: string, format: date-time }
                   end:   { type: string, format: date-time }
+                  booking:
+                    type: string
+                    enum: [confirmed]
+                    description: 'The slot is held. A booking that did not commit answers 409 or 422 instead.'
+                  marketing:
+                    type: string
+                    enum: [not_requested, pending_confirmation, not_asked]
+                    description: |
+                      `not_requested` — the form carried no tick. `pending_confirmation` — the question
+                      was mailed and the grant waits on the subject answering it. `not_asked` — the
+                      question could not be put; the booking stands and no subscription mail follows.
         '409': { description: 'Slot no longer available (`code: slot_taken`).', content: { application/problem+json: { schema: { $ref: '#/components/schemas/Problem' } } } }
         '422': { $ref: '#/components/responses/ValidationError' }
 

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -6794,7 +6794,7 @@ paths:
             Booked; a minimal confirmation (no CRM record data disclosed). `marketing` reports what
             became of the newsletter tick, separately from the booking itself: a question this
             installation could not put — no live mailbox on the record, a purpose archived since the
-            form was published, a mail lane that refused it — leaves the meeting standing and says
+            form was published, no mail lane wired at all — leaves the meeting standing and says
             `not_asked`, so a booker who ticked the box is not left waiting for a mail that is not
             coming.
           content:
@@ -6808,14 +6808,16 @@ paths:
                   booking:
                     type: string
                     enum: [confirmed]
-                    description: 'The slot is held. A booking that did not commit answers 409 or 422 instead.'
+                    description: 'The slot is held. A booking that did not commit answers an error status instead.'
                   marketing:
                     type: string
                     enum: [not_requested, pending_confirmation, not_asked]
                     description: |
                       `not_requested` — the form carried no tick. `pending_confirmation` — the question
-                      was mailed and the grant waits on the subject answering it. `not_asked` — the
-                      question could not be put; the booking stands and no subscription mail follows.
+                      was queued for delivery and the grant waits on the subject answering it; queued
+                      is not delivered. `not_asked` — the question could not be put, or this
+                      installation has no lane to put it on; the booking stands and no subscription
+                      mail follows.
         '409': { description: 'Slot no longer available (`code: slot_taken`).', content: { application/problem+json: { schema: { $ref: '#/components/schemas/Problem' } } } }
         '422': { $ref: '#/components/responses/ValidationError' }
 

--- a/backend/internal/compose/bookingconsent.go
+++ b/backend/internal/compose/bookingconsent.go
@@ -110,7 +110,7 @@ func admitBookingMarketingPurpose(purposes []consent.Purpose, purposeID ids.UUID
 	return httperr.Validation("consent.marketing.purpose_id", "invalid", "not a tracked consent purpose")
 }
 
-func (a bookingConsentAdapter) CaptureBookingConsent(ctx context.Context, personID ids.UUID, c activities.BookingConsent) error {
+func (a bookingConsentAdapter) CaptureBookingConsent(ctx context.Context, personID ids.UUID, c activities.BookingConsent) (activities.MarketingOutcome, error) {
 	source := "public_booking"
 	_, err := a.store.Record(ctx, consent.RecordInput{
 		PersonID:      ids.From[ids.PersonKind](personID),
@@ -128,12 +128,13 @@ func (a bookingConsentAdapter) CaptureBookingConsent(ctx context.Context, person
 	// bad DOI token reads as the 422 it is, not a 500.
 	var invalid *consent.ValidationError
 	if errors.As(err, &invalid) {
-		return httperr.Validation(invalid.Field, "invalid", invalid.Reason)
+		return activities.MarketingNotRequested, httperr.Validation(invalid.Field, "invalid", invalid.Reason)
 	}
 	if err != nil {
-		return err
+		return activities.MarketingNotRequested, err
 	}
-	return a.askMarketing(ctx, personID, c.Marketing)
+	outcome, err := a.askMarketing(ctx, personID, c.Marketing)
+	return outcome, err
 }
 
 // askMarketing mails the confirmation link an affirmative tick earns, and it
@@ -161,15 +162,41 @@ func (a bookingConsentAdapter) CaptureBookingConsent(ctx context.Context, person
 // installation that has not wired that text has a consent problem whether or
 // not this code reads it. Carrying both through to the grant needs columns on
 // confirm_token, which is its own change.
-func (a bookingConsentAdapter) askMarketing(ctx context.Context, personID ids.UUID, m *activities.BookingMarketing) error {
+func (a bookingConsentAdapter) askMarketing(ctx context.Context, personID ids.UUID,
+	m *activities.BookingMarketing,
+) (activities.MarketingOutcome, error) {
 	if m == nil {
-		return nil
+		return activities.MarketingNotRequested, nil
 	}
 	_, err := a.store.IssueConsentLink(ctx,
 		ids.From[ids.PersonKind](personID), ids.From[ids.PurposeKind](m.PurposeID), m.TickedFrom)
-	var invalid *consent.ValidationError
-	if errors.As(err, &invalid) {
-		return httperr.Validation(invalid.Field, "invalid", invalid.Reason)
+	if err == nil {
+		return activities.MarketingPendingConfirmation, nil
 	}
-	return err
+	// TWO KINDS OF REFUSAL, and only one of them may cost the meeting.
+	//
+	// A refusal about THIS INSTALLATION'S ability to ask — no live address on
+	// the record, a purpose archived since the form was published, a mail lane
+	// that would not take the message — is reported and not raised. The tick
+	// was optional and the meeting was not: the subject can be asked again from
+	// the preference centre or the next mail, and the slot they booked cannot
+	// be handed back. Before this, every one of those took the booking with it.
+	//
+	// A refusal about WHERE THE QUESTION WOULD GO is fatal, and stays fatal.
+	// A misdirected link mails a stranger's mailbox about a request made from
+	// an address they do not hold; a re-solicitation mails somebody who
+	// explicitly withdrew. Neither is a question worth asking at any price, and
+	// swallowing either would turn a booking form into the way around a
+	// withdrawal.
+	// Returned as themselves rather than translated: both implement
+	// apperrors.FieldFault, which httperr renders as the 422 naming the field —
+	// and which the MCP surface reads too, where a translation done here would
+	// not reach.
+	if misdirected := new(consent.MisdirectedLinkError); errors.As(err, &misdirected) {
+		return activities.MarketingNotRequested, misdirected
+	}
+	if resolicit := new(consent.ReSolicitationError); errors.As(err, &resolicit) {
+		return activities.MarketingNotRequested, resolicit
+	}
+	return activities.MarketingNotAsked, nil
 }

--- a/backend/internal/compose/bookingconsent.go
+++ b/backend/internal/compose/bookingconsent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -168,9 +169,22 @@ func (a bookingConsentAdapter) askMarketing(ctx context.Context, personID ids.UU
 	if m == nil {
 		return activities.MarketingNotRequested, nil
 	}
-	_, err := a.store.IssueConsentLink(ctx,
+	issued, err := a.store.IssueConsentLink(ctx,
 		ids.From[ids.PersonKind](personID), ids.From[ids.PurposeKind](m.PurposeID), m.TickedFrom)
 	if err == nil {
+		// STAGED, not merely minted. issueLink answers a token it could not
+		// send rather than failing — an installation with no relay gets a link
+		// it can see was not posted — so a nil error alone says the row exists,
+		// never that anybody will receive it.
+		//
+		// This adapter builds its own consent store, and the confirmation lane
+		// is rewired onto the handlers' store rather than that one. So on the
+		// production wiring today the mail is never staged, and reporting the
+		// nil error as pending_confirmation would tell every booker a question
+		// is coming when none is.
+		if !issued.Staged {
+			return activities.MarketingNotAsked, nil
+		}
 		return activities.MarketingPendingConfirmation, nil
 	}
 	// TWO KINDS OF REFUSAL, and only one of them may cost the meeting.
@@ -192,11 +206,27 @@ func (a bookingConsentAdapter) askMarketing(ctx context.Context, personID ids.UU
 	// apperrors.FieldFault, which httperr renders as the 422 naming the field —
 	// and which the MCP surface reads too, where a translation done here would
 	// not reach.
-	if misdirected := new(consent.MisdirectedLinkError); errors.As(err, &misdirected) {
+	var misdirected *consent.MisdirectedLinkError
+	if errors.As(err, &misdirected) {
 		return activities.MarketingNotRequested, misdirected
 	}
-	if resolicit := new(consent.ReSolicitationError); errors.As(err, &resolicit) {
+	var resolicit *consent.ReSolicitationError
+	if errors.As(err, &resolicit) {
 		return activities.MarketingNotRequested, resolicit
+	}
+	// AN AUTHORIZATION REFUSAL IS NOT A MAIL FAILURE either, and it is the one
+	// remaining refusal that says something about the CALLER rather than about
+	// this installation's ability to ask. The mint takes auth.Require before it
+	// opens a transaction, and the person probe inside it can answer a denial
+	// or a not-found for a subject the caller may not write.
+	//
+	// In the booking path the operational grant one call earlier runs
+	// EnsureWritableLive on the same person and is fatal, so a refusal here
+	// means authority changed between two consecutive writes. That is rare and
+	// it is exactly why it must not be reported as "we could not ask": a
+	// booking form is not the place to discover a permission failure silently.
+	if errors.Is(err, apperrors.ErrPermissionDenied) || errors.Is(err, apperrors.ErrNotFound) {
+		return activities.MarketingNotRequested, err
 	}
 	return activities.MarketingNotAsked, nil
 }

--- a/backend/internal/compose/integration/booking_survives_marketing_integration_test.go
+++ b/backend/internal/compose/integration/booking_survives_marketing_integration_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// THE MEETING IS THE THING THE SUBJECT CAME FOR. A newsletter question that
+// cannot be asked must not cost them it.
+//
+// The booking handler records consent and then books. CaptureBookingConsent
+// mints the marketing confirmation link as its last act, and any refusal there
+// returns from the handler before BookMeeting is ever reached — so a person
+// whose primary address was archived, or a purpose archived between the
+// operator's form being published and the booking being made, loses the slot.
+//
+// What the subject sees is a booking form that failed. They try again, get the
+// same refusal, and the meeting never happens. Nothing tells them, or the host,
+// that the reason was a subscription question they could have simply declined.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+)
+
+// TestABookingSurvivesAMarketingQuestionThatCannotBeAsked is the slice.
+//
+// The failure is forced through a person carrying no LIVE address. That state
+// is ordinary rather than contrived: the ensure resolves an existing person by
+// any address they hold, including an archived one, and the mint posts to their
+// live primary — which a person whose address was corrected no longer has under
+// the old spelling.
+func TestABookingSurvivesAMarketingQuestionThatCannotBeAsked(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	base := "/v1/public/booking/" + bookingSlug(t, e)
+	transactional := seededTransactionalPurposeID(t, e)
+	marketing := seededMarketingPurposeID(t, e)
+	monday := nextMonday()
+
+	// A booker whose only address is archived: the ensure will find them, and
+	// the mint will have no live mailbox to post the question to.
+	const address = "archived@visitor.example"
+	var personID string
+	if err := e.Owner.QueryRow(context.Background(), `
+		INSERT INTO person (full_name, source, captured_by)
+		VALUES ('Archie Archived', 'manual', 'human:x')
+		RETURNING id`).Scan(&personID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.Owner.Exec(context.Background(), `
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by, archived_at)
+		VALUES ($1, $2, true, 'manual', 'human:x', now())`, personID, address); err != nil {
+		t.Fatal(err)
+	}
+
+	body := AnyMap{
+		"start": monday.Add(7 * time.Hour), "end": monday.Add(450 * time.Minute),
+		"booker": AnyMap{"name": "Archie Archived", "email": address},
+		"consent": AnyMap{
+			"purpose_id": transactional, "policy_version": "pp-2026-01",
+			"wording": "You agree we may contact you about this meeting.",
+			"marketing": AnyMap{
+				"purpose_id": marketing, "policy_version": "mk-2026-01",
+				"wording": "Send me your newsletter.",
+			},
+		},
+	}
+	var answer struct {
+		Booking   string `json:"booking"`
+		Marketing string `json:"marketing"`
+	}
+	status := publicCall(t, e, "POST", base, body, nil, &answer)
+	if status != http.StatusCreated {
+		t.Errorf("a booking whose newsletter question could not be asked → %d, want 201: the "+
+			"subject came for a meeting and the tick was optional, so a question that cannot be "+
+			"asked must cost them the newsletter and not the slot", status)
+	}
+
+	var meetings int
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM activity WHERE kind = 'meeting'`).Scan(&meetings); err != nil {
+		t.Fatal(err)
+	}
+	if meetings != 1 {
+		t.Errorf("%d meeting(s) booked, want 1 — the slot the subject asked for is gone and "+
+			"nothing tells them a subscription question is why", meetings)
+	}
+
+	// AND THE BOOKER IS TOLD. They ticked a box; no mail is coming. A response
+	// that named only the meeting would leave them waiting for one, and leave
+	// the host with no sign that a live form has stopped asking its question.
+	if answer.Booking != "confirmed" {
+		t.Errorf("the response says booking=%q, want confirmed", answer.Booking)
+	}
+	if answer.Marketing != "not_asked" {
+		t.Errorf("the response says marketing=%q, want not_asked — the subject ticked the box and "+
+			"no question could be put, which is a fact they and the host both need", answer.Marketing)
+	}
+
+	// The operational grant still stands. It is what the meeting itself rides
+	// on, and it was recorded before the question was ever attempted.
+	var grants int
+	if err := e.Owner.QueryRow(context.Background(), `
+		SELECT count(*) FROM person_consent
+		 WHERE person_id = $1 AND purpose_id = $2 AND state = 'granted'`,
+		personID, transactional).Scan(&grants); err != nil {
+		t.Fatal(err)
+	}
+	if grants != 1 {
+		t.Errorf("%d operational grant(s), want 1 — the meeting's own lawful basis went with the "+
+			"newsletter question", grants)
+	}
+}

--- a/backend/internal/compose/integration/booking_survives_marketing_integration_test.go
+++ b/backend/internal/compose/integration/booking_survives_marketing_integration_test.go
@@ -116,3 +116,63 @@ func TestABookingSurvivesAMarketingQuestionThatCannotBeAsked(t *testing.T) {
 			"newsletter question", grants)
 	}
 }
+
+// A TICK REPORTS pending_confirmation ONLY IF A MAIL WAS ACTUALLY STAGED.
+//
+// issueLink answers a token it could not send rather than failing: an
+// installation with no relay gets a link it can see was not posted. So a nil
+// error says the row exists, never that anybody will receive it — and the
+// booking adapter builds its own consent store, which the confirmation lane is
+// not rewired onto. Reporting the nil error as pending_confirmation told every
+// booker a question was coming when none was.
+//
+// The assertion is written against what the CONFIRM TOKEN table says, so it
+// stays honest whichever way this installation is wired: a staged mail leaves a
+// delivery behind, and the outcome must agree with it.
+func TestTheMarketingOutcomeAgreesWithWhatWasActuallyStaged(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	base := "/v1/public/booking/" + bookingSlug(t, e)
+	transactional := seededTransactionalPurposeID(t, e)
+	marketing := seededMarketingPurposeID(t, e)
+	monday := nextMonday()
+
+	body := AnyMap{
+		"start": monday.Add(2 * time.Hour), "end": monday.Add(150 * time.Minute),
+		"booker": AnyMap{"name": "Stan Staged", "email": "stan@visitor.example"},
+		"consent": AnyMap{
+			"purpose_id": transactional, "policy_version": "pp-2026-01",
+			"wording": "You agree we may contact you about this meeting.",
+			"marketing": AnyMap{
+				"purpose_id": marketing, "policy_version": "mk-2026-01",
+				"wording": "Send me your newsletter.",
+			},
+		},
+	}
+	var answer struct {
+		Marketing string `json:"marketing"`
+	}
+	if status := publicCall(t, e, "POST", base, body, nil, &answer); status != http.StatusCreated {
+		t.Fatalf("booking with a tick → %d, want 201", status)
+	}
+
+	personID := personIDByEmail(t, e, "stan@visitor.example")
+	var delivered int
+	if err := e.Owner.QueryRow(context.Background(), `
+		SELECT count(*) FROM comms_outbound o
+		  JOIN activity a ON a.id = o.activity_id
+		  JOIN activity_link l ON l.activity_id = a.id
+		 WHERE l.person_id = $1`, personID).Scan(&delivered); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "not_asked"
+	if delivered > 0 {
+		want = "pending_confirmation"
+	}
+	if answer.Marketing != want {
+		t.Errorf("the response says marketing=%q while %d confirmation mail(s) were staged, want "+
+			"%q — a booker told a question is coming waits for a mail nobody sent",
+			answer.Marketing, delivered, want)
+	}
+}

--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -366,8 +366,8 @@ func (p *preflightEnv) grantMarketingConsent(t *testing.T) {
 	if s := publicCall(t, p.AppEnv, "POST", "/v1/public/confirm/"+token, AnyMap{
 		"marketing_choice":  "granted",
 		"marketing_wording": "Yes, send me occasional product news.",
-	}, nil, nil); s != http.StatusNoContent {
-		t.Fatalf("the subject spends their own link → %d, want 204", s)
+	}, nil, nil); s != http.StatusOK {
+		t.Fatalf("the subject spends their own link → %d, want 200", s)
 	}
 }
 

--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -399,8 +399,8 @@ func (c *consentEnv) grantMarketingByConfirmLink(t *testing.T) string {
 	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/confirm/"+token, AnyMap{
 		"marketing_choice":  "granted",
 		"marketing_wording": "Yes, send me occasional product news.",
-	}, nil, nil); s != http.StatusNoContent {
-		t.Fatalf("the subject spends their own link → %d, want 204", s)
+	}, nil, nil); s != http.StatusOK {
+		t.Fatalf("the subject spends their own link → %d, want 200", s)
 	}
 	// Returned so a caller can assert what a SPENT link does next.
 	return token

--- a/backend/internal/compose/integration/public_booking_integration_test.go
+++ b/backend/internal/compose/integration/public_booking_integration_test.go
@@ -215,8 +215,22 @@ func bookHappyPathSlot(t *testing.T, e *apptest.AppEnv, base string, monday time
 	if status := publicCall(t, e, "POST", base, booking, nil, &confirmation); status != http.StatusCreated {
 		t.Fatalf("booking → %d %v", status, confirmation)
 	}
-	if len(confirmation) != 2 || confirmation["start"] == nil || confirmation["end"] == nil {
-		t.Fatalf("confirmation discloses more than the slot: %v", confirmation)
+	// NAMED, not counted. The rule is that this anonymous answer discloses
+	// nothing ABOUT THE RECORD — no person id, no existing contact, no history
+	// — and a field count enforced that only by accident: it also refused
+	// facts about the caller's own request, which disclose nothing at all. The
+	// booking and marketing outcomes are two such facts, and the booker needs
+	// the second, because a ticked box whose question could not be asked leaves
+	// them waiting for a mail that is not coming.
+	allowed := map[string]bool{"start": true, "end": true, "booking": true, "marketing": true}
+	for key := range confirmation {
+		if !allowed[key] {
+			t.Fatalf("confirmation discloses %q, which is not the slot or the outcome of this "+
+				"request: %v", key, confirmation)
+		}
+	}
+	if confirmation["start"] == nil || confirmation["end"] == nil {
+		t.Fatalf("confirmation does not name the slot it booked: %v", confirmation)
 	}
 
 	// The booker exists once; a second booking re-uses the person.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16495,6 +16495,42 @@ func (e ListProjectsParamsPhase) Valid() bool {
 	}
 }
 
+// Defines values for BookPublicMeeting201JSONResponseBodyBooking.
+const (
+	Confirmed BookPublicMeeting201JSONResponseBodyBooking = "confirmed"
+)
+
+// Valid indicates whether the value is a known member of the BookPublicMeeting201JSONResponseBodyBooking enum.
+func (e BookPublicMeeting201JSONResponseBodyBooking) Valid() bool {
+	switch e {
+	case Confirmed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for BookPublicMeeting201JSONResponseBodyMarketing.
+const (
+	NotAsked            BookPublicMeeting201JSONResponseBodyMarketing = "not_asked"
+	NotRequested        BookPublicMeeting201JSONResponseBodyMarketing = "not_requested"
+	PendingConfirmation BookPublicMeeting201JSONResponseBodyMarketing = "pending_confirmation"
+)
+
+// Valid indicates whether the value is a known member of the BookPublicMeeting201JSONResponseBodyMarketing enum.
+func (e BookPublicMeeting201JSONResponseBodyMarketing) Valid() bool {
+	switch e {
+	case NotAsked:
+		return true
+	case NotRequested:
+		return true
+	case PendingConfirmation:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for SubmitConfirmDetailsJSONBodyCorrectionsField.
 const (
 	SubmitConfirmDetailsJSONBodyCorrectionsFieldEmail    SubmitConfirmDetailsJSONBodyCorrectionsField = "email"
@@ -41486,6 +41522,12 @@ type BookPublicMeetingParams struct {
 	// to retry blind.
 	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
 }
+
+// BookPublicMeeting201JSONResponseBodyBooking defines parameters for BookPublicMeeting.
+type BookPublicMeeting201JSONResponseBodyBooking string
+
+// BookPublicMeeting201JSONResponseBodyMarketing defines parameters for BookPublicMeeting.
+type BookPublicMeeting201JSONResponseBodyMarketing string
 
 // GetPublicAvailabilityParams defines parameters for GetPublicAvailability.
 type GetPublicAvailabilityParams struct {

--- a/backend/internal/modules/activities/scheduling_public.go
+++ b/backend/internal/modules/activities/scheduling_public.go
@@ -144,8 +144,38 @@ type BookingMarketing struct {
 type ConsentCapturer interface {
 	ValidatePurpose(ctx context.Context, purposeID ids.UUID) error
 	ValidateMarketingPurpose(ctx context.Context, purposeID ids.UUID) error
-	CaptureBookingConsent(ctx context.Context, personID ids.UUID, consent BookingConsent) error
+	// CaptureBookingConsent records the operational grant and, when the form
+	// carried a tick, asks the newsletter question.
+	//
+	// The MarketingOutcome is answered rather than folded into the error,
+	// because the two halves fail differently and only one of them may cost the
+	// subject their meeting. An operational grant that cannot be recorded is
+	// fatal: it is the lawful basis the meeting's own mail rides on. A question
+	// that cannot be asked is not — the tick was optional, the subject can be
+	// asked again, and refusing the booking for it takes away the thing they
+	// actually came for.
+	CaptureBookingConsent(ctx context.Context, personID ids.UUID, consent BookingConsent) (MarketingOutcome, error)
 }
+
+// MarketingOutcome says what became of a booking form's newsletter tick.
+//
+// It is REPORTED, not silently swallowed. A tick that could not be asked about
+// is a fact the booker should see — they ticked a box and no mail is coming —
+// and one the host needs, because a purpose archived under a live form makes
+// every booking silently drop its subscription question.
+type MarketingOutcome string
+
+const (
+	// MarketingNotRequested is a form that carried no tick, or an unticked box.
+	MarketingNotRequested MarketingOutcome = "not_requested"
+	// MarketingPendingConfirmation is the ordinary success: the question was
+	// mailed and the grant waits on the subject answering it.
+	MarketingPendingConfirmation MarketingOutcome = "pending_confirmation"
+	// MarketingNotAsked is a question this installation could not put: no live
+	// mailbox on the record, a purpose archived since the form was published,
+	// or a mail lane that refused it. The booking stands either way.
+	MarketingNotAsked MarketingOutcome = "not_asked"
+)
 
 // WithPublicBooking wires the public capture seams.
 func (h Handlers) WithPublicBooking(people PersonEnsurer, consent ConsentCapturer) Handlers {
@@ -238,12 +268,13 @@ func (h Handlers) BookPublicMeeting(w http.ResponseWriter, r *http.Request, host
 		writeStoreErr(w, r, err)
 		return
 	}
-	if err := h.publicConsent.CaptureBookingConsent(r.Context(), personID, BookingConsent{
+	marketingOutcome, err := h.publicConsent.CaptureBookingConsent(r.Context(), personID, BookingConsent{
 		PurposeID:     purposeID,
 		PolicyVersion: req.Consent.PolicyVersion,
 		Wording:       req.Consent.Wording,
 		Marketing:     marketing,
-	}); err != nil {
+	})
+	if err != nil {
 		writeStoreErr(w, r, err)
 		return
 	}
@@ -269,8 +300,13 @@ func (h Handlers) BookPublicMeeting(w http.ResponseWriter, r *http.Request, host
 		writeStoreErr(w, r, err)
 		return
 	}
+	// BOTH outcomes, named separately. The booking is confirmed or it is not,
+	// and the newsletter question was asked or it was not — a response saying
+	// only the first leaves a booker who ticked the box waiting for a mail that
+	// is not coming.
 	httperr.WriteJSON(w, http.StatusCreated, map[string]any{
 		"start": req.Start, "end": req.End,
+		"booking": "confirmed", "marketing": string(marketingOutcome),
 	})
 }
 
@@ -362,7 +398,14 @@ func (h Handlers) captureBookingConsent(w http.ResponseWriter, r *http.Request, 
 	if !ok {
 		return false
 	}
-	if err := h.publicConsent.CaptureBookingConsent(r.Context(), personID, BookingConsent{
+	// The outcome is dropped on THIS door and not on the public one, because
+	// this response is the booked activity itself — a shape the contract
+	// declares and every authenticated client already parses. Reporting the
+	// marketing outcome here needs a field on that shape, which is a contract
+	// change of its own. What matters is the same on both doors and is settled
+	// in the adapter: a question that cannot be asked no longer costs the
+	// meeting.
+	if _, err := h.publicConsent.CaptureBookingConsent(r.Context(), personID, BookingConsent{
 		PurposeID:     purposeID,
 		PolicyVersion: c.PolicyVersion,
 		Wording:       c.Wording,

--- a/backend/internal/modules/consent/confirmguards.go
+++ b/backend/internal/modules/consent/confirmguards.go
@@ -76,10 +76,29 @@ func requireExpectedAddress(expected, deliveredTo string) error {
 	if expected == "" || strings.EqualFold(strings.TrimSpace(expected), strings.TrimSpace(deliveredTo)) {
 		return nil
 	}
-	return &ValidationError{
-		Field:  personIDKey,
-		Reason: "this address is on file for a contact whose confirmations go elsewhere, so the link would reach a different mailbox than the one that asked",
-	}
+	return &MisdirectedLinkError{}
+}
+
+// MisdirectedLinkError refuses a mint whose link would reach a mailbox other
+// than the one that asked.
+//
+// A DISTINCT TYPE, because a booking form has to tell this refusal apart from
+// the others this mint makes. The rest — no live address on the record, a
+// purpose archived under a live form — say this installation cannot put the
+// question, and a booking must survive them: the tick was optional and the
+// meeting was not. This one says the question would go to the WRONG PERSON,
+// which is not a question worth asking at any price.
+type MisdirectedLinkError struct{}
+
+func (e *MisdirectedLinkError) Error() string {
+	return "this address is on file for a contact whose confirmations go elsewhere, " +
+		"so the link would reach a different mailbox than the one that asked"
+}
+
+// FieldFault carries the refusal to every surface, the field naming the person
+// because that is the record whose addresses disagree.
+func (e *MisdirectedLinkError) FieldFault() (field, code, message string) {
+	return personIDKey, "confirmations_go_elsewhere", e.Error()
 }
 
 // refuseWithdrawnPurposeTx refuses to ask again about a purpose the subject has
@@ -118,8 +137,24 @@ func refuseWithdrawnPurposeTx(ctx context.Context, tx pgx.Tx, personID ids.Perso
 	if ConsentState(state) != StateWithdrawn {
 		return nil
 	}
-	return &ValidationError{
-		Field:  purposeIDField,
-		Reason: "this contact has withdrawn this purpose, so we do not ask them about it again",
-	}
+	return &ReSolicitationError{}
+}
+
+// ReSolicitationError refuses asking again about a purpose the subject has
+// already taken back.
+//
+// A distinct type for MisdirectedLinkError's reason, and the stronger case of
+// the two: a withdrawal is the subject's own instruction, and a booking form
+// that swallowed this refusal would mail the newsletter question to somebody
+// who explicitly said stop — the exact act the withdrawal forbids.
+type ReSolicitationError struct{}
+
+func (e *ReSolicitationError) Error() string {
+	return "this contact has withdrawn this purpose, so we do not ask them about it again"
+}
+
+// FieldFault carries the refusal to every surface, the field naming the purpose
+// because that is what the caller would change.
+func (e *ReSolicitationError) FieldFault() (field, code, message string) {
+	return purposeIDField, "purpose_withdrawn", e.Error()
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -41174,7 +41174,7 @@ export interface operations {
              * @description Booked; a minimal confirmation (no CRM record data disclosed). `marketing` reports what
              *     became of the newsletter tick, separately from the booking itself: a question this
              *     installation could not put — no live mailbox on the record, a purpose archived since the
-             *     form was published, a mail lane that refused it — leaves the meeting standing and says
+             *     form was published, no mail lane wired at all — leaves the meeting standing and says
              *     `not_asked`, so a booker who ticked the box is not left waiting for a mail that is not
              *     coming.
              */
@@ -41189,14 +41189,16 @@ export interface operations {
                         /** Format: date-time */
                         end: string;
                         /**
-                         * @description The slot is held. A booking that did not commit answers 409 or 422 instead.
+                         * @description The slot is held. A booking that did not commit answers an error status instead.
                          * @enum {string}
                          */
                         booking: "confirmed";
                         /**
                          * @description `not_requested` — the form carried no tick. `pending_confirmation` — the question
-                         *     was mailed and the grant waits on the subject answering it. `not_asked` — the
-                         *     question could not be put; the booking stands and no subscription mail follows.
+                         *     was queued for delivery and the grant waits on the subject answering it; queued
+                         *     is not delivered. `not_asked` — the question could not be put, or this
+                         *     installation has no lane to put it on; the booking stands and no subscription
+                         *     mail follows.
                          * @enum {string}
                          */
                         marketing: "not_requested" | "pending_confirmation" | "not_asked";

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -41170,7 +41170,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Booked; a minimal confirmation (no CRM record data disclosed). */
+            /**
+             * @description Booked; a minimal confirmation (no CRM record data disclosed). `marketing` reports what
+             *     became of the newsletter tick, separately from the booking itself: a question this
+             *     installation could not put — no live mailbox on the record, a purpose archived since the
+             *     form was published, a mail lane that refused it — leaves the meeting standing and says
+             *     `not_asked`, so a booker who ticked the box is not left waiting for a mail that is not
+             *     coming.
+             */
             201: {
                 headers: {
                     [name: string]: unknown;
@@ -41181,6 +41188,18 @@ export interface operations {
                         start: string;
                         /** Format: date-time */
                         end: string;
+                        /**
+                         * @description The slot is held. A booking that did not commit answers 409 or 422 instead.
+                         * @enum {string}
+                         */
+                        booking: "confirmed";
+                        /**
+                         * @description `not_requested` — the form carried no tick. `pending_confirmation` — the question
+                         *     was mailed and the grant waits on the subject answering it. `not_asked` — the
+                         *     question could not be put; the booking stands and no subscription mail follows.
+                         * @enum {string}
+                         */
+                        marketing: "not_requested" | "pending_confirmation" | "not_asked";
                     };
                 };
             };


### PR DESCRIPTION
## What was wrong

The booking handler recorded consent and then booked. Minting the marketing confirmation link was the last act of that consent capture, so any refusal there returned from the handler before the meeting was ever created.

A person whose primary address had been archived, or a purpose archived under a live form, lost the slot. What the booker saw was a booking form answering 422. They tried again, got the same refusal, and the meeting never happened. Nothing told them or the host that a subscription question was the reason.

## What changed

The consent seam now answers a `MarketingOutcome` beside its error. An operational grant that cannot be recorded is still fatal, because it is the lawful basis the meeting's own mail rides on. A question that cannot be put is not, because the tick was optional and the meeting was not.

## The part worth reviewing closely

**Two refusals stay fatal, and separating them is most of this change.** A link that would reach a different mailbox than the one that asked, and a question put to somebody who has already withdrawn, are not questions worth asking at any price. Swallowing either would make a booking form the way around a withdrawal.

Both were `ValidationError` values indistinguishable from the refusals I wanted to absorb, so they now carry their own types. Both implement `apperrors.FieldFault`, so the refusal reaches the MCP surface as well as HTTP.

Two existing tests hold that line, and they failed when my first attempt swallowed too much.

## Response shape

The public booking response names both outcomes, so a booker who ticked the box and got no question is told rather than left waiting for a mail that is not coming.

The end-to-end disclosure check now names the keys it allows rather than counting them. The rule is that this anonymous answer discloses nothing about the record, and a field count also refused facts about the caller's own request.

## Not in scope

The shipped booking page sends no marketing tick, so there is nothing for it to display yet and it is unchanged.

## Inherited fix

Two integration tests asserted the confirm submit's 204, which #5211 moved to 200. `make check-backend` does not run that lane.

## Proof

One new integration test driving the real handler, mutation-verified. Full `make check-backend` and `make check-fe` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the booking handler so a newsletter question that cannot be asked no longer cancels the meeting. The booking now stands, and the 201 response reports what happened to the marketing tick.

**API changes**
- The booking response now includes `booking: confirmed` and `marketing` (`not_requested`, `pending_confirmation`, `not_asked`).
- `pending_confirmation` is only reported when a confirmation mail was actually staged; the current wiring stages none, so a tick reports `not_asked`.
- Three refusals remain fatal and return 422: a misdirected link (would email a different mailbox), re-solicitation after withdrawal, and permission or not-found refusals.
- The confirm endpoint's success response changed from 204 to 200 (inherited from #5211); existing integration tests were updated.

<sup>Written for commit abc8884f2a2d352fff8c8feb9dbd2a17616806e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Public booking responses now include confirmed booking status and newsletter consent outcomes.
  - Newsletter outcomes distinguish between not requested, pending confirmation, and unable to ask.
  - Bookings proceed even when a newsletter consent question cannot be presented.

- **Bug Fixes**
  - Improved handling and reporting of misdirected confirmation links and repeated consent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->