### PR TITLE
feat(jobs): the dead-work banner counts a window and names it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -22064,7 +22064,7 @@ components:
       description: |
         The installation's identity and reporting basis (ADR-0090/A135). Read by every role,
         changed only by admin/ops.
-      required: [name, timezone, base_currency, base_language, fiscal_year_start_month, forecast_forward_measure, base_currency_locked, max_upload_bytes, sign_in_providers]
+      required: [name, timezone, base_currency, base_language, fiscal_year_start_month, dead_work_banner_hours, forecast_forward_measure, base_currency_locked, max_upload_bytes, sign_in_providers]
       properties:
         name:
           type: string
@@ -22147,6 +22147,19 @@ components:
             a file too large is refused before it is sent instead of after. The ceiling bounds
             the whole request, part framing included, which is why a client should leave a
             little room rather than compare a file against it exactly.
+        dead_work_banner_hours:
+          type: integer
+          minimum: 1
+          maximum: 168
+          description: |
+            How far back the maintenance banner looks before it calls dead work a problem, in
+            hours. 24 by default, bounded above by River's own seven-day retention — a window
+            past that cannot narrow anything, since every terminal row still there is inside it.
+
+            The full count of discarded and cancelled work is unaffected and stays a report
+            figure. This bounds only the number that is styled as an alarm: River keeps a
+            terminal row for a week, so without it an outage that ended an hour ago goes on
+            asking for a hand until the rows retire.
         forecast_forward_measure:
           type: string
           enum: [commit_evidence, weighted, manager_call]
@@ -22207,6 +22220,19 @@ components:
             Password sign-in is not a member of this list and cannot be removed by any value of
             it. Omit the field to leave the choice unchanged; send an empty array to offer
             password only.
+        dead_work_banner_hours:
+          type: integer
+          minimum: 1
+          maximum: 168
+          description: |
+            How far back the maintenance banner looks before it calls dead work a problem, in
+            hours. 24 by default, bounded above by River's own seven-day retention — a window
+            past that cannot narrow anything, since every terminal row still there is inside it.
+
+            The full count of discarded and cancelled work is unaffected and stays a report
+            figure. This bounds only the number that is styled as an alarm: River keeps a
+            terminal row for a week, so without it an outage that ended an hour ago goes on
+            asking for a hand until the rows retire.
         forecast_forward_measure:
           type: string
           enum: [commit_evidence, weighted, manager_call]
@@ -36750,9 +36776,15 @@ components:
     JobHealth:
       type: object
       additionalProperties: false
-      required: [generated_at, kinds, recent_failures]
+      required: [generated_at, dead_window_hours, kinds, recent_failures]
       properties:
         generated_at: { type: string, format: date-time }
+        dead_window_hours:
+          type: integer
+          description: >
+            How far back `dead_recent` looks, from `installation.dead_work_banner_hours`. It travels
+            with the counts so a client can NAME the span it is rendering — a number shown without
+            one asks the reader to guess, and the guess is "since forever".
         kinds:
           type: array
           items: { $ref: '#/components/schemas/JobKindHealth' }
@@ -36765,7 +36797,7 @@ components:
     JobKindHealth:
       type: object
       additionalProperties: false
-      required: [kind, queue, fleet_wide, waiting, running, retrying, dead, oldest_waiting_age_seconds]
+      required: [kind, queue, fleet_wide, waiting, running, retrying, dead, dead_recent, oldest_waiting_age_seconds]
       properties:
         kind: { type: string, description: The stable job identifier River persists in river_job.kind. }
         queue: { type: string }
@@ -36781,7 +36813,15 @@ components:
           type: integer
           description: >
             Discarded or cancelled: this work will not happen without intervention. A discarded
-            job spent every attempt; a cancelled one was stopped deliberately.
+            job spent every attempt; a cancelled one was stopped deliberately. UNBOUNDED IN AGE —
+            River retains a terminal row for seven days, so this is a week's history and a report
+            figure, not a call to action.
+        dead_recent:
+          type: integer
+          description: >
+            The same count inside `dead_window_hours`. This is the one to alarm on: an outage that
+            ended an hour ago and one still running are indistinguishable in `dead`, and that is
+            the distinction a maintenance banner exists to draw.
         oldest_waiting_age_seconds:
           type: [integer, 'null']
           description: >

--- a/backend/internal/compose/handlers_installation_settings.go
+++ b/backend/internal/compose/handlers_installation_settings.go
@@ -120,6 +120,9 @@ func (h installationSettingsHandlers) UpdateInstallationSettings(w http.Response
 	// identity's own sentence, which quotes the value that was refused. A
 	// second check here would name a different field and say less.
 	patch.FiscalYearStartMonth = req.FiscalYearStartMonth
+	// Same again: the entry's own validator holds the 1..168 bound and names
+	// this field when it refuses, so a second check here would say less.
+	patch.DeadWorkBannerHours = req.DeadWorkBannerHours
 	// Same reasoning as the month above: the entry validates against the shared
 	// kernel's set, so an unknown measure comes back naming this field and
 	// quoting the value. Converted to a plain string because the patch carries
@@ -157,6 +160,7 @@ func (h installationSettingsHandlers) toContract(s identity.InstallationSettings
 		BaseCurrency:         s.BaseCurrency,
 		BaseLanguage:         crmcontracts.InstallationSettingsBaseLanguage(s.BaseLanguage),
 		FiscalYearStartMonth: s.FiscalYearStartMonth,
+		DeadWorkBannerHours:  s.DeadWorkBannerHours,
 		ForecastForwardMeasure: crmcontracts.InstallationSettingsForecastForwardMeasure(
 			s.ForecastForwardMeasure),
 		BaseCurrencyLocked: s.BaseCurrencyLocked,

--- a/backend/internal/compose/jobhealth.go
+++ b/backend/internal/compose/jobhealth.go
@@ -13,6 +13,7 @@ package compose
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -20,9 +21,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/platform/settings"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -179,10 +182,17 @@ func (h jobHealthHandlers) GetJobHealth(w http.ResponseWriter, r *http.Request) 
 	ctx, cancel := context.WithTimeout(ctx, jobHealthReadTimeout)
 	defer cancel()
 
+	window, err := deadWorkWindow(ctx, h.pool)
+	if err != nil {
+		slog.ErrorContext(ctx, "reading the dead-work banner window", "err", err)
+		httperr.Write(w, r, err)
+		return
+	}
+
 	// wsID.String(), not the uuid: ->> yields text, and a uuid-typed bind
 	// gives pgx the uuid OID and Postgres "operator does not exist: text =
 	// uuid".
-	health, err := jobs.WorkspaceHealth(ctx, h.pool, wsID.String(), dispatcherKinds())
+	health, err := jobs.WorkspaceHealth(ctx, h.pool, wsID.String(), dispatcherKinds(), window)
 	if err != nil {
 		// Never a partial 200. A page that renders half the fleet as if it
 		// were the whole one is the failure this endpoint exists to end.
@@ -191,11 +201,40 @@ func (h jobHealthHandlers) GetJobHealth(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	httperr.WriteJSON(w, http.StatusOK, jobHealthResponse(health))
+	httperr.WriteJSON(w, http.StatusOK, jobHealthResponse(health, window))
+}
+
+// deadWorkBannerReadActor names the entry read this endpoint performs after it
+// has already admitted the caller.
+//
+// A SYSTEM actor for the reason SignInPolicy gives for its own: the entry is
+// defined on installation_settings so that an admin changes it beside the rest
+// of the installation's identity, and every role may read this page. Demanding
+// installation_settings.read here would refuse the job-health screen to an
+// operator holding exactly the grant the screen is named for. The caller's own
+// authority is settled two gates above this line.
+const deadWorkBannerReadActor = "system:dead_work_banner_read"
+
+// deadWorkWindow answers how far back the banner looks.
+func deadWorkWindow(ctx context.Context, pool *pgxpool.Pool) (time.Duration, error) {
+	readCtx := principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem,
+		ID:   deadWorkBannerReadActor,
+	})
+	hours, err := settings.Get(readCtx, NewSettingsStore(pool), identity.DeadWorkBannerHours)
+	if err != nil {
+		return 0, fmt.Errorf("compose: reading the dead-work banner window: %w", err)
+	}
+	return time.Duration(hours) * time.Hour, nil
 }
 
 // jobHealthResponse maps the scoped read onto the contract.
-func jobHealthResponse(health jobs.Health) crmcontracts.JobHealth {
+//
+// The window travels with the counts, so the client can say which one it is
+// rendering. A banner that names a number without naming its span asks a reader
+// to guess, and the guess a reader makes is "since forever" — which is the
+// reading this whole change exists to stop.
+func jobHealthResponse(health jobs.Health, window time.Duration) crmcontracts.JobHealth {
 	kinds := make([]crmcontracts.JobKindHealth, 0, len(health.Kinds))
 	for _, k := range health.Kinds {
 		kinds = append(kinds, crmcontracts.JobKindHealth{
@@ -206,6 +245,7 @@ func jobHealthResponse(health jobs.Health) crmcontracts.JobHealth {
 			Running:                 int(k.Running),
 			Retrying:                int(k.Retrying),
 			Dead:                    int(k.Dead),
+			DeadRecent:              int(k.DeadRecent),
 			OldestWaitingAgeSeconds: secondsOrAbsent(k.OldestWaitingAgeSeconds),
 		})
 	}
@@ -233,9 +273,10 @@ func jobHealthResponse(health jobs.Health) crmcontracts.JobHealth {
 	}
 
 	return crmcontracts.JobHealth{
-		GeneratedAt:    time.Now().UTC(),
-		Kinds:          kinds,
-		RecentFailures: failures,
+		GeneratedAt:     time.Now().UTC(),
+		DeadWindowHours: int(window / time.Hour),
+		Kinds:           kinds,
+		RecentFailures:  failures,
 	}
 }
 

--- a/backend/internal/compose/jobhealth_test.go
+++ b/backend/internal/compose/jobhealth_test.go
@@ -157,7 +157,7 @@ func TestBothTenantAndDispatcherFailuresReachTheResponse(t *testing.T) {
 	got := jobHealthResponse(jobs.Health{Failures: []jobs.Failure{
 		{Kind: "tenant_pass", WorkspaceID: &someoneElse, State: "discarded"},
 		{Kind: "the_dispatcher", WorkspaceID: nil, State: "discarded"},
-	}})
+	}}, 24*time.Hour)
 
 	if len(got.RecentFailures) != 2 {
 		t.Fatalf("mapped %d failures, want 2", len(got.RecentFailures))
@@ -177,7 +177,7 @@ func TestAnAbsentOldestAgeStaysAbsent(t *testing.T) {
 	got := jobHealthResponse(jobs.Health{Kinds: []jobs.KindHealth{
 		{Kind: "idle", OldestWaitingAgeSeconds: nil},
 		{Kind: "waiting", OldestWaitingAgeSeconds: &measured},
-	}})
+	}}, 24*time.Hour)
 
 	if got.Kinds[0].OldestWaitingAgeSeconds != nil {
 		t.Errorf("an unmeasured age became %d", *got.Kinds[0].OldestWaitingAgeSeconds)
@@ -194,7 +194,7 @@ func TestAnAbsentOldestAgeStaysAbsent(t *testing.T) {
 // arrays, and a JSON null where a list belongs breaks a client that
 // iterates it.
 func TestAnIdleFleetMapsToEmptyListsNotNulls(t *testing.T) {
-	got := jobHealthResponse(jobs.Health{})
+	got := jobHealthResponse(jobs.Health{}, 24*time.Hour)
 
 	if got.Kinds == nil {
 		t.Error("kinds serialized as null rather than []")

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -25263,6 +25263,16 @@ type InstallationSettings struct {
 	// for one reader keeps that reader's language.
 	BaseLanguage InstallationSettingsBaseLanguage `json:"base_language"`
 
+	// DeadWorkBannerHours How far back the maintenance banner looks before it calls dead work a problem, in
+	// hours. 24 by default, bounded above by River's own seven-day retention — a window
+	// past that cannot narrow anything, since every terminal row still there is inside it.
+	//
+	// The full count of discarded and cancelled work is unaffected and stays a report
+	// figure. This bounds only the number that is styled as an alarm: River keeps a
+	// terminal row for a week, so without it an outage that ended an hour ago goes on
+	// asking for a hand until the rows retire.
+	DeadWorkBannerHours int `json:"dead_work_banner_hours"`
+
 	// FiscalYearStartMonth The month the installation's business year begins, 1..12. January (1) is the
 	// default, which is the calendar year every installation reported by before this
 	// setting existed.
@@ -25676,8 +25686,10 @@ type JobFailureState string
 
 // JobHealth defines model for JobHealth.
 type JobHealth struct {
-	GeneratedAt time.Time       `json:"generated_at"`
-	Kinds       []JobKindHealth `json:"kinds"`
+	// DeadWindowHours How far back `dead_recent` looks, from `installation.dead_work_banner_hours`. It travels with the counts so a client can NAME the span it is rendering — a number shown without one asks the reader to guess, and the guess is "since forever".
+	DeadWindowHours int             `json:"dead_window_hours"`
+	GeneratedAt     time.Time       `json:"generated_at"`
+	Kinds           []JobKindHealth `json:"kinds"`
 
 	// RecentFailures Most recent first, capped at 50. A bounded list, not a log.
 	RecentFailures []JobFailure `json:"recent_failures"`
@@ -25685,8 +25697,11 @@ type JobHealth struct {
 
 // JobKindHealth defines model for JobKindHealth.
 type JobKindHealth struct {
-	// Dead Discarded or cancelled: this work will not happen without intervention. A discarded job spent every attempt; a cancelled one was stopped deliberately.
+	// Dead Discarded or cancelled: this work will not happen without intervention. A discarded job spent every attempt; a cancelled one was stopped deliberately. UNBOUNDED IN AGE — River retains a terminal row for seven days, so this is a week's history and a report figure, not a call to action.
 	Dead int `json:"dead"`
+
+	// DeadRecent The same count inside `dead_window_hours`. This is the one to alarm on: an outage that ended an hour ago and one still running are indistinguishable in `dead`, and that is the distinction a maintenance banner exists to draw.
+	DeadRecent int `json:"dead_recent"`
 
 	// FleetWide True for a dispatcher — a job that fans work out and does no tenant work of its own. Its rows carry no workspace.
 	FleetWide bool `json:"fleet_wide"`
@@ -35167,6 +35182,16 @@ type UpdateInstallationSettingsRequest struct {
 	// BaseLanguage The language shared AI writing is written in. Never frozen: changing it re-means
 	// nothing already written, so artifacts stay in the language they were written in.
 	BaseLanguage *UpdateInstallationSettingsRequestBaseLanguage `json:"base_language,omitempty"`
+
+	// DeadWorkBannerHours How far back the maintenance banner looks before it calls dead work a problem, in
+	// hours. 24 by default, bounded above by River's own seven-day retention — a window
+	// past that cannot narrow anything, since every terminal row still there is inside it.
+	//
+	// The full count of discarded and cancelled work is unaffected and stays a report
+	// figure. This bounds only the number that is styled as an alarm: River keeps a
+	// terminal row for a week, so without it an outage that ended an hour ago goes on
+	// asking for a hand until the rows retire.
+	DeadWorkBannerHours *int `json:"dead_work_banner_hours,omitempty"`
 
 	// EnabledOidcProviders The provider keys the login screen may offer, of those this deployment configured.
 	// Sending a key the deployment has no credentials for enables nothing: the effective

--- a/backend/internal/modules/identity/installationsettings.go
+++ b/backend/internal/modules/identity/installationsettings.go
@@ -29,6 +29,10 @@ type InstallationSettings struct {
 	BaseLanguage string
 	// FiscalYearStartMonth is the month the business year begins, 1..12.
 	FiscalYearStartMonth int
+	// DeadWorkBannerHours is how far back the maintenance banner looks before
+	// it calls dead work a problem. The full count stays a report figure; this
+	// bounds the one that is styled as an alarm.
+	DeadWorkBannerHours int
 	// ForecastForwardMeasure is which remaining-pipeline reading a projected
 	// landing is built from. A string here rather than a values.ForwardMeasure
 	// because this struct is what the setting STORED, and reporting it as the
@@ -57,6 +61,7 @@ type InstallationPatch struct {
 	BaseCurrency           *string
 	BaseLanguage           *string
 	FiscalYearStartMonth   *int
+	DeadWorkBannerHours    *int
 	ForecastForwardMeasure *string
 	// EnabledOidcProviders replaces the whole list. A nil pointer leaves it
 	// unchanged; a pointer to an empty slice is a real choice — offer password
@@ -136,6 +141,10 @@ func (s *InstallationSettingsStore) GetInstallation(ctx context.Context) (Instal
 	if err != nil {
 		return InstallationSettings{}, err
 	}
+	bannerHours, err := settings.Get(ctx, s.settings, DeadWorkBannerHours)
+	if err != nil {
+		return InstallationSettings{}, err
+	}
 	measure, err := settings.Get(ctx, s.settings, ForecastForwardMeasure)
 	if err != nil {
 		return InstallationSettings{}, err
@@ -151,6 +160,7 @@ func (s *InstallationSettingsStore) GetInstallation(ctx context.Context) (Instal
 	return InstallationSettings{
 		Name: name, Timezone: zone, BaseCurrency: currency, BaseLanguage: language,
 		FiscalYearStartMonth:   fiscalStart,
+		DeadWorkBannerHours:    bannerHours,
 		ForecastForwardMeasure: measure,
 		BaseCurrencyLocked:     locked, BaseCurrencyLockedReason: why,
 		EnabledOidcProviders: providers,
@@ -246,6 +256,10 @@ func encodeInstallationPatch(in InstallationPatch) ([]pendingWrite, error) {
 	if err != nil {
 		return nil, err
 	}
+	bannerHours, err := encodePatchField(DeadWorkBannerHours, in.DeadWorkBannerHours)
+	if err != nil {
+		return nil, err
+	}
 	measure, err := encodePatchField(ForecastForwardMeasure, in.ForecastForwardMeasure)
 	if err != nil {
 		return nil, err
@@ -254,7 +268,7 @@ func encodeInstallationPatch(in InstallationPatch) ([]pendingWrite, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []pendingWrite{name, zone, currency, language, fiscal, measure, providers}, nil
+	return []pendingWrite{name, zone, currency, language, fiscal, bannerHours, measure, providers}, nil
 }
 
 // UpdateInstallation applies a sparse patch. Named for the same reason as

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -304,6 +304,7 @@ func Definitions() []settings.Definition {
 		BaseLanguage,
 		Country,
 		FiscalYearStartMonth,
+		DeadWorkBannerHours,
 		ForecastForwardMeasure,
 		EnabledOidcProviders,
 		SMTPPasswordRef,

--- a/backend/internal/modules/identity/settingsjobhealth.go
+++ b/backend/internal/modules/identity/settingsjobhealth.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// How far back the maintenance banner looks when it calls dead work a problem.
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/platform/settings"
+)
+
+// DeadWorkBannerHours is the age bound on the count that gets the red treatment.
+//
+// The full count of discarded and cancelled rows is not wrong — that work did
+// not happen — but River retains those rows for seven days, so a transient
+// outage that ended an hour ago goes on asserting that hundreds of jobs need a
+// hand for the rest of the week. What was wrong was presenting a settled history
+// as a live call to action, and the fix is which number gets the alarm rather
+// than the arithmetic.
+//
+// TWENTY-FOUR HOURS by default. Short enough that a finished outage clears
+// itself by the next working day; long enough that something which died
+// overnight is still on the banner in the morning, which is when an operator
+// first looks. An hour was the tempting number and it is too short — a
+// Friday-evening failure would be gone by Monday and nobody would ever see it.
+//
+// A SETTING because an installation's rhythm is its own: a team that watches
+// this hourly wants a shorter window than one that reads it on Monday, and a
+// constant here is a number somebody has to argue with in code.
+//
+// The upper bound is River's own retention. A window longer than the rows live
+// is a window that silently means "everything", which is the state this exists
+// to leave.
+var DeadWorkBannerHours = settings.Define[int](
+	"installation.dead_work_banner_hours",
+	installationSettingsObject,
+	"update",
+	24,
+	func(hours int) error {
+		if hours < 1 || hours > riverRetentionHours {
+			return fmt.Errorf("the dead-work banner looks back 1..%d hours, not %d", riverRetentionHours, hours)
+		}
+		return nil
+	},
+).AsInstallationIdentity()
+
+// riverRetentionHours is how long River's job cleaner keeps a discarded or
+// cancelled row at its defaults — seven days. It bounds the setting above
+// because a window past it cannot narrow anything: every row still there is
+// inside it, and the banner would be back to counting the week.
+const riverRetentionHours = 7 * 24

--- a/backend/internal/platform/jobs/deadwindow_integration_test.go
+++ b/backend/internal/platform/jobs/deadwindow_integration_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package jobs_test
+
+// The two dead counts, over a real river_job table.
+//
+// River retains a discarded or cancelled row for seven days, so the unbounded
+// count is a week of history: an outage that ended an hour ago and one still
+// running are the same number. That number is not wrong — the work did not
+// happen — but it is a report, and presenting it as a live call to action is
+// what made a finished outage keep a banner red until the rows retired.
+//
+// The observed case is the fixture: 531 rows from a DNS outage that had been
+// over for an hour. The banner must be able to say that is history while still
+// showing the total to anybody who wants it.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// deadCounts answers one kind's pair, or zeros when the kind is absent.
+func deadCounts(t *testing.T, health jobs.Health, kind string) (dead, recent int64) {
+	t.Helper()
+	for _, k := range health.Kinds {
+		if k.Kind == kind {
+			return k.Dead, k.DeadRecent
+		}
+	}
+	t.Fatalf("no health row for kind %q — the counts below would both be zero for the wrong reason", kind)
+	return 0, 0
+}
+
+func TestTheDeadBannerCountsTheWindowAndTheReportCountsTheWeek(t *testing.T) {
+	ctx := context.Background()
+	_, pool := migratedAppPool(t)
+	ws := ids.NewV7()
+
+	// The outage: 531 rows, all discarded, all finished an hour ago. The
+	// number is the observed one rather than a round fixture, because what
+	// made this a defect was the SIZE of a settled history shouting.
+	settled := time.Now().Add(-time.Hour)
+	for range 531 {
+		seedJob(ctx, t, pool, seed{
+			Kind: "capture_sync", State: "discarded", Workspace: ws, CreatedAt: settled,
+		})
+	}
+	// And one that died three days ago, well outside any sensible window —
+	// the week's history the report figure is for.
+	seedJob(ctx, t, pool, seed{
+		Kind: "capture_sync", State: "discarded", Workspace: ws,
+		CreatedAt: time.Now().AddDate(0, 0, -3),
+	})
+
+	// A window that ends between the two.
+	health, err := jobs.WorkspaceHealth(ctx, pool, ws.String(), nil, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("reading job health: %v", err)
+	}
+	dead, recent := deadCounts(t, health, "capture_sync")
+	if dead != 532 {
+		t.Errorf("the report figure counts %d, want 532 — the full history is what it is for, and "+
+			"narrowing it would destroy the record an investigator came for", dead)
+	}
+	if recent != 531 {
+		t.Errorf("the banner counts %d, want the 531 inside the window", recent)
+	}
+
+	// An hour ago is now outside the window, and the banner goes quiet while
+	// the report figure does not move. This is the case the whole change is
+	// about: the same rows, read as history.
+	health, err = jobs.WorkspaceHealth(ctx, pool, ws.String(), nil, time.Minute)
+	if err != nil {
+		t.Fatalf("reading job health on a one-minute window: %v", err)
+	}
+	dead, recent = deadCounts(t, health, "capture_sync")
+	if recent != 0 {
+		t.Errorf("the banner still counts %d after the outage left the window — a settled history "+
+			"goes on asking for a hand, which is the defect", recent)
+	}
+	if dead != 532 {
+		t.Errorf("the report figure moved to %d with the window — the window bounds the alarm, "+
+			"never the record", dead)
+	}
+}
+
+// The count above compares finalized_at directly, with no fallback. This is what
+// makes that safe: river_job refuses a terminal row that does not carry the
+// moment it died, so there is no undated row for the comparison to drop.
+//
+// Asserted rather than assumed, because the failure would be silent in the
+// worst direction — an undated terminal row would fall out of every window and
+// the banner would go quiet about the one row nobody can date.
+func TestATerminalRowMustCarryTheMomentItDied(t *testing.T) {
+	ctx := context.Background()
+	_, pool := migratedAppPool(t)
+	ws := ids.NewV7()
+
+	seedJob(ctx, t, pool, seed{Kind: "capture_sync", State: "discarded", Workspace: ws})
+	_, err := pool.Exec(ctx, `UPDATE river_job SET finalized_at = NULL WHERE kind = 'capture_sync'`)
+	if err == nil {
+		t.Fatal("river_job accepted a discarded row with no finalized_at — the banner's count " +
+			"compares that column directly, so such a row would silently leave every window")
+	}
+	if !strings.Contains(err.Error(), "finalized_or_finalized_at_null") {
+		t.Errorf("the refusal came from %v, not from finalized_or_finalized_at_null — the count "+
+			"relies on that constraint by name", err)
+	}
+}

--- a/backend/internal/platform/jobs/health.go
+++ b/backend/internal/platform/jobs/health.go
@@ -63,7 +63,18 @@ type KindHealth struct {
 	// intervention. The two are reported together here because the question
 	// the field answers is "will this run" and the answer is no either way;
 	// the exposition endpoint keeps them apart, where the question is why.
+	//
+	// UNBOUNDED IN AGE, and that is what makes it a report figure rather than
+	// an alarm: River retains a terminal row for seven days, so this counts a
+	// week of history and an outage that ended an hour ago reads the same as one
+	// still running.
 	Dead int64
+	// DeadRecent is the same count inside the caller's window — the number that
+	// earns the banner. The pair is the whole point: an operator can still see
+	// the week's total without being paged by it, and the red one answers "is
+	// something wrong NOW", which is the distinction the unbounded count cannot
+	// draw.
+	DeadRecent int64
 	// OldestWaitingAgeSeconds is nil when nothing of this kind is runnable
 	// right now. Nil and zero are different claims — nothing waiting versus
 	// something that just became runnable — so the absence is carried
@@ -133,8 +144,14 @@ const recentFailureLimit = 50
 // declaration in this package. This table has no RLS, so the untenanted arm
 // IS the scope — and a scope the calling surface states for itself is one
 // that surface can be gated on, which is where the gate for it lives.
-func WorkspaceHealth(ctx context.Context, pool *pgxpool.Pool, workspaceID string, dispatcherKinds []string) (Health, error) {
-	kinds, err := healthByKind(ctx, pool, workspaceID, dispatcherKinds)
+//
+// `recent` bounds DeadRecent, and arrives from the caller for the same reason:
+// it is an installation setting, and this package holds no settings reader.
+func WorkspaceHealth(
+	ctx context.Context, pool *pgxpool.Pool, workspaceID string,
+	dispatcherKinds []string, recent time.Duration,
+) (Health, error) {
+	kinds, err := healthByKind(ctx, pool, workspaceID, dispatcherKinds, recent)
 	if err != nil {
 		return Health{}, err
 	}
@@ -151,7 +168,10 @@ func WorkspaceHealth(ctx context.Context, pool *pgxpool.Pool, workspaceID string
 // somehow holds BOTH tenant and untenanted rows appears twice rather than
 // being silently attributed to one side. That would be the workspace
 // invariant breaking, and this endpoint should be the thing that shows it.
-func healthByKind(ctx context.Context, pool *pgxpool.Pool, workspaceID string, dispatcherKinds []string) ([]KindHealth, error) {
+func healthByKind(
+	ctx context.Context, pool *pgxpool.Pool, workspaceID string,
+	dispatcherKinds []string, recent time.Duration,
+) ([]KindHealth, error) {
 	const q = `
 		SELECT kind,
 		       queue,
@@ -160,6 +180,18 @@ func healthByKind(ctx context.Context, pool *pgxpool.Pool, workspaceID string, d
 		       count(*) FILTER (WHERE state::text = 'running')::bigint,
 		       count(*) FILTER (WHERE state::text = 'retryable')::bigint,
 		       count(*) FILTER (WHERE state::text IN ` + terminalBadStates + `)::bigint,
+		       -- The banner's own count. finalized_at is when a terminal row
+		       -- BECAME terminal, which is the moment an operator is being asked
+		       -- about — not created_at, which dates a job that may have sat in
+		       -- the queue for hours before it died.
+		       --
+		       -- Compared directly, with no coalesce: river_job's own
+		       -- finalized_or_finalized_at_null CHECK makes the column NOT NULL
+		       -- for exactly these states, so a fallback here would be a branch
+		       -- Postgres does not admit a row to reach.
+		       -- Held by: TestATerminalRowMustCarryTheMomentItDied
+		       count(*) FILTER (WHERE state::text IN ` + terminalBadStates + `
+		                          AND finalized_at >= now() - $3::interval)::bigint,
 		       max(EXTRACT(EPOCH FROM (now() - scheduled_at)))
 		           FILTER (WHERE state::text IN ` + runnableStates + `
 		                     AND scheduled_at <= now())::double precision
@@ -168,7 +200,7 @@ func healthByKind(ctx context.Context, pool *pgxpool.Pool, workspaceID string, d
 		GROUP BY 1, 2, 3
 		ORDER BY 1, 2, 3`
 
-	rows, err := pool.Query(ctx, q, workspaceID, dispatcherKinds)
+	rows, err := pool.Query(ctx, q, workspaceID, dispatcherKinds, recent)
 	if err != nil {
 		return nil, fmt.Errorf("jobs: reading job health by kind: %w", err)
 	}
@@ -178,7 +210,7 @@ func healthByKind(ctx context.Context, pool *pgxpool.Pool, workspaceID string, d
 	for rows.Next() {
 		var k KindHealth
 		if err := rows.Scan(&k.Kind, &k.Queue, &k.FleetWide,
-			&k.Waiting, &k.Running, &k.Retrying, &k.Dead,
+			&k.Waiting, &k.Running, &k.Retrying, &k.Dead, &k.DeadRecent,
 			&k.OldestWaitingAgeSeconds); err != nil {
 			return nil, fmt.Errorf("jobs: scanning job health by kind: %w", err)
 		}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15075,6 +15075,17 @@ export interface components {
              */
             max_upload_bytes: number;
             /**
+             * @description How far back the maintenance banner looks before it calls dead work a problem, in
+             *     hours. 24 by default, bounded above by River's own seven-day retention — a window
+             *     past that cannot narrow anything, since every terminal row still there is inside it.
+             *
+             *     The full count of discarded and cancelled work is unaffected and stays a report
+             *     figure. This bounds only the number that is styled as an alarm: River keeps a
+             *     terminal row for a week, so without it an outage that ended an hour ago goes on
+             *     asking for a hand until the rows retire.
+             */
+            dead_work_banner_hours: number;
+            /**
              * @description Which remaining-pipeline reading a projected landing is built from. A setting
              *     rather than a fixed choice, because it is a question about how this installation
              *     SELLS rather than about the software: a team with a disciplined commit stage means
@@ -15128,6 +15139,17 @@ export interface components {
              *     password only.
              */
             enabled_oidc_providers?: string[];
+            /**
+             * @description How far back the maintenance banner looks before it calls dead work a problem, in
+             *     hours. 24 by default, bounded above by River's own seven-day retention — a window
+             *     past that cannot narrow anything, since every terminal row still there is inside it.
+             *
+             *     The full count of discarded and cancelled work is unaffected and stays a report
+             *     figure. This bounds only the number that is styled as an alarm: River keeps a
+             *     terminal row for a week, so without it an outage that ended an hour ago goes on
+             *     asking for a hand until the rows retire.
+             */
+            dead_work_banner_hours?: number;
             /**
              * @description Which remaining-pipeline reading a projected landing is built from. Never frozen:
              *     it is applied on READ and stores nothing, so changing it re-computes every landing
@@ -26853,6 +26875,8 @@ export interface components {
         JobHealth: {
             /** Format: date-time */
             generated_at: string;
+            /** @description How far back `dead_recent` looks, from `installation.dead_work_banner_hours`. It travels with the counts so a client can NAME the span it is rendering — a number shown without one asks the reader to guess, and the guess is "since forever". */
+            dead_window_hours: number;
             kinds: components["schemas"]["JobKindHealth"][];
             /** @description Most recent first, capped at 50. A bounded list, not a log. */
             recent_failures: components["schemas"]["JobFailure"][];
@@ -26868,8 +26892,10 @@ export interface components {
             running: number;
             /** @description Failed at least once and backing off toward another attempt. */
             retrying: number;
-            /** @description Discarded or cancelled: this work will not happen without intervention. A discarded job spent every attempt; a cancelled one was stopped deliberately. */
+            /** @description Discarded or cancelled: this work will not happen without intervention. A discarded job spent every attempt; a cancelled one was stopped deliberately. UNBOUNDED IN AGE — River retains a terminal row for seven days, so this is a week's history and a report figure, not a call to action. */
             dead: number;
+            /** @description The same count inside `dead_window_hours`. This is the one to alarm on: an outage that ended an hour ago and one still running are indistinguishable in `dead`, and that is the distinction a maintenance banner exists to draw. */
+            dead_recent: number;
             /** @description How long the oldest runnable-and-unclaimed job of this kind has waited. Null when nothing of this kind is runnable now; a job scheduled for the future is not late. */
             oldest_waiting_age_seconds: number | null;
         };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4212,7 +4212,10 @@ export const de = {
   "jobs.waitedHours_other": "ältester wartet seit {count} Stunden",
   "jobs.waitedDays_one": "ältester wartet seit {count} Tag",
   "jobs.waitedDays_other": "ältester wartet seit {count} Tagen",
-  "jobs.deadTitle": "Tote Arbeit braucht deine Hand",
+  "jobs.deadTitle":
+    "{count} Jobs sind in den letzten {hours} Stunden gestorben",
+  "jobs.deadTotal":
+    "{count} in den letzten 7 Tagen verworfen oder abgebrochen — so lange werden die Einträge aufbewahrt.",
   "jobs.deadBody":
     "{count} Jobs sind verworfen oder abgebrochen: diese Arbeit passiert ohne Eingriff nicht mehr. Ein verworfener Job hat alle Versuche verbraucht, ein abgebrochener wurde absichtlich gestoppt. Lies die Fehler unten, bevor du etwas neu einreihst.",
   "jobs.failures": "Letzte Fehler",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4306,7 +4306,12 @@ export const en = {
   "jobs.waitedHours_other": "oldest has waited {count} hours",
   "jobs.waitedDays_one": "oldest has waited {count} day",
   "jobs.waitedDays_other": "oldest has waited {count} days",
-  "jobs.deadTitle": "Dead work needs a hand",
+  // The window is in the TITLE, not only the body: a count with no span asks
+  // the reader to guess, and the guess is "since forever" — which is what made
+  // a finished outage keep this red for a week.
+  "jobs.deadTitle": "{count} jobs died in the last {hours} hours",
+  "jobs.deadTotal":
+    "{count} discarded or cancelled in the last 7 days, which is as long as the records are kept.",
   "jobs.deadBody":
     "{count} jobs are discarded or cancelled: that work will not happen without intervention. A discarded job spent every attempt; a cancelled one was stopped deliberately. Read the failures below before re-queueing anything.",
   "jobs.failures": "Recent failures",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4144,7 +4144,9 @@ export const vi = {
   "jobs.waitedHours_other": "cũ nhất đã chờ {count} giờ",
   "jobs.waitedDays_one": "cũ nhất đã chờ {count} ngày",
   "jobs.waitedDays_other": "cũ nhất đã chờ {count} ngày",
-  "jobs.deadTitle": "Việc đã chết cần bạn ra tay",
+  "jobs.deadTitle": "{count} tác vụ đã chết trong {hours} giờ qua",
+  "jobs.deadTotal":
+    "{count} bị loại bỏ hoặc bị huỷ trong 7 ngày qua — đó cũng là thời gian bản ghi được giữ lại.",
   "jobs.deadBody":
     "{count} tác vụ đã bị loại bỏ hoặc bị huỷ: công việc đó sẽ không tự diễn ra nữa. Một tác vụ bị loại bỏ đã dùng hết mọi lần thử; một tác vụ bị huỷ là do có người chủ động dừng. Hãy đọc các lỗi bên dưới trước khi xếp lại vào hàng đợi.",
   "jobs.failures": "Lỗi gần đây",

--- a/frontend/src/screens/jobhealth.test.tsx
+++ b/frontend/src/screens/jobhealth.test.tsx
@@ -73,6 +73,7 @@ function stubRoutes(overrides: Record<string, () => Response> = {}) {
 
 const HEALTH = {
   generated_at: "2026-08-13T09:30:00Z",
+  dead_window_hours: 24,
   kinds: [
     {
       kind: "capture_classify",
@@ -82,6 +83,7 @@ const HEALTH = {
       running: 1,
       retrying: 2,
       dead: 0,
+      dead_recent: 0,
       oldest_waiting_age_seconds: 4_500,
     },
     {
@@ -92,6 +94,7 @@ const HEALTH = {
       running: 0,
       retrying: 0,
       dead: 0,
+      dead_recent: 0,
       oldest_waiting_age_seconds: null,
     },
   ],
@@ -288,7 +291,7 @@ describe("JobHealthCard", () => {
       "GET /admin/job-health": () =>
         jsonResponse({
           ...HEALTH,
-          kinds: [{ ...HEALTH.kinds[0], dead: 3, retrying: 0 }],
+          kinds: [{ ...HEALTH.kinds[0], dead: 3, dead_recent: 3, retrying: 0 }],
           recent_failures: [
             { ...HEALTH.recent_failures[0], state: "discarded", attempt: 5 },
           ],
@@ -301,9 +304,52 @@ describe("JobHealthCard", () => {
     expect(alert).toHaveClass("callout-danger");
     expect(alert).toHaveTextContent(/will not happen without intervention/i);
     expect(alert).toHaveTextContent(/3 jobs/);
+    // The span, in the sentence. A count with no window asks the reader to
+    // guess, and the guess is "since forever".
+    expect(alert).toHaveTextContent(/last 24 hours/i);
+    // Nothing to say about a week that holds no more than the day does.
+    expect(alert).not.toHaveTextContent(/7 days/i);
     // And the count itself carries the tone on the row it belongs to.
     expect(screen.getByText("3 dead")).toHaveClass("badge-danger");
     expect(screen.getByText("discarded")).toHaveClass("badge-danger");
+  });
+
+  // The case the window exists for: a settled outage. The rows are still there
+  // — River keeps them a week — and the banner must go quiet while the figure
+  // does not, or a finished outage goes on asking for a hand until they retire.
+  it("goes quiet once the dead work leaves the window, and still reports it", async () => {
+    stubRoutes({
+      "GET /admin/job-health": () =>
+        jsonResponse({
+          ...HEALTH,
+          kinds: [
+            { ...HEALTH.kinds[0], dead: 531, dead_recent: 0, retrying: 0 },
+          ],
+        }),
+    });
+    render(<JobHealthCard />);
+    await screen.findByText("531 dead");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  // And when both are non-zero and differ, the week's total travels WITH the
+  // alarm rather than instead of it.
+  it("names the week's total beside the window's count", async () => {
+    stubRoutes({
+      "GET /admin/job-health": () =>
+        jsonResponse({
+          ...HEALTH,
+          kinds: [
+            { ...HEALTH.kinds[0], dead: 531, dead_recent: 4, retrying: 0 },
+          ],
+        }),
+    });
+    render(<JobHealthCard />);
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/4 jobs died in the last 24 hours/i);
+    expect(alert).toHaveTextContent(
+      /531 discarded or cancelled in the last 7 days/i,
+    );
   });
 
   it("keeps a healthy report free of the dead-work alert", async () => {

--- a/frontend/src/screens/jobhealth.tsx
+++ b/frontend/src/screens/jobhealth.tsx
@@ -7,7 +7,6 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCan } from "../app/capability";
 import { Badge, EmptyState } from "../design-system/atoms";
-import { Callout } from "../design-system/callout";
 import { CardBoundary } from "../design-system/cardboundary";
 import { type Fact, FactList } from "../design-system/factlist";
 import { Panel, PanelBody } from "../design-system/panel";
@@ -30,6 +29,7 @@ import {
 } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { QueryGate, throwProblem, useMe } from "./common";
+import { DeadWorkCallout } from "./jobhealthdead";
 import "./jobhealth.css";
 
 // GET /admin/job-health — the operator's only window onto the background
@@ -328,23 +328,9 @@ function JobHealthBody({
     return <EmptyState>{t("jobs.empty")}</EmptyState>;
   }
 
-  const dead = health.kinds.reduce((total, kind) => total + kind.dead, 0);
   return (
     <>
-      {dead > 0 && (
-        // The one thing on this card an operator must not scroll past: dead
-        // work does not resume on its own. An `event` would be mentioned
-        // quietly; this one interrupts, because the reader has to act on it and
-        // nothing else on the page says so again.
-        <Callout
-          tone="danger"
-          kind="event"
-          live="alert"
-          title={t("jobs.deadTitle")}
-        >
-          <p>{t("jobs.deadBody", { count: formatNumber(dead, locale) })}</p>
-        </Callout>
-      )}
+      <DeadWorkCallout health={health} />
       <SettingList>
         <KindSection
           label={t("jobs.workspaceKinds")}

--- a/frontend/src/screens/jobhealthdead.tsx
+++ b/frontend/src/screens/jobhealthdead.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { components } from "../api/schema";
+import { Callout } from "../design-system/callout";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+
+type JobHealth = components["schemas"]["JobHealth"];
+
+// The maintenance page's one interruption, in its own file because it is the
+// one thing on that page that ARGUES rather than reports — and because the
+// argument takes two numbers and a rule about which of them is allowed to
+// shout.
+export function DeadWorkCallout({ health }: Readonly<{ health: JobHealth }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const dead = health.kinds.reduce((total, kind) => total + kind.dead, 0);
+  // TWO NUMBERS, and only one of them interrupts. The week's total is real
+  // information — that work did not happen — but River keeps a terminal row for
+  // seven days, so an outage that ended an hour ago reads exactly like one still
+  // running. What earns the alarm is the recent count; the total goes under it
+  // as a figure, so an operator can still see the history without being paged by
+  // it.
+  const recent = health.kinds.reduce(
+    (total, kind) => total + kind.dead_recent,
+    0,
+  );
+  if (recent === 0) {
+    return null;
+  }
+  return (
+    // The one thing on this card an operator must not scroll past: dead
+    // work does not resume on its own. An `event` would be mentioned
+    // quietly; this one interrupts, because the reader has to act on it and
+    // nothing else on the page says so again.
+    <Callout
+      tone="danger"
+      kind="event"
+      live="alert"
+      title={t("jobs.deadTitle", {
+        count: formatNumber(recent, locale),
+        hours: formatNumber(health.dead_window_hours, locale),
+      })}
+    >
+      <p>{t("jobs.deadBody", { count: formatNumber(recent, locale) })}</p>
+      {/* Only when the two differ: "531 recently, 531 this week" is a
+              sentence that reads as a second alarm rather than as context. */}
+      {dead > recent && (
+        <p className="t-sub">
+          {t("jobs.deadTotal", { count: formatNumber(dead, locale) })}
+        </p>
+      )}
+    </Callout>
+  );
+}


### PR DESCRIPTION
Closes #1750. Builds the ruling: age-bound the banner, keep the full count as a
report figure.

## The defect

River retains a discarded or cancelled row for seven days and the banner counted
all of them, so a transient outage that ended an hour ago went on asserting that
hundreds of jobs *"will not happen without intervention"* for the rest of the
week. Observed with **531 rows from a DNS outage that had been over for an
hour** — and the banner could not tell that from an outage still in progress,
which is the one distinction it exists to draw.

The count is not wrong. Those rows exist and that work did not happen. What was
wrong is **which number gets the red treatment**.

## Two counts

`dead` is untouched and becomes what it always was — a week of history, a report
figure. `dead_recent` is the same count inside a window, and the banner reads the
second.

**24 hours by default.** Short enough that a finished outage clears itself by the
next working day; long enough that something which died overnight is still on the
banner in the morning, which is when an operator first looks. An hour is the
tempting number and it is too short: a Friday-evening failure would be gone by
Monday and nobody would ever have seen it.

**A setting** (`installation.dead_work_banner_hours`), because an installation's
rhythm is its own and a constant here is a number somebody has to argue with in
code. Bounded above by River's own retention — a window longer than the rows live
silently means "everything", which is the state this exists to leave.

## The copy carries the span

*"531 jobs died in the last 24 hours"* — the window is in the **title**, not
buried. A count with no span asks the reader to guess, and the guess is "since
forever". The week's total sits under it as a plain figure, and **only when the
two differ**: "531 recently, 531 this week" reads as a second alarm rather than
as context.

The window travels on the wire (`dead_window_hours`) rather than being assumed
client-side, so the sentence cannot disagree with the number it describes.

## One thing the first draft got wrong

The count originally read `coalesce(finalized_at, now())`, guarding a terminal row
that carries no moment. **That row cannot exist** — `river_job`'s
`finalized_or_finalized_at_null` CHECK refuses it — so the fallback was a branch
Postgres does not admit a row to reach, and the test I wrote for it skipped.

A skipping test is the same shape as the defect this ticket is about, so both are
gone: the comparison is direct, and `TestATerminalRowMustCarryTheMomentItDied`
asserts the constraint the comparison relies on **by name**. That failure would
otherwise be silent in the worst direction — an undated terminal row would fall
out of every window and the banner would go quiet about the one row nobody can
date.

## Tests

- `TestTheDeadBannerCountsTheWindowAndTheReportCountsTheWeek` — the observed
  fixture: 531 discarded an hour ago plus one from three days back. At 24h the
  banner counts 531 and the report counts 532; at one minute the banner counts
  **0** and the report still counts 532. The window bounds the alarm, never the
  record.
- Frontend: the banner goes quiet once the work leaves the window while the row
  still shows `531 dead`, and names the week's total beside the window's count
  when they differ. Mutation-checked — summing `dead` instead of `dead_recent`
  fails both.

## One file split

`jobhealth.tsx` hit 501 lines, so the callout moved to `jobhealthdead.tsx`. It is
the one thing on that page that **argues** rather than reports, and the argument
is now two numbers and a rule about which may shout — which is a concept, not a
line count.

## Checks

`make check-backend`, `make check-fe`, `craft static --strict` (0/0/0), and the
`platform/jobs` plus job-health/installation-settings integration lanes.