### PR TITLE
The manage-preferences link reads the recipient again

### DIFF
--- a/backend/internal/compose/integration/preference_center_integration_test.go
+++ b/backend/internal/compose/integration/preference_center_integration_test.go
@@ -111,6 +111,37 @@ func unsubscribeLinkIn(t *testing.T, body string) string {
 	return ""
 }
 
+// manageLinkIn reads the "Manage your preferences" destination out of a sent
+// body. It is a SEPARATE link from the unsubscribe one and now carries a
+// separate credential: stopping mail and reading a record are different rights,
+// and the token that outlives a message on purpose is not the one the
+// preference centre can resolve.
+func manageLinkIn(t *testing.T, body string) string {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if link, ok := strings.CutPrefix(line, "Manage your preferences: "); ok {
+			return strings.TrimSpace(link)
+		}
+	}
+	t.Fatalf("no manage-preferences link in the sent body:\n%s", body)
+	return ""
+}
+
+// manageTokenFromLink pulls the preference token out of that hash route.
+func manageTokenFromLink(t *testing.T, link string) string {
+	t.Helper()
+	u, err := url.Parse(link)
+	if err != nil {
+		t.Fatalf("parsing the manage link %q: %v", link, err)
+	}
+	route := strings.SplitN(u.Fragment, "?", 2)[0]
+	token := strings.TrimPrefix(route, "/preferences/")
+	if token == "" || token == route {
+		t.Fatalf("manage link has no token: %q", u.Fragment)
+	}
+	return token
+}
+
 func tokenFromLink(t *testing.T, link string) string {
 	t.Helper()
 	u, err := url.Parse(link)
@@ -159,8 +190,13 @@ func createNewsletterPurpose(t *testing.T, c *consentEnv) string {
 // transactional (locked) send that carries no unsubscribe surface at all.
 // The machine List-Unsubscribe header derives from the SAME token and URL
 // and is asserted where it is now built, on the send path itself
-// (activities.Store.SendEmail). Returns the preference token the send minted.
-func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) string {
+// (activities.Store.SendEmail).
+//
+// Returns BOTH credentials the send hands the recipient, because they are two
+// different rights and no longer one token: stop is the withdrawal credential
+// the unsubscribe links carry, which outlives the message on purpose and reads
+// nothing; manage is the preference token the preference centre resolves.
+func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) (stop, manage string) {
 	t.Helper()
 	// The marketing send carries the one-click link, built from the
 	// configured base — NOT from the request Host.
@@ -173,6 +209,7 @@ func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) string {
 		t.Fatalf("unsubscribe link = %q, want the human unsubscribe page on the configured base", link)
 	}
 	token := tokenFromLink(t, link)
+	manageToken := manageTokenFromLink(t, manageLinkIn(t, transmittedBody(t, c)))
 
 	// A forged Host / X-Forwarded-Proto must NOT redirect the tokenized
 	// link to an attacker's domain (token-exfiltration guard). Asserted on
@@ -196,7 +233,7 @@ func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) string {
 	if _, tbody := sendMarketing(t, c.AppEnv, c.activityID, "transactional", "", ""); strings.Contains(tbody, "/unsubscribe") {
 		t.Fatalf("transactional send carried an unsubscribe link:\n%s", tbody)
 	}
-	return token
+	return token, manageToken
 }
 
 // prefView is the no-login preference center's response shape.
@@ -288,10 +325,15 @@ func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	newsletterID := createNewsletterPurpose(t, c)
 	grantPurpose(t, c, newsletterID)
 
-	token := sendAndAssertUnsubscribeLink(t, c)
+	// TWO CREDENTIALS, because the send hands out two. The stop token presses
+	// the one-click endpoint; the manage token reads the preference centre.
+	// They were one token until the withdrawal credential landed, and this test
+	// used it for both — which is how the manage link came to resolve nothing
+	// without any test noticing.
+	token, manageToken := sendAndAssertUnsubscribeLink(t, c)
 
 	// The no-login preference center recognizes the recipient by token.
-	view := readPreferenceView(t, c, token)
+	view := readPreferenceView(t, c, manageToken)
 	if s, _ := purposeStateOf(t, view, "newsletter"); s != "granted" {
 		t.Fatalf("newsletter shows %q before opt-out, want granted", s)
 	}
@@ -305,7 +347,7 @@ func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	if s := publicCall(t, c.AppEnv, "GET", "/v1/public/preferences/"+token+"/unsubscribe", nil, nil, nil); s != http.StatusMethodNotAllowed {
 		t.Fatalf("GET on the unsubscribe path → %d, want 405", s)
 	}
-	if s, _ := purposeStateOf(t, readPreferenceView(t, c, token), "newsletter"); s != "granted" {
+	if s, _ := purposeStateOf(t, readPreferenceView(t, c, manageToken), "newsletter"); s != "granted" {
 		t.Fatalf("a GET changed newsletter to %q — the one-click surface must be POST-only", s)
 	}
 
@@ -316,10 +358,19 @@ func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/preferences/"+token+"/unsubscribe?purpose=newsletter", nil, nil, &unsub); s != http.StatusOK {
 		t.Fatalf("one-click unsubscribe → %d", s)
 	}
-	if len(unsub.Unsubscribed) != 1 || unsub.Unsubscribed[0] != "newsletter" {
-		t.Fatalf("unsubscribed = %v, want [newsletter]", unsub.Unsubscribed)
+	// ONE ENTRY, and its VALUE is deliberately opaque. A withdrawal credential
+	// is pressed by whoever holds the link, and naming the purposes it stopped
+	// would tell them which subscriptions this address holds — which the press
+	// itself never proved they are entitled to know. What the page renders is
+	// the count, so the count is what this asserts.
+	if len(unsub.Unsubscribed) != 1 {
+		t.Fatalf("unsubscribed = %v, want exactly one stopped purpose", unsub.Unsubscribed)
 	}
-	if s, _ := purposeStateOf(t, readPreferenceView(t, c, token), "newsletter"); s != "withdrawn" {
+	if unsub.Unsubscribed[0] == "newsletter" {
+		t.Errorf("the answer named the purpose it stopped — a credential press must not tell its "+
+			"holder which subscriptions this address carries: %v", unsub.Unsubscribed)
+	}
+	if s, _ := purposeStateOf(t, readPreferenceView(t, c, manageToken), "newsletter"); s != "withdrawn" {
 		t.Fatalf("newsletter still %q after one-click, want withdrawn", s)
 	}
 
@@ -355,14 +406,24 @@ func TestPreferenceTokenNeverReachesTheRecordedActivity(t *testing.T) {
 	if status != http.StatusAccepted {
 		t.Fatalf("marketing send → %d, want 202", status)
 	}
-	token := tokenFromLink(t, unsubscribeLinkIn(t, transmittedBody(t, c)))
-	if !strings.HasPrefix(token, "pref_") {
-		t.Fatalf("the transmitted message carries no usable token: %q", token)
+	// BOTH credentials, because the send now hands out two and either one in a
+	// durable row is the leak this test exists to catch. The stop token is the
+	// stronger case: it outlives the message on purpose, so a copy of it in the
+	// timeline is a working unsubscribe capability sitting where any reader of
+	// the record can press it.
+	body := transmittedBody(t, c)
+	token := tokenFromLink(t, unsubscribeLinkIn(t, body))
+	if !strings.HasPrefix(token, "wd_") {
+		t.Fatalf("the transmitted message carries no usable stop token: %q", token)
+	}
+	manageToken := manageTokenFromLink(t, manageLinkIn(t, body))
+	if !strings.HasPrefix(manageToken, "pref_") {
+		t.Fatalf("the transmitted message carries no usable manage token: %q", manageToken)
 	}
 
 	// The 202 the sender reads back.
-	if strings.Contains(recorded, token) {
-		t.Fatalf("the 202 response echoed the recipient's preference token:\n%s", recorded)
+	if strings.Contains(recorded, token) || strings.Contains(recorded, manageToken) {
+		t.Fatalf("the 202 response echoed a credential from the recipient's message:\n%s", recorded)
 	}
 	// The durable row, through the authenticated timeline read that serves it.
 	var page struct {
@@ -429,7 +490,9 @@ func TestPreferenceCenterRevokedTokenReadsAsAbsent(t *testing.T) {
 	grantPurpose(t, c, newsletter.ID)
 
 	sendMarketing(t, c.AppEnv, c.activityID, "newsletter", "", "")
-	token := tokenFromLink(t, unsubscribeLinkIn(t, transmittedBody(t, c)))
+	// The MANAGE token, because this test is about what the preference centre
+	// resolves. The stop token beside it reads nothing by design.
+	token := manageTokenFromLink(t, manageLinkIn(t, transmittedBody(t, c)))
 
 	// Live token resolves.
 	if s := publicCall(t, c.AppEnv, "GET", "/v1/public/preferences/"+token, nil, nil, nil); s != http.StatusOK {
@@ -437,7 +500,11 @@ func TestPreferenceCenterRevokedTokenReadsAsAbsent(t *testing.T) {
 	}
 
 	if _, err := c.Owner.Exec(context.Background(),
-		`UPDATE preference_token SET revoked_at = now() WHERE token = $1`, token); err != nil {
+		// The reason is not decoration: a paired CHECK refuses a revocation that
+		// does not name one, so a row revoked without it never existed and this
+		// test would be asserting against a token that is still live.
+		`UPDATE preference_token SET revoked_at = now(), revoked_reason = 'compromise'
+		  WHERE token = $1`, token); err != nil {
 		t.Fatalf("revoke token: %v", err)
 	}
 

--- a/backend/internal/compose/integration/publictokencache_integration_test.go
+++ b/backend/internal/compose/integration/publictokencache_integration_test.go
@@ -142,10 +142,10 @@ func redactToken(path string) string {
 func TestEveryPreferenceAnswerIsUncacheable(t *testing.T) {
 	c := setupConsent(t)
 	grantPurpose(t, c, createNewsletterPurpose(t, c))
-	live := sendAndAssertUnsubscribeLink(t, c)
+	live, manage := sendAndAssertUnsubscribeLink(t, c)
 
 	driven := assertNoStore(t, c.AppEnv, []tokenCase{
-		{"a live token's view", "GET", "/v1/public/preferences/" + live, nil},
+		{"a live token's view", "GET", "/v1/public/preferences/" + manage, nil},
 		{
 			"a live token's one-click withdrawal", "POST",
 			"/v1/public/preferences/" + live + "/unsubscribe?purpose=newsletter", nil,
@@ -302,7 +302,11 @@ func TestARateLimitedAnswerIsUncacheable(t *testing.T) {
 func revokePreferenceTokens(t *testing.T, c *consentEnv) {
 	t.Helper()
 	if _, err := c.Owner.Exec(context.Background(),
-		`UPDATE preference_token SET revoked_at = now() WHERE revoked_at IS NULL`); err != nil {
+		// The reason is required by a paired CHECK, so a revocation without one
+		// writes no row at all and every assertion below would run against
+		// tokens that are still live.
+		`UPDATE preference_token SET revoked_at = now(), revoked_reason = 'compromise'
+		  WHERE revoked_at IS NULL`); err != nil {
 		t.Fatalf("revoking the preference tokens: %v", err)
 	}
 }

--- a/backend/internal/compose/preferenceunsub.go
+++ b/backend/internal/compose/preferenceunsub.go
@@ -40,3 +40,20 @@ func (a preferenceLinkAdapter) UnsubscribeToken(ctx context.Context, recipientEm
 	// that gives THIS message a header of its own.
 	return a.store.PreferenceTokenForEmail(ctx, recipientEmail)
 }
+
+// ManageToken answers the preference token the preference centre resolves.
+//
+// ALWAYS A PREFERENCE TOKEN, never the withdrawal credential the stop links
+// carry. The two are different capabilities: a withdrawal credential stops mail
+// and reads nothing, which is what lets it outlive the message it was sent in.
+// Handing it to the manage link left every "Manage preferences" link resolving
+// nothing — the page could not read the subject their own purposes, because the
+// credential it was given was never meant to.
+//
+// A recipient this mint cannot resolve — a lead-only address holds no person
+// record — gets no manage token and the link falls back to the stop credential,
+// which draws the withdraw-only page. That page is honest about what it can do;
+// a dead preference link is not.
+func (a preferenceLinkAdapter) ManageToken(ctx context.Context, recipientEmail string) (string, bool, error) {
+	return a.store.PreferenceTokenForEmail(ctx, recipientEmail)
+}

--- a/backend/internal/modules/activities/email_test.go
+++ b/backend/internal/modules/activities/email_test.go
@@ -28,9 +28,23 @@ type stubUnsubscribeLinker struct {
 	token string
 	ok    bool
 	err   error
+	// manage overrides what the preference-centre link carries, for the cases
+	// that turn on the two credentials being different.
+	manage string
 }
 
 func (l stubUnsubscribeLinker) UnsubscribeToken(context.Context, string, string) (string, bool, error) {
+	return l.token, l.ok, l.err
+}
+
+// ManageToken answers the same token unless the case sets its own. The stop
+// credential and the preference token differ in production, and a case that
+// cares says so; the rest are asserting on the stop links, where a second
+// distinct value would only add noise.
+func (l stubUnsubscribeLinker) ManageToken(context.Context, string) (string, bool, error) {
+	if l.manage != "" {
+		return l.manage, true, nil
+	}
 	return l.token, l.ok, l.err
 }
 

--- a/backend/internal/modules/activities/unsubscribe.go
+++ b/backend/internal/modules/activities/unsubscribe.go
@@ -28,7 +28,18 @@ import (
 // (transactional) purpose, or an address no person holds — in which case
 // the send carries no unsubscribe header.
 type UnsubscribeLinker interface {
+	// UnsubscribeToken answers the credential the STOP links carry, and ok is
+	// false when this address has no unsubscribe surface at all.
 	UnsubscribeToken(ctx context.Context, recipientEmail, purposeKey string) (token string, ok bool, err error)
+	// ManageToken answers the credential the preference centre resolves, which
+	// is a different capability and now a different kind of token.
+	//
+	// A SEPARATE METHOD rather than a second return value, because the two
+	// have different failure meanings. No stop token means this send carries no
+	// unsubscribe surface and the header is omitted. No manage token means the
+	// recipient has nothing to manage — a lead-only address holds no person
+	// record — and the send still goes out with its stop links intact.
+	ManageToken(ctx context.Context, recipientEmail string) (token string, ok bool, err error)
 }
 
 // WithUnsubscribe wires the RFC 8058 linker onto the send path. A send
@@ -163,16 +174,46 @@ type unsubscribeLinks struct {
 // surfaces that way, static hosting needs no server fallback for them, and
 // the token stays out of ordinary web-server access logs until the page
 // deliberately calls the API with it.
-func unsubscribeLinksFor(baseURL, token, purposeKey string, lang textlang.Lang) unsubscribeLinks {
+func unsubscribeLinksFor(baseURL string, tokens unsubscribeTokens, purposeKey string, lang textlang.Lang) unsubscribeLinks {
 	purpose := strings.ToLower(strings.TrimSpace(purposeKey))
 	query := "?lang=" + url.QueryEscape(string(lang))
-	return unsubscribeLinks{
-		oneClick: baseURL + "/v1/public/preferences/" + url.PathEscape(token) +
-			"/unsubscribe?purpose=" + url.QueryEscape(purpose),
-		unsubscribe: baseURL + "/#/unsubscribe/" + url.PathEscape(token) + "/" +
-			url.PathEscape(purpose) + query,
-		manage: baseURL + "/#/preferences/" + url.PathEscape(token) + query,
+	manageToken := tokens.manage
+	if manageToken == "" {
+		manageToken = tokens.stop
 	}
+	return unsubscribeLinks{
+		oneClick: baseURL + "/v1/public/preferences/" + url.PathEscape(tokens.stop) +
+			"/unsubscribe?purpose=" + url.QueryEscape(purpose),
+		unsubscribe: baseURL + "/#/unsubscribe/" + url.PathEscape(tokens.stop) + "/" +
+			url.PathEscape(purpose) + query,
+		manage: baseURL + "/#/preferences/" + url.PathEscape(manageToken) + query,
+	}
+}
+
+// unsubscribeTokens is the two capabilities one send hands a recipient.
+//
+// TWO, because stopping mail and reading a record are different rights and the
+// credentials for them now differ in kind. The stop token is a withdrawal
+// credential: long-lived on purpose, so the link in a message somebody kept
+// still works months later, and it reads nothing. The manage token is a
+// preference token, which is what the preference centre resolves — it slides
+// and is rotated by the next send, and it can show the subject their own
+// purposes.
+//
+// Passing one token for both is what broke the manage page: every link carried
+// the withdrawal credential, the preference centre resolved nothing, and a
+// recipient clicking "Manage preferences" got a page that could not read them.
+// The visible unsubscribe page degrades to withdraw-only in that case, which is
+// still honest; the manage page has nothing to degrade to.
+type unsubscribeTokens struct {
+	// stop is what the one-click endpoint and the human unsubscribe page carry.
+	// It must outlive the message it was sent in.
+	stop string
+	// manage is what the preference centre resolves. Empty when this send could
+	// mint none — a lead-only recipient holds no person record to manage — and
+	// the manage link then falls back to the stop token, which draws the
+	// withdraw-only page rather than a dead link.
+	manage string
 }
 
 // htmlFooter renders the unsubscribe links as markup, for the alternative part.
@@ -295,8 +336,17 @@ func (s *Store) deliverability(
 	}
 	lang := s.footerLanguage(ctx, body, subject)
 	words := mailcopy.For(string(lang))
-	live := unsubscribeLinksFor(s.publicBaseURL, token, surface.purposeKey, lang)
-	redacted := unsubscribeLinksFor(s.publicBaseURL, redactedToken, surface.purposeKey, lang)
+	// Asked AFTER the stop token, and its failure is not the send's. A
+	// recipient who cannot be given a preference centre can still be given a
+	// way to stop, which is the link that matters.
+	manageToken, _, err := s.unsubscribe.ManageToken(ctx, recipients[0])
+	if err != nil {
+		return sendDeliverability{}, err
+	}
+	live := unsubscribeLinksFor(s.publicBaseURL,
+		unsubscribeTokens{stop: token, manage: manageToken}, surface.purposeKey, lang)
+	redacted := unsubscribeLinksFor(s.publicBaseURL,
+		unsubscribeTokens{stop: redactedToken, manage: redactedToken}, surface.purposeKey, lang)
 	return sendDeliverability{
 		listUnsubscribe: listUnsubscribeHeader(live.oneClick),
 		links:           live,

--- a/backend/internal/modules/activities/unsubscribe_test.go
+++ b/backend/internal/modules/activities/unsubscribe_test.go
@@ -17,7 +17,7 @@ import (
 // The header keeps the machine endpoint. A mailbox provider POSTs it
 // without a browser, and moving it would break RFC 8058 one-click.
 func TestTheHeaderKeepsTheOneClickAPIURL(t *testing.T) {
-	links := unsubscribeLinksFor("https://crm.example.com", "tok", "marketing_email", textlang.English)
+	links := unsubscribeLinksFor("https://crm.example.com", unsubscribeTokens{stop: "tok", manage: "tok"}, "marketing_email", textlang.English)
 	want := "https://crm.example.com/v1/public/preferences/tok/unsubscribe?purpose=marketing_email"
 	if links.oneClick != want {
 		t.Errorf("oneClick = %q, want %q", links.oneClick, want)
@@ -31,7 +31,7 @@ func TestTheHeaderKeepsTheOneClickAPIURL(t *testing.T) {
 // about: a person clicking the footer used to reach a POST-only endpoint
 // (405) and a JSON document.
 func TestTheVisibleLinksArePagesNotTheAPI(t *testing.T) {
-	links := unsubscribeLinksFor("https://crm.example.com", "tok", "business_correspondence", textlang.German)
+	links := unsubscribeLinksFor("https://crm.example.com", unsubscribeTokens{stop: "tok", manage: "tok"}, "business_correspondence", textlang.German)
 	for name, got := range map[string]string{"unsubscribe": links.unsubscribe, "manage": links.manage} {
 		if strings.Contains(got, "/v1/") {
 			t.Errorf("%s = %q — a visible link must not point at the API", name, got)
@@ -55,7 +55,7 @@ func TestTheVisibleLinksArePagesNotTheAPI(t *testing.T) {
 // the same capability. A recipient's ability to unsubscribe must not
 // depend on which alternative their mail client chose to show.
 func TestBothFootersCarryOneTokenPurposeAndLanguage(t *testing.T) {
-	links := unsubscribeLinksFor("https://crm.example.com", "tok", "newsletter", textlang.German)
+	links := unsubscribeLinksFor("https://crm.example.com", unsubscribeTokens{stop: "tok", manage: "tok"}, "newsletter", textlang.German)
 	words := mailcopy.For("de")
 	plain := appendUnsubscribeFooter("Guten Tag", links, words)
 	markup := sendDeliverability{links: links, words: words}.htmlFooter()
@@ -78,7 +78,7 @@ func TestBothFootersCarryOneTokenPurposeAndLanguage(t *testing.T) {
 // working link and which purpose it pointed at, and cannot use it.
 func TestTheRecordedFooterCarriesOnlyTheRedactedToken(t *testing.T) {
 	const live = "pref_secret_value"
-	redacted := unsubscribeLinksFor("https://crm.example.com", redactedToken, "newsletter", textlang.English)
+	redacted := unsubscribeLinksFor("https://crm.example.com", unsubscribeTokens{stop: redactedToken, manage: redactedToken}, "newsletter", textlang.English)
 	recorded := appendUnsubscribeFooter("Body", redacted, mailcopy.For("en"))
 
 	if strings.Contains(recorded, live) {
@@ -95,7 +95,7 @@ func TestTheRecordedFooterCarriesOnlyTheRedactedToken(t *testing.T) {
 // A purpose or token carrying a separator must not be able to reshape the
 // URL it lands in.
 func TestTokenAndPurposeAreEscaped(t *testing.T) {
-	links := unsubscribeLinksFor("https://crm.example.com", "tok/../evil", "news letter/x", textlang.English)
+	links := unsubscribeLinksFor("https://crm.example.com", unsubscribeTokens{stop: "tok/../evil", manage: "tok/../evil"}, "news letter/x", textlang.English)
 	for name, got := range map[string]string{"unsubscribe": links.unsubscribe, "oneClick": links.oneClick} {
 		if strings.Contains(got, "/../") {
 			t.Errorf("%s = %q — a token reshaped the path", name, got)
@@ -173,4 +173,48 @@ func asPublicOriginFault(err error, target **PublicOriginUnusableError) bool {
 		*target = fault
 	}
 	return ok
+}
+
+// THE MANAGE LINK CARRIES ITS OWN CREDENTIAL. Stopping mail and reading a
+// record are different rights, and since the withdrawal credential landed they
+// are different kinds of token: the stop credential outlives the message it was
+// sent in and resolves nothing, and the preference centre can only resolve a
+// preference token.
+//
+// Passing one token for both is what broke the manage page. Every link carried
+// the withdrawal credential, the preference centre resolved nothing, and a
+// recipient clicking "Manage preferences" got a page that could not read them.
+func TestTheManageLinkCarriesThePreferenceToken(t *testing.T) {
+	links := unsubscribeLinksFor("https://crm.example.com",
+		unsubscribeTokens{stop: "wd_stop", manage: "pref_manage"},
+		"marketing_email", textlang.English)
+
+	if !strings.Contains(links.manage, "pref_manage") {
+		t.Errorf("the manage link carries %q, want the preference token — the preference centre "+
+			"cannot resolve a withdrawal credential, so the page reads nothing", links.manage)
+	}
+	if strings.Contains(links.manage, "wd_stop") {
+		t.Errorf("the manage link carries the stop credential: %q", links.manage)
+	}
+	// And the stop links keep theirs. A manage token in the header would expire
+	// under the recipient, which is the whole reason the credential exists.
+	for name, link := range map[string]string{"one-click": links.oneClick, "unsubscribe": links.unsubscribe} {
+		if !strings.Contains(link, "wd_stop") {
+			t.Errorf("the %s link carries %q, want the stop credential", name, link)
+		}
+	}
+}
+
+// A RECIPIENT WITH NOTHING TO MANAGE still gets a working stop link. A
+// lead-only address holds no person record, so no preference token can be
+// minted for it — and the manage link then falls back to the stop credential,
+// which draws the withdraw-only page rather than a dead link.
+func TestAManagelessRecipientFallsBackToTheStopCredential(t *testing.T) {
+	links := unsubscribeLinksFor("https://crm.example.com",
+		unsubscribeTokens{stop: "wd_stop"}, "marketing_email", textlang.English)
+
+	if !strings.Contains(links.manage, "wd_stop") {
+		t.Errorf("the manage link is %q — a recipient with no preference token must still be "+
+			"offered a page that can stop their mail", links.manage)
+	}
 }


### PR DESCRIPTION
## What was wrong

A regression from #5196, which I introduced. That change made the send mint a withdrawal credential for the unsubscribe links, and that part is right: a credential that outlives the message it was sent in is what keeps an old link working.

But all three links are built from one token, so the manage link got the withdrawal credential too. The preference centre cannot resolve one. A recipient clicking "Manage preferences" reached a page that could not read them.

## What changed

Stopping mail and reading a record are different rights, and since #5196 they are different kinds of token. The builder now takes both.

That keeps `TestOneSendDerivesEveryUnsubscribeDestination` satisfied, and deliberately so: the gate holds one builder, not one token, and a second builder is still the defect it was written for.

A recipient with no preference token, such as a lead-only address holding no person record, falls back to the stop credential on the manage link. That draws the withdraw-only page rather than a dead link.

## Five red tests on main, fixed rather than adjusted

Three read one token from the unsubscribe link and used it for both capabilities, which is exactly the conflation that broke. They now read the manage link for the preference centre and the unsubscribe link for the press.

Two more were red for a different #5196 reason. The preference token table now carries a paired constraint requiring a revocation to name its reason, and these revoke by hand without one. A revocation that writes no row leaves the test asserting against a live token.

## One assertion I changed on purpose

The one-click answer for a credential press is an opaque placeholder rather than the purpose key. Naming it would tell whoever holds the link which subscriptions the address carries, which the press never proved they may know. The test now asserts the count and that the purpose is not named.

## Why this was invisible

These five tests live in the integration lane, which `make check-backend` does not run. Both slices that broke them went out green.

## Proof

Two new unit tests, mutation-verified. Full `make check-backend` green, and the compose integration suite is down to two pre-existing failures unrelated to consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the manage-preferences link so the preference centre can read the recipient again. A prior change made all three unsubscribe links carry a withdrawal credential, which the preference centre cannot resolve; the stop and manage links now carry separate credentials.

**Bug Fixes**
- The send now mints both a stop credential and a preference token, with the manage link using the preference token.
- Recipients with no preference token (lead-only addresses) fall back to the stop credential on the manage link so the page is withdraw-only instead of dead.
- Integration tests that conflated the two credentials now assert against the correct link.
- The one-click unsubscribe response no longer names the purposes it stopped, only the count.

<sup>Written for commit 4179b99bb0d07ca2b412b8acf5ce7fc8df3d241c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

