### PR TITLE
fix(consent): the send mints its unsubscribe link under its own admission

### DIFF
--- a/backend/internal/modules/consent/withdrawalcredential.go
+++ b/backend/internal/modules/consent/withdrawalcredential.go
@@ -139,9 +139,38 @@ func (s *Store) EnsureWithdrawalCredentialTx(
 	//
 	// person:update rather than person:read, because minting one changes what
 	// can be done to the record even though it writes no consent state.
+	//
+	// A DELIBERATE mint asks this. The send path does not come through here —
+	// see mintWithdrawalCredentialTx below for why, and for what still holds
+	// there.
 	if err := auth.Require(ctx, entityPerson, principal.ActionUpdate); err != nil {
 		return "", err
 	}
+	return s.mintWithdrawalCredentialTx(ctx, tx, in)
+}
+
+// mintWithdrawalCredentialTx is the mint itself, without the object grant.
+//
+// The unsubscribe link a marketing message carries is minted ON THE SEND PATH,
+// under the sender's own principal, and RFC 8058 compels the message to carry
+// it. Asking person:update there asks the sender for authority over the
+// recipient in order to send them mail they can opt out of — and it is asked
+// before the code knows whether a person is involved at all: this path serves
+// an address matching NOBODY, by design, because the message is going to that
+// address regardless.
+//
+// What still holds, and is the check that actually encodes authority over a
+// named person, is EnsureWritableLive below: row-scoped, inside this
+// transaction, and closing the erasure race that a caller's earlier address
+// lookup opens. Splitting the object grant off does not touch it.
+//
+// So the two callers ask different questions, which is why they are two:
+// EnsureWithdrawalCredentialTx asks may you act on this person, and the send
+// asks may you send this message — which its own admission has already settled
+// by the time it reaches here.
+func (s *Store) mintWithdrawalCredentialTx(
+	ctx context.Context, tx pgx.Tx, in WithdrawalMintInput,
+) (token string, err error) {
 	address := normalizeAddress(in.Address)
 	if address == "" {
 		return "", &ValidationError{

--- a/backend/internal/modules/consent/withdrawalmint.go
+++ b/backend/internal/modules/consent/withdrawalmint.go
@@ -60,8 +60,12 @@ func (s *Store) WithdrawalTokenForEmail(
 				in.Scope, in.PurposeID = WithdrawalScopeNamedPurpose, purposeID
 			}
 		}
+		// The mint WITHOUT the object grant: this is the send path, whose own
+		// admission is the gate, and whose recipient may be an address no
+		// person holds. The row-scoped liveness check inside it still applies
+		// wherever a person IS named.
 		var mintErr error
-		token, mintErr = s.EnsureWithdrawalCredentialTx(ctx, tx, in)
+		token, mintErr = s.mintWithdrawalCredentialTx(ctx, tx, in)
 		return mintErr
 	})
 	if err != nil {


### PR DESCRIPTION
The fourth of four `main`-reds, and the one I said on #5196 I would not fix. I changed my mind for one reason and narrowed the fix so it stays true: **this takes no product decision.**

```
--- FAIL: TestPreferenceCenterOptOutBlocksAgentSend
    granted agent send → person.update: permission denied, want success
```

Bisected to `14192f373` (#5196); `49ff4900f` passes.

## What is wrong

#5196 put `person:update` on `EnsureWithdrawalCredentialTx`. Its only in-tree caller is `WithdrawalTokenForEmail` — the **send path's** seam for the unsubscribe link RFC 8058 compels every marketing message to carry. So the grant is demanded of whoever is sending, not of an operator deliberately minting a credential. The test's agent holds `person: {Read: true}`, which is right for a sender.

@target-ce traced it independently and added the fact that settles it: the mint runs under the **sender's own principal** the whole way down — `activities.deliverability` → `UnsubscribeLinker` → `preferenceLinkAdapter` → `WithdrawalTokenForEmail` → the mint — with no system escalation anywhere.

It is also asked before the code knows whether a person is involved. `WithdrawalTokenForEmail`'s own doc: *"An address matching NOBODY still gets a credential. The message is going to that address regardless."*

## What this changes, and what it does not

The mint moves down one level. `EnsureWithdrawalCredentialTx` keeps `person:update` **exactly as #5196 wrote it**, and the send calls the level below.

Two callers asking two different questions, which is why they are two:

| caller | asks |
|---|---|
| `EnsureWithdrawalCredentialTx` | may you act on this person |
| the send path | may you send this message — already settled by its own admission |

**The check that actually encodes authority over a named person is untouched.** `auth.EnsureWritableLive(ctx, tx, entityPerson, in.PersonID.UUID)` is row-scoped, inside the transaction, and closes the erasure race a caller's earlier address lookup opens. It sits below the split; both callers reach it.

## Why I am not deciding the question

Whether a sending agent *should* hold `person:update` is real and it is #5196's author's. This restores `main` without answering it: if the answer is that the send should ask too, the gate is where they left it and the send path is one line from asking.

## One thing worth a look separately

Removing `EnsureWritableLive` entirely leaves the consent lane's erasure and credential cases **green**. I did not chase it — my change does not touch that check — but the race it closes appears to be unheld by a test, and it is the half of this function that matters most.

## Verification

`internal/modules/consent` green; `make check-go` green; `internal/compose` green but for the three cases #5237 fixes.

Four `main`-reds, four PRs: #5225 (lead SLA), #5237 (attention lane), #5230 (craft blockers, @target-ce's), and this. Each is red on the others' subjects until they land, so none goes green alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sending withdrawal credentials now works when the sender is authorized to initiate the send, without requiring update permission over the recipient.
  - Withdrawal credentials can be sent to addresses that are not associated with an existing person.
  - Existing protections remain in place when a person is identified, and direct credential minting continues to require the appropriate authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->