### PR TITLE
test(consent): the withdrawal mint's authority probe is held

### DIFF
--- a/backend/internal/modules/consent/withdrawalcredential_integration_test.go
+++ b/backend/internal/modules/consent/withdrawalcredential_integration_test.go
@@ -654,3 +654,121 @@ func TestTheMintDoorsAskForTheGrantTheirQuestionNeeds(t *testing.T) {
 		}
 	}
 }
+
+// The mint refuses a subject whose record is no longer live.
+//
+// The race: a statement in a read-committed transaction takes a fresh snapshot,
+// so an erasure committing between the send path's address lookup and this
+// insert would leave the mint writing a NEW capability — carrying the plaintext
+// address — for the subject whose credentials that erasure had just deleted. The
+// person row survives an anonymize-in-place, so the foreign key does not catch
+// it and the fresh token resolves happily.
+//
+// TWO LINES HOLD IT, and this case is deliberately indifferent to which:
+// EnsureWritableLive's live half and LockSubjectLive's `archived_at IS NULL`
+// both refuse, so removing either alone leaves the property standing. That is
+// the right shape for a property this serious, and it is worth knowing rather
+// than discovering — a case pinned to one of them would report the belt gone
+// while the braces held.
+func TestTheMintRefusesASubjectWhoseRecordIsGone(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	// It works first, so the refusal below is about the erasure and not about
+	// the fixture never having been mintable.
+	before := mintWithdrawal(t, e, WithdrawalMintInput{
+		Address: "gone@example.test", Scope: WithdrawalScopeAllMarketing, PersonID: e.person,
+	})
+	if before == "" {
+		t.Fatal("the fixture minted no token before the erasure, so the refusal below would prove nothing")
+	}
+
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE person SET archived_at = now() WHERE id = $1`, e.person); err != nil {
+		t.Fatalf("retiring the subject: %v", err)
+	}
+
+	err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		_, mintErr := e.store.EnsureWithdrawalCredentialTx(e.ctx, tx, WithdrawalMintInput{
+			// A DIFFERENT scope, so the idempotent reuse of the live row above
+			// cannot answer this — the mint has to reach the insert to refuse.
+			Address: "gone@example.test", Scope: WithdrawalScopeNamedPurpose,
+			PurposeID: e.newsletter.UUID, PersonID: e.person,
+		})
+		return mintErr
+	})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("minting for an erased subject answered %v, want ErrNotFound — a capability carrying "+
+			"the plaintext address was written for the subject whose credentials were just deleted", err)
+	}
+}
+
+// A READ share is not authority to mint. This is the half of the mint's probe
+// nothing held, and the one that has no second line behind it.
+//
+// `person` is shareable, so a manual read grant widens who can SEE a contact
+// without widening who may act on them — and this path WRITES a bearer
+// credential that can stop that person's mail for two years. LockSubjectLive
+// below the probe asks only `archived_at IS NULL`, so it does not catch this;
+// ensureWriteAuthority inside EnsureWritableLive is the only thing that does,
+// and it is a no-op for an unbounded principal, which is why every existing
+// case in this package walked past it.
+//
+// Both directions, because the refusal alone would also pass against a
+// principal that simply cannot do anything: the same caller with a WRITE grant
+// mints successfully.
+func TestAReadShareOnAContactIsNotAuthorityToMintTheirOptOut(t *testing.T) {
+	e := setupChannelConsent(t)
+	colleague := ids.NewV7()
+
+	// Bounded to their OWN rows, which is what makes the share the only thing
+	// that can admit them: e.person is owned by somebody else.
+	shared := principal.WithActor(e.ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + colleague.String(), UserID: colleague,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				// The OBJECT grant is deliberately generous: this case is about
+				// the ROW, and a narrow object grant would refuse one gate
+				// earlier and prove nothing about the other.
+				"person": {Read: true, Update: true},
+			},
+			RowScope: principal.RowScopeOwn,
+		},
+	})
+
+	grant := func(t *testing.T, access string) {
+		t.Helper()
+		if _, err := e.owner.Exec(context.Background(), `
+			INSERT INTO record_grant (record_type, record_id, subject_type, subject_id, access, granted_by)
+			VALUES ('person', $1, 'user', $2, $3, $4)
+			ON CONFLICT (record_type, record_id, subject_type, subject_id)
+			DO UPDATE SET access = EXCLUDED.access`,
+			e.person, colleague, access, e.user); err != nil {
+			t.Fatalf("granting %s on the contact: %v", access, err)
+		}
+	}
+
+	grant(t, "read")
+	err := e.store.db.Tx(shared, func(tx pgx.Tx) error {
+		_, mintErr := e.store.EnsureWithdrawalCredentialTx(shared, tx, WithdrawalMintInput{
+			Address: "shared@example.test", Scope: WithdrawalScopeAllMarketing, PersonID: e.person,
+		})
+		return mintErr
+	})
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a read-share holder minted an opt-out credential (err = %v) — a share that lets "+
+			"somebody SEE a contact now lets them mint a bearer token over that contact's mail", err)
+	}
+
+	// The positive control: the same caller, one access level up.
+	grant(t, "write")
+	if err := e.store.db.Tx(shared, func(tx pgx.Tx) error {
+		_, mintErr := e.store.EnsureWithdrawalCredentialTx(shared, tx, WithdrawalMintInput{
+			Address: "shared@example.test", Scope: WithdrawalScopeAllMarketing, PersonID: e.person,
+		})
+		return mintErr
+	}); err != nil {
+		t.Fatalf("a write-share holder was refused (%v) — the refusal above is about the caller, "+
+			"not about the access level, and holds nothing", err)
+	}
+}


### PR DESCRIPTION
Follow-up to #5241, which noticed that `EnsureWritableLive` in
`EnsureWithdrawalCredentialTx` could be removed entirely with the consent lane
staying green. Confirmed independently — it stays green across `consent`,
`privacy` **and** the compose integration lane. The function's comment argues two
properties at length and nothing asserted either.

Checking **which** was unheld turned out to matter, because they are not alike.

## The live half is held twice

`LockSubjectLive` on the very next line asks `archived_at IS NULL` for its own
reason (holding the row so an erasure queues behind the mint). So removing the
probe leaves an erased subject still refused, and a case pinned to the probe
would have reported the belt gone while the braces held.

`TestTheMintRefusesASubjectWhoseRecordIsGone` therefore asserts the **property**
and is deliberately indifferent to which line delivers it — and says so, because
that is worth knowing rather than rediscovering.

## The write-authority half has nothing behind it

This is the real gap.

`person` is shareable, so a manual `read` grant widens who can SEE a contact
without widening who may act on them — and this path mints a **bearer credential
that can stop that person's mail for two years**. `LockSubjectLive` asks no
authority at all, and `ensureWriteAuthority` — the only thing that refuses —
short-circuits on `Unbounded(p)`. Every existing case in this package runs an
admin at `RowScopeAll`, so all of them walk straight past it.

`TestAReadShareOnAContactIsNotAuthorityToMintTheirOptOut` runs **bounded**
(`RowScopeOwn`), admitted to the contact by the share alone, and asserts both
directions:

- a `read` grant is refused with `ErrPermissionDenied`;
- the **same caller** with a `write` grant mints successfully.

Without the second half the refusal would also pass against a caller who simply
cannot do anything, which is the failure mode a one-sided authority test always
has.

The object grant in that fixture is deliberately generous (`person:
{Read, Update}`) — the case is about the ROW, and a narrow object grant would
refuse one gate earlier and prove nothing about this one.

## Mutation-checked, and the two mutations say different things

| mutation | live case | read-share case |
|---|---|---|
| probe removed | passes (the lock holds it) | **fails** |
| `EnsureWritableLive` → `EnsureVisibleLive` | passes | **fails** |

The second is the one worth having: it is exactly the distinction the comment
draws — *"EnsureWritableLive, not the VISIBLE twin PreferenceTokenForEmail uses"*
— and until now nothing would have noticed the downgrade.

## Scope

Tests only; no production change. It does not touch #5241's split, and applies
whichever way the `person:update` question on #5196 is settled — this is the row
gate under it, not the object gate.

## Checks

`make check-backend`, `craft static --strict` (0/0/0), and the full `consent`
integration lane.