### PR TITLE
fix: main goes green — four failures, four fixes, one branch

### DIFF
--- a/backend/internal/compose/attentionfeed_integration_test.go
+++ b/backend/internal/compose/attentionfeed_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -153,9 +154,18 @@ func TestADetectedDuplicateReachesTheDecisionLane(t *testing.T) {
 	}
 }
 
-// An overdue task is today's agreed work. Both halves of the filter are pinned:
-// what is due is carried, and what is done or still ahead is not.
-func TestAnOverdueTaskReachesThePlannedLane(t *testing.T) {
+// The planned lane carries today's agreed work AND what is coming, each said to
+// be what it is.
+//
+// It used to carry only what was owed, and this case pinned that: a task still
+// ahead was a task the lane refused. That was the defect rather than the rule —
+// a comparison sheet due tomorrow was invisible today, so work accepted from a
+// transcript looked like it had gone nowhere. The lane makes two bounded reads
+// now and names each row's run in `due_group`.
+//
+// What has NOT changed is the other half this case was always about: a task
+// that is done is carried by neither read.
+func TestThePlannedLaneCarriesWhatIsOwedAndWhatIsComing(t *testing.T) {
 	e := integration.Setup(t)
 	now := time.Now().UTC()
 	logTask(t, e, "Ring the buyer back", now.Add(-2*time.Hour), false)
@@ -164,8 +174,32 @@ func TestAnOverdueTaskReachesThePlannedLane(t *testing.T) {
 
 	day := assembleFeed(e.Admin(), t, e, now)
 	got := titlesOn(day.Planned)
-	if len(got) != 1 || got[0] != "Ring the buyer back" {
-		t.Fatalf("the planned lane = %v, want only the task actually due", got)
+	if len(got) != 2 {
+		t.Fatalf("the planned lane = %v, want the overdue task and the one still ahead", got)
+	}
+	if !slices.Contains(got, "Ring the buyer back") || !slices.Contains(got, "Next week's prep") {
+		t.Fatalf("the planned lane = %v, want both reads represented", got)
+	}
+	// The done one is the assertion that did not move: neither read carries it.
+	if slices.Contains(got, "Already handled") {
+		t.Errorf("a task already done reached the lane: %v", got)
+	}
+	// Each row says which run it belongs to, so a reader is never shown a
+	// deadline still ahead as though it were owed now.
+	//
+	// Asserted as overdue-or-not rather than against a named group: which of
+	// `today`, `tomorrow`, `this_week` and `later` a task seven days out lands
+	// in depends on what day the suite runs, and a case that pinned one of them
+	// would be a case the calendar breaks. The distinction this is about is the
+	// one that cannot move.
+	for _, item := range day.Planned {
+		if item.Title == nil || item.DueGroup == nil {
+			t.Fatalf("a planned row names no run (title=%v group=%v)", item.Title, item.DueGroup)
+		}
+		owed := *item.DueGroup == crmcontracts.AttentionItemDueGroupOverdue
+		if want := *item.Title == "Ring the buyer back"; owed != want {
+			t.Errorf("%q reads as %q, want overdue=%v", *item.Title, *item.DueGroup, want)
+		}
 	}
 	if day.Planned[0].Overdue == nil || !*day.Planned[0].Overdue {
 		t.Error("the task is not marked overdue, so the reader cannot see which work slipped")
@@ -263,9 +297,40 @@ func TestATaskDueExactlyAtTheBoundaryBelongsToTomorrow(t *testing.T) {
 	logTask(t, e, "Due exactly at midnight", endOfDay, false)
 
 	day := assembleFeed(e.Admin(), t, e, now)
-	got := titlesOn(day.Planned)
-	if len(got) != 1 || got[0] != "Due a moment before midnight" {
-		t.Fatalf("the planned lane = %v, want only the task due before the day ends", got)
+	// The lane carries both now — it reads what is coming as well as what is
+	// owed — so the boundary shows in which RUN each row belongs to rather than
+	// in which of them the lane refused.
+	if got := len(day.Planned); got != 2 {
+		t.Fatalf("the planned lane holds %d rows (%v), want both sides of the boundary", got, titlesOn(day.Planned))
+	}
+	assertDueGroup(t, day.Planned, map[string]crmcontracts.AttentionItemDueGroup{
+		"Due a moment before midnight": crmcontracts.AttentionItemDueGroupToday,
+		"Due exactly at midnight":      crmcontracts.AttentionItemDueGroupTomorrow,
+	})
+}
+
+// assertDueGroup holds each named row to the run it belongs to.
+func assertDueGroup(t *testing.T, items []crmcontracts.AttentionItem, want map[string]crmcontracts.AttentionItemDueGroup) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, item := range items {
+		if item.Title == nil || item.DueGroup == nil {
+			t.Fatalf("a planned row names no run (title=%v group=%v)", item.Title, item.DueGroup)
+		}
+		expected, named := want[*item.Title]
+		if !named {
+			t.Errorf("the lane carries %q, which this case did not seed", *item.Title)
+			continue
+		}
+		seen[*item.Title] = true
+		if *item.DueGroup != expected {
+			t.Errorf("%q reads as %q, want %q", *item.Title, *item.DueGroup, expected)
+		}
+	}
+	for title := range want {
+		if !seen[title] {
+			t.Errorf("the lane carries no %q at all", title)
+		}
 	}
 }
 
@@ -344,11 +409,16 @@ func TestTheWorklistsDayEndsAtTheInstallationsMidnight(t *testing.T) {
 	logTask(t, e, "Due tomorrow morning, local", time.Date(2026, 6, 15, 18, 0, 0, 0, time.UTC), false)
 
 	day := assembleFeed(e.Admin(), t, e, now)
-	got := titlesOn(day.Planned)
-	if len(got) != 1 || got[0] != "Due late tonight, local" {
-		t.Fatalf("the planned lane = %v, want only tonight's work: 18:00 UTC is 01:00 tomorrow "+
-			"where this installation is, and UTC's midnight is not its day", got)
+	// Both are carried; the LOCAL boundary is what decides which run each is in.
+	// 18:00 UTC is 01:00 tomorrow where this installation is, and UTC's midnight
+	// is not its day — so a row grouped `today` there would be the old bug.
+	if got := len(day.Planned); got != 2 {
+		t.Fatalf("the planned lane holds %d rows (%v), want both sides of the local boundary", got, titlesOn(day.Planned))
 	}
+	assertDueGroup(t, day.Planned, map[string]crmcontracts.AttentionItemDueGroup{
+		"Due late tonight, local":     crmcontracts.AttentionItemDueGroupToday,
+		"Due tomorrow morning, local": crmcontracts.AttentionItemDueGroupTomorrow,
+	})
 }
 
 // THE PLANNED BADGE COUNTS PAST THE LANE'S CAP, through the shipped wiring.

--- a/backend/internal/modules/activities/scheduling_public.go
+++ b/backend/internal/modules/activities/scheduling_public.go
@@ -184,6 +184,39 @@ func (h Handlers) WithPublicBooking(people PersonEnsurer, consent ConsentCapture
 	return h
 }
 
+// bookingRequestIsWellFormed refuses a booking that cannot be written down,
+// BEFORE anything is written.
+//
+// Every check here is one the store would also make, and each is made here for
+// the same reason: EnsurePersonByEmail commits a person row before the consent
+// grant is attempted, so a refusal after it leaves one behind — and this door is
+// unauthenticated, so a caller omitting a field in a loop grows the person table
+// one rejected request at a time.
+//
+// It writes the refusal itself and reports whether the caller may go on, which
+// is the shape the handler's other guards already use.
+func bookingRequestIsWellFormed(w http.ResponseWriter, r *http.Request, req crmcontracts.BookPublicMeetingJSONRequestBody) bool {
+	if req.Booker.Name == "" || req.Booker.Email == "" {
+		httperr.Write(w, r, httperr.Validation("booker", "required", "booker.name and booker.email are required"))
+		return false
+	}
+	if !req.End.After(req.Start) {
+		httperr.Write(w, r, httperr.Validation("end", "invalid", "end must follow start"))
+		return false
+	}
+	// Consent is mandatory: a public capture surface may not create a person it
+	// cannot attach a recordable consent to.
+	if req.Consent.PolicyVersion == "" {
+		httperr.Write(w, r, httperr.Validation("consent.policy_version", "required", "the consent wording version shown to the booker is required"))
+		return false
+	}
+	if req.Consent.Wording == nil || strings.TrimSpace(*req.Consent.Wording) == "" {
+		httperr.Write(w, r, httperr.Validation("consent.wording", "required", "the consent wording shown to the booker is required"))
+		return false
+	}
+	return true
+}
+
 // GetPublicAvailability implements (GET /public/booking/{host_slug}/availability).
 // The middleware already resolved the slug and bound workspace + the
 // system principal; the handler re-resolves for the host id (the
@@ -226,28 +259,7 @@ func (h Handlers) BookPublicMeeting(w http.ResponseWriter, r *http.Request, host
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	if req.Booker.Name == "" || req.Booker.Email == "" {
-		httperr.Write(w, r, httperr.Validation("booker", "required", "booker.name and booker.email are required"))
-		return
-	}
-	if !req.End.After(req.Start) {
-		httperr.Write(w, r, httperr.Validation("end", "invalid", "end must follow start"))
-		return
-	}
-	// Consent is mandatory and validated BEFORE any write: a public
-	// capture surface may not create a person it cannot attach a
-	// recordable consent to.
-	if req.Consent.PolicyVersion == "" {
-		httperr.Write(w, r, httperr.Validation("consent.policy_version", "required", "the consent wording version shown to the booker is required"))
-		return
-	}
-	// Checked HERE, not left to the consent writer, for the reason the comment
-	// above gives: EnsurePersonByEmail below commits a person row before the
-	// grant is attempted, so a refusal down there would leave one behind — and
-	// this door is unauthenticated, so a caller omitting the field in a loop
-	// grows the person table one rejected request at a time.
-	if req.Consent.Wording == nil || strings.TrimSpace(*req.Consent.Wording) == "" {
-		httperr.Write(w, r, httperr.Validation("consent.wording", "required", "the consent wording shown to the booker is required"))
+	if !bookingRequestIsWellFormed(w, r, req) {
 		return
 	}
 	purposeID := ids.UUID(req.Consent.PurposeId)

--- a/backend/internal/modules/consent/rightscase.go
+++ b/backend/internal/modules/consent/rightscase.go
@@ -199,9 +199,18 @@ func attemptRightsCase(ctx context.Context, tx pgx.Tx, kind string, personID ids
 		oneCalendarMonthAfter(receivedAt), submissionID, receipt,
 	).Scan(&caseID, &stored, &created)
 	if err != nil {
-		_ = nested.Rollback(ctx)
-		return ids.UUID{}, "", false, fmt.Errorf(
-			"consent: opening the rights case this request owes an answer to: %w", err)
+		opening := fmt.Errorf("consent: opening the rights case this request owes an answer to: %w", err)
+		// The rollback's own failure travels with the fault it was undoing.
+		// This savepoint exists so a collision can be retried against a
+		// transaction Postgres has not given up on — so a rollback that did NOT
+		// take is the one condition under which the retry above cannot work,
+		// and every remaining attempt fails identically with the first
+		// attempt's message. Discarding it turns that into three mystery
+		// failures with the right words and the wrong cause.
+		if rbErr := nested.Rollback(ctx); rbErr != nil {
+			return ids.UUID{}, "", false, errors.Join(opening, rbErr)
+		}
+		return ids.UUID{}, "", false, opening
 	}
 	if err := nested.Commit(ctx); err != nil {
 		return ids.UUID{}, "", false, fmt.Errorf("consent: opening the rights case: %w", err)

--- a/backend/internal/modules/consent/rightscase_integration_test.go
+++ b/backend/internal/modules/consent/rightscase_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -267,7 +268,14 @@ func TestAReplayedProposalOpensNoSecondCase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("opening a transaction: %v", err)
 	}
-	defer func() { _ = tx.Rollback(context.Background()) }()
+	// The rollback IS this case's cleanup — nothing here commits — so a failure
+	// is the test's own connection in trouble and worth saying. ErrTxClosed is
+	// the exception: a transaction already finished is what a clean run leaves.
+	t.Cleanup(func() {
+		if err := tx.Rollback(context.Background()); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("releasing the replay transaction: %v", err)
+		}
+	})
 
 	replayed, err := openRightsCaseTx(context.Background(), tx, e.person, submissionID,
 		submissionErasure, time.Now())

--- a/backend/internal/modules/consent/withdrawalcredential.go
+++ b/backend/internal/modules/consent/withdrawalcredential.go
@@ -139,9 +139,38 @@ func (s *Store) EnsureWithdrawalCredentialTx(
 	//
 	// person:update rather than person:read, because minting one changes what
 	// can be done to the record even though it writes no consent state.
+	//
+	// A DELIBERATE mint asks this. The send path does not come through here —
+	// see mintWithdrawalCredentialTx below for why, and for what still holds
+	// there.
 	if err := auth.Require(ctx, entityPerson, principal.ActionUpdate); err != nil {
 		return "", err
 	}
+	return s.mintWithdrawalCredentialTx(ctx, tx, in)
+}
+
+// mintWithdrawalCredentialTx is the mint itself, without the object grant.
+//
+// The unsubscribe link a marketing message carries is minted ON THE SEND PATH,
+// under the sender's own principal, and RFC 8058 compels the message to carry
+// it. Asking person:update there asks the sender for authority over the
+// recipient in order to send them mail they can opt out of — and it is asked
+// before the code knows whether a person is involved at all: this path serves
+// an address matching NOBODY, by design, because the message is going to that
+// address regardless.
+//
+// What still holds, and is the check that actually encodes authority over a
+// named person, is EnsureWritableLive below: row-scoped, inside this
+// transaction, and closing the erasure race that a caller's earlier address
+// lookup opens. Splitting the object grant off does not touch it.
+//
+// So the two callers ask different questions, which is why they are two:
+// EnsureWithdrawalCredentialTx asks may you act on this person, and the send
+// asks may you send this message — which its own admission has already settled
+// by the time it reaches here.
+func (s *Store) mintWithdrawalCredentialTx(
+	ctx context.Context, tx pgx.Tx, in WithdrawalMintInput,
+) (token string, err error) {
 	address := normalizeAddress(in.Address)
 	if address == "" {
 		return "", &ValidationError{

--- a/backend/internal/modules/consent/withdrawalmint.go
+++ b/backend/internal/modules/consent/withdrawalmint.go
@@ -60,8 +60,12 @@ func (s *Store) WithdrawalTokenForEmail(
 				in.Scope, in.PurposeID = WithdrawalScopeNamedPurpose, purposeID
 			}
 		}
+		// The mint WITHOUT the object grant: this is the send path, whose own
+		// admission is the gate, and whose recipient may be an address no
+		// person holds. The row-scoped liveness check inside it still applies
+		// wherever a person IS named.
 		var mintErr error
-		token, mintErr = s.EnsureWithdrawalCredentialTx(ctx, tx, in)
+		token, mintErr = s.mintWithdrawalCredentialTx(ctx, tx, in)
 		return mintErr
 	})
 	if err != nil {

--- a/backend/internal/modules/people/lead_update.go
+++ b/backend/internal/modules/people/lead_update.go
@@ -391,6 +391,11 @@ func buildLeadPatch(current crmcontracts.Lead, in UpdateLeadInput) (*storekit.Pa
 		// condition: no owner yet, and no clock yet.
 		if current.RoutedAt == nil && current.OwnerId == nil {
 			p.Set("routed_at", nil, leadSLAClock().UTC())
+			// And the breach stamp goes with it, for the reason
+			// startLeadResponseClockTx clears it on the claim path: a row that
+			// breached while it was nobody's is already escalated, and leaving
+			// the stamp would keep this owner's lead out of the scan for good.
+			p.Set("sla_breached_at", nil, nil)
 		}
 	}
 	return p, resumeRecompute, nil

--- a/backend/internal/modules/people/leadresponseclock.go
+++ b/backend/internal/modules/people/leadresponseclock.go
@@ -76,7 +76,11 @@ func startLeadResponseClockTx(ctx context.Context, tx pgx.Tx, id ids.UUID) error
 		return err
 	}
 	if _, err := tx.Exec(ctx,
-		`UPDATE lead SET routed_at = $2
+		// The breach stamp goes with the clock. A lead that breached while it
+		// was nobody's has been escalated to the intake seat already; starting
+		// this owner's clock without clearing it would leave a row that can
+		// never breach again, because the scan skips anything already stamped.
+		`UPDATE lead SET routed_at = $2, sla_breached_at = NULL
 		  WHERE id = $1 AND routed_at IS NULL AND archived_at IS NULL`,
 		id, leadSLAClock().UTC()); err != nil {
 		return fmt.Errorf("people: starting the lead response clock: %w", err)

--- a/backend/internal/modules/people/leadsla.go
+++ b/backend/internal/modules/people/leadsla.go
@@ -14,13 +14,11 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/settings"
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -135,161 +133,6 @@ type SLABreach struct {
 	OwnerID  *ids.UserID
 	Deadline time.Time
 	Name     string
-}
-
-// ScanLeadSLA marks every open lead whose first-response deadline has passed
-// unanswered and not yet been escalated (formulas §18.2), once per breach:
-// sla_breached_at is the at-most-once mark, and the row lock with SKIP
-// LOCKED lets two scans share the work without escalating a lead twice.
-// Each breach lands one audit row and lead.sla_breached; the escalation
-// task hangs off that event.
-//
-// With the target switched off the scan is a no-op: no deadline exists to
-// breach, and a breach row the installation never asked for would page an
-// owner about a rule they did not set.
-func (s *Store) ScanLeadSLA(ctx context.Context, now time.Time) ([]SLABreach, error) {
-	if err := auth.Require(ctx, "lead", principal.ActionUpdate); err != nil {
-		return nil, err
-	}
-	var breaches []SLABreach
-	err := s.tx(ctx, func(tx pgx.Tx) error {
-		policy, err := loadLeadSLAPolicy(ctx, tx)
-		if err != nil {
-			return err
-		}
-		if !policy.enabled {
-			return nil
-		}
-		rows, err := tx.Query(ctx, `
-			SELECT id, owner_id, COALESCE(routed_at, created_at) + $1 * interval '1 minute',
-			       COALESCE(NULLIF(btrim(full_name), ''), email::text, '')
-			FROM lead
-			WHERE `+leadOwesAReplySQL+` AND sla_breached_at IS NULL
-			  -- Only a lead somebody is answerable for. An unowned row's
-			  -- deadline is measured from created_at against nobody, and
-			  -- escalating it stamps sla_breached_at — which then suppresses
-			  -- the real escalation once a human takes the lead on.
-			  AND owner_id IS NOT NULL
-			  AND COALESCE(routed_at, created_at) + $1 * interval '1 minute' < $2
-			ORDER BY created_at
-			FOR UPDATE SKIP LOCKED`,
-			policy.targetMinutes(), now)
-		if err != nil {
-			return fmt.Errorf("select breached leads: %w", err)
-		}
-		candidates, err := collectBreaches(rows)
-		if err != nil {
-			return err
-		}
-		// Each candidate is re-checked against the ACTIVITIES before it is
-		// marked. first_response_at is projected by an event subscriber
-		// reacting to activity.captured, so it lags the activity's own commit
-		// by the bus's latency: a reply committed at 11:59 against a 12:00
-		// deadline can still be unprojected when a 12:01 scan runs, and the
-		// lead reads as unanswered because the projection has not caught up
-		// rather than because nobody answered.
-		//
-		// The scan owns the consequence — a breach event, an escalation task,
-		// and a number on somebody's review — so it reads the ground truth
-		// rather than the projection. Where it finds one, it stamps the column
-		// itself: the subscriber's later write is then the replay
-		// recordFirstResponseTx already answers as a no-op.
-		breaches = breaches[:0]
-		for _, b := range candidates {
-			answered, err := answeredBy(ctx, tx, b.LeadID, b.Deadline)
-			if err != nil {
-				return err
-			}
-			if answered != nil {
-				if _, err := recordFirstResponseTx(ctx, tx, b.LeadID, *answered); err != nil {
-					return err
-				}
-				continue
-			}
-			if err := markBreach(ctx, tx, b, now); err != nil {
-				return err
-			}
-			breaches = append(breaches, b)
-		}
-		return nil
-	})
-	return breaches, err
-}
-
-func collectBreaches(rows pgx.Rows) ([]SLABreach, error) {
-	defer rows.Close()
-	var out []SLABreach
-	for rows.Next() {
-		var b SLABreach
-		if err := rows.Scan(&b.LeadID, &b.OwnerID, &b.Deadline, &b.Name); err != nil {
-			return nil, err
-		}
-		out = append(out, b)
-	}
-	return out, rows.Err()
-}
-
-func markBreach(ctx context.Context, tx pgx.Tx, b SLABreach, now time.Time) error {
-	// The SLA sweep runs as an unbounded system principal, for whom this probe
-	// returns nil without a query. It is here so that the day a human-facing
-	// caller reaches this write — an operator forcing a breach, a retry surface —
-	// it arrives already scoped rather than silently unguarded.
-	if err := auth.EnsureWritableLive(ctx, tx, "lead", b.LeadID.UUID); err != nil {
-		return err
-	}
-	// The row is already locked by the scan's SELECT ... FOR UPDATE; the
-	// predicate is the CAS that keeps the mark at-most-once regardless.
-	tag, err := tx.Exec(ctx,
-		`UPDATE lead SET sla_breached_at = $2 WHERE id = $1 AND sla_breached_at IS NULL`, b.LeadID, now)
-	if err != nil {
-		return fmt.Errorf("mark sla breach: %w", err)
-	}
-	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("mark sla breach on %s: %w", b.LeadID, apperrors.ErrConflict)
-	}
-	// sla_breached_at is the lead's own column and it is the whole change; the
-	// deadline that was missed is context ABOUT the breach and rides evidence,
-	// because a lead has no `deadline` column and field history would project
-	// one as a field of the record that nobody can find.
-	//
-	// The before-image is exact rather than read: the UPDATE above is the
-	// at-most-once CAS, so the single row it affected held nothing here.
-	auditID, err := storekit.AuditWithEvidence(ctx, tx, "update", "lead", b.LeadID.UUID,
-		map[string]any{slaBreachedColumn: nil}, map[string]any{slaBreachedColumn: now},
-		map[string]any{"deadline": b.Deadline})
-	if err != nil {
-		return fmt.Errorf("audit sla breach: %w", err)
-	}
-	payload := crmcontracts.PublicEventLeadSlaBreached{Deadline: b.Deadline}
-	switch {
-	case b.OwnerID != nil:
-		owner := openapi_types.UUID(b.OwnerID.UUID)
-		payload.OwnerId = &owner
-		// An owned lead escalates to its OWNER: the desk that owes the answer
-		// is the desk that hears about the miss.
-		payload.EscalationTarget = &owner
-	default:
-		// A lead NOBODY owns is the queue's worst case — past its response
-		// target with no one who has picked it up — and it was the one case
-		// that reached nobody at all: an unassigned task and no notice.
-		//
-		// The configured intake seat answers for it. Unset means the
-		// installation has not said who runs the queue, and the breach stays
-		// where it was rather than being addressed to somebody who did not
-		// agree to it; the unassigned view is what surfaces those.
-		target, configured, err := unassignedEscalationTarget(ctx, tx)
-		if err != nil {
-			return err
-		}
-		if configured {
-			addressed := openapi_types.UUID(target)
-			payload.EscalationTarget = &addressed
-		}
-	}
-	if err := storekit.EmitEvent(ctx, tx, auditID, b.LeadID.UUID, payload); err != nil {
-		return fmt.Errorf("emit lead.sla_breached: %w", err)
-	}
-	return nil
 }
 
 // RecordLeadFirstResponse stamps the lead's first genuine response from an

--- a/backend/internal/modules/people/leadsla_integration_test.go
+++ b/backend/internal/modules/people/leadsla_integration_test.go
@@ -715,3 +715,49 @@ func TestAnIntakeSeatMustBeAbleToReadTheLeadsItAnswersFor(t *testing.T) {
 		t.Errorf("the refused nomination was stored anyway")
 	}
 }
+
+// Taking on a lead that already breached clears the stamp with the clock.
+//
+// The two have to move together. COALESCE(routed_at, created_at) restarts the
+// deadline when somebody picks the lead up, and sla_breached_at keeps a row out
+// of the scan for good — so a stamp left behind by the ownerless escalation
+// would mean the new owner could never breach, on a clock that had just been
+// restarted for them. That is the suppression the breach scan used to avoid by
+// refusing to escalate unowned rows at all, which cost the intake seat its
+// escalation.
+func TestTakingOnABreachedLeadClearsTheStampWithTheClock(t *testing.T) {
+	e := setupPromoteConsent(t)
+	e.enableFirstResponseSLA(t)
+	e.nameIntakeSeat(t, e.user)
+	now := time.Now().UTC()
+
+	// An inbound nobody picked up, past its target: the ownerless case that
+	// escalates to the intake seat.
+	lead := e.seedOwnerlessLeadCreatedAt(t, "waiting@example.test", now.Add(-DefaultFirstResponseTarget-time.Hour))
+	if _, err := e.store.ScanLeadSLA(e.ctx, now); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if target := e.breachTargetOf(t, lead); target == nil || *target != e.user.String() {
+		t.Fatalf("escalation target = %v, want the intake seat %s — the rest of this case rests on it having breached", target, e.user)
+	}
+
+	owner := ids.From[ids.UserKind](e.user)
+	if _, err := e.store.UpdateLead(e.ctx, lead, UpdateLeadInput{OwnerID: &owner}); err != nil {
+		t.Fatalf("taking the lead on: %v", err)
+	}
+
+	var breachedAt *time.Time
+	var routedAt *time.Time
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT sla_breached_at, routed_at FROM lead WHERE id = $1`, lead.UUID).
+		Scan(&breachedAt, &routedAt); err != nil {
+		t.Fatal(err)
+	}
+	if routedAt == nil {
+		t.Fatal("taking the lead on started no clock, so this case cannot say anything about the stamp beside it")
+	}
+	if breachedAt != nil {
+		t.Errorf("the breach stamp survived the take-on (%v) — the new owner's clock restarted and the scan will skip this row for good, so they can never breach on it",
+			breachedAt)
+	}
+}

--- a/backend/internal/modules/people/leadslascan.go
+++ b/backend/internal/modules/people/leadslascan.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The breach sweep: which overdue leads escalate, and to whom.
+//
+// Split from leadsla.go, which holds what an SLA state IS — the policy, the
+// clock, and the clauses the list reads it with. This is the pass that acts on
+// them, and it is the half with the judgement in it: whether an unowned row is
+// a person waiting or a name nobody asked for, and whether a deadline the
+// projection has not caught up with is really a breach.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// ScanLeadSLA marks every open lead whose first-response deadline has passed
+// unanswered and not yet been escalated (formulas §18.2), once per breach:
+// sla_breached_at is the at-most-once mark, and the row lock with SKIP
+// LOCKED lets two scans share the work without escalating a lead twice.
+// Each breach lands one audit row and lead.sla_breached; the escalation
+// task hangs off that event.
+//
+// With the target switched off the scan is a no-op: no deadline exists to
+// breach, and a breach row the installation never asked for would page an
+// owner about a rule they did not set.
+func (s *Store) ScanLeadSLA(ctx context.Context, now time.Time) ([]SLABreach, error) {
+	if err := auth.Require(ctx, "lead", principal.ActionUpdate); err != nil {
+		return nil, err
+	}
+	var breaches []SLABreach
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		policy, err := loadLeadSLAPolicy(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if !policy.enabled {
+			return nil
+		}
+		rows, err := tx.Query(ctx, `
+			SELECT id, owner_id, COALESCE(routed_at, created_at) + $1 * interval '1 minute',
+			       COALESCE(NULLIF(btrim(full_name), ''), email::text, '')
+			FROM lead
+			WHERE `+leadOwesAReplySQL+` AND sla_breached_at IS NULL
+			  -- An UNOWNED lead breaches, unless NOBODY ASKED US for it: an
+			  -- inbound nobody picked up is the queue's worst case and escalates
+			  -- to the intake seat, while a name a pass read off a website is
+			  -- not somebody's work and a clock nobody started is not a breach.
+			  -- lead_source.intent already draws that line — siteread and crawl
+			  -- are low "for crawl's reason: nobody asked us for anything" — so
+			  -- reading it keeps one answer, and a prospecting source an
+			  -- operator adds gets the rule with it. Owned rows are
+			  -- unconditional: the clock is theirs however it arrived.
+			  --
+			  -- A subquery, not a join: leadOwesAReplySQL is shared and names
+			  -- its columns unqualified, so a second table makes "id" ambiguous
+			  -- for every reader of it. COALESCE so an unnamed source still
+			  -- breaches — an unknown arrival is likelier to be a person
+			  -- waiting, which is the direction to be wrong in.
+			  AND (owner_id IS NOT NULL
+			       OR COALESCE((SELECT intent FROM lead_source WHERE key = lead.source), '') <> 'low')
+			  AND COALESCE(routed_at, created_at) + $1 * interval '1 minute' < $2
+			ORDER BY created_at
+			FOR UPDATE SKIP LOCKED`,
+			policy.targetMinutes(), now)
+		if err != nil {
+			return fmt.Errorf("select breached leads: %w", err)
+		}
+		candidates, err := collectBreaches(rows)
+		if err != nil {
+			return err
+		}
+		// Each candidate is re-checked against the ACTIVITIES before it is
+		// marked. first_response_at is projected by an event subscriber
+		// reacting to activity.captured, so it lags the activity's own commit
+		// by the bus's latency: a reply committed at 11:59 against a 12:00
+		// deadline can still be unprojected when a 12:01 scan runs, and the
+		// lead reads as unanswered because the projection has not caught up
+		// rather than because nobody answered.
+		//
+		// The scan owns the consequence — a breach event, an escalation task,
+		// and a number on somebody's review — so it reads the ground truth
+		// rather than the projection. Where it finds one, it stamps the column
+		// itself: the subscriber's later write is then the replay
+		// recordFirstResponseTx already answers as a no-op.
+		breaches = breaches[:0]
+		for _, b := range candidates {
+			answered, err := answeredBy(ctx, tx, b.LeadID, b.Deadline)
+			if err != nil {
+				return err
+			}
+			if answered != nil {
+				if _, err := recordFirstResponseTx(ctx, tx, b.LeadID, *answered); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := markBreach(ctx, tx, b, now); err != nil {
+				return err
+			}
+			breaches = append(breaches, b)
+		}
+		return nil
+	})
+	return breaches, err
+}
+
+func collectBreaches(rows pgx.Rows) ([]SLABreach, error) {
+	defer rows.Close()
+	var out []SLABreach
+	for rows.Next() {
+		var b SLABreach
+		if err := rows.Scan(&b.LeadID, &b.OwnerID, &b.Deadline, &b.Name); err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+func markBreach(ctx context.Context, tx pgx.Tx, b SLABreach, now time.Time) error {
+	// The SLA sweep runs as an unbounded system principal, for whom this probe
+	// returns nil without a query. It is here so that the day a human-facing
+	// caller reaches this write — an operator forcing a breach, a retry surface —
+	// it arrives already scoped rather than silently unguarded.
+	if err := auth.EnsureWritableLive(ctx, tx, "lead", b.LeadID.UUID); err != nil {
+		return err
+	}
+	// The row is already locked by the scan's SELECT ... FOR UPDATE; the
+	// predicate is the CAS that keeps the mark at-most-once regardless.
+	tag, err := tx.Exec(ctx,
+		`UPDATE lead SET sla_breached_at = $2 WHERE id = $1 AND sla_breached_at IS NULL`, b.LeadID, now)
+	if err != nil {
+		return fmt.Errorf("mark sla breach: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("mark sla breach on %s: %w", b.LeadID, apperrors.ErrConflict)
+	}
+	// sla_breached_at is the lead's own column and it is the whole change; the
+	// deadline that was missed is context ABOUT the breach and rides evidence,
+	// because a lead has no `deadline` column and field history would project
+	// one as a field of the record that nobody can find.
+	//
+	// The before-image is exact rather than read: the UPDATE above is the
+	// at-most-once CAS, so the single row it affected held nothing here.
+	auditID, err := storekit.AuditWithEvidence(ctx, tx, "update", "lead", b.LeadID.UUID,
+		map[string]any{slaBreachedColumn: nil}, map[string]any{slaBreachedColumn: now},
+		map[string]any{"deadline": b.Deadline})
+	if err != nil {
+		return fmt.Errorf("audit sla breach: %w", err)
+	}
+	payload := crmcontracts.PublicEventLeadSlaBreached{Deadline: b.Deadline}
+	switch {
+	case b.OwnerID != nil:
+		owner := openapi_types.UUID(b.OwnerID.UUID)
+		payload.OwnerId = &owner
+		// An owned lead escalates to its OWNER: the desk that owes the answer
+		// is the desk that hears about the miss.
+		payload.EscalationTarget = &owner
+	default:
+		// A lead NOBODY owns is the queue's worst case — past its response
+		// target with no one who has picked it up — and it was the one case
+		// that reached nobody at all: an unassigned task and no notice.
+		//
+		// The configured intake seat answers for it. Unset means the
+		// installation has not said who runs the queue, and the breach stays
+		// where it was rather than being addressed to somebody who did not
+		// agree to it; the unassigned view is what surfaces those.
+		target, configured, err := unassignedEscalationTarget(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if configured {
+			addressed := openapi_types.UUID(target)
+			payload.EscalationTarget = &addressed
+		}
+	}
+	if err := storekit.EmitEvent(ctx, tx, auditID, b.LeadID.UUID, payload); err != nil {
+		return fmt.Errorf("emit lead.sla_breached: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
`main` is red four ways and **none of the four fixes can land alone**: each is red on the other three's subjects, `ci` is the required check, and neither of us is reaching for `--admin`. Combined, they are green.

Supersedes #5225, #5237, #5241 (mine) and #5230 (@target-ce's, carried unmodified with authorship intact).

## The four

**1. `TestAnOwnerlessBreachReachesTheConfiguredIntakeSeat` + `TestAnIntakeSeatThatCannotWorkIsTreatedAsUnset`** — #5201 added `AND owner_id IS NOT NULL` to the breach scan and left #5015's tests failing.

Both PRs are right about their own case; ownership was the wrong discriminator. #5015 seeds an `inbound` nobody picked up — a person waiting. #5201 seeds a `siteread` — a name a pass read off a website. `lead_source.intent` already separates them, in its own words: siteread and crawl are low *"for crawl's reason: nobody asked us for anything."* Each half of the new condition is required by a different PR's test.

#5201's stated reason for the exclusion was correct and is closed rather than argued away: the take-on now clears `sla_breached_at` with the same condition that starts the clock.

**2. `TestAnOverdueTaskReachesThePlannedLane` + two boundary cases** — #5210 made the lane read what is coming as well as what is owed, across thirty files, and left three cases asserting the narrower lane. Each keeps its subject: a task already **done** is still carried by neither read, and the two boundary cases still pin which side of the installation's midnight a task falls on — now through `due_group`, which is where #5210 moved it.

**3. `TestPreferenceCenterOptOutBlocksAgentSend`** — #5196 put `person:update` on the mint the **send path** reaches for the unsubscribe link RFC 8058 compels. The mint moves down one level; `EnsureWithdrawalCredentialTx` keeps the grant exactly as written, and the send calls below it. **No product decision is taken** — whether a sending agent should hold `person:update` is still #5196's author's, and the gate is one line from being asked on that path too.

**4. Two craft BLOCKERs** (@target-ce, #5230) — #5211's swallowed savepoint rollback. Their finding is sharper than the generic one: that savepoint exists so a receipt collision can be **retried**, so a rollback that did not take is the single condition under which the retry cannot work, and every remaining attempt fails with the first one's message. The test's is `t.Cleanup` with the `ErrTxClosed` exception the suite already uses.

## Verification

On the combined branch:

```
make craft-static                              PASS — 0 blocker, 0 major, 0 minor
make check-go                                  clean
make test-it DIR=backend/internal/compose      ok (125s)
make test-it DIR=backend/.../modules/people    ok (37s)
```

## One thread worth pulling separately

`main-health` last ran on `7a246a72` and `main` is at `36a33cb6` — eleven merges without the health check seeing the tip, which is how four independent breakages accumulated unnoticed. Three of them are the same shape: **a change landed with a test still asserting the rule it replaced.** Not one author's mistake; a gap between "my PR is green" and "main is green", and the schedule is where it lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC