### PR TITLE
The MCP surface says what it is not for, and stops promising a human who is not there

### DIFF
--- a/backend/internal/compose/analyticsshare_integration_test.go
+++ b/backend/internal/compose/analyticsshare_integration_test.go
@@ -29,9 +29,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// freezeTwoTeams seeds one priced deal per team and freezes the pair, through
-// the REAL writer and the real deal read, so what the recompute later re-sums
-// is what production would have written.
+// freezeTwoTeams seeds one priced deal per team and freezes them.
 func (e *forecastEnv) freezeTwoTeams(t *testing.T, mine, theirs int64) ids.UUID {
 	t.Helper()
 	// Inside the period on purpose. seedOpenDeal dates a deal 30 days out,
@@ -40,7 +38,14 @@ func (e *forecastEnv) freezeTwoTeams(t *testing.T, mine, theirs int64) ids.UUID 
 	// pass or fail by the calendar rather than by the recompute.
 	e.seedDealClosingWithin(t, "Mine", &e.Rep1, mine)
 	e.seedDealClosingWithin(t, "Theirs", &e.Rep3, theirs)
+	return e.freezeWorkspace(t)
+}
 
+// freezeWorkspace freezes whatever deals are already seeded, through the REAL
+// writer and the real deal read, so what the recompute later re-sums is what
+// production would have written.
+func (e *forecastEnv) freezeWorkspace(t *testing.T) ids.UUID {
+	t.Helper()
 	store := forecasting.NewStore(InstallationDB(e.Pool))
 	admin := snapshotWriterCtx(e.WS)
 	var id ids.UUID
@@ -65,7 +70,7 @@ func (e *forecastEnv) freezeTwoTeams(t *testing.T, mine, theirs int64) ids.UUID 
 		})
 		return err
 	}); err != nil {
-		t.Fatalf("freezing the pair: %v", err)
+		t.Fatalf("freezing the seeded deals: %v", err)
 	}
 	return id
 }
@@ -74,10 +79,20 @@ func (e *forecastEnv) freezeTwoTeams(t *testing.T, mine, theirs int64) ids.UUID 
 // so it falls in the current quarter whatever day the suite runs on.
 func (e *forecastEnv) seedDealClosingWithin(t *testing.T, name string, owner *ids.UUID, amountMinor int64) {
 	t.Helper()
+	e.seedDealPricedIn(t, name, owner, amountMinor, "EUR")
+}
+
+// seedDealPricedIn is the same plant in a named currency. This environment
+// populates no rate sheet at all, so anything but the installation's own base
+// currency produces a deal that CARRIES an amount and has no base — priced and
+// unconvertible, the one population `priced_count` and `fx_missing_count`
+// disagree about.
+func (e *forecastEnv) seedDealPricedIn(t *testing.T, name string, owner *ids.UUID, amountMinor int64, currency string) {
+	t.Helper()
 	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, amount_minor, currency,
 			expected_close_date, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, $6, 'EUR', (now() + interval '2 days')::date, 'manual', 'human:x')`,
-		name, e.pipeline, e.stages[20], owner, amountMinor)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, (now() + interval '2 days')::date, 'manual', 'human:x')`,
+		name, e.pipeline, e.stages[20], owner, amountMinor, currency)
 }
 
 // writerUser is the seat snapshotWriterCtx acts as.
@@ -697,4 +712,74 @@ func (e *forecastEnv) writableScope(
 			return scopeErr
 		})
 	return out, err
+}
+
+// PRICED is amount_minor; CONVERTED is base_minor, and the priced-but-
+// unconvertible deal is the one population the two answers differ on.
+//
+// The share recompute and forecasting.Compute are two writers of these counts
+// and cannot be one helper — Compute decides in Go over rows it holds, this is
+// an aggregate under a per-recipient FILTER that never loads them. So the two
+// are asserted EQUAL here, which fails whichever of them drifts, rather than
+// pinning constants that would stay green while they parted company.
+func TestASharedSnapshotCountsPricingRatherThanConversion(t *testing.T) {
+	const priced = 100_000
+	e := setupForecast(t)
+	e.seedDealClosingWithin(t, "Convertible", &e.Rep1, priced)
+	e.seedDealPricedIn(t, "Priced in francs", &e.Rep1, priced, "CHF")
+	// A third deal on the OTHER team, so the narrowed read below counts fewer
+	// rows than the whole state and the count is shown to ride the same
+	// visibility clause as its siblings rather than to be taken over the table.
+	e.seedDealClosingWithin(t, "Another team's", &e.Rep3, priced)
+
+	id := e.freezeWorkspace(t)
+	whole := e.readShared(snapshotWriterCtx(e.WS), t, id).Readings
+
+	if whole.EligibleCount != 3 {
+		t.Fatalf("the frozen state holds %d eligible deals, want the 3 seeded", whole.EligibleCount)
+	}
+	if whole.FxMissingCount != 1 {
+		t.Fatalf("%d deals are unconvertible, want the 1 priced in francs", whole.FxMissingCount)
+	}
+	if whole.PricedCount != 3 {
+		t.Errorf("priced_count = %d, want 3 — ALL THREE carry an amount, and the unconvertible "+
+			"one is already reported by fx_missing_count; counting conversion here tells a "+
+			"recipient the total misses two deals when it misses one", whole.PricedCount)
+	}
+
+	// The declared mirror: what the recipient is re-summed equals what the
+	// writer froze. Read off the stored row rather than restated, so a change
+	// to either side reds this.
+	var stored forecasting.Readings
+	if err := forecasting.NewStore(InstallationDB(e.Pool)).InTx(snapshotWriterCtx(e.WS),
+		func(ctx context.Context, tx pgx.Tx) error {
+			return tx.QueryRow(ctx,
+				`SELECT eligible_count, priced_count, fx_missing_count
+				 FROM forecast_snapshot WHERE id = $1`, id).
+				Scan(&stored.EligibleCount, &stored.PricedCount, &stored.FxMissingCount)
+		}); err != nil {
+		t.Fatalf("reading the frozen row: %v", err)
+	}
+	if whole.PricedCount != stored.PricedCount || whole.EligibleCount != stored.EligibleCount ||
+		whole.FxMissingCount != stored.FxMissingCount {
+		t.Errorf("the recompute answers eligible=%d priced=%d fx_missing=%d and the row "+
+			"forecasting.Compute froze says %d/%d/%d — the two writers of these counts have "+
+			"come to mean different things",
+			whole.EligibleCount, whole.PricedCount, whole.FxMissingCount,
+			stored.EligibleCount, stored.PricedCount, stored.FxMissingCount)
+	}
+
+	// AND UNDER NARROWING, because a count is a disclosure. The predicate that
+	// changed sits inside the same visibility clause as every sibling
+	// aggregate, and a count taken over the table instead would tell a
+	// team-scoped recipient how many deals exist outside their population.
+	narrow := e.readShared(e.forecastReader(
+		e.dealReadCtx(e.Rep1, []ids.UUID{e.Team1}, principal.RowScopeTeam)), t, id).Readings
+	if narrow.PricedCount != 2 {
+		t.Errorf("a team-scoped recipient counted %d priced deals, want their own team's 2 — "+
+			"the count must narrow with the rows it counts", narrow.PricedCount)
+	}
+	if narrow.EligibleCount != 2 {
+		t.Errorf("a team-scoped recipient counted %d eligible deals, want 2", narrow.EligibleCount)
+	}
 }

--- a/backend/internal/compose/analyticssharesnapshot.go
+++ b/backend/internal/compose/analyticssharesnapshot.go
@@ -90,7 +90,17 @@ func ReadSharedSnapshot(
 		  COALESCE(sum(c.base_minor)     FILTER (WHERE c.in_open AND %[1]s), 0),
 		  COALESCE(sum(c.weighted_minor) FILTER (WHERE c.in_open AND %[1]s), 0),
 		  count(*) FILTER (WHERE %[1]s),
-		  count(*) FILTER (WHERE c.base_minor IS NOT NULL AND %[1]s),
+		  -- PRICED is amount_minor. CONVERTED is base_minor, and the deal priced
+		  -- in a currency no rate reached is the one population they differ on —
+		  -- the population fx_missing_count names two lines below. Counting
+		  -- conversion here reports that single gap twice.
+		  --
+		  -- SECOND WRITER, and it cannot be one helper: forecasting.Compute
+		  -- decides this in Go over rows it already holds, while this is an
+		  -- aggregate under a per-recipient FILTER that never loads them. The two
+		  -- are held equal by TestASharedSnapshotCountsPricingRatherThanConversion,
+		  -- which asserts this recompute against the row Compute stored.
+		  count(*) FILTER (WHERE c.amount_minor IS NOT NULL AND %[1]s),
 		  count(*) FILTER (WHERE NOT c.close_provisional AND %[1]s),
 		  count(*) FILTER (WHERE c.exclusion_reason = 'fx_missing' AND %[1]s),
 		  -- Whether anything was kept back, asked of THIS snapshot rather than

--- a/backend/internal/compose/approvalprose_test.go
+++ b/backend/internal/compose/approvalprose_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// No tool may PROMISE a human in the loop that its tier does not put there.
+//
+// The governance line at the end of every description is derived from
+// spec.Tier, and the admission gate enforces that same tier, so it is true by
+// construction. The prose above it is hand-written and is not — and the two
+// came apart. ADR-0055 stopped these verbs staging by default; the derived
+// line followed the tier automatically; ten descriptions went on saying "a
+// person approves this call before it runs" directly above "Governance: runs
+// immediately".
+//
+// The cost is not a stale sentence. A model reading send_email was told
+// somebody would catch a mistaken send, and by default nobody would — so the
+// surface understated its own authority to the one party deciding whether to
+// use it, which is the opposite of what every other rule here is for.
+//
+// PHRASED AS CONTRADICTION, not as banned words. An installation may raise a
+// verb to confirm-first, and a description that says so CONDITIONALLY is true
+// at either tier and must stay legal. What must never appear is an
+// unconditional promise under a tier that gives none.
+//
+// It lives in compose because only compose has the whole surface: a registry
+// built in the agents package has no tools in it, so a census there would walk
+// nothing and report PASS.
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+)
+
+// promisesAHuman matches an UNCONDITIONAL claim that a person answers the call
+// before it takes effect.
+var promisesAHuman = regexp.MustCompile(
+	`(?i)a person approves (this|the) call|a person approves the (send|move)|` +
+		`a person approves it (first|before)|once a person approves`)
+
+// conditionallyStaged is the phrasing true at either tier: it says what happens
+// where an installation HAS raised the verb, and promises nothing where it has
+// not.
+var conditionallyStaged = regexp.MustCompile(`(?i)where an installation has raised`)
+
+func TestNoToolPromisesAnApprovalItsTierDoesNotRequire(t *testing.T) {
+	t.Parallel()
+	specs := servedSurface(t).Specs()
+	if len(specs) == 0 {
+		t.Fatal("the served surface offered no tools, so this census walked nothing")
+	}
+	checked := 0
+	for _, spec := range specs {
+		if spec.Tier != mcp.TierAutoExecute {
+			continue
+		}
+		checked++
+		sentence := promisesAHuman.FindString(spec.Description)
+		if sentence == "" {
+			continue
+		}
+		// A conditional clause elsewhere does not license an unconditional
+		// promise — a caller reads the promise, not the qualification three
+		// sentences away — but it is reported so a reader can see it was seen.
+		qualified := ""
+		if conditionallyStaged.MatchString(spec.Description) {
+			qualified = "; it does also carry a conditional clause, which does not undo this"
+		}
+		t.Errorf("%s runs immediately and its description says %q%s — a caller is told a "+
+			"person will catch a mistake that nothing will catch",
+			spec.Name, sentence, qualified)
+	}
+	// A census that stops reaching auto-execute tools reports PASS in the same
+	// words as one with nothing left to fix.
+	if checked < 20 {
+		t.Fatalf("only %d auto-execute tools were read out of %d served — the walk has lost "+
+			"part of the surface", checked, len(specs))
+	}
+}
+
+// The conditional phrasing must stay legal, or the rule above collapses into
+// "never mention approval" and strips the one sentence a confirm-first
+// installation's caller needs.
+func TestTheConditionalPhrasingIsNotMistakenForAPromise(t *testing.T) {
+	t.Parallel()
+	legal := "The lead is demoted when this call answers. Where an installation has raised this " +
+		"verb to confirm first, the answer is a staged approval instead."
+	if promisesAHuman.MatchString(legal) {
+		t.Errorf("the conditional form reads as an unconditional promise, so no description "+
+			"can state the truth at both tiers:\n%s", legal)
+	}
+	if banned := "A person approves this call before it runs."; !promisesAHuman.MatchString(banned) {
+		t.Errorf("the pattern no longer catches the sentence it exists for:\n%s", banned)
+	}
+}

--- a/backend/internal/modules/agents/explain.go
+++ b/backend/internal/modules/agents/explain.go
@@ -330,7 +330,13 @@ const maxRemedyBudget = 4 * httperr.MaxFaultText
 // The summary is the sentence the human's own card carries, so the person and
 // the agent are waiting on one described thing.
 //
-// IT ALSO SAYS WHAT IS NOT BLOCKED, because an agent reads a refusal as a stop.
+// IT ALSO SAYS WHAT IS NOT BLOCKED, AND TO REPORT WHAT ALREADY HAPPENED,
+// because an agent reads a refusal as a stop and then writes its answer about
+// the stop. Two measured runs merged a duplicate and archived a dead company
+// correctly and then said only "one approval waiting: reassign the account" —
+// two completed writes the reader was never told about. Doing the rest and
+// reporting the rest are separate instructions, and only the first was given.
+//
 // Asked to merge two words and then give the survivor a meaning, a measured run
 // staged the merge, relayed the summary correctly, and finished with "Confirm
 // and I'll proceed, then add the description afterward" — deferring an
@@ -352,5 +358,6 @@ func stagedExplanation(staged *workflow.StagedApprovalError) string {
 	return "Confirm-first (🟡): a person answers this before it runs. " + what +
 		" Tell them that, in those words; they release it in the CRM, and this exact call then " +
 		"repeats with \"approval_id\": \"" + staged.ApprovalID.String() + "\". " +
-		"Blocks THIS call only — do the rest of what you were asked that does not depend on it."
+		"Blocks THIS call only — do the rest of what you were asked that does not depend on it, " +
+		"and report what you DID alongside what is waiting."
 }

--- a/backend/internal/modules/agents/results_identity.go
+++ b/backend/internal/modules/agents/results_identity.go
@@ -38,6 +38,39 @@ type ListColleaguesResult struct {
 	// nothing would read a capped list as the whole roster and report that a
 	// colleague does not work here.
 	Truncated bool `json:"truncated,omitempty"`
+	// AllColleagues is the set the narrowing was matched against, present ONLY
+	// when a narrowing `q` matched none of it — the same obligation a refusal
+	// naming a closed vocabulary carries.
+	//
+	// An empty `colleagues` answers two different questions identically: this
+	// workspace employs nobody, and nobody here is spelled the way you asked.
+	// A caller cannot tell them apart, and the one it picks is the wrong one:
+	// asked to hand an account to a colleague, an assistant read `[]` and
+	// reported that the person does not work here — with the seat sitting in
+	// the roster under a spelling it had not tried.
+	//
+	// So the miss hands over the set it was matched against. `colleagues` stays
+	// empty, because that is the honest answer to what was asked.
+	//
+	// NOT named `roster`, which is what this whole result already is.
+	//
+	// A POINTER, so a successful fallback over a workspace that employs nobody
+	// serializes as `[]` and an unreadable one is absent. A plain slice made
+	// those two the same bytes — which is the defect this field exists to
+	// remove, one level up: "nobody works here" and "I could not find out" are
+	// different answers, and a caller cannot act on the difference it cannot
+	// see. The warnings say which; the data now says it too.
+	AllColleagues *[]Colleague `json:"all_colleagues,omitempty"`
+	// AllColleaguesTruncated bounds AllColleagues, and is its OWN flag rather
+	// than a second meaning for Truncated above.
+	//
+	// The two answer different questions — "your query has more matches than
+	// fit" and "the fallback list is capped" — and one flag beside an empty
+	// `colleagues` reads as the first. It would read as it in the case that
+	// matters most: a large workspace, the name absent from the first page, and
+	// a caller MORE certain the person does not work here than a bare empty
+	// list left it.
+	AllColleaguesTruncated bool `json:"all_colleagues_truncated,omitempty"`
 }
 
 // ListTagsResult is the workspace's tag vocabulary. Empty is a real answer —

--- a/backend/internal/modules/agents/stagedanswer_test.go
+++ b/backend/internal/modules/agents/stagedanswer_test.go
@@ -173,4 +173,13 @@ func TestAStagedAnswerSaysTheRestOfTheTaskIsNotBlocked(t *testing.T) {
 		t.Errorf("the answer does not say what is still doable, so a caller defers work the "+
 			"approval never blocked:\n%s", said)
 	}
+	// Doing the rest and REPORTING the rest are separate instructions, and an
+	// answer carrying only the first produces exactly what two measured runs
+	// produced: a duplicate merged, a dead company archived, and a final answer
+	// that mentions neither because it is written about the one thing that
+	// stopped.
+	if !strings.Contains(said, "report what you DID") {
+		t.Errorf("the answer does not ask for what already happened, so a caller reports the "+
+			"approval and silently drops the writes it completed:\n%s", said)
+	}
 }

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -4359,6 +4359,40 @@
       "data": {
         "type": "object",
         "properties": {
+          "all_colleagues": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "display_name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "is_agent": {
+                  "type": "boolean"
+                },
+                "seat_type": {
+                  "type": "string"
+                },
+                "user_id": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "required": [
+                "display_name",
+                "email",
+                "is_agent",
+                "seat_type",
+                "user_id"
+              ]
+            }
+          },
+          "all_colleagues_truncated": {
+            "type": "boolean"
+          },
           "colleagues": {
             "type": "array",
             "items": {

--- a/backend/internal/modules/agents/toolcopy_analyticsreport.go
+++ b/backend/internal/modules/agents/toolcopy_analyticsreport.go
@@ -6,6 +6,23 @@ package agents
 // Written copy for composing a report. See toolcopy.go for what each field
 // answers.
 //
+// THE PURPOSE LEADS WITH THE JOB, not with the mechanism, and that ordering is
+// load-bearing. Asked for "a short written pipeline section for the board pack",
+// three measured runs read a catalogue of 75 tools, took the figures from
+// forecast_readings and typed them into prose — the one thing this tool refuses
+// to let a document do. It was served every time and chosen none of them. Its
+// first sentence had been "Render a report whose every figure comes from a
+// saved analytics run": true, and about handles, run ids and cells, while the
+// words a caller scans for — write, document, section, summary — were absent or
+// buried. A tool nobody picks for the job it does is a tool that is not there.
+//
+// AND IT SAYS WHAT IT IS NOT FOR, in the same breath, because the first attempt
+// at this over-reached. Offering "a written-up answer with figures in it" took
+// a model off run_report for a question that just wanted a number — asked for
+// one, it went and composed. The boundary belongs beside the invitation: a
+// Purpose broad enough to be found is broad enough to be found by the wrong
+// caller, and Instead: alone was too far down to stop it.
+//
 // The BLOCK VOCABULARY is deliberately not here. Fourteen block kinds with
 // their fields would be run_report's 3.4KB mistake again — text every client
 // holds for a session and every scheduled run re-sends on every step, to answer
@@ -19,9 +36,12 @@ package agents
 // instruction to read first costs a turn on every goal, including the ones with
 // nothing to look up.
 var composeAnalyticsReportCopy = toolCopy{
-	Purpose: "Render a report whose every figure comes from a saved analytics run. The " +
-		"document carries the STRUCTURE and the WORDS; each number names a run id and a cell " +
-		"inside it, and the server resolves those handles under the reader's own authority.",
+	Purpose: "WRITE a DOCUMENT somebody keeps and reads — a board-pack section, a summary " +
+		"for a meeting — whose every number comes from a saved analytics run instead of " +
+		"being typed. Not for answering with a figure: a number in the reply is " +
+		"run_analytics_query's or run_report's. The document carries the STRUCTURE and the " +
+		"WORDS; each figure names a run id and a cell inside it, and the server resolves " +
+		"those handles under the reader's own authority.",
 	Limits: "It writes no number of its own and refuses any document that does. A block " +
 		"carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the " +
 		"literal is what renders, the two can disagree, and no reader could tell the page " +

--- a/backend/internal/modules/agents/toolcopy_colleagues.go
+++ b/backend/internal/modules/agents/toolcopy_colleagues.go
@@ -8,7 +8,10 @@ var listColleaguesCopy = toolCopy{
 	Purpose: "List the people who work HERE — colleagues holding a seat, not the contacts stored " +
 		"as person records.",
 	Limits: "Reads only, and lists seats that can actually receive work — archived, suspended " +
-		"and locked-out ones are absent. `truncated` means there are more.",
+		"and locked-out ones are absent. `truncated` means there are more. A `q` matching nobody " +
+		"answers with `all_colleagues` and a warning; that list is ABSENT if it could not be read " +
+		"and partial if `all_colleagues_truncated`, so read the warning before concluding a " +
+		"person has no seat.",
 	Instead: "search_records/person finds a CUSTOMER contact; this finds a colleague.",
 	Retain:  "user_id is what assignee_id and owner_id take. Never assign to an is_agent seat.",
 }

--- a/backend/internal/modules/agents/toolcopy_comms.go
+++ b/backend/internal/modules/agents/toolcopy_comms.go
@@ -36,8 +36,9 @@ var sendEmailCopy = toolCopy{
 		"the thread it belongs to.",
 	Limits: "It sends EXACTLY the subject and body it is given and composes nothing, so it is " +
 		"not the tool to reach for when the message does not exist yet. Every recipient must " +
-		"have granted the consent purpose the call names, and a person approves the send before " +
-		"it leaves — a message leaving the workspace cannot be recalled.",
+		"have granted the consent purpose the call names. A message leaving the workspace cannot " +
+		"be recalled, and by default nothing holds it: where an installation has raised this verb " +
+		"to confirm first, the answer is a staged approval instead of a send.",
 	Instead: "Use draft_email first to produce the message and let it be read, and send_message " +
 		"when the conversation is on a chat channel rather than mail.",
 	Retain: "Send the same activity_id, subject and body the draft produced, and keep the staged " +
@@ -50,7 +51,9 @@ var sendAccountEmailCopy = toolCopy{
 		"conversation rather than answering one, and file it on the records it is about.",
 	Limits: "Sends EXACTLY the subject and body given; composes nothing. Needs at least one link " +
 		"naming the records it belongs to. Every recipient must have granted the named consent " +
-		"purpose, and a person approves the send first — a sent mail cannot be recalled.",
+		"purpose. A sent mail cannot be recalled, and by default nothing holds it: where an " +
+		"installation has raised this verb to confirm first, the answer is a staged approval " +
+		"instead of a send.",
 	Instead: "Use send_email to answer a conversation already recorded here; this starts a " +
 		"separate thread beside it.",
 	Retain: "Keep the staged approval id and re-send the identical text and links: the approval " +
@@ -62,7 +65,8 @@ var sendMessageCopy = toolCopy{
 		"— on the thread it was captured from.",
 	Limits: "It replies to an existing conversation named by activity_id; it cannot start one, " +
 		"and it cannot choose a channel. The recipient must have granted the consent purpose the " +
-		"call names, and a person approves it before it leaves.",
+		"call names. By default the message leaves when this call answers; where an installation " +
+		"has raised this verb to confirm first, the answer is a staged approval instead.",
 	Instead: "Use send_email when the thread is a mail thread, and log_activity when the point is " +
 		"to record that something was said rather than to say it.",
 	Retain: "Keep the activity_id of the conversation and the staged approval id; the approval " +
@@ -83,7 +87,9 @@ var bookMeetingCopy = toolCopy{
 	Purpose: "Hold a slot in the host's calendar and record the meeting against the records it " +
 		"is about.",
 	Limits: "Needs at least one link saying what it is about. The slot is taken and the meeting " +
-		"is a real commitment, so a person approves it first. No attendee list: who is invited is " +
+		"is a real commitment, and by default it is taken when this call answers — where an " +
+		"installation has raised this verb to confirm first, the answer is a staged approval " +
+		"instead. No attendee list: who is invited is " +
 		"the calendar connection's business. Check the slot is free first — this tool does not.",
 	Instead: "Use check_availability to find the time, and log_activity to record a meeting that " +
 		"already happened.",
@@ -94,8 +100,9 @@ var bookMeetingCopy = toolCopy{
 var enrichCopy = toolCopy{
 	Purpose: "Learn about an organization by reading its public website, and propose what was " +
 		"found for a person to accept onto the record.",
-	Limits: "It reaches OUTSIDE the workspace, so a person approves the call before it runs, and " +
-		"what it returns is a proposal — nothing lands on the record until someone accepts it. " +
+	Limits: "It reaches OUTSIDE the workspace, and what it returns is a PROPOSAL — nothing " +
+		"lands on the record until someone accepts it, which is the review that guards this, not " +
+		"an approval on the call. " +
 		"Reading one page answers immediately; reading a whole site is queued and answers with a " +
 		"read id rather than the content. What it finds is captured text from a third party, not " +
 		"a fact this workspace has verified.",

--- a/backend/internal/modules/agents/toolcopy_forecast.go
+++ b/backend/internal/modules/agents/toolcopy_forecast.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Written copy for the forecast reads. See toolcopy.go for what each field
+// answers.
+//
+// These five were the last tools on the surface carrying a hand-rolled
+// Description literal instead of a toolCopy, and the cost was not tidiness.
+// The struct has an Instead field; a literal has nowhere to put one. So the
+// forecast family named no neighbour and no neighbour named it — a complete
+// isolate in a catalogue of 75 tools, and every measured wrong-tool choice in
+// this area had one leg in it:
+//
+//   - asked for a board-pack section, a model took figures from
+//     forecast_readings and typed them into prose, which is the one thing
+//     compose_analytics_report refuses to let a document do;
+//   - asked whether the numbers could be trusted, a model read
+//     forecast_input_checks and never data_coverage, so it reported a clean
+//     set of findings over sources nobody had opened.
+//
+// Both are the same defect: three tools answer "can I trust this number?" and
+// none of them said which question it is holding. The boundaries below are the
+// point of the conversion.
+
+var forecastReadingsCopy = toolCopy{
+	// EVERY FIGURE IS NAMED rather than counted. "Four readings" is the
+	// contract's own phrasing and the payload carries five money fields, so a
+	// caller told a number has to guess which one is not a reading — and
+	// `weighted` is the one that goes unreported when it guesses.
+	Purpose: "Answer what a period is expected to close — `won`, `evidence`, `best_case` and " +
+		"`open`, plus `weighted` — under the installation's own fiscal calendar and base " +
+		"currency.",
+	Limits: "`won` counts deals by the day they ACTUALLY closed, not the day they were " +
+		"expected to. `evidence` is committed pipeline whose close date somebody confirmed; a " +
+		"provisional date stays in `open` and out of `evidence`. `coverage_note` says what the " +
+		"totals do not cover and is absent only when they cover every eligible deal, so " +
+		"quoting a total without it reports a partial pipeline as a complete one.",
+	Instead: "run_report's forecast report and a hand-summed query_workspace also produce a " +
+		"number, and NEITHER is the forecast: only this applies the fiscal calendar, the base " +
+		"currency conversion and the weighting. These figures also cannot be cited in a " +
+		"composed document — for a board-pack section or anything a reader keeps, " +
+		"run_analytics_query with save and compose_analytics_report from the run id. Ask " +
+		"forecast_input_checks whether the inputs behind these numbers were read.",
+	Retain: "Quote `as_of`, `timezone` and `base_currency` with the number — a total placed " +
+		"in the reader's own zone is a different total — and `eligible_count`, `priced_count` " +
+		"and `fx_missing_count` are the counts `coverage_note` is written from.",
+}
+
+var forecastMovementCopy = toolCopy{
+	Purpose: "Explain why a forecast changed between two points, as named causes that account " +
+		"for the whole difference.",
+	Limits: "Opening plus every bucket equals closing, exactly, so the buckets are a complete " +
+		"account of the change and not a selection from it. A deal appears in exactly ONE " +
+		"bucket: one that both slipped and was repriced has moved for one reason as far as a " +
+		"reader is concerned, which is that it left. Two buckets are about the machinery " +
+		"rather than the business, and quoting them as sales movement is the mistake this " +
+		"classification exists to prevent: `definition` means the two snapshots were computed " +
+		"under different rules, and then the WHOLE difference is in that bucket; `model` means " +
+		"a probability the product re-scored.",
+	Instead: "IT NEEDS TWO SNAPSHOT IDS, and nothing on this surface hands one out — no tool " +
+		"lists snapshots and no resource publishes them, so a caller that has not been given " +
+		"ids from elsewhere cannot call this. Reading forecast_readings twice and subtracting " +
+		"is NOT the same answer and must not be reported as one: the difference between two " +
+		"reads is a number with no account of where it went.",
+	Retain: "`reopened_or_archived` carries a deal that left the population entirely — " +
+		"archived, or no longer visible to this caller — with its whole prior contribution, so " +
+		"no money disappears without a row that says where it went.",
+}
+
+var forecastInputChecksCopy = toolCopy{
+	Purpose: "Answer whether the forecast's inputs are sound enough to quote — a verdict, and " +
+		"how much of the pipeline last night's check reached.",
+	Limits: "A forecast is only as good as its inputs, and the failures are mundane: a close " +
+		"date that went by, an amount that disagrees with the offer that was sent, a deal " +
+		"nobody has heard from in ninety days. `checks_incomplete` is NOT a worse " +
+		"`needs_review` — one says the pipeline has problems, the other says we could not " +
+		"look, and reporting the first when the second is true tells somebody their pipeline " +
+		"is sound when nobody read the mailbox.",
+	Instead: "This is the VERDICT. list_input_checks is the findings themselves, one row per " +
+		"problem, when the question is what to go and fix. data_coverage is the third " +
+		"question and the one this cannot answer: whether the CONNECTORS were readable at " +
+		"all, which is what makes a clean verdict trustworthy rather than merely clean.",
+	Retain: "Read `readiness` before quoting any forecast figure. `sources` says why: each " +
+		"carries the state the run reached, and only a `checked` source has a date — an absent " +
+		"or unread source means the run could not confirm anything from it, which is different " +
+		"from finding nothing there. `eligible_deals` is how much there was to check.",
+}
+
+var listInputChecksCopy = toolCopy{
+	Purpose: "List the open input problems behind the forecast, most material first, so they " +
+		"can be fixed.",
+	Limits: "A close date that went by, or an amount that disagrees with the offer that was " +
+		"sent, makes a total wrong without making the arithmetic wrong. Scoped to what this " +
+		"caller can open, with no count of what was withheld — a count of what somebody may " +
+		"not read is itself a statement about how much there is.",
+	Instead: "forecast_input_checks answers the VERDICT — whether the numbers are quotable at " +
+		"all — which is the question before this one and the cheaper call. data_coverage " +
+		"answers whether the sources were readable, which an empty list here cannot " +
+		"distinguish from a clean pipeline.",
+	Retain: "`affected_minor` absent means the money at stake cannot be said, not that " +
+		"nothing is at stake.",
+}
+
+var dataCoverageCopy = toolCopy{
+	Purpose: "Answer how much of what is going on this workspace can actually SEE — which " +
+		"connectors the nightly check could read, and how far back each reaches.",
+	Limits: "Needs the data_coverage grant, which operators hold and sellers do not — a " +
+		"refusal here is a seat boundary, not a missing run. Only a `checked` source carries a " +
+		"date; on any other state nothing was read, and a quiet week is indistinguishable from " +
+		"a broken connector until somebody looks.",
+	Instead: "forecast_input_checks and list_input_checks answer what the check FOUND, and " +
+		"both are silent on whether it could look — a clean set of findings over sources " +
+		"nobody opened reads as good news and is not. Ask this one when the question is " +
+		"whether to trust the other two.",
+}

--- a/backend/internal/modules/agents/toolcopy_import.go
+++ b/backend/internal/modules/agents/toolcopy_import.go
@@ -33,11 +33,12 @@ var readImportRunCopy = toolCopy{
 
 var readImportReportCopy = toolCopy{
 	Purpose: "What an import will do, or did: rows created, updated, failed, unusable, duplicates.",
-	Limits:  "These counts are what a person approves. Same shape before and after.",
+	Limits:  "These counts are what a person weighs before committing. Same shape before and after.",
 }
 
 var commitImportCopy = toolCopy{
-	Purpose: "Write a checked import into the workspace, once a person approves.",
+	Purpose: "Write a checked import into the workspace. The dry run is the check; by default " +
+		"this commits when it answers.",
 	Limits:  "Only from awaiting_approval. Undoing one needs the web app.",
 	Instead: "read_import_report first; nobody should approve what they have not read.",
 }

--- a/backend/internal/modules/agents/toolcopy_intents.go
+++ b/backend/internal/modules/agents/toolcopy_intents.go
@@ -149,6 +149,14 @@ var atRiskRelationshipsCopy = toolCopy{
 		"intro_path_to and who_knows take next.",
 }
 
+// The prebuilt reports exist so a common question costs one call. That is only
+// true if a caller reaching for a number finds them BEFORE it finds the
+// ad-hoc query path, and it stopped being true: asked how much of the logged
+// activity was inbound against outbound — which `activities-by-kind` answers
+// outright — a model went to describe_analytics_vocabulary and composed two
+// queries instead. Correct, three times the work, and around the curation.
+// So the boundary is stated here rather than left to be inferred from which
+// tool sounds more general.
 var runReportCopy = toolCopy{
 	Purpose: "Answer a question about totals, counts or breakdowns — pipeline by stage, deals " +
 		"won by owner, activity volume over time — by running one of this workspace's prebuilt " +
@@ -156,7 +164,10 @@ var runReportCopy = toolCopy{
 	Limits: "Only the named reports exist, each with its own filter, grouping and measure names; " +
 		"anything else is refused. It aggregates: how many and how much, never which record.",
 	Instead: "Use search_records or whats_slipping_this_week when the answer wanted is the " +
-		"records themselves rather than a number over them.",
+		"records themselves rather than a number over them. Reach for run_analytics_query " +
+		"only when NO prebuilt report answers the question: a report already carries the " +
+		"filter and the grouping, so it is one call where a query is a vocabulary lookup " +
+		"and a query.",
 	Retain: "Call a report with no plan first to see its default answer, then narrow with the " +
 		"names its catalog entry lists.",
 }

--- a/backend/internal/modules/agents/toolcopy_records.go
+++ b/backend/internal/modules/agents/toolcopy_records.go
@@ -139,7 +139,9 @@ var archiveRecordCopy = toolCopy{
 	Instead: "Use merge_records when a duplicate's history should end up on the record that " +
 		"survives, and disqualify_lead when a lead is going nowhere — a lead's own transition " +
 		"records the reason where archiving would not.",
-	Retain: "A person approves this call before it runs; do not report the record as archived " +
+	Retain: "By default the record is archived when this call answers; where an installation " +
+		"has raised this verb to confirm first, the answer is a staged approval and you must not " +
+		"report the record as archived " +
 		"until the retry that carries their approval has answered.",
 }
 
@@ -152,7 +154,7 @@ var mergeRecordsCopy = toolCopy{
 	Instead: "Use archive_record when the extra record has nothing worth keeping, rather than " +
 		"merging to make it disappear.",
 	Retain: "target_id is the record that survives and source_id the one merged away — read both " +
-		"records before choosing, because a person approves the call as you described it.",
+		"records before choosing: the fold cannot be called back, and by default nothing holds it.",
 }
 
 var advanceDealCopy = toolCopy{
@@ -201,8 +203,10 @@ var promoteLeadCopy = toolCopy{
 		"promotion, and there is no trigger for it.",
 	Instead: "Use qualify_lead when the lead is merely incomplete rather than ready, and " +
 		"disqualify_lead when the engagement says the opposite.",
-	Retain: "A person approves this call before it runs; the promoted person's id comes back only " +
-		"from the retry that carries their approval.",
+	Retain: "By default the lead is promoted when this call answers and the promoted person's " +
+		"id comes back with it. Where an installation has raised this verb to confirm first, the " +
+		"answer is a staged approval instead and the id arrives only from the retry that " +
+		"carries it.",
 }
 
 var disqualifyLeadCopy = toolCopy{
@@ -211,7 +215,8 @@ var disqualifyLeadCopy = toolCopy{
 		"a deletion and not an archive.",
 	Instead: "Use promote_lead when engagement says the opposite, and qualify_lead when the lead " +
 		"is only missing information.",
-	Retain: "A person approves this call before it runs; do not report the lead as disqualified " +
+	Retain: "By default the lead is disqualified when this call answers; where an installation " +
+		"has raised this verb to confirm first, do not report the lead as disqualified " +
 		"until the retry carrying their approval has answered.",
 }
 
@@ -236,8 +241,10 @@ var advanceProjectPhaseCopy = toolCopy{
 		"the phase history either way.",
 	Instead: "Use advance_deal for a deal's pipeline stages; a project's phases are a different " +
 		"vocabulary on a different record.",
-	Retain: "Send if_version with the version you read; a person approves the move before it " +
-		"runs.",
+	Retain: "Send if_version with the version you read. By default the phase moves when this " +
+		"call answers. Where an installation has raised this verb to confirm first, the answer " +
+		"is a staged approval and the phase has NOT moved — keep its id and do not report the " +
+		"project as advanced until the retry that carries the approval has answered.",
 }
 
 var listPipelinesCopy = toolCopy{

--- a/backend/internal/modules/agents/tools_colleagues.go
+++ b/backend/internal/modules/agents/tools_colleagues.go
@@ -23,6 +23,7 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -83,5 +84,58 @@ func (t listColleagues) Handle(ctx context.Context, in json.RawMessage) (json.Ra
 	if colleagues == nil {
 		colleagues = []Colleague{}
 	}
-	return json.Marshal(ListColleaguesResult{Colleagues: colleagues, Truncated: truncated})
+	out := ListColleaguesResult{Colleagues: colleagues, Truncated: truncated}
+	if len(colleagues) == 0 && strings.TrimSpace(args.Q) != "" {
+		// TrimSpace because the roster read trims before deciding whether a
+		// narrowing was asked for at all; two spellings of "the caller narrowed"
+		// would disagree on `q` of "   ".
+		attachEveryColleague(ctx, t.list, &out)
+	}
+	return json.Marshal(out)
+}
+
+// CodeRosterUnreadable says the fallback roster could not be read, so an absent
+// `all_colleagues` is unknown rather than empty.
+const CodeRosterUnreadable = "colleague_roster_unreadable"
+
+// CodeNameMatchedNoColleague says the narrowing matched nobody and names what
+// the answer carries instead.
+const CodeNameMatchedNoColleague = "name_matched_no_colleague"
+
+// attachEveryColleague hands over the set the narrowing was matched against,
+// and says in the envelope what happened — the channel a degraded answer uses
+// here already (CodeSemanticRankingDegraded, CodeDuplicateCheckFailed), which
+// costs nothing until the miss and keeps the standing tool copy short.
+//
+// It returns nothing and cannot fail the call, for the reason reportDuplicates
+// gives: the question that was asked has already been answered correctly, and
+// throwing that away because a courtesy read failed hands the caller a tool
+// failure where it had a true answer.
+func attachEveryColleague(ctx context.Context, list ColleagueLister, out *ListColleaguesResult) {
+	everyone, truncated, err := list(ctx, "")
+	if err != nil {
+		noteWarning(ctx, CodeRosterUnreadable,
+			"Nobody here is spelled that way. The rest of the roster could not be read to show "+
+				"you who is, so treat this as unknown rather than as an empty workspace.")
+		return
+	}
+	if everyone == nil {
+		everyone = []Colleague{}
+	}
+	out.AllColleagues, out.AllColleaguesTruncated = &everyone, truncated
+	if len(everyone) == 0 {
+		noteWarning(ctx, CodeNameMatchedNoColleague,
+			"This workspace has no colleagues who can receive work.")
+		return
+	}
+	if truncated {
+		noteWarning(ctx, CodeNameMatchedNoColleague,
+			"Nobody here is spelled that way. `all_colleagues` is a CAPPED page of the roster, "+
+				"not all of it, so do not conclude from it that the person has no seat — narrow "+
+				"differently, on a surname or an email fragment.")
+		return
+	}
+	noteWarning(ctx, CodeNameMatchedNoColleague,
+		"Nobody here is spelled that way. `all_colleagues` is everyone who can receive work; "+
+			"pick from it, or tell the user the person has no seat.")
 }

--- a/backend/internal/modules/agents/tools_colleagues_test.go
+++ b/backend/internal/modules/agents/tools_colleagues_test.go
@@ -6,6 +6,9 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -43,9 +46,9 @@ func TestListColleaguesAnswersSeatsWithWhatAssignmentNeeds(t *testing.T) {
 	}
 }
 
-// A filter matching nobody is an answer, not an error, and it serializes as an
-// empty list rather than null — a caller iterating the result must not have to
-// guard for both.
+// A filter matching nobody is an answer, not an error, and every list in it
+// serializes as an empty array rather than null — a caller iterating the result
+// must not have to guard for both.
 func TestListColleaguesAnswersAnEmptyRosterAsAList(t *testing.T) {
 	out, err := listColleagues{list: func(context.Context, string) ([]Colleague, bool, error) {
 		return nil, false, nil
@@ -53,8 +56,11 @@ func TestListColleaguesAnswersAnEmptyRosterAsAList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("answered %v, want an empty roster", err)
 	}
-	if got := string(out); got != `{"colleagues":[]}` {
-		t.Errorf("empty roster serialized as %s, want an empty array", got)
+	// `all_colleagues` rides along because a narrowing that matched nobody is
+	// answered with the set it was matched against, and here that set is empty
+	// too — which the wire says as `[]` rather than by leaving the field out.
+	if got := string(out); got != `{"colleagues":[],"all_colleagues":[]}` {
+		t.Errorf("empty roster serialized as %s, want empty arrays", got)
 	}
 }
 
@@ -73,5 +79,247 @@ func TestListColleaguesSaysWhenTheRosterIsLongerThanTheAnswer(t *testing.T) {
 	}
 	if !got.Truncated {
 		t.Error("a capped roster did not report truncated")
+	}
+}
+
+// An empty list answers two different questions identically: this workspace
+// employs nobody, and nobody here is spelled the way you asked. A caller cannot
+// tell them apart, and the one it picks is the wrong one — asked to hand an
+// account to a colleague, an assistant read the empty list and reported that
+// the person does not work here, with the seat sitting in the roster under a
+// spelling it had not tried.
+func TestAColleagueMissHandsOverTheRosterItWasMatchedAgainst(t *testing.T) {
+	t.Parallel()
+	lena, tom := ids.NewV7(), ids.NewV7()
+	asked := []string{}
+	out, err := listColleagues{list: func(_ context.Context, q string) ([]Colleague, bool, error) {
+		asked = append(asked, q)
+		if q != "" {
+			return nil, false, nil
+		}
+		return []Colleague{
+			{UserID: lena, DisplayName: "Lena Fischer", Email: "lena.fischer@demo.test"},
+			{UserID: tom, DisplayName: "Tom Brand", Email: "tom@demo.test"},
+		}, false, nil
+	}}.Handle(context.Background(), json.RawMessage(`{"q":"Fischer, Lena"}`))
+	if err != nil {
+		t.Fatalf("answered %v, want a roster", err)
+	}
+
+	var got ListColleaguesResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(got.Colleagues) != 0 {
+		t.Errorf("the narrowed answer is not empty (%+v) — it must stay the honest answer to "+
+			"what was asked", got.Colleagues)
+	}
+	if got.AllColleagues == nil || len(*got.AllColleagues) != 2 {
+		t.Fatalf("the miss handed over %d seats, want the 2 it was matched against — a caller "+
+			"told only \"no match\" reports that the person does not work here", len(*got.AllColleagues))
+	}
+	if (*got.AllColleagues)[0].UserID != lena {
+		t.Errorf("the roster is not the seats the lister answered: %+v", *got.AllColleagues)
+	}
+	if want := []string{"Fischer, Lena", ""}; !slices.Equal(asked, want) {
+		t.Errorf("the lister was asked %v, want %v — the roster read happens ONLY on the miss", asked, want)
+	}
+}
+
+// And not on a hit: a narrowing that found somebody has no second question to
+// answer, and reading the whole roster to attach it would cost every successful
+// call an extra query.
+func TestAColleagueHitDoesNotAlsoReadTheWholeRoster(t *testing.T) {
+	t.Parallel()
+	reads := 0
+	out, err := listColleagues{list: func(_ context.Context, q string) ([]Colleague, bool, error) {
+		reads++
+		return []Colleague{{UserID: ids.NewV7(), DisplayName: "Lena Fischer"}}, false, nil
+	}}.Handle(context.Background(), json.RawMessage(`{"q":"Lena"}`))
+	if err != nil {
+		t.Fatalf("answered %v, want a roster", err)
+	}
+	if reads != 1 {
+		t.Errorf("the lister was read %d times for a query that matched, want 1", reads)
+	}
+	var got ListColleaguesResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if got.AllColleagues != nil {
+		t.Errorf("a matching query also carried the whole roster: %+v", got.AllColleagues)
+	}
+}
+
+// A roster read with no `q` has nothing to fall back to, and must not recurse
+// into itself looking for one.
+func TestAnEmptyWorkspaceAnswersEmptyWithoutAskingTwice(t *testing.T) {
+	t.Parallel()
+	reads := 0
+	out, err := listColleagues{list: func(context.Context, string) ([]Colleague, bool, error) {
+		reads++
+		return nil, false, nil
+	}}.Handle(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("answered %v, want an empty roster", err)
+	}
+	if reads != 1 {
+		t.Errorf("an unnarrowed empty roster was read %d times, want 1", reads)
+	}
+	if got := string(out); got != `{"colleagues":[]}` {
+		t.Errorf("an empty workspace answered %s", got)
+	}
+}
+
+// colleagueMiss drives one narrowing that finds nobody, with an envelope around
+// it so the warnings the miss raises are readable.
+func colleagueMiss(t *testing.T, q string, list ColleagueLister) (ListColleaguesResult, *envelopeFacts) {
+	t.Helper()
+	ctx, facts := withEnvelopeFacts(context.Background())
+	out, err := listColleagues{list: list}.Handle(ctx, json.RawMessage(`{"q":"`+q+`"}`))
+	if err != nil {
+		t.Fatalf("answered %v, want an answer", err)
+	}
+	var got ListColleaguesResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	return got, facts
+}
+
+func warnedWith(facts *envelopeFacts, code string) (Warning, bool) {
+	for _, w := range facts.warnings {
+		if w.Code == code {
+			return w, true
+		}
+	}
+	return Warning{}, false
+}
+
+// A CAPPED fallback is the case this whole affordance can get wrong. Two
+// hundred alphabetical names with the one asked for absent reads as proof the
+// person has no seat — a caller MORE certain of the wrong answer than a bare
+// empty list left it. So the cap rides its own flag, and the warning says do
+// not conclude absence from it.
+func TestACappedFallbackSaysItIsAPageAndNotTheWorkforce(t *testing.T) {
+	t.Parallel()
+	got, facts := colleagueMiss(t, "Fischer", func(_ context.Context, q string) ([]Colleague, bool, error) {
+		if q != "" {
+			return nil, false, nil
+		}
+		return []Colleague{{UserID: ids.NewV7(), DisplayName: "Aaron Adler"}}, true, nil
+	})
+
+	if got.Truncated {
+		t.Error("the query's own flag says the NARROWING has more matches — it matched nothing")
+	}
+	if !got.AllColleaguesTruncated {
+		t.Error("a capped fallback does not say it is capped, so a caller reads a page as the workforce")
+	}
+	warning, ok := warnedWith(facts, CodeNameMatchedNoColleague)
+	if !ok {
+		t.Fatalf("the miss raised no warning: %+v", facts.warnings)
+	}
+	if !strings.Contains(warning.Message, "CAPPED") {
+		t.Errorf("the warning does not say the list is a page:\n%s", warning.Message)
+	}
+}
+
+// The question that was asked has already been answered correctly by the time
+// the fallback runs. A courtesy read that fails must not turn that into a tool
+// failure — the shape reportDuplicates settled for the same situation — and an
+// absent fallback must read as unknown rather than as an empty workspace.
+func TestAnUnreadableFallbackDoesNotDestroyTheAnswerItWasAddedTo(t *testing.T) {
+	t.Parallel()
+	got, facts := colleagueMiss(t, "Fischer", func(_ context.Context, q string) ([]Colleague, bool, error) {
+		if q != "" {
+			return nil, false, nil
+		}
+		return nil, false, errors.New("the roster read failed")
+	})
+
+	if got.AllColleagues != nil {
+		t.Errorf("a failed fallback still attached a list: %+v", *got.AllColleagues)
+	}
+	warning, ok := warnedWith(facts, CodeRosterUnreadable)
+	if !ok {
+		t.Fatalf("a failed fallback is silent, so an absent list reads as an empty workspace: %+v",
+			facts.warnings)
+	}
+	if !strings.Contains(warning.Message, "unknown") {
+		t.Errorf("the warning does not say the answer is unknown:\n%s", warning.Message)
+	}
+}
+
+// A workspace that really employs nobody says THAT, rather than leaving the
+// caller to read an absent list.
+func TestAWorkspaceWithNoSeatsSaysSoRatherThanGoingQuiet(t *testing.T) {
+	t.Parallel()
+	_, facts := colleagueMiss(t, "Fischer", func(context.Context, string) ([]Colleague, bool, error) {
+		return nil, false, nil
+	})
+	warning, ok := warnedWith(facts, CodeNameMatchedNoColleague)
+	if !ok {
+		t.Fatalf("an empty workspace raised no warning: %+v", facts.warnings)
+	}
+	if !strings.Contains(warning.Message, "no colleagues") {
+		t.Errorf("the warning does not say the workspace has nobody:\n%s", warning.Message)
+	}
+}
+
+// Whitespace is not a narrowing. The roster read trims before deciding, so a
+// handler that did not would call it twice for a `q` the service treats as
+// absent — one invariant with two definitions across a seam.
+func TestWhitespaceIsNotANarrowingOnEitherSideOfTheSeam(t *testing.T) {
+	t.Parallel()
+	reads := 0
+	ctx, _ := withEnvelopeFacts(context.Background())
+	if _, err := (listColleagues{list: func(context.Context, string) ([]Colleague, bool, error) {
+		reads++
+		return nil, false, nil
+	}}).Handle(ctx, json.RawMessage(`{"q":"   "}`)); err != nil {
+		t.Fatalf("answered %v", err)
+	}
+	if reads != 1 {
+		t.Errorf("a whitespace `q` was read %d times, want 1 — the handler and the roster read "+
+			"disagree about what counts as narrowing", reads)
+	}
+}
+
+// The two fallback outcomes must differ in the BYTES, not only in a warning.
+//
+// A workspace that employs nobody and a roster that could not be read are
+// different answers, and a caller acting on `data` alone saw the same thing
+// from both — the omitted field. That is the defect this whole field exists to
+// remove, one level up.
+func TestAnEmptyFallbackAndAnUnreadableOneAreDifferentOnTheWire(t *testing.T) {
+	t.Parallel()
+	ctx, _ := withEnvelopeFacts(context.Background())
+
+	empty, err := listColleagues{list: func(context.Context, string) ([]Colleague, bool, error) {
+		return nil, false, nil
+	}}.Handle(ctx, json.RawMessage(`{"q":"Fischer"}`))
+	if err != nil {
+		t.Fatalf("answered %v", err)
+	}
+	if !strings.Contains(string(empty), `"all_colleagues":[]`) {
+		t.Errorf("a workspace that employs nobody does not say so in the data:\n%s", empty)
+	}
+
+	unreadable, err := listColleagues{list: func(_ context.Context, q string) ([]Colleague, bool, error) {
+		if q == "" {
+			return nil, false, errors.New("the roster read failed")
+		}
+		return nil, false, nil
+	}}.Handle(ctx, json.RawMessage(`{"q":"Fischer"}`))
+	if err != nil {
+		t.Fatalf("answered %v", err)
+	}
+	if strings.Contains(string(unreadable), "all_colleagues") {
+		t.Errorf("an unreadable roster claims a list it never read:\n%s", unreadable)
+	}
+	if string(empty) == string(unreadable) {
+		t.Errorf("both fallback outcomes serialize identically, so a caller reading the data "+
+			"cannot tell an empty workspace from one it could not see:\n%s", empty)
 	}
 }

--- a/backend/internal/modules/agents/tools_forecast.go
+++ b/backend/internal/modules/agents/tools_forecast.go
@@ -51,16 +51,7 @@ type forecastReadings struct {
 func (t forecastReadings) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "forecast_readings", Title: "Read the forecast", Version: toolVersionV1,
-		Description: "What a period is expected to close, in four readings. " +
-			"`won` counts deals by the day they ACTUALLY closed, not the day they were " +
-			"expected to. `evidence` is committed pipeline whose close date somebody " +
-			"confirmed; a provisional date stays in `open` and out of `evidence`. " +
-			"`coverage_note` says what the totals do not cover, and it is absent only when " +
-			"they cover every eligible deal — so quoting a total without it reports a " +
-			"partial pipeline as a complete one. `eligible_count`, `priced_count` and " +
-			"`fx_missing_count` are the counts it is written from. " +
-			"Quote `as_of`, `timezone` and `base_currency` with the number: a total placed " +
-			"in the reader's own zone is a different total.",
+		Description:   forecastReadingsCopy.render(),
 		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
 		OpenAPIOp: "getForecast",
 		InputSchema: schema(`{"type":"object","properties":{
@@ -151,20 +142,7 @@ type forecastMovement struct {
 func (t forecastMovement) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "forecast_movement", Title: "What moved the forecast", Version: toolVersionV1,
-		Description: "The difference between two forecast snapshots, classified into named " +
-			"causes. Opening plus every bucket equals closing, exactly — so the buckets " +
-			"are a complete account of the change and not a selection from it. " +
-			"A deal appears in exactly ONE bucket: one that both slipped and was repriced " +
-			"has moved for one reason as far as a reader is concerned, which is that it " +
-			"left. " +
-			"Two buckets are about the machinery rather than the business, and quoting " +
-			"them as sales movement is the mistake this classification exists to prevent. " +
-			"`definition` means the two snapshots were computed under different rules, and " +
-			"then the WHOLE difference is in that bucket. `model` means a probability the " +
-			"product re-scored. " +
-			"`reopened_or_archived` carries a deal that left the population entirely — " +
-			"archived, or no longer visible to this caller — with its whole prior " +
-			"contribution, so no money disappears without a row that says where it went.",
+		Description:   forecastMovementCopy.render(),
 		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
 		OpenAPIOp: "getForecastMovement",
 		InputSchema: schema(`{"type":"object","required":["from","to"],"properties":{
@@ -229,20 +207,8 @@ type forecastInputChecks struct {
 func (t forecastInputChecks) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "forecast_input_checks", Title: "What the forecast's inputs were checked against",
-		Version: toolVersionV1,
-		Description: "What last night's input check found, and how much of the pipeline it " +
-			"reached. A forecast is only as good as its inputs, and the failures are " +
-			"mundane: a close date that went by, an amount that disagrees with the offer " +
-			"that was sent, a deal nobody has heard from in ninety days. " +
-			"Read `readiness` before quoting any forecast figure. `checks_incomplete` is " +
-			"NOT a worse `needs_review` — one says the pipeline has problems, the other " +
-			"says we could not look, and reporting the first when the second is true tells " +
-			"somebody their pipeline is sound when nobody read the mailbox. " +
-			"`sources` says why: each carries the state the run reached, and only a " +
-			"`checked` source has a date. An absent or unread source means the run could " +
-			"not confirm anything from it, which is different from finding nothing there. " +
-			"`eligible_deals` is how much there was to check — compared against an earlier " +
-			"run it shows a pass that covered less of the pipeline.",
+		Version:       toolVersionV1,
+		Description:   forecastInputChecksCopy.render(),
 		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
 		OpenAPIOp:    "getForecastAssurance",
 		InputSchema:  schema(`{"type":"object","properties":{},"additionalProperties":false}`),
@@ -299,15 +265,8 @@ type listInputChecks struct {
 func (t listInputChecks) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "list_input_checks", Title: "What the forecast's inputs still need",
-		Version: toolVersionV1,
-		Description: "The open findings from the nightly input check, most material first. " +
-			"Read them before quoting a forecast figure: a close date that went by, or an " +
-			"amount that disagrees with the offer that was sent, makes a total wrong " +
-			"without making the arithmetic wrong. " +
-			"Scoped to what this caller can open, with no count of what was withheld — a " +
-			"count of what somebody may not read is itself a statement about how much " +
-			"there is. `affected_minor` absent means the money at stake cannot be said, " +
-			"not that nothing is at stake.",
+		Version:       toolVersionV1,
+		Description:   listInputChecksCopy.render(),
 		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
 		OpenAPIOp:    "listInputChecks",
 		InputSchema:  schema(`{"type":"object","properties":{},"additionalProperties":false}`),
@@ -366,12 +325,7 @@ type dataCoverage struct {
 func (t dataCoverage) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "data_coverage", Title: "How current the sources are", Version: toolVersionV1,
-		Description: "Which connectors the nightly check could read, and how far back each " +
-			"reaches. Needs the data_coverage grant, which operators hold and sellers do " +
-			"not — a refusal here is a seat boundary, not a missing run. " +
-			"Only a `checked` source carries a date. On any other state nothing was read, " +
-			"and a quiet week is indistinguishable from a broken connector until somebody " +
-			"looks.",
+		Description:   dataCoverageCopy.render(),
 		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
 		OpenAPIOp:    "getDataCoverage",
 		InputSchema:  schema(`{"type":"object","properties":{},"additionalProperties":false}`),

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,9 +6,9 @@
   "catalog": {
     "tools": 75,
     "system_frame_tokens": 353,
-    "tokens": 22639,
-    "median_tool_tokens": 266,
-    "mean_tool_tokens": 301
+    "tokens": 23542,
+    "median_tool_tokens": 267,
+    "mean_tool_tokens": 313
   },
   "agents": [
     {
@@ -72,11 +72,15 @@
   "tool_cost": [
     {
       "name": "run_report",
-      "tokens": 939
+      "tokens": 990
     },
     {
       "name": "send_account_email",
-      "tokens": 742
+      "tokens": 768
+    },
+    {
+      "name": "send_email",
+      "tokens": 698
     },
     {
       "name": "log_activity",
@@ -87,16 +91,16 @@
       "tokens": 677
     },
     {
-      "name": "send_email",
-      "tokens": 675
-    },
-    {
       "name": "update_record",
       "tokens": 572
     },
     {
       "name": "send_message",
-      "tokens": 518
+      "tokens": 546
+    },
+    {
+      "name": "forecast_readings",
+      "tokens": 509
     },
     {
       "name": "list_records",
@@ -123,8 +127,20 @@
       "tokens": 473
     },
     {
+      "name": "forecast_movement",
+      "tokens": 453
+    },
+    {
       "name": "advance_deal",
       "tokens": 447
+    },
+    {
+      "name": "compose_analytics_report",
+      "tokens": 440
+    },
+    {
+      "name": "book_meeting",
+      "tokens": 424
     },
     {
       "name": "annotate_brief",
@@ -135,28 +151,12 @@
       "tokens": 401
     },
     {
-      "name": "book_meeting",
-      "tokens": 393
-    },
-    {
       "name": "enrich",
-      "tokens": 393
-    },
-    {
-      "name": "compose_analytics_report",
-      "tokens": 390
+      "tokens": 398
     },
     {
       "name": "search_records",
       "tokens": 385
-    },
-    {
-      "name": "forecast_readings",
-      "tokens": 357
-    },
-    {
-      "name": "forecast_movement",
-      "tokens": 351
     },
     {
       "name": "describe_report_vocabulary",
@@ -167,16 +167,32 @@
       "tokens": 345
     },
     {
+      "name": "advance_project_phase",
+      "tokens": 340
+    },
+    {
       "name": "prep_for_meeting",
       "tokens": 326
+    },
+    {
+      "name": "forecast_input_checks",
+      "tokens": 324
     },
     {
       "name": "demote_lead",
       "tokens": 316
     },
     {
+      "name": "promote_lead",
+      "tokens": 303
+    },
+    {
       "name": "merge_records",
-      "tokens": 292
+      "tokens": 294
+    },
+    {
+      "name": "archive_record",
+      "tokens": 290
     },
     {
       "name": "describe_analytics_vocabulary",
@@ -185,10 +201,6 @@
     {
       "name": "catch_me_up_on",
       "tokens": 280
-    },
-    {
-      "name": "advance_project_phase",
-      "tokens": 279
     },
     {
       "name": "draft_email",
@@ -207,10 +219,6 @@
       "tokens": 272
     },
     {
-      "name": "promote_lead",
-      "tokens": 270
-    },
-    {
       "name": "list_approvals",
       "tokens": 267
     },
@@ -225,14 +233,6 @@
     {
       "name": "check_availability",
       "tokens": 263
-    },
-    {
-      "name": "archive_record",
-      "tokens": 261
-    },
-    {
-      "name": "forecast_input_checks",
-      "tokens": 252
     },
     {
       "name": "account_coverage",
@@ -267,6 +267,14 @@
       "tokens": 211
     },
     {
+      "name": "disqualify_lead",
+      "tokens": 209
+    },
+    {
+      "name": "list_input_checks",
+      "tokens": 209
+    },
+    {
       "name": "at_risk_relationships",
       "tokens": 208
     },
@@ -291,16 +299,20 @@
       "tokens": 197
     },
     {
+      "name": "data_coverage",
+      "tokens": 195
+    },
+    {
+      "name": "list_colleagues",
+      "tokens": 195
+    },
+    {
       "name": "who_knows",
       "tokens": 194
     },
     {
       "name": "list_pipelines",
       "tokens": 191
-    },
-    {
-      "name": "disqualify_lead",
-      "tokens": 190
     },
     {
       "name": "intro_path_to",
@@ -331,28 +343,16 @@
       "tokens": 153
     },
     {
-      "name": "list_input_checks",
-      "tokens": 146
-    },
-    {
       "name": "get_record_tags",
       "tokens": 142
     },
     {
-      "name": "list_colleagues",
-      "tokens": 141
+      "name": "commit_import",
+      "tokens": 128
     },
     {
       "name": "whoami",
       "tokens": 128
-    },
-    {
-      "name": "commit_import",
-      "tokens": 118
-    },
-    {
-      "name": "data_coverage",
-      "tokens": 109
     },
     {
       "name": "list_tags",
@@ -364,7 +364,7 @@
     },
     {
       "name": "read_import_report",
-      "tokens": 73
+      "tokens": 77
     },
     {
       "name": "read_import_run",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1634 | 4% | 21576 | 6 | 6 |
 | `overnight_at_risk_sweep` | 7 | 2509 | 7% | 20701 | 15 | 10 |
-| _whole served catalog, for scale_ | 75 | 22639 | 69% | — | — | — |
+| _whole served catalog, for scale_ | 75 | 23542 | 71% | — | — | — |
 
 ### `morning_brief`
 
@@ -126,7 +126,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 266 tokens, mean 301, across 75 served tools.
+Median 267 tokens, mean 313, across 75 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -135,47 +135,47 @@ a term in an addition.
 
 | Tool | Tokens | Named as the wrong reach in |
 |---|---:|---:|
-| `run_report` | 939 | 3 scenarios |
-| `send_account_email` | 742 | — |
+| `run_report` | 990 | 3 scenarios |
+| `send_account_email` | 768 | — |
+| `send_email` | 698 | 1 scenario |
 | `log_activity` | 677 | 1 scenario |
 | `preview_import` | 677 | — |
-| `send_email` | 675 | 1 scenario |
 | `update_record` | 572 | 4 scenarios |
-| `send_message` | 518 | — |
+| `send_message` | 546 | — |
+| `forecast_readings` | 509 | — |
 | `list_records` | 508 | — |
 | `progress_deal` | 505 | 3 scenarios |
 | `resolve_entities` | 498 | — |
 | `query_workspace` | 484 | 3 scenarios |
 | `run_analytics_query` | 476 | — |
 | `create_record` | 473 | 1 scenario |
+| `forecast_movement` | 453 | — |
 | `advance_deal` | 447 | 1 scenario |
+| `compose_analytics_report` | 440 | — |
+| `book_meeting` | 424 | — |
 | `annotate_brief` | 418 | — |
 | `review_commitments` | 401 | 1 scenario |
-| `book_meeting` | 393 | — |
-| `enrich` | 393 | — |
-| `compose_analytics_report` | 390 | — |
+| `enrich` | 398 | — |
 | `search_records` | 385 | 9 scenarios |
-| `forecast_readings` | 357 | — |
-| `forecast_movement` | 351 | — |
 | `describe_report_vocabulary` | 349 | — |
 | `search_context` | 345 | — |
+| `advance_project_phase` | 340 | — |
 | `prep_for_meeting` | 326 | — |
+| `forecast_input_checks` | 324 | — |
 | `demote_lead` | 316 | — |
-| `merge_records` | 292 | — |
+| `promote_lead` | 303 | — |
+| `merge_records` | 294 | — |
+| `archive_record` | 290 | — |
 | `describe_analytics_vocabulary` | 286 | — |
 | `catch_me_up_on` | 280 | 3 scenarios |
-| `advance_project_phase` | 279 | — |
 | `draft_email` | 279 | — |
 | `relink_activity` | 277 | — |
 | `draft_follow_ups_for` | 273 | — |
 | `decide_approval` | 272 | — |
-| `promote_lead` | 270 | — |
 | `list_approvals` | 267 | — |
 | `prepare_handoff` | 267 | 1 scenario |
 | `describe_query_vocabulary` | 266 | — |
 | `check_availability` | 263 | — |
-| `archive_record` | 261 | — |
-| `forecast_input_checks` | 252 | — |
 | `account_coverage` | 245 | 2 scenarios |
 | `describe_report_blocks` | 245 | — |
 | `decide_approval_bundle` | 235 | — |
@@ -184,15 +184,18 @@ a term in an addition.
 | `create_task` | 222 | — |
 | `read_record` | 222 | 3 scenarios |
 | `whats_slipping_this_week` | 211 | 2 scenarios |
+| `disqualify_lead` | 209 | — |
+| `list_input_checks` | 209 | — |
 | `at_risk_relationships` | 208 | — |
 | `read_brief` | 206 | — |
 | `relink_activities` | 206 | — |
 | `update_tag` | 205 | — |
 | `merge_tags` | 198 | — |
 | `relink_thread` | 197 | — |
+| `data_coverage` | 195 | — |
+| `list_colleagues` | 195 | — |
 | `who_knows` | 194 | — |
 | `list_pipelines` | 191 | — |
-| `disqualify_lead` | 190 | — |
 | `intro_path_to` | 190 | 2 scenarios |
 | `create_tag` | 183 | — |
 | `list_channel_providers` | 174 | — |
@@ -200,15 +203,12 @@ a term in an addition.
 | `check_location_support` | 156 | — |
 | `read_project_360` | 156 | — |
 | `read_approval` | 153 | — |
-| `list_input_checks` | 146 | — |
 | `get_record_tags` | 142 | — |
-| `list_colleagues` | 141 | — |
+| `commit_import` | 128 | — |
 | `whoami` | 128 | — |
-| `commit_import` | 118 | — |
-| `data_coverage` | 109 | — |
 | `list_tags` | 95 | — |
 | `get_tag` | 86 | — |
-| `read_import_report` | 73 | — |
+| `read_import_report` | 77 | — |
 | `read_import_run` | 67 | — |
 
 ## Related

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 75,
     "resources": 12,
-    "tool_catalog_bytes": 215535,
+    "tool_catalog_bytes": 219500,
     "resource_catalog_bytes": 4584,
-    "approx_wire_tokens_total": 55029,
+    "approx_wire_tokens_total": 56021,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 53073,
+      "description_bytes": 56685,
       "input_schema_bytes": 45533,
-      "output_schema_bytes": 100738,
-      "description_plus_input_schema_bytes": 98606
+      "output_schema_bytes": 101091,
+      "description_plus_input_schema_bytes": 102218
     }
   },
   "tools": {
@@ -442,7 +442,7 @@
           "readOnlyHint": false,
           "title": "Move a project to a phase"
         },
-        "description": "Move a project to another phase — initiative, pursuing, delivering, closed. The four names are fixed but the order is not enforced: a project may go back a phase, and a closed one may be reopened. Closing requires a reason, which is recorded on the phase history either way. Use advance_deal for a deal's pipeline stages; a project's phases are a different vocabulary on a different record. Send if_version with the version you read; a person approves the move before it runs. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Move a project to another phase — initiative, pursuing, delivering, closed. The four names are fixed but the order is not enforced: a project may go back a phase, and a closed one may be reopened. Closing requires a reason, which is recorded on the phase history either way. Use advance_deal for a deal's pipeline stages; a project's phases are a different vocabulary on a different record. Send if_version with the version you read. By default the phase moves when this call answers. Where an installation has raised this verb to confirm first, the answer is a staged approval and the phase has NOT moved — keep its id and do not report the project as advanced until the retry that carries the approval has answered. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -890,7 +890,7 @@
           "readOnlyHint": false,
           "title": "Archive a record"
         },
-        "description": "Retire a record that should no longer be worked — a duplicate, a dead account, a project that ended. Archiving hides the record from day-to-day work; it does not delete it and does not move anything attached to it, so an archived duplicate still holds the activities and deals that were logged against it. Use merge_records when a duplicate's history should end up on the record that survives, and disqualify_lead when a lead is going nowhere — a lead's own transition records the reason where archiving would not. A person approves this call before it runs; do not report the record as archived until the retry that carries their approval has answered. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Retire a record that should no longer be worked — a duplicate, a dead account, a project that ended. Archiving hides the record from day-to-day work; it does not delete it and does not move anything attached to it, so an archived duplicate still holds the activities and deals that were logged against it. Use merge_records when a duplicate's history should end up on the record that survives, and disqualify_lead when a lead is going nowhere — a lead's own transition records the reason where archiving would not. By default the record is archived when this call answers; where an installation has raised this verb to confirm first, the answer is a staged approval and you must not report the record as archived until the retry that carries their approval has answered. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -1224,7 +1224,7 @@
           "readOnlyHint": false,
           "title": "Book a meeting"
         },
-        "description": "Hold a slot in the host's calendar and record the meeting against the records it is about. Needs at least one link saying what it is about. The slot is taken and the meeting is a real commitment, so a person approves it first. No attendee list: who is invited is the calendar connection's business. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: runs immediately; requires passport scope \"send\".)",
+        "description": "Hold a slot in the host's calendar and record the meeting against the records it is about. Needs at least one link saying what it is about. The slot is taken and the meeting is a real commitment, and by default it is taken when this call answers — where an installation has raised this verb to confirm first, the answer is a staged approval instead. No attendee list: who is invited is the calendar connection's business. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: runs immediately; requires passport scope \"send\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -1877,7 +1877,7 @@
           "readOnlyHint": false,
           "title": "Commit an import"
         },
-        "description": "Write a checked import into the workspace, once a person approves. Only from awaiting_approval. Undoing one needs the web app. read_import_report first; nobody should approve what they have not read. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Write a checked import into the workspace. The dry run is the check; by default this commits when it answers. Only from awaiting_approval. Undoing one needs the web app. read_import_report first; nobody should approve what they have not read. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -2016,7 +2016,7 @@
           "readOnlyHint": true,
           "title": "Compose an analytics report"
         },
-        "description": "Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "WRITE a DOCUMENT somebody keeps and reads — a board-pack section, a summary for a meeting — whose every number comes from a saved analytics run instead of being typed. Not for answering with a figure: a number in the reply is run_analytics_query's or run_report's. The document carries the STRUCTURE and the WORDS; each figure names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -2687,7 +2687,7 @@
           "readOnlyHint": true,
           "title": "How current the sources are"
         },
-        "description": "Which connectors the nightly check could read, and how far back each reaches. Needs the data_coverage grant, which operators hold and sellers do not — a refusal here is a seat boundary, not a missing run. Only a `checked` source carries a date. On any other state nothing was read, and a quiet week is indistinguishable from a broken connector until somebody looks. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer how much of what is going on this workspace can actually SEE — which connectors the nightly check could read, and how far back each reaches. Needs the data_coverage grant, which operators hold and sellers do not — a refusal here is a seat boundary, not a missing run. Only a `checked` source carries a date; on any other state nothing was read, and a quiet week is indistinguishable from a broken connector until somebody looks. forecast_input_checks and list_input_checks answer what the check FOUND, and both are silent on whether it could look — a clean set of findings over sources nobody opened reads as good news and is not. Ask this one when the question is whether to trust the other two. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {},
@@ -3792,7 +3792,7 @@
           "readOnlyHint": false,
           "title": "Disqualify a lead"
         },
-        "description": "Close out a lead that is not going anywhere, so it stops appearing as live work. It is the lead's own terminal state and keeps the record and its history; it is not a deletion and not an archive. Use promote_lead when engagement says the opposite, and qualify_lead when the lead is only missing information. A person approves this call before it runs; do not report the lead as disqualified until the retry carrying their approval has answered. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Close out a lead that is not going anywhere, so it stops appearing as live work. It is the lead's own terminal state and keeps the record and its history; it is not a deletion and not an archive. Use promote_lead when engagement says the opposite, and qualify_lead when the lead is only missing information. By default the lead is disqualified when this call answers; where an installation has raised this verb to confirm first, do not report the lead as disqualified until the retry carrying their approval has answered. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -4266,7 +4266,7 @@
           "readOnlyHint": false,
           "title": "Enrich an organization from its website"
         },
-        "description": "Learn about an organization by reading its public website, and propose what was found for a person to accept onto the record. It reaches OUTSIDE the workspace, so a person approves the call before it runs, and what it returns is a proposal — nothing lands on the record until someone accepts it. Reading one page answers immediately; reading a whole site is queued and answers with a read id rather than the content. What it finds is captured text from a third party, not a fact this workspace has verified. Use qualify_lead when the missing values are already derivable from the record itself, which costs no external read and needs no approval. Keep the organization_id you enriched, and the read id when a whole-site read was queued — the result is collected against it later. (Governance: a person approves every call before it runs; requires passport scope \"enrich\".)",
+        "description": "Learn about an organization by reading its public website, and propose what was found for a person to accept onto the record. It reaches OUTSIDE the workspace, and what it returns is a PROPOSAL — nothing lands on the record until someone accepts it, which is the review that guards this, not an approval on the call. Reading one page answers immediately; reading a whole site is queued and answers with a read id rather than the content. What it finds is captured text from a third party, not a fact this workspace has verified. Use qualify_lead when the missing values are already derivable from the record itself, which costs no external read and needs no approval. Keep the organization_id you enriched, and the read id when a whole-site read was queued — the result is collected against it later. (Governance: a person approves every call before it runs; requires passport scope \"enrich\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -4398,7 +4398,7 @@
           "readOnlyHint": true,
           "title": "What the forecast's inputs were checked against"
         },
-        "description": "What last night's input check found, and how much of the pipeline it reached. A forecast is only as good as its inputs, and the failures are mundane: a close date that went by, an amount that disagrees with the offer that was sent, a deal nobody has heard from in ninety days. Read `readiness` before quoting any forecast figure. `checks_incomplete` is NOT a worse `needs_review` — one says the pipeline has problems, the other says we could not look, and reporting the first when the second is true tells somebody their pipeline is sound when nobody read the mailbox. `sources` says why: each carries the state the run reached, and only a `checked` source has a date. An absent or unread source means the run could not confirm anything from it, which is different from finding nothing there. `eligible_deals` is how much there was to check — compared against an earlier run it shows a pass that covered less of the pipeline. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer whether the forecast's inputs are sound enough to quote — a verdict, and how much of the pipeline last night's check reached. A forecast is only as good as its inputs, and the failures are mundane: a close date that went by, an amount that disagrees with the offer that was sent, a deal nobody has heard from in ninety days. `checks_incomplete` is NOT a worse `needs_review` — one says the pipeline has problems, the other says we could not look, and reporting the first when the second is true tells somebody their pipeline is sound when nobody read the mailbox. This is the VERDICT. list_input_checks is the findings themselves, one row per problem, when the question is what to go and fix. data_coverage is the third question and the one this cannot answer: whether the CONNECTORS were readable at all, which is what makes a clean verdict trustworthy rather than merely clean. Read `readiness` before quoting any forecast figure. `sources` says why: each carries the state the run reached, and only a `checked` source has a date — an absent or unread source means the run could not confirm anything from it, which is different from finding nothing there. `eligible_deals` is how much there was to check. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {},
@@ -4544,7 +4544,7 @@
           "readOnlyHint": true,
           "title": "What moved the forecast"
         },
-        "description": "The difference between two forecast snapshots, classified into named causes. Opening plus every bucket equals closing, exactly — so the buckets are a complete account of the change and not a selection from it. A deal appears in exactly ONE bucket: one that both slipped and was repriced has moved for one reason as far as a reader is concerned, which is that it left. Two buckets are about the machinery rather than the business, and quoting them as sales movement is the mistake this classification exists to prevent. `definition` means the two snapshots were computed under different rules, and then the WHOLE difference is in that bucket. `model` means a probability the product re-scored. `reopened_or_archived` carries a deal that left the population entirely — archived, or no longer visible to this caller — with its whole prior contribution, so no money disappears without a row that says where it went. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Explain why a forecast changed between two points, as named causes that account for the whole difference. Opening plus every bucket equals closing, exactly, so the buckets are a complete account of the change and not a selection from it. A deal appears in exactly ONE bucket: one that both slipped and was repriced has moved for one reason as far as a reader is concerned, which is that it left. Two buckets are about the machinery rather than the business, and quoting them as sales movement is the mistake this classification exists to prevent: `definition` means the two snapshots were computed under different rules, and then the WHOLE difference is in that bucket; `model` means a probability the product re-scored. IT NEEDS TWO SNAPSHOT IDS, and nothing on this surface hands one out — no tool lists snapshots and no resource publishes them, so a caller that has not been given ids from elsewhere cannot call this. Reading forecast_readings twice and subtracting is NOT the same answer and must not be reported as one: the difference between two reads is a number with no account of where it went. `reopened_or_archived` carries a deal that left the population entirely — archived, or no longer visible to this caller — with its whole prior contribution, so no money disappears without a row that says where it went. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -4741,7 +4741,7 @@
           "readOnlyHint": true,
           "title": "Read the forecast"
         },
-        "description": "What a period is expected to close, in four readings. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. `coverage_note` says what the totals do not cover, and it is absent only when they cover every eligible deal — so quoting a total without it reports a partial pipeline as a complete one. `eligible_count`, `priced_count` and `fx_missing_count` are the counts it is written from. Quote `as_of`, `timezone` and `base_currency` with the number: a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer what a period is expected to close — `won`, `evidence`, `best_case` and `open`, plus `weighted` — under the installation's own fiscal calendar and base currency. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. `coverage_note` says what the totals do not cover and is absent only when they cover every eligible deal, so quoting a total without it reports a partial pipeline as a complete one. run_report's forecast report and a hand-summed query_workspace also produce a number, and NEITHER is the forecast: only this applies the fiscal calendar, the base currency conversion and the weighting. These figures also cannot be cited in a composed document — for a board-pack section or anything a reader keeps, run_analytics_query with save and compose_analytics_report from the run id. Ask forecast_input_checks whether the inputs behind these numbers were read. Quote `as_of`, `timezone` and `base_currency` with the number — a total placed in the reader's own zone is a different total — and `eligible_count`, `priced_count` and `fx_missing_count` are the counts `coverage_note` is written from. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -5737,7 +5737,7 @@
           "readOnlyHint": true,
           "title": "List colleagues"
         },
-        "description": "List the people who work HERE — colleagues holding a seat, not the contacts stored as person records. Reads only, and lists seats that can actually receive work — archived, suspended and locked-out ones are absent. `truncated` means there are more. search_records/person finds a CUSTOMER contact; this finds a colleague. user_id is what assignee_id and owner_id take. Never assign to an is_agent seat. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "List the people who work HERE — colleagues holding a seat, not the contacts stored as person records. Reads only, and lists seats that can actually receive work — archived, suspended and locked-out ones are absent. `truncated` means there are more. A `q` matching nobody answers with `all_colleagues` and a warning; that list is ABSENT if it could not be read and partial if `all_colleagues_truncated`, so read the warning before concluding a person has no seat. search_records/person finds a CUSTOMER contact; this finds a colleague. user_id is what assignee_id and owner_id take. Never assign to an is_agent seat. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -5753,6 +5753,40 @@
           "properties": {
             "data": {
               "properties": {
+                "all_colleagues": {
+                  "items": {
+                    "properties": {
+                      "display_name": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "is_agent": {
+                        "type": "boolean"
+                      },
+                      "seat_type": {
+                        "type": "string"
+                      },
+                      "user_id": {
+                        "format": "uuid",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "display_name",
+                      "email",
+                      "is_agent",
+                      "seat_type",
+                      "user_id"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "all_colleagues_truncated": {
+                  "type": "boolean"
+                },
                 "colleagues": {
                   "items": {
                     "properties": {
@@ -5879,7 +5913,7 @@
           "readOnlyHint": true,
           "title": "What the forecast's inputs still need"
         },
-        "description": "The open findings from the nightly input check, most material first. Read them before quoting a forecast figure: a close date that went by, or an amount that disagrees with the offer that was sent, makes a total wrong without making the arithmetic wrong. Scoped to what this caller can open, with no count of what was withheld — a count of what somebody may not read is itself a statement about how much there is. `affected_minor` absent means the money at stake cannot be said, not that nothing is at stake. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "List the open input problems behind the forecast, most material first, so they can be fixed. A close date that went by, or an amount that disagrees with the offer that was sent, makes a total wrong without making the arithmetic wrong. Scoped to what this caller can open, with no count of what was withheld — a count of what somebody may not read is itself a statement about how much there is. forecast_input_checks answers the VERDICT — whether the numbers are quotable at all — which is the question before this one and the cheaper call. data_coverage answers whether the sources were readable, which an empty list here cannot distinguish from a clean pipeline. `affected_minor` absent means the money at stake cannot be said, not that nothing is at stake. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {},
@@ -6701,7 +6735,7 @@
           "readOnlyHint": false,
           "title": "Merge two records"
         },
-        "description": "Collapse two records for the same real person or company into one, moving the source's activities, deals and links onto the record that survives. People merge with people and organizations with organizations; the source is archived and redirected to the target, and the direction is not reversible by calling this again the other way round. Use archive_record when the extra record has nothing worth keeping, rather than merging to make it disappear. target_id is the record that survives and source_id the one merged away — read both records before choosing, because a person approves the call as you described it. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Collapse two records for the same real person or company into one, moving the source's activities, deals and links onto the record that survives. People merge with people and organizations with organizations; the source is archived and redirected to the target, and the direction is not reversible by calling this again the other way round. Use archive_record when the extra record has nothing worth keeping, rather than merging to make it disappear. target_id is the record that survives and source_id the one merged away — read both records before choosing: the fold cannot be called back, and by default nothing holds it. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -8511,7 +8545,7 @@
           "readOnlyHint": false,
           "title": "Promote a lead to a person"
         },
-        "description": "Turn a lead who has genuinely engaged into a person record, carrying their history across. It requires a trigger naming the engagement that justifies it — a reply, a booked or held meeting, or a human's decision. Cold outreach that nobody answered is not a promotion, and there is no trigger for it. Use qualify_lead when the lead is merely incomplete rather than ready, and disqualify_lead when the engagement says the opposite. A person approves this call before it runs; the promoted person's id comes back only from the retry that carries their approval. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Turn a lead who has genuinely engaged into a person record, carrying their history across. It requires a trigger naming the engagement that justifies it — a reply, a booked or held meeting, or a human's decision. Cold outreach that nobody answered is not a promotion, and there is no trigger for it. Use qualify_lead when the lead is merely incomplete rather than ready, and disqualify_lead when the engagement says the opposite. By default the lead is promoted when this call answers and the promoted person's id comes back with it. Where an installation has raised this verb to confirm first, the answer is a staged approval instead and the id arrives only from the retry that carries it. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -9501,7 +9535,7 @@
           "readOnlyHint": true,
           "title": "Read an import report"
         },
-        "description": "What an import will do, or did: rows created, updated, failed, unusable, duplicates. These counts are what a person approves. Same shape before and after. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "What an import will do, or did: rows created, updated, failed, unusable, duplicates. These counts are what a person weighs before committing. Same shape before and after. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -11918,7 +11952,7 @@
           "readOnlyHint": true,
           "title": "Run a report"
         },
-        "description": "Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, each with its own filter, grouping and measure names; anything else is refused. It aggregates: how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan first to see its default answer, then narrow with the names its catalog entry lists. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, each with its own filter, grouping and measure names; anything else is refused. It aggregates: how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Reach for run_analytics_query only when NO prebuilt report answers the question: a report already carries the filter and the grouping, so it is one call where a query is a vocabulary lookup and a query. Call a report with no plan first to see its default answer, then narrow with the names its catalog entry lists. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -12502,7 +12536,7 @@
           "readOnlyHint": false,
           "title": "Start an email conversation from a record"
         },
-        "description": "Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. Sends EXACTLY the subject and body given; composes nothing. Needs at least one link naming the records it belongs to. Every recipient must have granted the named consent purpose, and a person approves the send first — a sent mail cannot be recalled. Use send_email to answer a conversation already recorded here; this starts a separate thread beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: runs immediately; requires passport scope \"send\".)",
+        "description": "Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. Sends EXACTLY the subject and body given; composes nothing. Needs at least one link naming the records it belongs to. Every recipient must have granted the named consent purpose. A sent mail cannot be recalled, and by default nothing holds it: where an installation has raised this verb to confirm first, the answer is a staged approval instead of a send. Use send_email to answer a conversation already recorded here; this starts a separate thread beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: runs immediately; requires passport scope \"send\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -12744,7 +12778,7 @@
           "readOnlyHint": false,
           "title": "Send an email"
         },
-        "description": "Put a mail on the wire to a real recipient, from this workspace, and record it on the thread it belongs to. It sends EXACTLY the subject and body it is given and composes nothing, so it is not the tool to reach for when the message does not exist yet. Every recipient must have granted the consent purpose the call names, and a person approves the send before it leaves — a message leaving the workspace cannot be recalled. Use draft_email first to produce the message and let it be read, and send_message when the conversation is on a chat channel rather than mail. Send the same activity_id, subject and body the draft produced, and keep the staged approval id: the approval is bound to that exact message, so changed text needs a new approval. (Governance: runs immediately; requires passport scope \"send\".)",
+        "description": "Put a mail on the wire to a real recipient, from this workspace, and record it on the thread it belongs to. It sends EXACTLY the subject and body it is given and composes nothing, so it is not the tool to reach for when the message does not exist yet. Every recipient must have granted the consent purpose the call names. A message leaving the workspace cannot be recalled, and by default nothing holds it: where an installation has raised this verb to confirm first, the answer is a staged approval instead of a send. Use draft_email first to produce the message and let it be read, and send_message when the conversation is on a chat channel rather than mail. Send the same activity_id, subject and body the draft produced, and keep the staged approval id: the approval is bound to that exact message, so changed text needs a new approval. (Governance: runs immediately; requires passport scope \"send\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -12960,7 +12994,7 @@
           "readOnlyHint": false,
           "title": "Reply on a channel conversation"
         },
-        "description": "Reply on a captured chat conversation — the channels this workspace has connected — on the thread it was captured from. It replies to an existing conversation named by activity_id; it cannot start one, and it cannot choose a channel. The recipient must have granted the consent purpose the call names, and a person approves it before it leaves. Use send_email when the thread is a mail thread, and log_activity when the point is to record that something was said rather than to say it. Keep the activity_id of the conversation and the staged approval id; the approval binds the exact text, so changed text needs a new approval. (Governance: runs immediately; requires passport scope \"send\".)",
+        "description": "Reply on a captured chat conversation — the channels this workspace has connected — on the thread it was captured from. It replies to an existing conversation named by activity_id; it cannot start one, and it cannot choose a channel. The recipient must have granted the consent purpose the call names. By default the message leaves when this call answers; where an installation has raised this verb to confirm first, the answer is a staged approval instead. Use send_email when the thread is a mail thread, and log_activity when the point is to record that something was said rather than to say it. Keep the activity_id of the conversation and the staged approval id; the approval binds the exact text, so changed text needs a new approval. (Governance: runs immediately; requires passport scope \"send\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 75 |
 | Resources | 12 |
-| Tool catalog | 210.5 KB |
+| Tool catalog | 214.4 KB |
 | Resource catalog | 4.5 KB |
-| Approx. wire tokens | 55029 |
+| Approx. wire tokens | 56021 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 98.4 KB | 46% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 51.8 KB | 24% | Yes, every step |
-| Input schemas | 44.5 KB | 21% | Yes, every step |
+| Output schemas | 98.7 KB | 46% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 55.4 KB | 25% | Yes, every step |
+| Input schemas | 44.5 KB | 20% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.8 KB | 7% | Partly |
-| **Description + input schema** | **96.3 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **99.8 KB** | **46%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -66,21 +66,21 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 |---|---|:-:|---|---:|
 | [`account_coverage`](#account_coverage) | Relationship coverage on a deal | yes |  | 3.2 KB |
 | [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.1 KB |
-| [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.2 KB |
+| [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.5 KB |
 | [`annotate_brief`](#annotate_brief) | Write findings onto the morning brief |  |  | 2.9 KB |
 | [`apply_tag`](#apply_tag) | Apply a tag to a record |  |  | 2.2 KB |
-| [`archive_record`](#archive_record) | Archive a record |  |  | 2.2 KB |
+| [`archive_record`](#archive_record) | Archive a record |  |  | 2.4 KB |
 | [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.6 KB |
-| [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.7 KB |
+| [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.8 KB |
 | [`catch_me_up_on`](#catch_me_up_on) | Catch me up on a record | yes |  | 2.8 KB |
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
 | [`check_location_support`](#check_location_support) | Can a card read this device's location | yes | [`ui://margince/geo-probe.html`](#geo_probe_view) | 1.8 KB |
-| [`commit_import`](#commit_import) | Commit an import |  |  | 1.7 KB |
-| [`compose_analytics_report`](#compose_analytics_report) | Compose an analytics report | yes |  | 2.6 KB |
+| [`commit_import`](#commit_import) | Commit an import |  |  | 1.8 KB |
+| [`compose_analytics_report`](#compose_analytics_report) | Compose an analytics report | yes |  | 2.8 KB |
 | [`create_record`](#create_record) | Create a record |  |  | 3.5 KB |
 | [`create_tag`](#create_tag) | Create a tag |  |  | 1.9 KB |
 | [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
-| [`data_coverage`](#data_coverage) | How current the sources are | yes |  | 1.7 KB |
+| [`data_coverage`](#data_coverage) | How current the sources are | yes |  | 2.0 KB |
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 2.9 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 2.9 KB |
 | [`demote_lead`](#demote_lead) | Reverse a lead promotion |  |  | 2.4 KB |
@@ -88,20 +88,20 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`describe_query_vocabulary`](#describe_query_vocabulary) | Describe the query vocabulary | yes |  | 2.1 KB |
 | [`describe_report_blocks`](#describe_report_blocks) | Describe the report block grammar | yes |  | 2.0 KB |
 | [`describe_report_vocabulary`](#describe_report_vocabulary) | Describe the report vocabulary | yes |  | 2.4 KB |
-| [`disqualify_lead`](#disqualify_lead) | Disqualify a lead |  |  | 1.9 KB |
+| [`disqualify_lead`](#disqualify_lead) | Disqualify a lead |  |  | 2.0 KB |
 | [`draft_email`](#draft_email) | Draft an email |  |  | 2.5 KB |
 | [`draft_follow_ups_for`](#draft_follow_ups_for) | Draft follow-ups |  |  | 2.6 KB |
-| [`enrich`](#enrich) | Enrich an organization from its website |  |  | 2.6 KB |
-| [`forecast_input_checks`](#forecast_input_checks) | What the forecast's inputs were checked against | yes |  | 2.4 KB |
-| [`forecast_movement`](#forecast_movement) | What moved the forecast | yes |  | 3.0 KB |
-| [`forecast_readings`](#forecast_readings) | Read the forecast | yes |  | 3.2 KB |
+| [`enrich`](#enrich) | Enrich an organization from its website |  |  | 2.7 KB |
+| [`forecast_input_checks`](#forecast_input_checks) | What the forecast's inputs were checked against | yes |  | 2.7 KB |
+| [`forecast_movement`](#forecast_movement) | What moved the forecast | yes |  | 3.4 KB |
+| [`forecast_readings`](#forecast_readings) | Read the forecast | yes |  | 3.8 KB |
 | [`get_record_tags`](#get_record_tags) | Get a record's tags | yes |  | 1.9 KB |
 | [`get_tag`](#get_tag) | Get a tag | yes |  | 1.6 KB |
 | [`intro_path_to`](#intro_path_to) | Find a warm introduction path | yes |  | 2.3 KB |
 | [`list_approvals`](#list_approvals) | List what is waiting for a decision | yes |  | 2.9 KB |
 | [`list_channel_providers`](#list_channel_providers) | List messaging transports | yes |  | 2.0 KB |
-| [`list_colleagues`](#list_colleagues) | List colleagues | yes |  | 1.9 KB |
-| [`list_input_checks`](#list_input_checks) | What the forecast's inputs still need | yes |  | 2.1 KB |
+| [`list_colleagues`](#list_colleagues) | List colleagues | yes |  | 2.4 KB |
+| [`list_input_checks`](#list_input_checks) | What the forecast's inputs still need | yes |  | 2.3 KB |
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
 | [`list_records`](#list_records) | List records | yes |  | 3.3 KB |
 | [`list_tags`](#list_tags) | List tags | yes |  | 1.6 KB |
@@ -112,7 +112,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.9 KB |
 | [`preview_import`](#preview_import) | Preview an import |  |  | 4.2 KB |
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.4 KB |
-| [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.4 KB |
+| [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.6 KB |
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
 | [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 4.0 KB |
 | [`read_approval`](#read_approval) | Read one staged action in full | yes |  | 2.4 KB |
@@ -128,12 +128,12 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`resolve_entities`](#resolve_entities) | Resolve people and companies | yes |  | 3.6 KB |
 | [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 3.4 KB |
 | [`run_analytics_query`](#run_analytics_query) | Run an analytics query | yes |  | 3.2 KB |
-| [`run_report`](#run_report) | Run a report | yes |  | 5.0 KB |
+| [`run_report`](#run_report) | Run a report | yes |  | 5.2 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.1 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.8 KB |
-| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 4.2 KB |
-| [`send_email`](#send_email) | Send an email |  |  | 3.9 KB |
-| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 3.3 KB |
+| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 4.3 KB |
+| [`send_email`](#send_email) | Send an email |  |  | 4.0 KB |
+| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 3.4 KB |
 | [`update_record`](#update_record) | Update a record |  |  | 3.8 KB |
 | [`update_tag`](#update_tag) | Rename or recolour a tag |  |  | 2.0 KB |
 | [`whats_slipping_this_week`](#whats_slipping_this_week) | What's slipping this week | yes | [`ui://margince/pipeline-review.html`](#pipeline_review_view) | 2.3 KB |
@@ -783,7 +783,7 @@ Move a deal to a different stage of its pipeline. The stage is named by id from 
 
 **Move a project to a phase**
 
-Move a project to another phase — initiative, pursuing, delivering, closed. The four names are fixed but the order is not enforced: a project may go back a phase, and a closed one may be reopened. Closing requires a reason, which is recorded on the phase history either way. Use advance_deal for a deal's pipeline stages; a project's phases are a different vocabulary on a different record. Send if_version with the version you read; a person approves the move before it runs. (Governance: runs immediately; requires passport scope "write".)
+Move a project to another phase — initiative, pursuing, delivering, closed. The four names are fixed but the order is not enforced: a project may go back a phase, and a closed one may be reopened. Closing requires a reason, which is recorded on the phase history either way. Use advance_deal for a deal's pipeline stages; a project's phases are a different vocabulary on a different record. Send if_version with the version you read. By default the phase moves when this call answers. Where an installation has raised this verb to confirm first, the answer is a staged approval and the phase has NOT moved — keep its id and do not report the project as advanced until the retry that carries the approval has answered. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -1261,7 +1261,7 @@ Tag a person, company, deal, lead or project by tag_id, or by tag_name, which mu
 
 **Archive a record**
 
-Retire a record that should no longer be worked — a duplicate, a dead account, a project that ended. Archiving hides the record from day-to-day work; it does not delete it and does not move anything attached to it, so an archived duplicate still holds the activities and deals that were logged against it. Use merge_records when a duplicate's history should end up on the record that survives, and disqualify_lead when a lead is going nowhere — a lead's own transition records the reason where archiving would not. A person approves this call before it runs; do not report the record as archived until the retry that carries their approval has answered. (Governance: runs immediately; requires passport scope "write".)
+Retire a record that should no longer be worked — a duplicate, a dead account, a project that ended. Archiving hides the record from day-to-day work; it does not delete it and does not move anything attached to it, so an archived duplicate still holds the activities and deals that were logged against it. Use merge_records when a duplicate's history should end up on the record that survives, and disqualify_lead when a lead is going nowhere — a lead's own transition records the reason where archiving would not. By default the record is archived when this call answers; where an installation has raised this verb to confirm first, the answer is a staged approval and you must not report the record as archived until the retry that carries their approval has answered. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -1615,7 +1615,7 @@ Answer "where are our relationships thin?": across the caller's OPEN deals, the 
 
 **Book a meeting**
 
-Hold a slot in the host's calendar and record the meeting against the records it is about. Needs at least one link saying what it is about. The slot is taken and the meeting is a real commitment, so a person approves it first. No attendee list: who is invited is the calendar connection's business. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: runs immediately; requires passport scope "send".)
+Hold a slot in the host's calendar and record the meeting against the records it is about. Needs at least one link saying what it is about. The slot is taken and the meeting is a real commitment, and by default it is taken when this call answers — where an installation has raised this verb to confirm first, the answer is a staged approval instead. No attendee list: who is invited is the calendar connection's business. Check the slot is free first — this tool does not. Use check_availability to find the time, and log_activity to record a meeting that already happened. Keep the staged approval id and re-send the identical start, end and links: the approval is bound to the meeting as it was described. (Governance: runs immediately; requires passport scope "send".)
 
 <details><summary>Input schema</summary>
 
@@ -2301,7 +2301,7 @@ Renders its result in [`ui://margince/geo-probe.html`](#geo_probe_view), visible
 
 **Commit an import**
 
-Write a checked import into the workspace, once a person approves. Only from awaiting_approval. Undoing one needs the web app. read_import_report first; nobody should approve what they have not read. (Governance: runs immediately; requires passport scope "write".)
+Write a checked import into the workspace. The dry run is the check; by default this commits when it answers. Only from awaiting_approval. Undoing one needs the web app. read_import_report first; nobody should approve what they have not read. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -2450,7 +2450,7 @@ Write a checked import into the workspace, once a person approves. Only from awa
 
 **Compose an analytics report**
 
-Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope "read".)
+WRITE a DOCUMENT somebody keeps and reads — a board-pack section, a summary for a meeting — whose every number comes from a saved analytics run instead of being typed. Not for answering with a figure: a number in the reply is run_analytics_query's or run_report's. The document carries the STRUCTURE and the WORDS; each figure names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -3161,7 +3161,7 @@ Put a to-do on someone's list: what is owed, by whom, on which records. Creates 
 
 **How current the sources are**
 
-Which connectors the nightly check could read, and how far back each reaches. Needs the data_coverage grant, which operators hold and sellers do not — a refusal here is a seat boundary, not a missing run. Only a `checked` source carries a date. On any other state nothing was read, and a quiet week is indistinguishable from a broken connector until somebody looks. (Governance: runs immediately; requires passport scope "read".)
+Answer how much of what is going on this workspace can actually SEE — which connectors the nightly check could read, and how far back each reaches. Needs the data_coverage grant, which operators hold and sellers do not — a refusal here is a seat boundary, not a missing run. Only a `checked` source carries a date; on any other state nothing was read, and a quiet week is indistinguishable from a broken connector until somebody looks. forecast_input_checks and list_input_checks answer what the check FOUND, and both are silent on whether it could look — a clean set of findings over sources nobody opened reads as good news and is not. Ask this one when the question is whether to trust the other two. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -4346,7 +4346,7 @@ Answer what a run_report plan may SAY: for each prebuilt report, the names its g
 
 **Disqualify a lead**
 
-Close out a lead that is not going anywhere, so it stops appearing as live work. It is the lead's own terminal state and keeps the record and its history; it is not a deletion and not an archive. Use promote_lead when engagement says the opposite, and qualify_lead when the lead is only missing information. A person approves this call before it runs; do not report the lead as disqualified until the retry carrying their approval has answered. (Governance: runs immediately; requires passport scope "write".)
+Close out a lead that is not going anywhere, so it stops appearing as live work. It is the lead's own terminal state and keeps the record and its history; it is not a deletion and not an archive. Use promote_lead when engagement says the opposite, and qualify_lead when the lead is only missing information. By default the lead is disqualified when this call answers; where an installation has raised this verb to confirm first, do not report the lead as disqualified until the retry carrying their approval has answered. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -4850,7 +4850,7 @@ Draft a follow-up for each deal in a segment at once — today only the slipping
 
 **Enrich an organization from its website**
 
-Learn about an organization by reading its public website, and propose what was found for a person to accept onto the record. It reaches OUTSIDE the workspace, so a person approves the call before it runs, and what it returns is a proposal — nothing lands on the record until someone accepts it. Reading one page answers immediately; reading a whole site is queued and answers with a read id rather than the content. What it finds is captured text from a third party, not a fact this workspace has verified. Use qualify_lead when the missing values are already derivable from the record itself, which costs no external read and needs no approval. Keep the organization_id you enriched, and the read id when a whole-site read was queued — the result is collected against it later. (Governance: a person approves every call before it runs; requires passport scope "enrich".)
+Learn about an organization by reading its public website, and propose what was found for a person to accept onto the record. It reaches OUTSIDE the workspace, and what it returns is a PROPOSAL — nothing lands on the record until someone accepts it, which is the review that guards this, not an approval on the call. Reading one page answers immediately; reading a whole site is queued and answers with a read id rather than the content. What it finds is captured text from a third party, not a fact this workspace has verified. Use qualify_lead when the missing values are already derivable from the record itself, which costs no external read and needs no approval. Keep the organization_id you enriched, and the read id when a whole-site read was queued — the result is collected against it later. (Governance: a person approves every call before it runs; requires passport scope "enrich".)
 
 <details><summary>Input schema</summary>
 
@@ -4992,7 +4992,7 @@ Learn about an organization by reading its public website, and propose what was 
 
 **What the forecast's inputs were checked against**
 
-What last night's input check found, and how much of the pipeline it reached. A forecast is only as good as its inputs, and the failures are mundane: a close date that went by, an amount that disagrees with the offer that was sent, a deal nobody has heard from in ninety days. Read `readiness` before quoting any forecast figure. `checks_incomplete` is NOT a worse `needs_review` — one says the pipeline has problems, the other says we could not look, and reporting the first when the second is true tells somebody their pipeline is sound when nobody read the mailbox. `sources` says why: each carries the state the run reached, and only a `checked` source has a date. An absent or unread source means the run could not confirm anything from it, which is different from finding nothing there. `eligible_deals` is how much there was to check — compared against an earlier run it shows a pass that covered less of the pipeline. (Governance: runs immediately; requires passport scope "read".)
+Answer whether the forecast's inputs are sound enough to quote — a verdict, and how much of the pipeline last night's check reached. A forecast is only as good as its inputs, and the failures are mundane: a close date that went by, an amount that disagrees with the offer that was sent, a deal nobody has heard from in ninety days. `checks_incomplete` is NOT a worse `needs_review` — one says the pipeline has problems, the other says we could not look, and reporting the first when the second is true tells somebody their pipeline is sound when nobody read the mailbox. This is the VERDICT. list_input_checks is the findings themselves, one row per problem, when the question is what to go and fix. data_coverage is the third question and the one this cannot answer: whether the CONNECTORS were readable at all, which is what makes a clean verdict trustworthy rather than merely clean. Read `readiness` before quoting any forecast figure. `sources` says why: each carries the state the run reached, and only a `checked` source has a date — an absent or unread source means the run could not confirm anything from it, which is different from finding nothing there. `eligible_deals` is how much there was to check. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -5148,7 +5148,7 @@ What last night's input check found, and how much of the pipeline it reached. A 
 
 **What moved the forecast**
 
-The difference between two forecast snapshots, classified into named causes. Opening plus every bucket equals closing, exactly — so the buckets are a complete account of the change and not a selection from it. A deal appears in exactly ONE bucket: one that both slipped and was repriced has moved for one reason as far as a reader is concerned, which is that it left. Two buckets are about the machinery rather than the business, and quoting them as sales movement is the mistake this classification exists to prevent. `definition` means the two snapshots were computed under different rules, and then the WHOLE difference is in that bucket. `model` means a probability the product re-scored. `reopened_or_archived` carries a deal that left the population entirely — archived, or no longer visible to this caller — with its whole prior contribution, so no money disappears without a row that says where it went. (Governance: runs immediately; requires passport scope "read".)
+Explain why a forecast changed between two points, as named causes that account for the whole difference. Opening plus every bucket equals closing, exactly, so the buckets are a complete account of the change and not a selection from it. A deal appears in exactly ONE bucket: one that both slipped and was repriced has moved for one reason as far as a reader is concerned, which is that it left. Two buckets are about the machinery rather than the business, and quoting them as sales movement is the mistake this classification exists to prevent: `definition` means the two snapshots were computed under different rules, and then the WHOLE difference is in that bucket; `model` means a probability the product re-scored. IT NEEDS TWO SNAPSHOT IDS, and nothing on this surface hands one out — no tool lists snapshots and no resource publishes them, so a caller that has not been given ids from elsewhere cannot call this. Reading forecast_readings twice and subtracting is NOT the same answer and must not be reported as one: the difference between two reads is a number with no account of where it went. `reopened_or_archived` carries a deal that left the population entirely — archived, or no longer visible to this caller — with its whole prior contribution, so no money disappears without a row that says where it went. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -5355,7 +5355,7 @@ The difference between two forecast snapshots, classified into named causes. Ope
 
 **Read the forecast**
 
-What a period is expected to close, in four readings. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. `coverage_note` says what the totals do not cover, and it is absent only when they cover every eligible deal — so quoting a total without it reports a partial pipeline as a complete one. `eligible_count`, `priced_count` and `fx_missing_count` are the counts it is written from. Quote `as_of`, `timezone` and `base_currency` with the number: a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope "read".)
+Answer what a period is expected to close — `won`, `evidence`, `best_case` and `open`, plus `weighted` — under the installation's own fiscal calendar and base currency. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. `coverage_note` says what the totals do not cover and is absent only when they cover every eligible deal, so quoting a total without it reports a partial pipeline as a complete one. run_report's forecast report and a hand-summed query_workspace also produce a number, and NEITHER is the forecast: only this applies the fiscal calendar, the base currency conversion and the weighting. These figures also cannot be cited in a composed document — for a board-pack section or anything a reader keeps, run_analytics_query with save and compose_analytics_report from the run id. Ask forecast_input_checks whether the inputs behind these numbers were read. Quote `as_of`, `timezone` and `base_currency` with the number — a total placed in the reader's own zone is a different total — and `eligible_count`, `priced_count` and `fx_missing_count` are the counts `coverage_note` is written from. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -6411,7 +6411,7 @@ Find out which messaging transports exist in THIS installation, and what each is
 
 **List colleagues**
 
-List the people who work HERE — colleagues holding a seat, not the contacts stored as person records. Reads only, and lists seats that can actually receive work — archived, suspended and locked-out ones are absent. `truncated` means there are more. search_records/person finds a CUSTOMER contact; this finds a colleague. user_id is what assignee_id and owner_id take. Never assign to an is_agent seat. (Governance: runs immediately; requires passport scope "read".)
+List the people who work HERE — colleagues holding a seat, not the contacts stored as person records. Reads only, and lists seats that can actually receive work — archived, suspended and locked-out ones are absent. `truncated` means there are more. A `q` matching nobody answers with `all_colleagues` and a warning; that list is ABSENT if it could not be read and partial if `all_colleagues_truncated`, so read the warning before concluding a person has no seat. search_records/person finds a CUSTOMER contact; this finds a colleague. user_id is what assignee_id and owner_id take. Never assign to an is_agent seat. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -6437,6 +6437,40 @@ List the people who work HERE — colleagues holding a seat, not the contacts st
   "properties": {
     "data": {
       "properties": {
+        "all_colleagues": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "is_agent": {
+                "type": "boolean"
+              },
+              "seat_type": {
+                "type": "string"
+              },
+              "user_id": {
+                "format": "uuid",
+                "type": "string"
+              }
+            },
+            "required": [
+              "display_name",
+              "email",
+              "is_agent",
+              "seat_type",
+              "user_id"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "all_colleagues_truncated": {
+          "type": "boolean"
+        },
         "colleagues": {
           "items": {
             "properties": {
@@ -6563,7 +6597,7 @@ List the people who work HERE — colleagues holding a seat, not the contacts st
 
 **What the forecast's inputs still need**
 
-The open findings from the nightly input check, most material first. Read them before quoting a forecast figure: a close date that went by, or an amount that disagrees with the offer that was sent, makes a total wrong without making the arithmetic wrong. Scoped to what this caller can open, with no count of what was withheld — a count of what somebody may not read is itself a statement about how much there is. `affected_minor` absent means the money at stake cannot be said, not that nothing is at stake. (Governance: runs immediately; requires passport scope "read".)
+List the open input problems behind the forecast, most material first, so they can be fixed. A close date that went by, or an amount that disagrees with the offer that was sent, makes a total wrong without making the arithmetic wrong. Scoped to what this caller can open, with no count of what was withheld — a count of what somebody may not read is itself a statement about how much there is. forecast_input_checks answers the VERDICT — whether the numbers are quotable at all — which is the question before this one and the cheaper call. data_coverage answers whether the sources were readable, which an empty list here cannot distinguish from a clean pipeline. `affected_minor` absent means the money at stake cannot be said, not that nothing is at stake. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -7435,7 +7469,7 @@ Record something that happened — a call, a meeting, a note, a message — on t
 
 **Merge two records**
 
-Collapse two records for the same real person or company into one, moving the source's activities, deals and links onto the record that survives. People merge with people and organizations with organizations; the source is archived and redirected to the target, and the direction is not reversible by calling this again the other way round. Use archive_record when the extra record has nothing worth keeping, rather than merging to make it disappear. target_id is the record that survives and source_id the one merged away — read both records before choosing, because a person approves the call as you described it. (Governance: runs immediately; requires passport scope "write".)
+Collapse two records for the same real person or company into one, moving the source's activities, deals and links onto the record that survives. People merge with people and organizations with organizations; the source is archived and redirected to the target, and the direction is not reversible by calling this again the other way round. Use archive_record when the extra record has nothing worth keeping, rather than merging to make it disappear. target_id is the record that survives and source_id the one merged away — read both records before choosing: the fold cannot be called back, and by default nothing holds it. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -9298,7 +9332,7 @@ Move a deal to a new stage and leave a note on its timeline saying why, in one c
 
 **Promote a lead to a person**
 
-Turn a lead who has genuinely engaged into a person record, carrying their history across. It requires a trigger naming the engagement that justifies it — a reply, a booked or held meeting, or a human's decision. Cold outreach that nobody answered is not a promotion, and there is no trigger for it. Use qualify_lead when the lead is merely incomplete rather than ready, and disqualify_lead when the engagement says the opposite. A person approves this call before it runs; the promoted person's id comes back only from the retry that carries their approval. (Governance: runs immediately; requires passport scope "write".)
+Turn a lead who has genuinely engaged into a person record, carrying their history across. It requires a trigger naming the engagement that justifies it — a reply, a booked or held meeting, or a human's decision. Cold outreach that nobody answered is not a promotion, and there is no trigger for it. Use qualify_lead when the lead is merely incomplete rather than ready, and disqualify_lead when the engagement says the opposite. By default the lead is promoted when this call answers and the promoted person's id comes back with it. Where an installation has raised this verb to confirm first, the answer is a staged approval instead and the id arrives only from the retry that carries it. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -10331,7 +10365,7 @@ Renders its result in [`ui://margince/account-brief.html`](#account_brief_view),
 
 **Read an import report**
 
-What an import will do, or did: rows created, updated, failed, unusable, duplicates. These counts are what a person approves. Same shape before and after. (Governance: runs immediately; requires passport scope "read".)
+What an import will do, or did: rows created, updated, failed, unusable, duplicates. These counts are what a person weighs before committing. Same shape before and after. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -12851,7 +12885,7 @@ Compute a grouped aggregate — counts, sums, averages, medians — over a gover
 
 **Run a report**
 
-Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, each with its own filter, grouping and measure names; anything else is refused. It aggregates: how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan first to see its default answer, then narrow with the names its catalog entry lists. (Governance: runs immediately; requires passport scope "read".)
+Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, each with its own filter, grouping and measure names; anything else is refused. It aggregates: how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Reach for run_analytics_query only when NO prebuilt report answers the question: a report already carries the filter and the grouping, so it is one call where a query is a vocabulary lookup and a query. Call a report with no plan first to see its default answer, then narrow with the names its catalog entry lists. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -13465,7 +13499,7 @@ Find people, organizations, deals, leads and projects when you know roughly what
 
 **Start an email conversation from a record**
 
-Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. Sends EXACTLY the subject and body given; composes nothing. Needs at least one link naming the records it belongs to. Every recipient must have granted the named consent purpose, and a person approves the send first — a sent mail cannot be recalled. Use send_email to answer a conversation already recorded here; this starts a separate thread beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: runs immediately; requires passport scope "send".)
+Put a mail on the wire to a real recipient, from this workspace, starting a new conversation rather than answering one, and file it on the records it is about. Sends EXACTLY the subject and body given; composes nothing. Needs at least one link naming the records it belongs to. Every recipient must have granted the named consent purpose. A sent mail cannot be recalled, and by default nothing holds it: where an installation has raised this verb to confirm first, the answer is a staged approval instead of a send. Use send_email to answer a conversation already recorded here; this starts a separate thread beside it. Keep the staged approval id and re-send the identical text and links: the approval is bound to that exact message. The activity_id that comes back is the new conversation. (Governance: runs immediately; requires passport scope "send".)
 
 <details><summary>Input schema</summary>
 
@@ -13717,7 +13751,7 @@ Put a mail on the wire to a real recipient, from this workspace, starting a new 
 
 **Send an email**
 
-Put a mail on the wire to a real recipient, from this workspace, and record it on the thread it belongs to. It sends EXACTLY the subject and body it is given and composes nothing, so it is not the tool to reach for when the message does not exist yet. Every recipient must have granted the consent purpose the call names, and a person approves the send before it leaves — a message leaving the workspace cannot be recalled. Use draft_email first to produce the message and let it be read, and send_message when the conversation is on a chat channel rather than mail. Send the same activity_id, subject and body the draft produced, and keep the staged approval id: the approval is bound to that exact message, so changed text needs a new approval. (Governance: runs immediately; requires passport scope "send".)
+Put a mail on the wire to a real recipient, from this workspace, and record it on the thread it belongs to. It sends EXACTLY the subject and body it is given and composes nothing, so it is not the tool to reach for when the message does not exist yet. Every recipient must have granted the consent purpose the call names. A message leaving the workspace cannot be recalled, and by default nothing holds it: where an installation has raised this verb to confirm first, the answer is a staged approval instead of a send. Use draft_email first to produce the message and let it be read, and send_message when the conversation is on a chat channel rather than mail. Send the same activity_id, subject and body the draft produced, and keep the staged approval id: the approval is bound to that exact message, so changed text needs a new approval. (Governance: runs immediately; requires passport scope "send".)
 
 <details><summary>Input schema</summary>
 
@@ -13943,7 +13977,7 @@ Put a mail on the wire to a real recipient, from this workspace, and record it o
 
 **Reply on a channel conversation**
 
-Reply on a captured chat conversation — the channels this workspace has connected — on the thread it was captured from. It replies to an existing conversation named by activity_id; it cannot start one, and it cannot choose a channel. The recipient must have granted the consent purpose the call names, and a person approves it before it leaves. Use send_email when the thread is a mail thread, and log_activity when the point is to record that something was said rather than to say it. Keep the activity_id of the conversation and the staged approval id; the approval binds the exact text, so changed text needs a new approval. (Governance: runs immediately; requires passport scope "send".)
+Reply on a captured chat conversation — the channels this workspace has connected — on the thread it was captured from. It replies to an existing conversation named by activity_id; it cannot start one, and it cannot choose a channel. The recipient must have granted the consent purpose the call names. By default the message leaves when this call answers; where an installation has raised this verb to confirm first, the answer is a staged approval instead. Use send_email when the thread is a mail thread, and log_activity when the point is to record that something was said rather than to say it. Keep the activity_id of the conversation and the staged approval id; the approval binds the exact text, so changed text needs a new approval. (Governance: runs immediately; requires passport scope "send".)
 
 <details><summary>Input schema</summary>
 

--- a/docs/reference/mcp-tool-coverage.json
+++ b/docs/reference/mcp-tool-coverage.json
@@ -5,7 +5,7 @@
     "driven": 36,
     "never_driven": 39,
     "permitted_but_never_required": 19,
-    "tokens_served_but_never_driven": 12378,
+    "tokens_served_but_never_driven": 12728,
     "use_case_cases": 21,
     "acceptance_criteria_named": 48,
     "tools_added_by_shipped_units": 7,
@@ -1151,7 +1151,7 @@
   "tools": [
     {
       "name": "send_account_email",
-      "tokens": 742,
+      "tokens": 768,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],
@@ -1161,7 +1161,7 @@
     },
     {
       "name": "send_email",
-      "tokens": 675,
+      "tokens": 698,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],
@@ -1187,7 +1187,7 @@
     },
     {
       "name": "send_message",
-      "tokens": 518,
+      "tokens": 546,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],
@@ -1251,6 +1251,16 @@
       "measured_by_model": {}
     },
     {
+      "name": "forecast_movement",
+      "tokens": 453,
+      "agents": [],
+      "required_by_cases": [],
+      "permitted_in_cases": [],
+      "driven": false,
+      "graded_by_certification_tasks": null,
+      "measured_by_model": {}
+    },
+    {
       "name": "advance_deal",
       "tokens": 447,
       "agents": [],
@@ -1260,6 +1270,16 @@
       "graded_by_certification_tasks": [
         "agent_loop"
       ],
+      "measured_by_model": {}
+    },
+    {
+      "name": "book_meeting",
+      "tokens": 424,
+      "agents": [],
+      "required_by_cases": [],
+      "permitted_in_cases": [],
+      "driven": false,
+      "graded_by_certification_tasks": null,
       "measured_by_model": {}
     },
     {
@@ -1291,18 +1311,8 @@
       "measured_by_model": {}
     },
     {
-      "name": "book_meeting",
-      "tokens": 393,
-      "agents": [],
-      "required_by_cases": [],
-      "permitted_in_cases": [],
-      "driven": false,
-      "graded_by_certification_tasks": null,
-      "measured_by_model": {}
-    },
-    {
       "name": "enrich",
-      "tokens": 393,
+      "tokens": 398,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],
@@ -1311,16 +1321,6 @@
         "agent_loop",
         "enrich"
       ],
-      "measured_by_model": {}
-    },
-    {
-      "name": "forecast_movement",
-      "tokens": 351,
-      "agents": [],
-      "required_by_cases": [],
-      "permitted_in_cases": [],
-      "driven": false,
-      "graded_by_certification_tasks": null,
       "measured_by_model": {}
     },
     {
@@ -1349,6 +1349,19 @@
       "graded_by_certification_tasks": [
         "agent_loop"
       ],
+      "measured_by_model": {}
+    },
+    {
+      "name": "forecast_input_checks",
+      "tokens": 324,
+      "agents": [],
+      "required_by_cases": [],
+      "permitted_in_cases": [
+        "case21_what_are_we_closing",
+        "case22_can_i_trust_the_numbers"
+      ],
+      "driven": false,
+      "graded_by_certification_tasks": null,
       "measured_by_model": {}
     },
     {
@@ -1438,19 +1451,6 @@
       "required_by_cases": [],
       "permitted_in_cases": [
         "case4_use_the_moment"
-      ],
-      "driven": false,
-      "graded_by_certification_tasks": null,
-      "measured_by_model": {}
-    },
-    {
-      "name": "forecast_input_checks",
-      "tokens": 252,
-      "agents": [],
-      "required_by_cases": [],
-      "permitted_in_cases": [
-        "case21_what_are_we_closing",
-        "case22_can_i_trust_the_numbers"
       ],
       "driven": false,
       "graded_by_certification_tasks": null,
@@ -1555,6 +1555,19 @@
       "measured_by_model": {}
     },
     {
+      "name": "list_input_checks",
+      "tokens": 209,
+      "agents": [],
+      "required_by_cases": [],
+      "permitted_in_cases": [
+        "case21_what_are_we_closing",
+        "case22_can_i_trust_the_numbers"
+      ],
+      "driven": false,
+      "graded_by_certification_tasks": null,
+      "measured_by_model": {}
+    },
+    {
       "name": "at_risk_relationships",
       "tokens": 208,
       "agents": [
@@ -1643,19 +1656,6 @@
       "measured_by_model": {}
     },
     {
-      "name": "list_input_checks",
-      "tokens": 146,
-      "agents": [],
-      "required_by_cases": [],
-      "permitted_in_cases": [
-        "case21_what_are_we_closing",
-        "case22_can_i_trust_the_numbers"
-      ],
-      "driven": false,
-      "graded_by_certification_tasks": null,
-      "measured_by_model": {}
-    },
-    {
       "name": "whoami",
       "tokens": 128,
       "agents": [],
@@ -1687,7 +1687,7 @@
     },
     {
       "name": "run_report",
-      "tokens": 939,
+      "tokens": 990,
       "agents": [],
       "required_by_cases": [
         "case7_ask_for_a_number"
@@ -1789,6 +1789,39 @@
         "claude-sonnet-5": {
           "runs": 6,
           "passed": 6,
+          "reliability": 1,
+          "cases_below_their_bar": []
+        }
+      }
+    },
+    {
+      "name": "forecast_readings",
+      "tokens": 509,
+      "agents": [],
+      "required_by_cases": [
+        "case21_what_are_we_closing"
+      ],
+      "permitted_in_cases": [
+        "case22_can_i_trust_the_numbers"
+      ],
+      "driven": true,
+      "graded_by_certification_tasks": null,
+      "measured_by_model": {
+        "claude-haiku-4-5-20251001": {
+          "runs": 3,
+          "passed": 3,
+          "reliability": 1,
+          "cases_below_their_bar": []
+        },
+        "claude-opus-5": {
+          "runs": 3,
+          "passed": 3,
+          "reliability": 1,
+          "cases_below_their_bar": []
+        },
+        "claude-sonnet-5": {
+          "runs": 3,
+          "passed": 3,
           "reliability": 1,
           "cases_below_their_bar": []
         }
@@ -1929,7 +1962,7 @@
     },
     {
       "name": "compose_analytics_report",
-      "tokens": 390,
+      "tokens": 440,
       "agents": [],
       "required_by_cases": [
         "case20_put_it_in_the_board_pack"
@@ -2019,39 +2052,6 @@
       }
     },
     {
-      "name": "forecast_readings",
-      "tokens": 357,
-      "agents": [],
-      "required_by_cases": [
-        "case21_what_are_we_closing"
-      ],
-      "permitted_in_cases": [
-        "case22_can_i_trust_the_numbers"
-      ],
-      "driven": true,
-      "graded_by_certification_tasks": null,
-      "measured_by_model": {
-        "claude-haiku-4-5-20251001": {
-          "runs": 3,
-          "passed": 3,
-          "reliability": 1,
-          "cases_below_their_bar": []
-        },
-        "claude-opus-5": {
-          "runs": 3,
-          "passed": 3,
-          "reliability": 1,
-          "cases_below_their_bar": []
-        },
-        "claude-sonnet-5": {
-          "runs": 3,
-          "passed": 3,
-          "reliability": 1,
-          "cases_below_their_bar": []
-        }
-      }
-    },
-    {
       "name": "search_context",
       "tokens": 345,
       "agents": [],
@@ -2095,8 +2095,76 @@
       }
     },
     {
+      "name": "advance_project_phase",
+      "tokens": 340,
+      "agents": [],
+      "required_by_cases": [
+        "case41_close_the_project"
+      ],
+      "permitted_in_cases": [],
+      "driven": true,
+      "graded_by_certification_tasks": null,
+      "measured_by_model": {
+        "claude-haiku-4-5-20251001": {
+          "runs": 3,
+          "passed": 0,
+          "reliability": 0,
+          "cases_below_their_bar": [
+            "case41_close_the_project"
+          ]
+        },
+        "claude-opus-5": {
+          "runs": 3,
+          "passed": 3,
+          "reliability": 1,
+          "cases_below_their_bar": []
+        },
+        "claude-sonnet-5": {
+          "runs": 3,
+          "passed": 0,
+          "reliability": 0,
+          "cases_below_their_bar": [
+            "case41_close_the_project"
+          ]
+        }
+      }
+    },
+    {
+      "name": "promote_lead",
+      "tokens": 303,
+      "agents": [],
+      "required_by_cases": [
+        "case40_sort_the_queue"
+      ],
+      "permitted_in_cases": [],
+      "driven": true,
+      "graded_by_certification_tasks": null,
+      "measured_by_model": {
+        "claude-haiku-4-5-20251001": {
+          "runs": 3,
+          "passed": 2,
+          "reliability": 0.6666666666666666,
+          "cases_below_their_bar": []
+        },
+        "claude-opus-5": {
+          "runs": 3,
+          "passed": 1,
+          "reliability": 0.3333333333333333,
+          "cases_below_their_bar": [
+            "case40_sort_the_queue"
+          ]
+        },
+        "claude-sonnet-5": {
+          "runs": 3,
+          "passed": 2,
+          "reliability": 0.6666666666666666,
+          "cases_below_their_bar": []
+        }
+      }
+    },
+    {
       "name": "merge_records",
-      "tokens": 292,
+      "tokens": 294,
       "agents": [],
       "required_by_cases": [
         "case33_two_cards_for_one_company"
@@ -2130,11 +2198,11 @@
       }
     },
     {
-      "name": "advance_project_phase",
-      "tokens": 279,
+      "name": "archive_record",
+      "tokens": 290,
       "agents": [],
       "required_by_cases": [
-        "case41_close_the_project"
+        "case33_two_cards_for_one_company"
       ],
       "permitted_in_cases": [],
       "driven": true,
@@ -2145,7 +2213,7 @@
           "passed": 0,
           "reliability": 0,
           "cases_below_their_bar": [
-            "case41_close_the_project"
+            "case33_two_cards_for_one_company"
           ]
         },
         "claude-opus-5": {
@@ -2156,10 +2224,10 @@
         },
         "claude-sonnet-5": {
           "runs": 3,
-          "passed": 0,
-          "reliability": 0,
+          "passed": 1,
+          "reliability": 0.3333333333333333,
           "cases_below_their_bar": [
-            "case41_close_the_project"
+            "case33_two_cards_for_one_company"
           ]
         }
       }
@@ -2219,39 +2287,6 @@
           "passed": 3,
           "reliability": 1,
           "cases_below_their_bar": []
-        },
-        "claude-sonnet-5": {
-          "runs": 3,
-          "passed": 2,
-          "reliability": 0.6666666666666666,
-          "cases_below_their_bar": []
-        }
-      }
-    },
-    {
-      "name": "promote_lead",
-      "tokens": 270,
-      "agents": [],
-      "required_by_cases": [
-        "case40_sort_the_queue"
-      ],
-      "permitted_in_cases": [],
-      "driven": true,
-      "graded_by_certification_tasks": null,
-      "measured_by_model": {
-        "claude-haiku-4-5-20251001": {
-          "runs": 3,
-          "passed": 2,
-          "reliability": 0.6666666666666666,
-          "cases_below_their_bar": []
-        },
-        "claude-opus-5": {
-          "runs": 3,
-          "passed": 1,
-          "reliability": 0.3333333333333333,
-          "cases_below_their_bar": [
-            "case40_sort_the_queue"
-          ]
         },
         "claude-sonnet-5": {
           "runs": 3,
@@ -2331,41 +2366,6 @@
       }
     },
     {
-      "name": "archive_record",
-      "tokens": 261,
-      "agents": [],
-      "required_by_cases": [
-        "case33_two_cards_for_one_company"
-      ],
-      "permitted_in_cases": [],
-      "driven": true,
-      "graded_by_certification_tasks": null,
-      "measured_by_model": {
-        "claude-haiku-4-5-20251001": {
-          "runs": 3,
-          "passed": 0,
-          "reliability": 0,
-          "cases_below_their_bar": [
-            "case33_two_cards_for_one_company"
-          ]
-        },
-        "claude-opus-5": {
-          "runs": 3,
-          "passed": 3,
-          "reliability": 1,
-          "cases_below_their_bar": []
-        },
-        "claude-sonnet-5": {
-          "runs": 3,
-          "passed": 1,
-          "reliability": 0.3333333333333333,
-          "cases_below_their_bar": [
-            "case33_two_cards_for_one_company"
-          ]
-        }
-      }
-    },
-    {
       "name": "qualify_lead",
       "tokens": 229,
       "agents": [],
@@ -2427,6 +2427,39 @@
           "runs": 3,
           "passed": 3,
           "reliability": 1,
+          "cases_below_their_bar": []
+        }
+      }
+    },
+    {
+      "name": "disqualify_lead",
+      "tokens": 209,
+      "agents": [],
+      "required_by_cases": [
+        "case40_sort_the_queue"
+      ],
+      "permitted_in_cases": [],
+      "driven": true,
+      "graded_by_certification_tasks": null,
+      "measured_by_model": {
+        "claude-haiku-4-5-20251001": {
+          "runs": 3,
+          "passed": 2,
+          "reliability": 0.6666666666666666,
+          "cases_below_their_bar": []
+        },
+        "claude-opus-5": {
+          "runs": 3,
+          "passed": 1,
+          "reliability": 0.3333333333333333,
+          "cases_below_their_bar": [
+            "case40_sort_the_queue"
+          ]
+        },
+        "claude-sonnet-5": {
+          "runs": 3,
+          "passed": 2,
+          "reliability": 0.6666666666666666,
           "cases_below_their_bar": []
         }
       }
@@ -2533,13 +2566,15 @@
       }
     },
     {
-      "name": "disqualify_lead",
-      "tokens": 190,
+      "name": "data_coverage",
+      "tokens": 195,
       "agents": [],
       "required_by_cases": [
-        "case40_sort_the_queue"
+        "case22_can_i_trust_the_numbers"
       ],
-      "permitted_in_cases": [],
+      "permitted_in_cases": [
+        "case21_what_are_we_closing"
+      ],
       "driven": true,
       "graded_by_certification_tasks": null,
       "measured_by_model": {
@@ -2551,17 +2586,54 @@
         },
         "claude-opus-5": {
           "runs": 3,
-          "passed": 1,
-          "reliability": 0.3333333333333333,
-          "cases_below_their_bar": [
-            "case40_sort_the_queue"
-          ]
+          "passed": 3,
+          "reliability": 1,
+          "cases_below_their_bar": []
         },
         "claude-sonnet-5": {
           "runs": 3,
-          "passed": 2,
-          "reliability": 0.6666666666666666,
+          "passed": 3,
+          "reliability": 1,
           "cases_below_their_bar": []
+        }
+      }
+    },
+    {
+      "name": "list_colleagues",
+      "tokens": 195,
+      "agents": [],
+      "required_by_cases": [
+        "case33_two_cards_for_one_company"
+      ],
+      "permitted_in_cases": [
+        "case30_a_word_for_it",
+        "case31_wrong_word_on_the_record",
+        "case32_two_words_for_one_thing"
+      ],
+      "driven": true,
+      "graded_by_certification_tasks": null,
+      "measured_by_model": {
+        "claude-haiku-4-5-20251001": {
+          "runs": 3,
+          "passed": 0,
+          "reliability": 0,
+          "cases_below_their_bar": [
+            "case33_two_cards_for_one_company"
+          ]
+        },
+        "claude-opus-5": {
+          "runs": 3,
+          "passed": 3,
+          "reliability": 1,
+          "cases_below_their_bar": []
+        },
+        "claude-sonnet-5": {
+          "runs": 3,
+          "passed": 1,
+          "reliability": 0.3333333333333333,
+          "cases_below_their_bar": [
+            "case33_two_cards_for_one_company"
+          ]
         }
       }
     },
@@ -2767,47 +2839,8 @@
       }
     },
     {
-      "name": "list_colleagues",
-      "tokens": 141,
-      "agents": [],
-      "required_by_cases": [
-        "case33_two_cards_for_one_company"
-      ],
-      "permitted_in_cases": [
-        "case30_a_word_for_it",
-        "case31_wrong_word_on_the_record",
-        "case32_two_words_for_one_thing"
-      ],
-      "driven": true,
-      "graded_by_certification_tasks": null,
-      "measured_by_model": {
-        "claude-haiku-4-5-20251001": {
-          "runs": 3,
-          "passed": 0,
-          "reliability": 0,
-          "cases_below_their_bar": [
-            "case33_two_cards_for_one_company"
-          ]
-        },
-        "claude-opus-5": {
-          "runs": 3,
-          "passed": 3,
-          "reliability": 1,
-          "cases_below_their_bar": []
-        },
-        "claude-sonnet-5": {
-          "runs": 3,
-          "passed": 1,
-          "reliability": 0.3333333333333333,
-          "cases_below_their_bar": [
-            "case33_two_cards_for_one_company"
-          ]
-        }
-      }
-    },
-    {
       "name": "commit_import",
-      "tokens": 118,
+      "tokens": 128,
       "agents": [],
       "required_by_cases": [
         "case10_finish_the_import"
@@ -2823,39 +2856,6 @@
           "cases_below_their_bar": [
             "case10_finish_the_import"
           ]
-        },
-        "claude-opus-5": {
-          "runs": 3,
-          "passed": 3,
-          "reliability": 1,
-          "cases_below_their_bar": []
-        },
-        "claude-sonnet-5": {
-          "runs": 3,
-          "passed": 3,
-          "reliability": 1,
-          "cases_below_their_bar": []
-        }
-      }
-    },
-    {
-      "name": "data_coverage",
-      "tokens": 109,
-      "agents": [],
-      "required_by_cases": [
-        "case22_can_i_trust_the_numbers"
-      ],
-      "permitted_in_cases": [
-        "case21_what_are_we_closing"
-      ],
-      "driven": true,
-      "graded_by_certification_tasks": null,
-      "measured_by_model": {
-        "claude-haiku-4-5-20251001": {
-          "runs": 3,
-          "passed": 2,
-          "reliability": 0.6666666666666666,
-          "cases_below_their_bar": []
         },
         "claude-opus-5": {
           "runs": 3,
@@ -2949,7 +2949,7 @@
     },
     {
       "name": "read_import_report",
-      "tokens": 73,
+      "tokens": 77,
       "agents": [],
       "required_by_cases": [
         "case10_finish_the_import"

--- a/docs/reference/mcp-tool-coverage.md
+++ b/docs/reference/mcp-tool-coverage.md
@@ -29,7 +29,7 @@ This page does not grade single steps or name a best model per site — that is
 | … some case requires | 36 |
 | … **no case requires** | 39 |
 | … of those, permitted somewhere but never required | 19 |
-| Prompt tokens spent on tools no case requires | 12378 |
+| Prompt tokens spent on tools no case requires | 12728 |
 | Use cases | 21 |
 | Acceptance criteria the cases declare, each with a statement | 48 |
 
@@ -238,26 +238,26 @@ Every run of every case requiring this tool passed, for the model named.
 | Tool | Reliability | Runs | Required by |
 |---|---:|---:|---|
 | `run_report` | 1.00 | 3 | `case7_ask_for_a_number` |
-| `search_records` | 1.00 | 3 | `case5_before_the_meeting` |
 | `forecast_readings` | 1.00 | 3 | `case21_what_are_we_closing` |
-| `merge_records` | 1.00 | 3 | `case33_two_cards_for_one_company` |
+| `search_records` | 1.00 | 3 | `case5_before_the_meeting` |
 | `advance_project_phase` | 1.00 | 3 | `case41_close_the_project` |
+| `merge_records` | 1.00 | 3 | `case33_two_cards_for_one_company` |
+| `archive_record` | 1.00 | 3 | `case33_two_cards_for_one_company` |
 | `relink_activity` | 1.00 | 3 | `case9_filed_in_the_wrong_place` |
 | `decide_approval` | 1.00 | 3 | `case8_whats_waiting` |
 | `list_approvals` | 1.00 | 3 | `case8_whats_waiting` |
 | `check_availability` | 1.00 | 3 | `case23_find_us_a_slot` |
-| `archive_record` | 1.00 | 3 | `case33_two_cards_for_one_company` |
 | `apply_tag` | 1.00 | 3 | `case30_a_word_for_it` |
 | `relink_activities` | 1.00 | 3 | `case9_filed_in_the_wrong_place` |
+| `data_coverage` | 1.00 | 3 | `case22_can_i_trust_the_numbers` |
+| `list_colleagues` | 1.00 | 3 | `case33_two_cards_for_one_company` |
 | `create_tag` | 1.00 | 3 | `case30_a_word_for_it` |
 | `list_channel_providers` | 1.00 | 3 | `case42_can_i_answer_on_whatsapp` |
 | `remove_tag` | 1.00 | 3 | `case31_wrong_word_on_the_record` |
 | `read_project_360` | 1.00 | 3 | `case41_close_the_project` |
 | `read_approval` | 1.00 | 3 | `case8_whats_waiting` |
 | `get_record_tags` | 1.00 | 3 | `case31_wrong_word_on_the_record` |
-| `list_colleagues` | 1.00 | 3 | `case33_two_cards_for_one_company` |
 | `commit_import` | 1.00 | 3 | `case10_finish_the_import` |
-| `data_coverage` | 1.00 | 3 | `case22_can_i_trust_the_numbers` |
 | `read_import_report` | 1.00 | 3 | `case10_finish_the_import` |
 
 ### `claude-sonnet-5`
@@ -272,12 +272,12 @@ Every run of every case requiring this tool passed, for the model named.
 | `check_availability` | 1.00 | 3 | `case23_find_us_a_slot` |
 | `apply_tag` | 1.00 | 3 | `case30_a_word_for_it` |
 | `relink_activities` | 1.00 | 3 | `case9_filed_in_the_wrong_place` |
+| `data_coverage` | 1.00 | 3 | `case22_can_i_trust_the_numbers` |
 | `create_tag` | 1.00 | 3 | `case30_a_word_for_it` |
 | `list_channel_providers` | 1.00 | 3 | `case42_can_i_answer_on_whatsapp` |
 | `remove_tag` | 1.00 | 3 | `case31_wrong_word_on_the_record` |
 | `get_record_tags` | 1.00 | 3 | `case31_wrong_word_on_the_record` |
 | `commit_import` | 1.00 | 3 | `case10_finish_the_import` |
-| `data_coverage` | 1.00 | 3 | `case22_can_i_trust_the_numbers` |
 | `read_import_report` | 1.00 | 3 | `case10_finish_the_import` |
 
 ## 2. What is failing now
@@ -296,25 +296,25 @@ Driven, and not every run passed. Open the case to see what was asked.
 | `compose_analytics_report` | 0.00 | 0/3 | `case20_put_it_in_the_board_pack` | `case20_put_it_in_the_board_pack` |
 | `search_records` | 0.33 | 1/3 | `case5_before_the_meeting` | `case5_before_the_meeting` |
 | `search_context` | 0.00 | 0/3 | `case6_ask_the_company` | `case6_ask_the_company` |
-| `merge_records` | 0.00 | 0/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `advance_project_phase` | 0.00 | 0/3 | `case41_close_the_project` | `case41_close_the_project` |
-| `decide_approval` | 0.33 | 1/3 | `case8_whats_waiting` | `case8_whats_waiting` |
 | `promote_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
+| `merge_records` | 0.00 | 0/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
+| `archive_record` | 0.00 | 0/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
+| `decide_approval` | 0.33 | 1/3 | `case8_whats_waiting` | `case8_whats_waiting` |
 | `list_approvals` | 0.33 | 1/3 | `case8_whats_waiting` | `case8_whats_waiting` |
 | `check_availability` | 0.33 | 1/3 | `case23_find_us_a_slot` | `case23_find_us_a_slot` |
-| `archive_record` | 0.00 | 0/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `qualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
+| `disqualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
 | `update_tag` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
 | `merge_tags` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
-| `disqualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
+| `data_coverage` | 0.67 | 2/3 | — | `case22_can_i_trust_the_numbers` |
+| `list_colleagues` | 0.00 | 0/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `list_channel_providers` | 0.67 | 2/3 | — | `case42_can_i_answer_on_whatsapp` |
 | `remove_tag` | 0.00 | 0/3 | `case31_wrong_word_on_the_record` | `case31_wrong_word_on_the_record` |
 | `read_project_360` | 0.00 | 0/3 | `case41_close_the_project` | `case41_close_the_project` |
 | `read_approval` | 0.33 | 1/3 | `case8_whats_waiting` | `case8_whats_waiting` |
 | `get_record_tags` | 0.00 | 0/3 | `case31_wrong_word_on_the_record` | `case31_wrong_word_on_the_record` |
-| `list_colleagues` | 0.00 | 0/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `commit_import` | 0.33 | 1/3 | `case10_finish_the_import` | `case10_finish_the_import` |
-| `data_coverage` | 0.67 | 2/3 | — | `case22_can_i_trust_the_numbers` |
 | `list_tags` | 0.50 | 3/6 | `case32_two_words_for_one_thing` | `case30_a_word_for_it`, `case32_two_words_for_one_thing` |
 | `get_tag` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
 | `read_import_report` | 0.33 | 1/3 | `case10_finish_the_import` | `case10_finish_the_import` |
@@ -332,9 +332,9 @@ Driven, and not every run passed. Open the case to see what was asked.
 | `search_context` | 0.00 | 0/3 | `case6_ask_the_company` | `case6_ask_the_company` |
 | `promote_lead` | 0.33 | 1/3 | `case40_sort_the_queue` | `case40_sort_the_queue` |
 | `qualify_lead` | 0.33 | 1/3 | `case40_sort_the_queue` | `case40_sort_the_queue` |
+| `disqualify_lead` | 0.33 | 1/3 | `case40_sort_the_queue` | `case40_sort_the_queue` |
 | `update_tag` | 0.67 | 2/3 | — | `case32_two_words_for_one_thing` |
 | `merge_tags` | 0.67 | 2/3 | — | `case32_two_words_for_one_thing` |
-| `disqualify_lead` | 0.33 | 1/3 | `case40_sort_the_queue` | `case40_sort_the_queue` |
 | `list_tags` | 0.83 | 5/6 | — | `case30_a_word_for_it`, `case32_two_words_for_one_thing` |
 | `get_tag` | 0.67 | 2/3 | — | `case32_two_words_for_one_thing` |
 
@@ -348,19 +348,19 @@ Driven, and not every run passed. Open the case to see what was asked.
 | `compose_analytics_report` | 0.00 | 0/3 | `case20_put_it_in_the_board_pack` | `case20_put_it_in_the_board_pack` |
 | `search_records` | 0.33 | 1/3 | `case5_before_the_meeting` | `case5_before_the_meeting` |
 | `search_context` | 0.00 | 0/3 | `case6_ask_the_company` | `case6_ask_the_company` |
-| `merge_records` | 0.33 | 1/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `advance_project_phase` | 0.00 | 0/3 | `case41_close_the_project` | `case41_close_the_project` |
-| `decide_approval` | 0.67 | 2/3 | — | `case8_whats_waiting` |
 | `promote_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
-| `list_approvals` | 0.67 | 2/3 | — | `case8_whats_waiting` |
+| `merge_records` | 0.33 | 1/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `archive_record` | 0.33 | 1/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
+| `decide_approval` | 0.67 | 2/3 | — | `case8_whats_waiting` |
+| `list_approvals` | 0.67 | 2/3 | — | `case8_whats_waiting` |
 | `qualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
+| `disqualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
 | `update_tag` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
 | `merge_tags` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
-| `disqualify_lead` | 0.67 | 2/3 | — | `case40_sort_the_queue` |
+| `list_colleagues` | 0.33 | 1/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `read_project_360` | 0.00 | 0/3 | `case41_close_the_project` | `case41_close_the_project` |
 | `read_approval` | 0.67 | 2/3 | — | `case8_whats_waiting` |
-| `list_colleagues` | 0.33 | 1/3 | `case33_two_cards_for_one_company` | `case33_two_cards_for_one_company` |
 | `list_tags` | 0.50 | 3/6 | `case32_two_words_for_one_thing` | `case30_a_word_for_it`, `case32_two_words_for_one_thing` |
 | `get_tag` | 0.00 | 0/3 | `case32_two_words_for_one_thing` | `case32_two_words_for_one_thing` |
 
@@ -400,21 +400,22 @@ A tool in the `Permitted in` column is worse than one with nothing: a case is al
 
 | Tool | Tokens | Graded by | Permitted in | Attached to |
 |---|---:|---|---|---|
-| `send_account_email` | 742 | — | — | — |
-| `send_email` | 675 | `agent_loop` | — | — |
+| `send_account_email` | 768 | — | — | — |
+| `send_email` | 698 | `agent_loop` | — | — |
 | `update_record` | 572 | `agent_loop` | `case33_two_cards_for_one_company` | — |
-| `send_message` | 518 | — | — | — |
+| `send_message` | 546 | — | — | — |
 | `list_records` | 508 | — | `case10_finish_the_import`, `case21_what_are_we_closing`, `case30_a_word_for_it`, `case31_wrong_word_on_the_record`, `case32_two_words_for_one_thing`, `case33_two_cards_for_one_company`, `case40_sort_the_queue`, `case41_close_the_project`, `case7_ask_for_a_number`, `case9_filed_in_the_wrong_place` | `morning_brief`, `overnight_at_risk_sweep` |
 | `progress_deal` | 505 | `agent_loop` | — | — |
 | `resolve_entities` | 498 | `agent_loop` | `case1_log_it`, `case23_find_us_a_slot`, `case2_business_card`, `case30_a_word_for_it`, `case33_two_cards_for_one_company`, `case42_can_i_answer_on_whatsapp` | — |
+| `forecast_movement` | 453 | — | — | — |
 | `advance_deal` | 447 | `agent_loop` | — | — |
+| `book_meeting` | 424 | — | — | — |
 | `annotate_brief` | 418 | — | — | `morning_brief` |
 | `review_commitments` | 401 | `agent_loop` | `case41_close_the_project` | `overnight_at_risk_sweep` |
-| `book_meeting` | 393 | — | — | — |
-| `enrich` | 393 | `agent_loop`, `enrich` | — | — |
-| `forecast_movement` | 351 | — | — | — |
+| `enrich` | 398 | `agent_loop`, `enrich` | — | — |
 | `describe_report_vocabulary` | 349 | — | `case20_put_it_in_the_board_pack`, `case7_ask_for_a_number` | — |
 | `prep_for_meeting` | 326 | `agent_loop` | `case23_find_us_a_slot`, `case5_before_the_meeting` | — |
+| `forecast_input_checks` | 324 | — | `case21_what_are_we_closing`, `case22_can_i_trust_the_numbers` | — |
 | `demote_lead` | 316 | — | — | — |
 | `describe_analytics_vocabulary` | 286 | — | — | — |
 | `catch_me_up_on` | 280 | `agent_loop` | `case23_find_us_a_slot`, `case33_two_cards_for_one_company`, `case40_sort_the_queue`, `case41_close_the_project`, `case5_before_the_meeting`, `case6_ask_the_company`, `case9_filed_in_the_wrong_place` | `morning_brief`, `overnight_at_risk_sweep` |
@@ -422,13 +423,13 @@ A tool in the `Permitted in` column is worse than one with nothing: a case is al
 | `draft_follow_ups_for` | 273 | — | — | — |
 | `prepare_handoff` | 267 | `agent_loop` | `case41_close_the_project` | — |
 | `describe_query_vocabulary` | 266 | — | `case4_use_the_moment` | — |
-| `forecast_input_checks` | 252 | — | `case21_what_are_we_closing`, `case22_can_i_trust_the_numbers` | — |
 | `account_coverage` | 245 | `agent_loop` | `case5_before_the_meeting` | — |
 | `describe_report_blocks` | 245 | — | `case20_put_it_in_the_board_pack` | — |
 | `decide_approval_bundle` | 235 | — | — | — |
 | `create_task` | 222 | `deal_health` | `case42_can_i_answer_on_whatsapp` | — |
 | `read_record` | 222 | `agent_loop` | `case10_finish_the_import`, `case1_log_it`, `case21_what_are_we_closing`, `case23_find_us_a_slot`, `case2_business_card`, `case30_a_word_for_it`, `case31_wrong_word_on_the_record`, `case32_two_words_for_one_thing`, `case33_two_cards_for_one_company`, `case40_sort_the_queue`, `case41_close_the_project`, `case42_can_i_answer_on_whatsapp`, `case4_use_the_moment`, `case5_before_the_meeting`, `case6_ask_the_company`, `case7_ask_for_a_number`, `case8_whats_waiting`, `case9_filed_in_the_wrong_place` | `morning_brief`, `overnight_at_risk_sweep` |
 | `whats_slipping_this_week` | 211 | `agent_loop` | — | `overnight_at_risk_sweep` |
+| `list_input_checks` | 209 | — | `case21_what_are_we_closing`, `case22_can_i_trust_the_numbers` | — |
 | `at_risk_relationships` | 208 | `agent_loop` | — | `overnight_at_risk_sweep` |
 | `read_brief` | 206 | — | — | `morning_brief` |
 | `relink_thread` | 197 | — | — | — |
@@ -436,7 +437,6 @@ A tool in the `Permitted in` column is worse than one with nothing: a case is al
 | `list_pipelines` | 191 | `agent_loop` | `case1_log_it`, `case20_put_it_in_the_board_pack` | — |
 | `intro_path_to` | 190 | `agent_loop` | — | — |
 | `check_location_support` | 156 | — | — | — |
-| `list_input_checks` | 146 | — | `case21_what_are_we_closing`, `case22_can_i_trust_the_numbers` | — |
 | `whoami` | 128 | — | `case30_a_word_for_it`, `case31_wrong_word_on_the_record`, `case32_two_words_for_one_thing`, `case33_two_cards_for_one_company`, `case40_sort_the_queue`, `case42_can_i_answer_on_whatsapp` | — |
 | `read_import_run` | 67 | — | `case10_finish_the_import`, `case3_spreadsheet` | — |
 

--- a/e2e/llm/scenarios/case21-what-are-we-closing.yaml
+++ b/e2e/llm/scenarios/case21-what-are-we-closing.yaml
@@ -67,7 +67,11 @@ may_call:
 
 must_mention:
   # It came back with money, not with a description of the forecast.
-  - "[0-9]"
+  # A MONEY FIGURE, not any digit. A bare [0-9] is satisfied by a date, an id
+  # or a quarter label — and "the forecast for Q3 is EUR 0 across 0 deals"
+  # passed it. The route is already held by must_call: forecast_readings, so
+  # what this adds is that a FIGURE reached the reader.
+  - "(?:\u20ac|EUR|\$)\s?[0-9]|[0-9][0-9.,]*\s?(?:\u20ac|EUR|k\b|m\b|million|Mio)|\b[0-9]+\s+(?:open |won |priced )?deals?\b|\b[0-9]{1,3}(?:[.,][0-9]{3})+\b"
   # CRITERION 4 — the unpriced deal is named as absent from the total.
   #
   # Judged on the FINDING, not the wording. "One deal carries no amount, so it

--- a/e2e/llm/scenarios/case3-spreadsheet.yaml
+++ b/e2e/llm/scenarios/case3-spreadsheet.yaml
@@ -41,8 +41,14 @@ must_mention:
   # MECHANICAL, both. Criterion 1 needs the usable count to appear at all, and
   # criterion 6 needs the unusable row named — a count and a noun are what a
   # regex reads reliably, and neither of these has leaked.
-  - "3|three"
-  - "skip|skipped|issue|problem|could not|missing name|blank|row"
+  # ANCHORED TO WHAT IS COUNTED. A bare "3|three" is satisfied by a row
+  # number, an id or a date — the same defect case 10 fixed and case 7 deleted
+  # its own bare digit for. What this criterion is about is how many rows the
+  # dry run would write, so the number has to be beside the noun.
+  - "(?:creat\w*|import\w*|add\w*|anleg\w*)[^.]{0,20}\(?\*{0,2}\b(?:3|three|drei)\b\)?(?:[^.]{0,20}(?:rows?|records?|companies|organi[sz]ations?|contacts?|people|Zeilen|Datensätze)|\s*[:\-*•—|]|\s*\n)|\b(?:3|three|drei)\b[^.]{0,20}(?:creat\w*|import\w*|new\b|angelegt)(?:[^.]{0,20}(?:rows?|records?|companies|organi[sz]ations?|contacts?|people|Zeilen|Datensätze)|\s*[:\-*•—|]|\s*\n)|\b(?:3|three|drei)\s+(?:\w+\s+){0,3}(?:rows?|records?|companies|organi[sz]ations?|contacts?|people|Zeilen|Datensätze)"
+  # And the unusable row is REPORTED, not merely a sentence containing the
+  # word "row". Anchored to the row being left out, in either order.
+  - "(?:skip\w*|left out|not imported|unusable|rejected|übersprung\w*)[^.]{0,60}(?:row|record|line|name|Zeile|Datensatz)|(?:row|record|line|Zeile)[^.]{0,60}(?:skip\w*|left out|no name|blank|unusable|leer|fehlt|could not be (?:used|imported))"
 
 # CRITERION 1's REAL QUESTION IS SEMANTIC and had no guard that could fail.
 # The case is about showing the numbers BEFORE anything is written, and the only

--- a/e2e/llm/scenarios/case33-two-cards-for-one-company.yaml
+++ b/e2e/llm/scenarios/case33-two-cards-for-one-company.yaml
@@ -96,26 +96,33 @@ may_call:
   - whoami
 
 must_mention:
-  # Criterion 1: the surviving record is NAMED, and by its own name rather than
-  # as "the duplicate" or "the other one".
+  # Criterion 1, first half: the company is named at all.
+  - "Ostfriesen Kranbau"
+  # Criterion 1, second half: WHICH card survived, and that it survived.
   #
-  # EITHER TWIN MAY SURVIVE, and pinning one was this pattern asserting something
-  # the prompt never asked for. "Put it back to one record without losing any of
-  # that correspondence" is satisfied in both directions — a merge moves the
-  # source's activities onto the survivor — so a run that keeps the card the mail
-  # is already on has answered the question, and a run that keeps the older card
-  # has too. A measured run did exactly the first and was failed for the spelling:
-  # it merged correctly, archived correctly, said "Kept: Ostfriesen Kranbau
-  # Gesellschaft mbH (the one with the email history)", and the judge passed
-  # criterion 1 while this pattern reported a product defect that was not there.
+  # EITHER TWIN MAY SURVIVE. The prompt names no direction and a merge moves the
+  # source's activities onto the survivor either way, so keeping the card the
+  # mail is already on and keeping the older card both answer it.
   #
-  # The full suffix is required either way — "Ostfriesen Kranbau" alone would be
-  # satisfied by an answer naming neither card in particular, which is the thing
-  # criterion 1 exists to catch.
-  - "Ostfriesen Kranbau (?:GmbH|Gesellschaft mbH)"
-  # Criterion 1: and the direction is stated rather than left to the reader.
-  # Both orders, because an answer may lead with either record.
-  - "Ostfriesen Kranbau (?:GmbH|Gesellschaft mbH)[^.]{0,120}(?:surviv|kept|keeping|remains|stays|wins|the one I|target)|(?:surviv|kept|keeping|merged into|folded into|onto)[^.]{0,120}Ostfriesen Kranbau (?:GmbH|Gesellschaft mbH)"
+  # ANCHORED ON A TOKEN UNIQUE TO A TWIN, because the suffix alone is not one.
+  # "Gesellschaft mbH" belongs to one card; bare "GmbH" belongs to the other AND
+  # to Sauerland Kunststoff GmbH, which this same prompt guarantees the answer
+  # will name — so "merged the two Ostfriesen records and archived Sauerland
+  # Kunststoff GmbH" scored a survivor it never named. A false green is worse
+  # than the false red it replaced: the red at least made somebody look.
+  # "Kranbau GmbH" cannot be Sauerland, and an answer is still not obliged to
+  # repeat the whole company name beside the suffix. Three measured runs said it three ways — "kept the
+  # \"Gesellschaft mbH\" version", "kept \"Ostfriesen Kranbau Gesellschaft mbH\"
+  # as the surviving record", and a heading followed by "Kept Gesellschaft mbH"
+  # — all three correct, and a pattern demanding the name and the suffix be
+  # adjacent greened only the middle one.
+  #
+  # It still fails what it exists to fail: "I merged the two Ostfriesen Kranbau
+  # records into one" names no survivor and matches nothing here, because no
+  # suffix appears near the survival word. Whether the survivor NAMED is the one
+  # the merge actually produced stays the judge's question — that half can read
+  # the transcript and this one cannot.
+  - "(?:Gesellschaft mbH|Kranbau GmbH)[^.]{0,140}(?:surviv|kept|keeping|remains|stays|wins|the one I|target)|(?:surviv|kept|keeping|merged into|folded into|onto)[^.]{0,140}(?:Gesellschaft mbH|Kranbau GmbH)"
   # Criterion 2: the closed company was retired, and it is the closed company
   # that was retired. Anchored to Sauerland both ways round — an unanchored
   # "archived" is true of the merge's own source record and would green an

--- a/e2e/llm/scenarios/case4-use-the-moment.yaml
+++ b/e2e/llm/scenarios/case4-use-the-moment.yaml
@@ -40,7 +40,13 @@ may_call:
 # say so sends a rep into a colleague's account.
 must_mention:
   - "Sofia Meier|Lena Fischer|Phạm Hương Giang"
-  - "owner|owned by|belongs to|check with|speak to|message"
+  # CRITERION 6 is the ADVICE, not the fact. Naming the owner satisfied the old
+  # alternation, so "all three are owned by Sofia Meier" — knowing the owner and
+  # saying nothing about what to do — scored the criterion that exists to stop a
+  # rep walking into a colleague's account. "message" made it looser still: "I
+  # will draft a message" matched. Anchored to telling the reader to go via the
+  # owner first.
+  - "(?:check|speak|talk|clear it|confirm|coordinate|touch base|abstimmen|Bescheid)[^.]{0,60}(?:with|to|mit)?[^.]{0,20}(?:owner|Sofia|Lena|Ph\u1ea1m|colleague|whoever owns|rep who owns)|(?:owner|Sofia Meier|Lena Fischer|Ph\u1ea1m H\u01b0\u01a1ng Giang)[^.]{0,60}(?:before you|first|should know|would want|ask them|let them know|not your|not yours|not you\b|nicht dein)"
 
 # Run 1 of the real scenario failed exactly here: correct companies, and it
 # never said whose they were, because the row carried a bare uuid.

--- a/e2e/llm/scenarios/case5-before-the-meeting.yaml
+++ b/e2e/llm/scenarios/case5-before-the-meeting.yaml
@@ -39,10 +39,24 @@ may_call:
 
 must_mention:
   # Criterion 1: it found the account from a description, not a name.
-  - "Vietnam Partner"
+  # "JSC", not "Vietnam Partner" alone. The prompt already says "Vietnam
+  # partner", so the old assertion was satisfied by echoing the question back
+  # and could not tell a run that FOUND the account from one that repeated the
+  # user. The legal suffix appears only on the record.
+  #
+  # It is thin — the fixture named the company after the description the user
+  # gives, so there is no other token the workspace alone can supply. Mai
+  # Nguyen below is the stronger evidence that the record was opened, and this
+  # entry is the weaker half of a pair rather than the case's proof.
+  - "Vietnam Partner JSC|\bJSC\b"
   # Criterion 5: the promise nobody kept. The fixture logs an outbound message
   # saying the list would be sent, and nothing after it.
-  - "Aufstellung|list|promised|zugesagt|never sent|no record|outstanding|follow up"
+  # THE UNKEPT PROMISE, which the header calls the highest-value thing this
+  # case produces. A bare "list" matched; so did "no record" — so an answer
+  # DENYING the finding ("there is no record of Mai Nguyen, nothing was
+  # promised") scored the criterion. Anchored to something being owed and not
+  # delivered.
+  - "(?:Aufstellung|breakdown|summary)[\s\S]{0,120}(?:waiting|no reply|outstanding|never (?:replied|came|sent)|quiet|promis\w*|zugesagt|owed)|(?:waiting for them|no reply|outstanding|promis\w*|zugesagt|owed)[\s\S]{0,120}(?:Aufstellung|breakdown|summary)"
   # Criterion 2's server half is already pinned; here it must NAME the people
   # rather than describing seats.
   - "Mai Nguyen"

--- a/e2e/llm/scenarios/case9-filed-in-the-wrong-place.yaml
+++ b/e2e/llm/scenarios/case9-filed-in-the-wrong-place.yaml
@@ -99,7 +99,13 @@ must_mention:
   # and a real answer writes "the three Rückruf calls" — one word, and not a
   # month, which is what keeps "3 March 2025" out. "3 moved, 0 failed" is the
   # other shape a batch report takes.
-  - "\b(?:3|three|drei)\s+(?:(?!Jan|Feb|Mar|Apr|Ma[iy]|Jun|Jul|Aug|Sep|O[kc]t|Nov|De[czs])[\w-]+\s+){0,1}(?:activit\w*|e-?mails?|mails?|messages?|calls?|items?|records?|entries|Aktivit\w+|Anrufe?|Rückrufe?)|\b(?:3|three|drei)\s+(?:mov\w*|re-?link\w*|re-?fil\w*|transferr?\w*)|(?:mov\w*|re-?link\w*|re-?fil\w*|transferr?\w*)[^\n]{0,25}\ball (?:3|three|drei)\b|\ball (?:3|three|drei)\b[^\n]{0,30}(?:mov\w*|re-?link\w*|re-?fil\w*|transferr?\w*)"
+  # THE WORDS BETWEEN THE COUNT AND THE NOUN are budgeted at three, not one.
+  # A run says "the three Aachener Metallwerke calls" — the company is two
+  # words, and the count-noun pair is four words apart. At one, that natural
+  # sentence missed while "the three Aachener mails" passed, so the pattern was
+  # scoring how long the company's name is. The month lookahead still stands
+  # between "3" and a date, which is the thing this must not read as a count.
+  - "\b(?:3|three|drei)\s+(?:(?!Jan|Feb|Mar|Apr|Ma[iy]|Jun|Jul|Aug|Sep|O[kc]t|Nov|De[czs])[\w-]+\s+){0,3}(?:activit\w*|e-?mails?|mails?|messages?|calls?|items?|records?|entries|Aktivit\w+|Anrufe?|Rückrufe?)|\b(?:3|three|drei)\s+(?:mov\w*|re-?link\w*|re-?fil\w*|transferr?\w*)|(?:mov\w*|re-?link\w*|re-?fil\w*|transferr?\w*)[^\n]{0,25}\ball (?:3|three|drei)\b|\ball (?:3|three|drei)\b[^\n]{0,30}(?:mov\w*|re-?link\w*|re-?fil\w*|transferr?\w*)"
 
 must_not_mention:
   # CRITERION 3, and the failure this case exists for: re-writing history instead

--- a/e2e/llm/seed-llm-fixtures.sh
+++ b/e2e/llm/seed-llm-fixtures.sh
@@ -79,6 +79,54 @@ api() {
   fi
 }
 
+# activate_seat gives a seeded colleague a password, which is what makes the
+# seat ACTIVE and therefore a colleague at all.
+#
+# POST /users writes status='invited' — a seat with no password_hash signs in
+# nowhere — and identity.Colleagues lists only status='active'. So every seat
+# this seed created was invisible to list_colleagues, on every call of every
+# run, and two scoring criteria across two cases could not be reached by any
+# model: the tool was right to find nobody and the fixture was what was wrong.
+#
+# The route back is the one the product itself uses for an installation with no
+# outbound email: mint a single-use set-password link, then redeem it. Issuance
+# admits an invited member deliberately, and redemption is what sets
+# status='active'.
+#
+# The token rides in the URL FRAGMENT, which is why it is split on `#` here
+# rather than read from a query parameter.
+activate_seat() {
+  local user_id="$1" who="$2" password="colleague-password-123"
+  local link status
+  # ONLY an invited seat. Redemption revokes every live session and replaces the
+  # password, so calling this on a seat that is already active turns a re-run of
+  # an idempotent seed into a logout for whoever was using it.
+  status="$(api GET "/users/$user_id" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("status",""))
+except Exception:
+    print("")')"
+  [[ "$status" != "active" ]] || return 0
+  link="$(api POST "/users/$user_id/password-link" '{}' | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("set_password_url",""))
+except Exception:
+    print("")')"
+  [[ -n "$link" ]] || { echo "could not mint a set-password link for $who" >&2; exit 1; }
+  local token="${link##*#}"
+  token="${token##*token=}"
+  [[ -n "$token" && "$token" != "$link" ]] || {
+    echo "the set-password link for $who carries no fragment token: $link" >&2; exit 1; }
+  local code
+  code="$(status_of POST /auth/reset-password \
+    "$(printf '{"token":%s,"new_password":"%s"}' "$(json_string "$token")" "$password")")"
+  [[ "$code" = "204" ]] || { echo "redeeming $who's set-password link answered HTTP $code" >&2; exit 1; }
+}
+
+# json_string quotes a value as a JSON string, so a token containing a quote or
+# a backslash cannot break out of the body it is placed in.
+json_string() { printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'; }
+
 # id_of reads the id out of a create response, or empty when the create was
 # refused (a 409 on a natural key, which a re-run expects).
 id_of() { printf '%s' "$1" | python3 -c 'import json,sys
@@ -254,6 +302,7 @@ rows = json.load(sys.stdin).get("data", [])
 print(rows[0]["id"] if rows else "")')"
 fi
 [[ -n "$colleague" ]] || { echo "could not resolve the colleague seat" >&2; exit 1; }
+activate_seat "$colleague" "Sofia Meier"
 
 # --- CASE 4: companies in and around Köln, owned by the colleague ------------
 #
@@ -560,6 +609,31 @@ if [[ -z "$aachen" ]]; then
     file_mail_on_company "Rückruf Aachener Metallwerke ($n/3)" \
       "Abstimmung zum Angebot für Aachener Metallwerke." "$(days_ago "$n")" "$vorort"
   done
+fi
+
+# --- CASE 2: the person the card names is already here, once -----------------
+#
+# Case 2 asserts that the assistant REPORTS the duplicate its create filed —
+# "a queue nobody is told about is a queue nobody reads". Nothing seeded the
+# other half, so there was no duplicate to file: three runs scored on the word
+# "already" borrowed from case 8's approval queue, and the one honest answer
+# ("neither she nor Terralogic existed, so I created both") scored FAIL.
+#
+# A NAME COLLISION is the lane that files a review row on a manual create.
+# manualDedupePerson passes QueueNameCollisions, so a second "Lucy Vo" is
+# queued for a human rather than refused — which is exactly the state the case
+# describes. The email and phone are deliberately DIFFERENT: an exact address
+# match is a claimed-address refusal, not a duplicate report, and that would
+# test the opposite thing.
+#
+# She sits at another company on purpose. Two people really can share a name,
+# so the review row is a question; if this Lucy were at Terralogic the honest
+# answer would be "that is the same person", and the case is about reporting
+# the QUEUE, not about being right.
+lucy_twin="$(person_id_by_email "Lucy Vo" "l.vo@saigontech.test")"
+if [[ -z "$lucy_twin" ]]; then
+  body="$(printf '{"full_name":"Lucy Vo","owner_id":"%s","title":"Procurement Lead","emails":[{"email":"l.vo@saigontech.test","is_primary":true}],"phones":[{"phone":"+842839334455","is_primary":true}]}' "$colleague")"
+  lucy_twin="$(create_or_die "/people" "$body" "the Lucy Vo already on file")"
 fi
 
 # --- CASE 20 + 21: a priced pipeline, and one deal nobody put a number on ----
@@ -1000,6 +1074,7 @@ if [[ -z "$lena" ]]; then
     "email":"lena.fischer@demo.test","display_name":"Lena Fischer","role":"rep"}')")"
 fi
 [[ -n "$lena" ]] || { echo "could not resolve the Lena Fischer seat" >&2; exit 1; }
+activate_seat "$lena" "Lena Fischer"
 
 # --- CASE 40: the lead queue, one lead per terminal outcome -----------------
 #
@@ -1112,5 +1187,25 @@ if [[ -z "$nuria" ]]; then
   nuria="$(create_or_die "/people" "$body" "Nuria Sanz")"
   link_employment "$nuria" "$levante" "Nuria Sanz at Levante Cold Chain"
 fi
+
+# --- THE ROSTER IS VERIFIED, not assumed ---------------------------------
+#
+# The seats above are the fixture's most silent failure mode. A seat that stays
+# `invited` is not a colleague, list_colleagues answers `[]`, and a run reads
+# that as "this person does not work here" — a scenario failure with the fixture
+# as its cause and nothing saying so. It went unnoticed across whole sweeps.
+#
+# Asked of the ROSTER READ the tools use, not of the rows this script created:
+# a seat that exists and is not listed is exactly the state being guarded
+# against, so checking that the POST succeeded would prove nothing.
+roster="$(api GET '/users?limit=100' | python3 -c 'import json,sys
+rows = json.load(sys.stdin).get("data", [])
+print("\n".join(r.get("email","") for r in rows if r.get("status") == "active"))')"
+for seat in sofia.meier@demo.test lena.fischer@demo.test; do
+  printf '%s\n' "$roster" | grep -qx "$seat" || {
+    echo "$seat holds no ACTIVE seat, so list_colleagues will not name them and every case " \
+         "that hands work to a colleague fails for the fixture's reason" >&2
+    exit 1; }
+done
 
 echo "LLM fixtures seeded"

--- a/e2e/llm/why.py
+++ b/e2e/llm/why.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Why did a run not call the tool its scenario requires?
+
+A failing `must_call` says which tool was missed and nothing about why. The
+answer is almost always one of three things, and they need different fixes:
+
+  the tool was never served        -> a scope, a tier floor, or a registration
+  it was served and not chosen     -> the tool's own copy, read beside its rivals
+  it was chosen and refused        -> the refusal, which the transcript carries
+
+This prints the evidence for all three, per run, so the question is answered by
+reading rather than reconstructed by hand each time. Reads only what the lane
+already records; it drives no model and costs nothing.
+
+    e2e/llm/why.py case20_put_it_in_the_board_pack
+"""
+
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+RECORDS = ROOT / "e2e" / "llm" / "records"
+SCENARIOS = ROOT / "e2e" / "llm" / "scenarios"
+SERVED = ROOT / "docs" / "reference" / "mcp-info.json"
+
+
+def must_call(scenario):
+    """The tools the scenario requires, read off its own YAML.
+
+    Parsed by hand rather than with a YAML library: the patterns in these files
+    carry regex escapes a strict loader rejects, and this only needs one list.
+    """
+    for path in SCENARIOS.glob("*.yaml"):
+        if f"name: {scenario}" not in path.read_text():
+            continue
+        wanted, inside = [], False
+        for line in path.read_text().splitlines():
+            if line.startswith("must_call:"):
+                inside = True
+                continue
+            if inside:
+                if line.startswith("  - "):
+                    wanted.append(line[4:].strip())
+                elif line and not line.startswith((" ", "#")):
+                    break
+        return wanted
+    return []
+
+
+def served_descriptions():
+    """Every tool the surface publishes, by bare name."""
+    if not SERVED.exists():
+        return {}
+    out = {}
+
+    def walk(node):
+        if isinstance(node, dict):
+            name, text = node.get("name"), node.get("description")
+            if isinstance(name, str) and isinstance(text, str):
+                out[name] = text
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(json.load(SERVED.open()))
+    return out
+
+
+def read_run(path):
+    """One run's served tool list, its calls, and its final answer."""
+    offered, called, answer = [], [], ""
+    for line in path.read_text().splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "system" and event.get("subtype") == "init":
+            offered = [t.split("__")[-1] for t in event.get("tools") or []]
+        if event.get("type") == "assistant":
+            for block in event.get("message", {}).get("content", []):
+                if block.get("type") == "tool_use":
+                    called.append(block["name"].split("__")[-1])
+                elif block.get("type") == "text" and block["text"].strip():
+                    answer = block["text"]
+    return offered, called, answer
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+    scenario = sys.argv[1]
+    wanted = must_call(scenario)
+    descriptions = served_descriptions()
+    runs = sorted(RECORDS.glob(f"{scenario}.run*.jsonl"))
+    if not runs:
+        sys.exit(f"no transcripts for {scenario} under {RECORDS}")
+
+    print(f"{scenario}: must_call {wanted or '(none)'}")
+    # A TRANSCRIPT IS THE LAST ATTEMPT, not necessarily the run the verdict
+    # counted: the lane retries inside a run, and each attempt overwrites the
+    # file. So a case whose log says a tool was never called can still show
+    # that tool here, and the two are not in conflict — they are answering
+    # about different attempts. Read the verdict from the sweep log; read the
+    # SHAPE of what a model does from these.
+    print("(transcripts are each run's LAST attempt — for the counted verdict, "
+          "read the sweep log)\n")
+    missed_anywhere = set()
+    for path in runs:
+        offered, called, answer = read_run(path)
+        missed = [t for t in wanted if t not in called]
+        missed_anywhere.update(missed)
+        print(f"--- {path.name}")
+        print(f"    served : {len(offered)} tools")
+        print(f"    called : {', '.join(called) or '(nothing)'}")
+        for tool in missed:
+            where = "SERVED and not chosen" if tool in offered else "NEVER SERVED"
+            print(f"    missed : {tool} — {where}")
+        print(f"    answer : {answer[:160].replace(chr(10), ' ')}")
+        print()
+
+    for tool in sorted(missed_anywhere):
+        text = descriptions.get(tool)
+        if not text:
+            continue
+        # The copy is what a model chose against, so it is printed whole rather
+        # than summarised: the first sentence is what a scan reads.
+        print(f"=== {tool} reads, to a caller scanning for a job:")
+        print("    " + text.replace("\n", " ")[:600])
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Ten tools told a model a person would approve a call that in fact runs immediately. A tool that writes board documents described its plumbing instead of its job. Five forecast tools could not name a neighbour because they had opted out of the copy struct that has the field for it. And a third of the e2e-llm suite was scoring phrasing rather than behaviour.

Closes #5184 and #5189.

## Measured, three models, one tree

| model | cases | runs |
|---|---|---|
| **sonnet** (the target) | 13/21 → **15/21** | 40/63 → **44/63** |
| haiku | 10/21 → 10/21 | 29/63 → **32/63** |
| opus | 17/21 → **15/21** | 50/63 → 47/63 |

**Net at case level: zero.** Sonnet gains two, opus loses two. The gains are the cases this work targeted; the losses are one known trade and one variance, both attributed below. I would rather hand you that than a headline.

### What earned the gains

| case | what changed | result |
|---|---|---|
| **case33** two cards for one company | the fixture had no active colleague seats at all, plus the staged answer now reports what it DID, plus a pattern that stopped demanding one spelling | haiku **0/3 → 3/3**, sonnet **1/3 → 3/3** |
| **case32** two words for one thing | the staged 🟡 answer carries the summary the human's card was given | sonnet **0/3 → 3/3**, opus 2/3 → 3/3 |
| **case20** board pack | `compose_analytics_report`'s Purpose leads with the JOB, not the mechanism | sonnet **0/3 → 3/3**, opus 2/3 → 3/3 |
| case22, case23, case31 | — | up on haiku |

### What the losses cost, honestly

- **opus case7 3/3 → 0/3 — this branch caused it.** Making `compose_analytics_report` findable for "write me a board section" also made it findable for "give me a number", and opus stopped calling `run_report`. Narrowing the Purpose and giving `run_report` an explicit boundary recovered part of it and not all. It is a real trade: sonnet gains case20, opus loses case7. Undecided rather than hidden — see the note at the end.
- **opus case1 2/3 → 1/3 — not this branch.** A judge criterion about turning a raised topic into a committed action item, on `log_activity`/`create_task`. The diff contains zero changes to either tool's copy. Variance.
- **opus case3 3/3 → 1/3 — not the regex.** This one is worth reading, because the corrective re-run after the table-cell fix *did not recover it* (sonnet 3/3, haiku 1/3, opus 0/3) and named the real cause: every remaining failure is the **judge**, whose words are *"the answer reports the import as already completed with 'Done. Imported' in past tense"*. The criterion asks for a preview of what the import **would** do before anything is written; the model writes the rows and then reports them. A live finding about the dry-run surface that this PR does not fix.

## 1. Ten tools promised a human who is not there

```
send_email description:  "a person approves the send before it leaves"
send_email governance:   "runs immediately"
```

ADR-0055 stopped these verbs staging by default. The governance line is derived from the enforced tier, so it followed. The prose above it is hand-written, and did not. A model reading `send_email` was told somebody would catch a mistaken send, and by default nobody would — the surface understating its own authority to the one party deciding whether to use it.

Fixed on all ten, using the phrasing `demote_lead` already had, which is true at either tier. **And gated:** `TestNoToolPromisesAnApprovalItsTierDoesNotRequire` fails when prose and tier disagree. Written as a contradiction check rather than banned words, because an installation may legitimately turn approval on — a second test holds that the conditional form stays sayable, and a floor fails the census if it stops reaching the surface.

## 2. The forecast family had opted out of the copy discipline

Five tools used hand-rolled `Description` strings instead of `toolCopy`. A string has nowhere to put an `Instead`, so they named nobody and nobody named them.

```
BEFORE                            AFTER
forecast_readings      → nobody   → run_report, query_workspace,
forecast_movement      → nobody     compose_analytics_report,
forecast_input_checks  → nobody     run_analytics_query, forecast_input_checks
list_input_checks      → nobody   (and the other four likewise)
data_coverage          → nobody
```

Three tools answer "can I trust these numbers?" — the verdict, the findings, and whether the sources were readable at all — and none said which question it held. A clean set of findings over sources nobody opened reads as good news and is not. `forecast_movement` now also admits it **cannot be called**: it needs snapshot ids nothing on this surface hands out, and says that reading `forecast_readings` twice and subtracting is not the same answer.

## 3. An empty colleague list was two different answers

`{"colleagues": []}` meant both "this workspace employs nobody" and "nobody here is spelled the way you asked". A caller cannot tell them apart, and it picked wrong: *"Lena Fischer isn't in the system yet."*

A miss now hands back the set it was matched against, through the envelope's warning channel rather than standing tool copy — a `Limits` sentence is paid on every listing of all 75 tools, and this one is only true on the miss. A successful empty fallback (`[]`) and an unreadable one (absent) are different bytes. The cap rides its own flag, because 200 alphabetical names with the one asked for absent reads as *proof* of absence.

**And the tool was right all along.** `POST /users` writes `status='invited'`; `identity.Colleagues` lists only `status='active'`. Verified across a full sweep: **5 calls, 0 non-empty.** Two criteria on two cases were unreachable by any model and were scoring as model failures. The seed now mints a set-password link and redeems it, then verifies the roster READ rather than the rows it wrote.

## 4. A staged call says what it staged, and what it already did

The staging composed a summary for the human's inbox card and threw it away, so an agent could only report that something was pending. Now it carries it, escaped and bounded on the way out — the summary holds a caller-chosen field name and a workspace record label, and this text lands in a transcript whose later prompts the same run reads.

It also says the approval blocks **that call only** and to report what already happened. Two measured runs had merged a duplicate and archived a dead company and mentioned neither, because they wrote their answer about the one thing that stopped.

## 5. A share count meant conversion, not pricing

`count(*) FILTER (WHERE c.base_minor IS NOT NULL)` scanned into `priced_count`, whose contract says *"how many carried an amount"*. The one population they differ on is the deal priced in a currency no rate reached — which `fx_missing_count` already names, so the single gap was reported twice.

**Held, not just fixed.** The two writers cannot share a helper, so they are asserted equal against the frozen row. Broken from both sides: the SQL reverted gives `priced_count = 1, want 2`; `Compute` broken instead gives `recompute says 3/3/1, frozen row says 3/2/1`. A constants-only test sails through the second.

## 6. A third of the suite was scoring the wrong thing

- **case2 asserted a duplicate the fixture never seeded.** Two runs passed on the word "already" borrowed from case8's approval queue; the one honest answer scored FAIL. `manualDedupePerson` files a review row on a name collision — the code's own example is literally "Lucy Vo" — so the seed now plants one.
- **case3** `"3|three"` + `"row"` was satisfied by "rows 1-3" with no report at all.
- **case21** a bare `[0-9]` was satisfied by a date.
- **case4** naming the owner satisfied the criterion about *advising* the rep to check with them.
- **case5** `"Vietnam Partner"` was satisfied by echoing the prompt; `"list|no record"` was satisfied by an answer *denying* the finding.
- **case9** required the count and the noun one word apart, so "the three Aachener Metallwerke calls" — a two-word company — failed.
- **case33** demanded one spelling of the survivor.

Every replacement was verified in **both** directions against the recorded transcripts, the curated fixtures in `e2e/llm/testdata/`, and a constructed false green. Two rounds were needed: my first attempt would have redded twelve correct answers.

**New: `e2e/llm/why.py`.** A failing `must_call` says which tool was missed and never why — and the answer is one of three things needing three different fixes: never served, served-and-not-chosen, or chosen-and-refused. It prints all three per run from records the lane already keeps, at no cost. It answered case20 in one command.

## Two things I got wrong along the way

- **My first case33 fix shipped a false green.** Accepting bare `GmbH` also matched *Sauerland Kunststoff GmbH*, the other company in the same prompt, so an answer naming no survivor would have passed. Now anchored on tokens unique to the twins. A false green is worse than the false red it replaces: the red at least makes somebody look.
- **`deterministic-gates` caught a case3 pattern that redded the correct fixture.** `e2e/llm/testdata/` is a better oracle than the live records and I had not been using it. The *defective* fixtures matter too: they must pass the regex and fail only the judge, or a too-tight pattern fails them for the wrong reason.

## Why no coverage table in this diff

The published `docs/reference/mcp-tool-coverage.*` is **deliberately untouched**. The three-model sweep's verdict records were lost to a `git reset --hard` of mine before a corrective re-run, and reconstructing them from the logs would put figures in a committed record that the tool did not write. Committing only the cases I still have would publish exactly the blended table I criticised in the haiku row this morning.

So the numbers above come from the sweep logs, and the table will be regenerated by the next clean sweep. `case3` in particular was first measured against a pattern I fixed mid-sweep and was re-measured afterwards on a synced tree — with the result recorded in the loss list above.

## Open, and not resolved by this PR

- **The case7/case20 trade.** Worth a decision rather than more copy iteration; three rounds bought one run.
- **case40's bounce note reaches no model in any run**, so the passing runs disqualify a lead on record age — the guess the case exists to rule out.
- `Instead:` renders 3rd of 4, landing 50–60% into every description. A model skimming 75 tools reads openings, and the boundary is never in one.
