### PR TITLE
claim: the craftsmanship job is red on main (whole-tree craft-static)

### DIFF
--- a/.claim-marker
+++ b/.claim-marker
@@ -1,0 +1,1 @@
+claiming the craftsmanship job


### PR DESCRIPTION
## What I am taking

The **`craftsmanship`** CI job — `make craft-static`, the whole-tree sweep. Three findings, none of them in a file any open PR touches:

```
backend/internal/modules/consent/rightscase.go
  202: [BLOCKER] swallowed-errors — blank-assigning a call result discards a possible error
backend/internal/modules/consent/rightscase_integration_test.go
  270: [BLOCKER] swallowed-errors — same
backend/internal/modules/activities/scheduling_public.go
  212: [MAJOR] long-func — BookPublicMeeting is 81 code lines (> 80)

BLOCK — 2 blocker, 1 major, 0 minor
```

Not the integration lane. #5224 covers integration tests and this is a different job, so the two claims do not overlap.

## It is main, not a PR

Reproduced on a clean detached worktree at `origin/main`, and confirmed failing in CI on run 34451039064 (`craftsmanship — failure`).

## Why it matters more than it looks

The job is gated on `backend == 'true'`, so it fails on **every** backend pull request. The pre-push hook is diff-scoped and stays green, which is why this can land unnoticed: an author pushes clean and only meets it in CI.

`BookPublicMeeting` at 81 lines is one line over the ceiling, so it was almost certainly a merge of two changes that were each under it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Claims the `craftsmanship` CI job (`make craft-static`) on main, which is currently red with two blocker findings and one major finding.

The job is gated on `backend == 'true'`, so it fails on every backend PR, but the diff-scoped pre-push hook passes locally and only surfaces in CI. The findings are in files no open PR touches, and this claim does not overlap with the integration-lane claim in #5224.

<sup>Written for commit f18fcdda48e6bc16010db138a4e3486b715b600d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

