### PR TITLE
Every direct mailer names which kind of exemption it is

### DIFF
--- a/backend/gates/directmailbypass_test.go
+++ b/backend/gates/directmailbypass_test.go
@@ -27,17 +27,27 @@ package gates
 // never when it is correspondence with a data subject about the relationship,
 // which is what the consent engine exists to authorize.
 //
-// KNOWN GAP, ratified below rather than hidden: consent's confirm-details link
-// is mailed directly. The eight-PR consent plan's PR 3 was to move it onto the
-// durable lane and never landed, so the message that asks somebody to check
-// what is held about them is itself unrecorded. It is waived because refusing
-// it would delete a working feature, and the waiver names the cost so the debt
-// is legible instead of forgotten.
+// THAT KNOWN GAP IS CLOSED. Consent's confirm-details link used to be mailed
+// directly, and this comment used to say so — the message asking somebody to
+// check what is held about them was itself unrecorded. It now stages a delivery
+// through the controller lane (consent.stageConfirmMail → the compose queue),
+// so it is no longer in the census and no longer needs a waiver naming its cost.
+//
+// EVERY WAIVER ALSO NAMES ITS PURPOSE, from the closed set below. The prose was
+// doing two jobs at once — saying which admissible category a sender falls
+// under, and arguing why. Prose alone cannot be counted, so a fifth category
+// could arrive one plausible paragraph at a time and nobody would see the
+// population had grown a new KIND of exemption rather than another instance of
+// an existing one. Naming the purpose separates the two: the category is a
+// decision somebody has to make deliberately, and the sentence beside it is
+// still where the argument lives.
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -76,6 +86,59 @@ var directMailHolders = gatekit.Waive(map[string]string{
 		"a delivery; this one is what a staged delivery is finally handed to",
 })
 
+// directMailPurpose is the closed set of reasons a message may skip the
+// delivery lane. CLOSED is the point: adding a fifth is a decision about what
+// this product considers admissible to send unrecorded, and it belongs to
+// whoever owns that question rather than to whoever is adding a mailer.
+type directMailPurpose string
+
+const (
+	// purposeSeatCredential is a credential reaching a colleague's own address:
+	// an invite, a reset. It must work when the account is unreachable by every
+	// other route, which is exactly what the delivery lane cannot promise.
+	purposeSeatCredential directMailPurpose = "seat_credential"
+	// purposeOperatorDigest is internal reporting addressed to a seat in this
+	// installation — a digest of their own week. There is no consent question
+	// about telling a colleague what they did.
+	purposeOperatorDigest directMailPurpose = "operator_digest"
+	// purposeBuyerRoomCredential is a single-use link that IS the act a human
+	// just performed, not a message about the relationship.
+	purposeBuyerRoomCredential directMailPurpose = "buyer_room_credential"
+	// purposeLaneTransport is the adapter UNDER the lane rather than a way
+	// around it: it runs only after the delivery row exists and the gate has
+	// answered.
+	purposeLaneTransport directMailPurpose = "lane_transport"
+)
+
+// admissibleDirectMailPurposes is what the enum admits, read by the gate below
+// so a purpose invented at a call site fails rather than passing unnoticed.
+var admissibleDirectMailPurposes = map[directMailPurpose]bool{
+	purposeSeatCredential:      true,
+	purposeOperatorDigest:      true,
+	purposeBuyerRoomCredential: true,
+	purposeLaneTransport:       true,
+}
+
+// directMailPurposes says which category each ratified sender falls under.
+//
+// Kept beside the reasons rather than folded into them because gatekit's waiver
+// values are prose, and a category that lives inside a paragraph cannot be
+// counted. Every key here must have a reason in directMailHolders and the other
+// way round; the gate holds both directions.
+//
+// A DATA SUBJECT IS NEVER A PURPOSE. The rule these categories serve is that a
+// message to a data subject about the relationship goes through the consent
+// engine — every entry here is addressed to a colleague, or is a credential the
+// recipient asked for, or is the transport itself.
+var directMailPurposes = map[string]directMailPurpose{
+	"internal/compose/weeklymailjobs.go":          purposeOperatorDigest,
+	"internal/compose/briefmailjobs.go":           purposeOperatorDigest,
+	"internal/modules/identity/handlers_users.go": purposeSeatCredential,
+	"internal/modules/identity/reset.go":          purposeSeatCredential,
+	"internal/modules/dealrooms/invitemail.go":    purposeBuyerRoomCredential,
+	"internal/compose/controllermailwiring.go":    purposeLaneTransport,
+}
+
 func TestOnlyRatifiedCodeMailsWithoutTheDeliveryLane(t *testing.T) {
 	t.Parallel()
 
@@ -95,6 +158,7 @@ func TestOnlyRatifiedCodeMailsWithoutTheDeliveryLane(t *testing.T) {
 
 	for _, f := range files {
 		if directMailHolders.Waived(t, f.Path) {
+			assertPurposeIsNamed(t, f.Path)
 			continue
 		}
 		t.Errorf("%s hands a message straight to the relay: it writes no comms_outbound row, so the "+
@@ -103,6 +167,115 @@ func TestOnlyRatifiedCodeMailsWithoutTheDeliveryLane(t *testing.T) {
 			"directMailHolders with what the bypass costs", f.Path)
 	}
 	directMailHolders.AssertAllMatched(t)
+	assertEveryPurposeHasAReason(t)
+}
+
+// assertPurposeIsNamed refuses a ratified sender whose category nobody chose.
+func assertPurposeIsNamed(t *testing.T, path string) {
+	t.Helper()
+	purpose, named := directMailPurposes[path]
+	if !named {
+		t.Errorf("%s is ratified with a reason but names no purpose: say which of the four "+
+			"admissible categories it falls under in directMailPurposes, or route it through the "+
+			"delivery lane. A reason argues; the purpose is what can be counted", path)
+		return
+	}
+	if !admissibleDirectMailPurposes[purpose] {
+		t.Errorf("%s claims purpose %q, which is not one this product admits. The set is closed: "+
+			"a fifth category is a decision about what may be sent unrecorded, and it is not made "+
+			"by adding a mailer", path, purpose)
+	}
+}
+
+// assertEveryPurposeHasAReason holds the other direction. A purpose left behind
+// after its sender moved onto the delivery lane would otherwise sit here
+// forever, describing a file that no longer bypasses anything.
+func assertEveryPurposeHasAReason(t *testing.T) {
+	t.Helper()
+	reasons := map[string]bool{}
+	for _, subject := range directMailHolders.Subjects() {
+		reasons[subject] = true
+	}
+	for path := range directMailPurposes {
+		if !reasons[path] {
+			t.Errorf("directMailPurposes names %s, which holds no waiver in directMailHolders — "+
+				"the sender was routed through the lane or moved, and its purpose outlived it", path)
+		}
+	}
+}
+
+// TestNoExtensionMailsWithoutTheDeliveryLane closes the census's other side.
+//
+// An extension is Go in this repository that composes into the same binary and
+// can hold the same seam, so a census walking only internal/ would report a
+// clean tree over an extension mailing directly. None does today, and that is
+// precisely why this lands now: a walk widened AFTER the first extension mailer
+// exists is a walk widened to ratify it.
+//
+// A SEPARATE TEST rather than a second root on the census above, because
+// gatekit refuses a root that matches nothing — a root finding nothing
+// certifies nothing, which is the right rule and the reason the census is worth
+// trusting. Extensions legitimately hold no sender, so the assertion here is
+// the opposite shape: not "every sender is ratified" but "there is no sender".
+// The day one appears, this fails and somebody decides whether it belongs on
+// the delivery lane or in the ratified population above.
+func TestNoExtensionMailsWithoutTheDeliveryLane(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join("..", "extensions")
+	var senders []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			return fmt.Errorf("parsing %s: %w", path, parseErr)
+		}
+		if callsSendOnAMailerField(file) {
+			senders = append(senders, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the extensions: %v", err)
+	}
+	// The walk itself is proven, so an empty answer means "no sender" rather
+	// than "found no files". Without this a renamed directory would report a
+	// clean tree for the same reason a stale root does.
+	if !walkedAnyGo(t, root) {
+		t.Fatalf("%s holds no Go at all — the extension tree has moved and this check is "+
+			"certifying nothing", root)
+	}
+	for _, path := range senders {
+		t.Errorf("%s hands a message straight to the relay from an extension: it writes no "+
+			"comms_outbound row, so the send takes no authorization decision and appears in no "+
+			"subject-access export. Route it through the delivery lane, or ratify it in "+
+			"directMailHolders beside the core senders and name its purpose", path)
+	}
+}
+
+// walkedAnyGo reports whether the tree holds Go at all, so an empty census
+// cannot be mistaken for a clean one.
+func walkedAnyGo(t *testing.T, root string) bool {
+	t.Helper()
+	found := false
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".go") {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return found
 }
 
 // sendsThroughTheRelay reports whether a file calls the relay.


### PR DESCRIPTION
## What was wrong

The census enumerating who may skip the delivery lane recorded a sentence per sender and nothing countable.

Prose was doing two jobs: saying which admissible category a sender falls under, and arguing why. A fifth category could then arrive one plausible paragraph at a time, and nobody would see the population had grown a new kind of exemption rather than another instance of an existing one.

## What changed

Each ratified sender now also names a purpose from a closed set of four: a credential to a colleague's own address, an operator digest addressed to a seat, a single-use buyer-room link that is the act itself, and the adapter under the lane rather than a way around it.

The set is closed because adding a fifth is a decision about what this product considers admissible to send unrecorded, and that decision does not belong to whoever is adding a mailer. The reasons stay: the purpose is what can be counted, the sentence beside it is where the argument lives.

## Extensions are walked now

An extension composes into the same binary and can hold the same seam, so a census reading only the internal tree would report clean over one mailing directly. None does today, which is why this lands now. A walk widened after the first extension mailer exists is a walk widened to ratify it.

It is a separate test rather than a second root. Gatekit refuses a root matching nothing, on the reasoning that a root finding nothing certifies nothing, and that rule is what makes the census worth trusting. Extensions legitimately hold no sender, so the assertion is the opposite shape: not that every sender is ratified but that there is no sender, with the walk itself proven so an empty answer cannot be mistaken for a clean one.

## One comment deleted rather than reworded

The file recorded a known gap: consent's confirm-details link was mailed directly, so the message asking somebody to check what is held about them was itself unrecorded. It now stages a delivery through the controller lane, so the debt is paid.

## Proof

Four mutations verified: a missing purpose, a stale one, an invented one, and an extension mailer. Full `make check-backend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives every sender that bypasses the delivery lane a named purpose from a closed set of four, so a new exemption kind can't arrive as just another paragraph. Also walks `extensions/` for direct mailers and closes a known gap where consent's confirm-details link was mailed unrecorded.

**Census changes**
- Each ratified sender now names one of four purposes: seat credential, operator digest, buyer-room credential, or lane transport.
- Missing, invented, or purposeless senders fail the test, and a purpose without a matching waiver fails too.
- `extensions/` is walked in a separate test, and the walk itself is proven so an empty result means no sender, not a clean tree.
- Consent's confirm-details link now stages through the controller lane, so the previously waived gap is closed.

<sup>Written for commit c648be44f2255ad6fd7f5020100fe18b5290895e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

