### PR TITLE
main is red: the head catalog never learned the withheld-contact column

### DIFF
--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1402,6 +1402,7 @@ public.capture_pending_counterparty.resolved_by_owner boolean NOT NULL gen=- def
 public.capture_pending_counterparty.served_model text gen=- def=-
 public.capture_pending_counterparty.status text NOT NULL gen=- def='pending'::text
 public.capture_pending_counterparty.updated_at timestamp with time zone NOT NULL gen=- def=now()
+public.capture_pending_counterparty.withheld_from_workspace boolean NOT NULL gen=- def=false
 public.capture_pending_counterparty_pkey CREATE UNIQUE INDEX capture_pending_counterparty_pkey ON public.capture_pending_counterparty USING btree (id)
 public.capture_sender_override acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.capture_sender_override.address text NOT NULL gen=- def=-


### PR DESCRIPTION
`main` is red on one test, and so is every open pull request: `TestMigrationsBuildTheCommittedSchema`.

```
headcatalog_integration_test.go:76: the migrations build a different schema than testdata/head_catalog.txt records.

  only in the live schema (1):
    public.capture_pending_counterparty.withheld_from_workspace boolean NOT NULL gen=- def=false
```

## Tests this claim covers

- `backend/migrations` — `TestMigrationsBuildTheCommittedSchema`

That is the whole red. Three failing `ci` runs sampled across three unrelated branches ([#5252](https://github.com/margince/margince/pull/5252), [#5255](https://github.com/margince/margince/pull/5255), [#5257](https://github.com/margince/margince/pull/5257)) each fail on that test and nothing else — the shard number differs, the test does not.

## Cause

[#5252](https://github.com/margince/margince/pull/5252) landed `1789030524_a_withheld_contact_says_so_on_the_ledger`, which adds
`capture_pending_counterparty.withheld_from_workspace`, without regenerating
`migrations/testdata/head_catalog.txt` in the same commit. AGENTS.md asks for
both in one commit precisely because the golden file is the only record of what
the migrations are supposed to build.

Its own `ci` never got the chance to say so: the run in flight was cancelled when
the branch was updated ([34461056453](https://github.com/margince/margince/actions/runs/34461056453)), the merge went in, and the
post-merge run ([34462192591](https://github.com/margince/margince/actions/runs/34462192591)) reported the failure two minutes later — which is
what filed [#5256](https://github.com/margince/margince/issues/5256).

## The fix

The one line the migration adds, written by the file's only writer:

```
make test-it DIR=backend/migrations RUN=TestMigrationsBuildTheCommittedSchema IT_ARGS=-update-catalog
```

One inserted line, no removals. Nothing else in the schema drifted, which also
rules out the migration having changed more than it meant to.

Closes #5256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)