### PR TITLE
main is red: a bare any in the refusal recorder, and a head catalog that never learned a column

### DIFF
--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -144,22 +144,29 @@ type RefusalRecorder interface {
 // once the transaction is done with. It answers the error either way, so a
 // composition with no recorder refuses exactly as it did before.
 func recordRefusal(ctx context.Context, stager DeliveryStager, err error) error {
-	return recordRefusalOn(ctx, stager, err)
+	recorder, ok := stager.(RefusalRecorder)
+	if !ok {
+		return err
+	}
+	return recordRefusalOn(ctx, recorder, err)
 }
 
 // recordChannelRefusal is the same offer to the channel stager, which is a
 // different interface carrying the same optional seam.
 func recordChannelRefusal(ctx context.Context, stager ChannelDeliveryStager, err error) error {
-	return recordRefusalOn(ctx, stager, err)
+	recorder, ok := stager.(RefusalRecorder)
+	if !ok {
+		return err
+	}
+	return recordRefusalOn(ctx, recorder, err)
 }
 
-// recordRefusalOn is the shared body both transports call. A refusal recorded
-// on mail and one recorded on a channel answer the same rule because they run
-// the same code.
-func recordRefusalOn(ctx context.Context, stager any, err error) error {
-	recorder, ok := stager.(RefusalRecorder)
-	if !ok || err == nil {
-		return err
+// recordRefusalOn is the shared body both transports call once they hold a
+// recorder. A refusal recorded on mail and one recorded on a channel answer
+// the same rule because they run the same code.
+func recordRefusalOn(ctx context.Context, recorder RefusalRecorder, err error) error {
+	if err == nil {
+		return nil
 	}
 	return recorder.RecordPendingReview(ctx, err)
 }

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1402,6 +1402,7 @@ public.capture_pending_counterparty.resolved_by_owner boolean NOT NULL gen=- def
 public.capture_pending_counterparty.served_model text gen=- def=-
 public.capture_pending_counterparty.status text NOT NULL gen=- def='pending'::text
 public.capture_pending_counterparty.updated_at timestamp with time zone NOT NULL gen=- def=now()
+public.capture_pending_counterparty.withheld_from_workspace boolean NOT NULL gen=- def=false
 public.capture_pending_counterparty_pkey CREATE UNIQUE INDEX capture_pending_counterparty_pkey ON public.capture_pending_counterparty USING btree (id)
 public.capture_sender_override acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.capture_sender_override.address text NOT NULL gen=- def=-


### PR DESCRIPTION
`main` is red on two independent causes and every open pull request inherits both.

```
craftsmanship: backend/internal/modules/activities/email.go:159 [MAJOR] naked-any
integration:   TestMigrationsBuildTheCommittedSchema — only in the live schema:
               public.capture_pending_counterparty.withheld_from_workspace boolean NOT NULL def=false
```

## Tests this claim covers

- `craftsmanship` — `craft static --strict`, `naked-any` at `activities/email.go:159` (from #5255)
- `backend/migrations` — `TestMigrationsBuildTheCommittedSchema` (from #5252), folded from #5258 by agreement with its owner pending, on the repo owner's call: the two claims blocked each other's CI, so one PR carries both fixes. #5258 closes as superseded when this lands; its commit is cherry-picked here with `-x`.

## Fixes

- Each transport's stager is asserted for the optional `RefusalRecorder` seam where its type is known; the shared body takes the recorder itself. No `any`, no waiver.
- `migrations/testdata/head_catalog.txt` records the withheld-contact column (#5258's commit, unchanged).

## Gates

- `craft static --strict` on the Go file: `PASS — 0 blocker, 0 major, 0 minor`
- `make check-go` green
- `make test-it DIR=backend/migrations RUN=TestMigrationsBuildTheCommittedSchema`: `--- PASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)