### PR TITLE
fix(compose): require TLS on the Postgres connection in production

### DIFF
--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/netguard"
 	"github.com/margince/margince/backend/internal/platform/overlaybudget"
 	"github.com/margince/margince/backend/internal/shared/buildinfo"
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
 	"github.com/margince/margince/backend/pkg/extension"
 )
 
@@ -55,7 +56,14 @@ import (
 //
 // The pool is closed on a failed assertion rather than handed back for the
 // caller to close, so a boot that stops here leaves no connections behind.
-func boundPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+func boundPool(ctx context.Context, dsn string, env runtimeenv.Environment) (*pgxpool.Pool, error) {
+	// Before anything dials: a production installation whose Postgres DSN
+	// cannot guarantee TLS refuses here rather than serving a single request
+	// over it. compose/dbtls.go carries why "cannot guarantee" rather than
+	// "did not request".
+	if err := compose.AssertDatabaseTLS(dsn, env); err != nil {
+		return nil, err
+	}
 	pool, err := database.NewPool(ctx, dsn)
 	if err != nil {
 		return nil, err

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/platform/licensecheck"
 	"github.com/margince/margince/backend/internal/platform/mailer"
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
 )
 
 func main() {
@@ -82,7 +83,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	}
 	config.WarnUndeclared(logger, cfg.unknownVars)
 
-	pool, vault, err := openInstallation(ctx, cfg.dsn)
+	pool, vault, err := openInstallation(ctx, cfg.dsn, cfg.posture)
 	if err != nil {
 		return err
 	}
@@ -187,8 +188,8 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 // closes it here instead, because there is no pool to return alongside an error.
 //
 //nolint:ireturn // the vault seam has two providers behind one Vault; returning the interface is the design, and this only carries what ForRole handed back.
-func openInstallation(ctx context.Context, dsn string) (*pgxpool.Pool, keyvault.Vault, error) {
-	pool, err := boundPool(ctx, dsn)
+func openInstallation(ctx context.Context, dsn string, env runtimeenv.Environment) (*pgxpool.Pool, keyvault.Vault, error) {
+	pool, err := boundPool(ctx, dsn, env)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -366,7 +367,7 @@ func baseComposeOptions(ctx context.Context, cfg apiConfig, capCfg compose.Captu
 	}
 	opts = append(opts, microsoftSignInOpts...)
 
-	schemaOpts, schemaPool, closeSchemaPool, err := schemaPoolOptions(ctx, cfg.schemaDSN, stdout)
+	schemaOpts, schemaPool, closeSchemaPool, err := schemaPoolOptions(ctx, cfg.schemaDSN, cfg.posture, stdout)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -440,9 +441,14 @@ func blobstoreOptions(ctx context.Context, stdout io.Writer) ([]compose.Option, 
 // (ErrSchemaChangesUnavailable) and reset skips the finalize step; the
 // returned pool is nil in that case, and the close func is a no-op, so
 // run() can always defer it unconditionally.
-func schemaPoolOptions(ctx context.Context, schemaDSN string, stdout io.Writer) ([]compose.Option, *pgxpool.Pool, func(), error) {
+func schemaPoolOptions(ctx context.Context, schemaDSN string, env runtimeenv.Environment, stdout io.Writer) ([]compose.Option, *pgxpool.Pool, func(), error) {
 	if schemaDSN == "" {
 		return nil, nil, func() {}, nil
+	}
+	// Same gate the serving pool passed in run() — a second Postgres
+	// credential is still a Postgres credential, and this one runs DDL.
+	if err := compose.AssertDatabaseTLS(schemaDSN, env); err != nil {
+		return nil, nil, nil, err
 	}
 	// The engine serializes every ALTER on a table behind a transaction-scoped
 	// advisory lock (customfields.beginSchemaChange), so this pool never runs

--- a/backend/cmd/worker/dbtls.go
+++ b/backend/cmd/worker/dbtls.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
+)
+
+// boundWorkerPool refuses to dial a production installation's Postgres DSN
+// when it cannot guarantee TLS, then opens the pool. Checked before ANY
+// connection attempt — compose/dbtls.go carries why "cannot guarantee"
+// rather than "did not request" — mirroring cmd/api's boundPool (its own
+// boot.go), which holds the same check for the serving role sharing this DSN.
+func boundWorkerPool(ctx context.Context, dsn string, env runtimeenv.Environment) (*pgxpool.Pool, error) {
+	if err := compose.AssertDatabaseTLS(dsn, env); err != nil {
+		return nil, err
+	}
+	return database.NewPool(ctx, dsn)
+}

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/platform/config"
-	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/platform/events"
 	"github.com/margince/margince/backend/internal/platform/httpserver"
@@ -70,7 +69,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	cfg, deployCfg, logger := boot.cfg, boot.deploy, boot.log
 	config.WarnUndeclared(logger, cfg.unknownVars)
 
-	pool, err := database.NewPool(ctx, cfg.dsn)
+	pool, err := boundWorkerPool(ctx, cfg.dsn, cfg.posture)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/compose/dbtls.go
+++ b/backend/internal/compose/dbtls.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
+)
+
+// AssertDatabaseTLS refuses a production boot whose Postgres DSN cannot
+// guarantee TLS. It mirrors refuseUnlicensedProduction's shape exactly: a
+// non-production installation is unheld, because MARGINCE_ENV is what names a
+// deployment as one — the same distinction this tree already trusts for the
+// license and the runtime role.
+//
+// "Cannot guarantee" is deliberate, not "did not request": sslmode's default
+// (unset, which pgconn resolves to "prefer") and "allow" both let the first
+// connection attempt negotiate TLS and silently RETRY IN THE CLEAR if that
+// fails — a network path that starts encrypted and degrades to plaintext on
+// the next reconnect, with nothing in this process ever noticing. Only
+// require/verify-ca/verify-full remove that fallback, which is what
+// tlsEnforced checks for directly off the parsed pgconn.Config rather than
+// pattern-matching the DSN string — a DSN can name sslmode through a URL
+// query, a keyword/value pair, or PGSSLMODE, and pgconn already resolves all
+// three into the one struct this reads.
+func AssertDatabaseTLS(dsn string, env runtimeenv.Environment) error {
+	if env.IsNonProduction() {
+		return nil
+	}
+	cfg, err := database.PoolConfig(dsn)
+	if err != nil {
+		return fmt.Errorf("compose: reading the Postgres DSN's TLS posture: %w", err)
+	}
+	if tlsEnforced(cfg) {
+		return nil
+	}
+	return fmt.Errorf("this installation is production and its Postgres connection does not force TLS "+
+		"(sslmode is unset, \"disable\", \"allow\" or \"prefer\" — each permits a plaintext connection): "+
+		"add sslmode=require (or verify-ca / verify-full, to also check the server's certificate) to the DSN, "+
+		"or, if this is a development or test installation, set %s=%s",
+		runtimeenv.EnvVar, runtimeenv.Development)
+}
+
+// tlsEnforced reports whether every connection attempt pgconn would make for
+// this config uses TLS — the primary attempt, and every fallback sslmode
+// "prefer" or "allow" register for a plaintext retry when the primary one
+// fails to negotiate TLS.
+func tlsEnforced(cfg *pgxpool.Config) bool {
+	if cfg.ConnConfig.TLSConfig == nil {
+		return false
+	}
+	for _, fallback := range cfg.ConnConfig.Fallbacks {
+		if fallback.TLSConfig == nil {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/compose/dbtls_test.go
+++ b/backend/internal/compose/dbtls_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
+)
+
+// MARGINCE_ENV is fail-closed (runtimeenv.Parse("") is Production), so an
+// installation that names no posture is held to this the same way it is held
+// to a license.
+func TestAssertDatabaseTLSRefusesAProductionBootWithoutEnforcedTLS(t *testing.T) {
+	cases := map[string]string{
+		"sslmode unset":   "postgres://app:pw@db.internal:5432/margince",
+		"sslmode=disable": "postgres://app:pw@db.internal:5432/margince?sslmode=disable",
+		"sslmode=allow":   "postgres://app:pw@db.internal:5432/margince?sslmode=allow",
+		"sslmode=prefer":  "postgres://app:pw@db.internal:5432/margince?sslmode=prefer",
+	}
+	for name, dsn := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := AssertDatabaseTLS(dsn, runtimeenv.Parse(""))
+			if err == nil {
+				t.Fatalf("AssertDatabaseTLS(%q) booted a production installation that permits a plaintext connection", dsn)
+			}
+			for _, want := range []string{"sslmode=require", runtimeenv.EnvVar, string(runtimeenv.Development)} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("boot refusal %q does not name %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// require/verify-ca/verify-full all remove the plaintext fallback prefer and
+// allow register — that is the one property this check holds, not a
+// preference for any one of the three over the others.
+func TestAssertDatabaseTLSAdmitsAnyModeThatRemovesThePlaintextFallback(t *testing.T) {
+	for _, mode := range []string{"require", "verify-ca", "verify-full"} {
+		t.Run(mode, func(t *testing.T) {
+			dsn := "postgres://app:pw@db.internal:5432/margince?sslmode=" + mode
+			if err := AssertDatabaseTLS(dsn, runtimeenv.Parse("")); err != nil {
+				t.Fatalf("AssertDatabaseTLS(%q) = %v, want nil", dsn, err)
+			}
+		})
+	}
+}
+
+// A non-production installation is unheld — the same MARGINCE_ENV escape
+// hatch EnsureLicense already grants, and for the same reason: it is what
+// lets make dev's own plaintext Postgres keep booting unedited.
+func TestAssertDatabaseTLSAdmitsAnyModeInNonProduction(t *testing.T) {
+	for _, env := range []runtimeenv.Environment{runtimeenv.Development, runtimeenv.Test} {
+		t.Run(string(env), func(t *testing.T) {
+			dsn := "postgres://app:pw@db.internal:5432/margince?sslmode=disable"
+			if err := AssertDatabaseTLS(dsn, env); err != nil {
+				t.Fatalf("AssertDatabaseTLS(%q, %q) = %v, want nil", dsn, env, err)
+			}
+		})
+	}
+}
+
+func TestAssertDatabaseTLSNamesAnUnparseableDSN(t *testing.T) {
+	err := AssertDatabaseTLS("not a dsn at all", runtimeenv.Parse(""))
+	if err == nil {
+		t.Fatal("AssertDatabaseTLS accepted an unparseable DSN")
+	}
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -28,9 +28,9 @@ configurable logger.
 
 | Flag | Env | Default | Meaning |
 |---|---|---|---|
-| `--dsn` | `MARGINCE_DSN` | — (required) | Postgres DSN, runtime app role |
+| `--dsn` | `MARGINCE_DSN` | — (required) | Postgres DSN, runtime app role. **In production** (`MARGINCE_ENV` unset or anything but `dev`/`test`), the DSN must force TLS — `sslmode=require`, `verify-ca` or `verify-full`; the unset default, `disable`, `allow` and `prefer` all permit a plaintext fallback and are refused at boot, before any connection is attempted, naming the setting. Both `cmd/api` and `cmd/worker` hold this on the same DSN; a non-production installation is unheld, the same escape hatch the license check grants |
 | `--config` | `MARGINCE_CONFIG` | `margince.yaml` | the deployment configuration file (bootstrap + auth — workspace, bootstrap_admin, seeds, email; strict decoding, secrets as `*_file` references). A missing file boots an existing installation; bootstrapping an empty database requires `workspace` + `bootstrap_admin` |
-| `--schema-dsn` | `MARGINCE_SCHEMA_DSN` | — | Postgres DSN, **owner** role, for the customfields runtime-DDL pool; unset = `createCustomField`/`updateCustomFieldOptions` answer 501 |
+| `--schema-dsn` | `MARGINCE_SCHEMA_DSN` | — | Postgres DSN, **owner** role, for the customfields runtime-DDL pool; unset = `createCustomField`/`updateCustomFieldOptions` answer 501. Held to the same production TLS requirement as `--dsn` above |
 | `--addr` | — | `:8080` | listen address |
 | `--redis` | `MARGINCE_REDIS` | `localhost:16379` | Redis address (event bus). May name a logical database as `host:port/N` (0–15) — see below |
 | `--redis-password` | `MARGINCE_REDIS_PASSWORD` | — (none) | Event-bus credential, where the instance requires one. Empty is the ordinary case: an instance reached over a network the deployment controls needs none. Set it wherever the bus is reachable by anything else — the desktop bundle mints one per installation, because its bus listens on loopback and any local account could otherwise read the stream. Prefer the environment over the flag: argv is readable by every process on the machine |
@@ -377,7 +377,7 @@ api's boot line says so; `cmd/worker` is load-bearing for E10 retry. See
 
 | Flag | Env | Default | Meaning |
 |---|---|---|---|
-| `--dsn` | `MARGINCE_DSN` | — (required) | Postgres DSN, runtime app role |
+| `--dsn` | `MARGINCE_DSN` | — (required) | Postgres DSN, runtime app role. Held to the same production TLS requirement `cmd/api`'s `--dsn` row documents (above) — one DSN, one rule |
 | `--public-base-url` | `MARGINCE_PUBLIC_BASE_URL` | — | canonical external scheme+host for buyer-facing links (RFC 8058 unsubscribe / preference center); required for a marketing send originated by this role's Surface-B agent run — without it that send refuses rather than emit a forgeable link |
 | `--config` | `MARGINCE_CONFIG` | `margince.yaml` | the deployment configuration file; the worker reads it for the `ai.capture_payloads` posture the Surface-B runner honors (capture applies to **both** the api and worker roles — the worker runs the richest content source, the agent runs). A missing file boots with capture off |
 | `--redis` | `MARGINCE_REDIS` | `localhost:16379` | Redis address (event bus). May name a logical database as `host:port/N` (0–15) — see below |


### PR DESCRIPTION
## What

Investigated how this product actually authenticates and secures its own
Postgres connections — the running Go code, not `deploy/terraform/`. Five of
six areas checked out already correct (two-role privilege boot check,
app-level tenant isolation — RLS is deliberately retired, not a gap —
customfields schema-pool role downgrade, DSN/secret redaction). The one real
gap: nothing ever required TLS on the connection itself. `compose.AssertDatabaseTLS`
closes it — a production installation now refuses to boot unless its Postgres
DSN forces TLS.

## Why

`sslmode`'s default (unset → pgconn's "prefer") and "allow" both let the
first connection attempt negotiate TLS and silently retry in the clear if
that fails — a path that starts encrypted and can degrade to plaintext on
reconnect, unnoticed. Mirrors `EnsureLicense`'s shape exactly
(`internal/compose/license.go`): production is held, `MARGINCE_ENV=dev`/`test`
is the same escape hatch the license check already grants, so `make dev`'s
own plaintext Postgres keeps booting unedited.

## How verified

- [x] `make check` is green (ran as `make check-go`, the narrower backend-only
      lane — no frontend files changed)
- [x] `make test-integration` — N/A, no tenant data / RLS / write shape
      touched; this is a boot-time DSN check with no database interaction
- [x] `make craft-static` reports no new blockers (0 blocker, 0 major, 0 minor
      on every changed file, diff-scoped against origin/main)
- [x] This diff and description carry no secrets, no customer data, no local
      machine paths, and nothing quoted from or pointing at a private document

New unit tests in `internal/compose/dbtls_test.go`: every sslmode that
permits a plaintext fallback is refused in production (unset, disable, allow,
prefer); every mode that removes it is admitted (require, verify-ca,
verify-full); every mode is admitted in dev/test; an unparseable DSN is
refused rather than silently passed through.

One incidental fix riding along: the first placement of this check pushed
`cmd/api`'s and `cmd/worker`'s `run()` past the 80-code-line ceiling —
resolved by moving the check into each role's own pool-construction helper
(`boundPool`, new `boundWorkerPool`) rather than inlining it, which is also
the architecturally correct spot (checked before any connection is attempted,
same as `AssertRuntimeRole`).

## AI involvement

Fully AI-generated (Claude Code). The Postgres TLS enforcement mechanism
(reading `pgconn.Config`'s `TLSConfig`/`Fallbacks` fields directly, rather
than pattern-matching the DSN string) was verified against the pinned pgx
v5.10.0 source in the module cache before being written, not assumed from
training data. The enforcement level (hard-refuse in production vs.
warn-only) was an explicit choice, not an autonomous one.

## How this differs from #5303

Both PRs add TLS support and can look interchangeable at a glance — they're
not. This one **enforces itself**: `compose.AssertDatabaseTLS` refuses to
boot a production installation whose DSN doesn't force TLS, no companion
change required anywhere else. [#5303](../../pull/5303) (Redis + S3) is the
opposite shape — it only adds the *capability* (`MARGINCE_REDIS_TLS`,
`MARGINCE_BLOBSTORE_KMS_KEY_ID`, both opt-in/default-off) and leaves actual
enforcement to a paired Terraform PR (#5281's `transit_encryption_mode` and
bucket-policy flips). This PR needed no Terraform counterpart because
Postgres TLS enforcement is entirely a client-side decision.

## Accountability

By opening this PR I confirm I am accountable for this change and can
explain every line in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires Postgres DSNs to force TLS in production, so installations with `sslmode` unset, `disable`, `allow`, or `prefer` now refuse to boot instead of silently degrading to a plaintext connection. Deployments must set `sslmode=require` (or `verify-ca`/`verify-full`) on their DSNs; `dev` and `test` installs boot unedited.

- Enforced for the `cmd/api` and `cmd/worker` serving pools and the customfields schema DSN.
- Checks pgconn's parsed config rather than the DSN string, so `sslmode` set via URL query, keyword/value pair, or `PGSSLMODE` is covered.
- An unparseable DSN is refused instead of passed through.
- Documents the requirement in `docs/reference/configuration.md`.

<sup>Written for commit aadd7802544e9aae6525048a94554648da41c1f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Production API and worker database connections now require TLS settings that prevent plaintext connections.
  - Database startup validation also applies to the API’s schema-owner connection.

- **Bug Fixes**
  - Services now refuse to start when production database connection settings do not guarantee TLS.
  - Development and test environments remain compatible with any database TLS mode.

- **Documentation**
  - Documented the required production PostgreSQL TLS settings and startup validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
