### PR TITLE
A question still in flight is not a yes

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3509,6 +3509,7 @@ export const de = {
     "Wenn Sie den Grund kennen — man hat Sie darum gebeten, Sie hatten ein Treffen, es ist ein Kunde —, halten Sie ihn fest. Er wird unter Ihrem Namen gespeichert.",
   "sendPermission.unprovenRefuses":
     "Der Versand wird abgelehnt, bis Margince einen Nachweis hat.",
+  "sendPermission.checking": "Prüfe, ob diese Nachricht gesendet werden darf …",
   "sendPermission.unanswered":
     "Margince konnte nicht prüfen, ob diese Nachricht gesendet werden darf. Beim Senden wird erneut geprüft.",
   "sendPermission.reason.objected":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3592,6 +3592,7 @@ export const en = {
     "If you know why — they asked you to, you met, they are a customer — say so and it is recorded against your name.",
   "sendPermission.unprovenRefuses":
     "Sending it will be refused until Margince has a record.",
+  "sendPermission.checking": "Checking whether this message may be sent…",
   "sendPermission.unanswered":
     "Margince could not check whether this message may be sent. Sending it asks again.",
   "sendPermission.reason.objected":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3466,6 +3466,7 @@ export const vi = {
     "Nếu bạn biết lý do — họ đã đề nghị, bạn đã gặp họ, họ là khách hàng — hãy nêu ra và điều đó được ghi lại dưới tên bạn.",
   "sendPermission.unprovenRefuses":
     "Việc gửi sẽ bị từ chối cho đến khi Margince có ghi nhận.",
+  "sendPermission.checking": "Đang kiểm tra xem có thể gửi tin nhắn này không…",
   "sendPermission.unanswered":
     "Margince không kiểm tra được tin nhắn này có được phép gửi hay không. Khi gửi sẽ kiểm tra lại.",
   "sendPermission.reason.objected":

--- a/frontend/src/screens/approvalrow.tsx
+++ b/frontend/src/screens/approvalrow.tsx
@@ -420,6 +420,7 @@ export function ApprovalRow({
           {!decided && staged !== undefined && (
             <SendPermission
               preview={permission.preview}
+              asking={permission.asking}
               unanswered={permission.unanswered}
             />
           )}

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -75,6 +75,10 @@ import {
   SubjectRow,
   TransportRow,
 } from "./composehead";
+import {
+  deadRecipientsAmong,
+  useChannelReachable,
+} from "./composereachability";
 import { RELINK_KINDS, type RelinkKind, RelinkModal } from "./composerelink";
 import {
   momentLabel,
@@ -111,7 +115,6 @@ import "./compose.css";
 // and typed on the backend; this file only calls them.
 
 type Activity = components["schemas"]["Activity"];
-type Person360 = components["schemas"]["Person360"];
 type EmailDraft = components["schemas"]["EmailDraft"];
 type VoiceProfile = components["schemas"]["VoiceProfile"];
 
@@ -1591,14 +1594,14 @@ function useProjectFiling(input: {
   return { projectId, setProjectId: setPicked };
 }
 
-// One frozen empty list rather than a fresh `[]` in the default: a new array on
-// every render would remake the transport lookup below each time a keystroke
-// re-rendered the drawer.
 // Re-exported so the surfaces that import them from here — writeto, recordemail,
 // timelineactions, companyheader, composeattachments — keep one import path.
 // The extraction moved code; it is not an invitation to touch ten call sites.
 export { RELINK_KINDS, type RelinkKind, RelinkModal };
 
+// One frozen empty list rather than a fresh `[]` in the default: a new array on
+// every render would remake the transport lookup below each time a keystroke
+// re-rendered the drawer.
 const NO_TRANSPORTS: readonly Transport[] = [];
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: this modal was already at the ceiling; the account-started origin (ADR-0087/A132) adds three necessary branches — the recipient/deal pickers, the grounded-draft gate and the drawer placement, and the transport dial adds the fourth. The head, the attachment shelf, the drafting call, the form fill, the body edit and both draft controls are extracted (composehead.tsx, composeattachments.tsx); what is left is one dialog's own wiring, and splitting the send/consent/refusal/voice flow apart from the fields it gates would scatter it.
@@ -2799,6 +2802,7 @@ export function ComposeModal({
                     control as a prop the day the override exists. */}
                 <SendPermission
                   preview={permission.preview}
+                  asking={permission.asking}
                   unanswered={permission.unanswered}
                 />
               </>
@@ -2843,84 +2847,6 @@ export function ComposeModal({
         </div>
       </ConfirmModal>
     </>
-  );
-}
-
-// WHICH OF THESE ADDRESSES IS KNOWN NOT TO ARRIVE. The person page badges an
-// address whose latest delivery hard-bounced with nothing clean since, and the
-// composer is where that matters: the mark was visible only on a page the rep
-// is not looking at while they write.
-//
-// A function of the 360 the drawer is already holding, rather than a read of its
-// own. That payload comes back under the SAME key the person page fetches under,
-// so opening the composer from that page costs no request at all and the two
-// surfaces cannot disagree about which address is dead — and it now answers a
-// second question beside this one (who the recipient fields offer), which two
-// hooks reaching for the same view would have asked twice. A composer that never
-// learned a person — a deal timeline has no single one — is handed nothing and
-// warns about nothing.
-//
-// The section carries its own grant. A caller who may not read the send ledger
-// gets it omitted rather than empty, and this then marks nothing: an unanswered
-// read is not "the address is fine", and a warning invented from an absence
-// would be a claim about correspondence the reader may not see.
-//
-// Free-typed addresses with no person context stay unwarned on purpose (#3160):
-// deriving deadness for an arbitrary string needs an endpoint of its own.
-function deadRecipientsAmong(
-  view: Person360 | undefined,
-  recipients: readonly string[],
-) {
-  const dead = view?.dead_addresses;
-  if (dead == null || dead.length === 0) return [];
-  // Addresses compare case-insensitively — a rep who types Anna@… must be
-  // warned about anna@…, and the ledger stores what the provider reported.
-  const marked = new Set(dead.map((address) => address.toLowerCase()));
-  // ONE MENTION PER ADDRESS. To and Cc are asked about together, and a rep who
-  // has the same address in both would otherwise read it named twice in a
-  // sentence about one thing being wrong with it.
-  const named = new Map<string, string>();
-  for (const address of recipients) {
-    const key = address.toLowerCase();
-    if (marked.has(key) && !named.has(key)) {
-      named.set(key, address);
-    }
-  }
-  return [...named.values()];
-}
-
-// A channel reply can only land on a live, unblocked identity, and the
-// failure otherwise arrives after the rep has already written the message —
-// worse than never offering the box (design §9.3). Reachability is read off
-// the person the row's own timeline names: `["person", personId]` is the same
-// query key the 360 screen already fetches under, so this rides its cache
-// instead of opening a second request. A caller that never learned a personId
-// (e.g. a deal timeline, which has no single person to check) gets the
-// pre-existing behaviour of always offering the reply — this only ever turns
-// the action OFF, never on, for a row it cannot verify.
-function useChannelReachable(
-  isChannel: boolean,
-  personId: string | undefined,
-  provider: string | undefined,
-) {
-  const person = useQuery({
-    queryKey: ["person", personId],
-    queryFn: async () => {
-      const { data, error } = await api.GET("/people/{id}", {
-        params: { path: { id: personId as string } },
-      });
-      if (error) throwProblem(error);
-      return data;
-    },
-    enabled: isChannel && personId != null,
-  });
-  if (!isChannel || personId == null) return true;
-  // Matched against the row's OWN transport. A hardcoded "telegram" here would
-  // withhold the reply on every other transport's rows and offer it on a
-  // Telegram-reachable person's rows whatever carried the conversation — the
-  // kind stopped naming the transport at ADR-0107/A158, so the row has to say.
-  return (person.data?.reachability ?? []).some(
-    (channel) => channel.provider === provider && channel.reachable,
   );
 }
 

--- a/frontend/src/screens/composereachability.ts
+++ b/frontend/src/screens/composereachability.ts
@@ -1,0 +1,93 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { throwProblem } from "./common";
+
+type Person360 = components["schemas"]["Person360"];
+
+// Which addresses a message would not arrive at, and whether a channel reply
+// can be offered at all. Extracted from compose.tsx unchanged.
+//
+// Both answers come off the person's 360, which is why they belong together:
+// the composer holds that payload already, and two hooks reaching for the same
+// view would ask for it twice.
+
+// WHICH OF THESE ADDRESSES IS KNOWN NOT TO ARRIVE. The person page badges an
+// address whose latest delivery hard-bounced with nothing clean since, and the
+// composer is where that matters: the mark was visible only on a page the rep
+// is not looking at while they write.
+//
+// A function of the 360 the drawer is already holding, rather than a read of its
+// own. That payload comes back under the SAME key the person page fetches under,
+// so opening the composer from that page costs no request at all and the two
+// surfaces cannot disagree about which address is dead — and it now answers a
+// second question beside this one (who the recipient fields offer), which two
+// hooks reaching for the same view would have asked twice. A composer that never
+// learned a person — a deal timeline has no single one — is handed nothing and
+// warns about nothing.
+//
+// The section carries its own grant. A caller who may not read the send ledger
+// gets it omitted rather than empty, and this then marks nothing: an unanswered
+// read is not "the address is fine", and a warning invented from an absence
+// would be a claim about correspondence the reader may not see.
+//
+// Free-typed addresses with no person context stay unwarned on purpose (#3160):
+// deriving deadness for an arbitrary string needs an endpoint of its own.
+export function deadRecipientsAmong(
+  view: Person360 | undefined,
+  recipients: readonly string[],
+) {
+  const dead = view?.dead_addresses;
+  if (dead == null || dead.length === 0) return [];
+  // Addresses compare case-insensitively — a rep who types Anna@… must be
+  // warned about anna@…, and the ledger stores what the provider reported.
+  const marked = new Set(dead.map((address) => address.toLowerCase()));
+  // ONE MENTION PER ADDRESS. To and Cc are asked about together, and a rep who
+  // has the same address in both would otherwise read it named twice in a
+  // sentence about one thing being wrong with it.
+  const named = new Map<string, string>();
+  for (const address of recipients) {
+    const key = address.toLowerCase();
+    if (marked.has(key) && !named.has(key)) {
+      named.set(key, address);
+    }
+  }
+  return [...named.values()];
+}
+
+// A channel reply can only land on a live, unblocked identity, and the
+// failure otherwise arrives after the rep has already written the message —
+// worse than never offering the box (design §9.3). Reachability is read off
+// the person the row's own timeline names: `["person", personId]` is the same
+// query key the 360 screen already fetches under, so this rides its cache
+// instead of opening a second request. A caller that never learned a personId
+// (e.g. a deal timeline, which has no single person to check) gets the
+// pre-existing behaviour of always offering the reply — this only ever turns
+// the action OFF, never on, for a row it cannot verify.
+export function useChannelReachable(
+  isChannel: boolean,
+  personId: string | undefined,
+  provider: string | undefined,
+) {
+  const person = useQuery({
+    queryKey: ["person", personId],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/people/{id}", {
+        params: { path: { id: personId as string } },
+      });
+      if (error) throwProblem(error);
+      return data;
+    },
+    enabled: isChannel && personId != null,
+  });
+  if (!isChannel || personId == null) return true;
+  // Matched against the row's OWN transport. A hardcoded "telegram" here would
+  // withhold the reply on every other transport's rows and offer it on a
+  // Telegram-reachable person's rows whatever carried the conversation — the
+  // activity kind no longer names the transport — a `message` row can have been
+  // carried by any provider — so only the row itself can say which one this
+  // conversation used (ADR-0107).
+  return (person.data?.reachability ?? []).some(
+    (channel) => channel.provider === provider && channel.reachable,
+  );
+}

--- a/frontend/src/screens/scheduledsends.tsx
+++ b/frontend/src/screens/scheduledsends.tsx
@@ -359,6 +359,7 @@ function SendRow({
       {actionable && (
         <SendPermission
           preview={permission.preview}
+          asking={permission.asking}
           unanswered={permission.unanswered}
         />
       )}

--- a/frontend/src/screens/sendpermission.test.tsx
+++ b/frontend/src/screens/sendpermission.test.tsx
@@ -298,3 +298,45 @@ describe("when the question did not arrive", () => {
     expect(screen.queryByText(/asked not to receive marketing/i)).toBeNull();
   });
 });
+
+describe("an answer that has not arrived is not an answer", () => {
+  // THE DEFECT THIS SLICE EXISTS FOR. `decidingRecipient(undefined)` returned
+  // "allowed", so a composer waiting on the engine looked exactly like one that
+  // had been told yes — and a rep who pressed Send in that window met the
+  // refusal at the button.
+  //
+  // Three situations reached that one answer: nobody asked, the asking is in
+  // flight, and the answer came back clean. Only the third is permission.
+  it("draws checking while the question is in flight", () => {
+    render(
+      <LocaleProvider initial="en">
+        <SendPermission preview={undefined} asking />
+      </LocaleProvider>,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(/check/i);
+  });
+
+  it("does not claim the send is allowed while it is still asking", () => {
+    const { state } = decidingRecipient(undefined, true);
+    expect(state).toBe("checking");
+  });
+
+  // An unasked question is not a refusal either. A surface with no recipient
+  // yet has nothing to ask about, and drawing a warning there would tell a rep
+  // something is wrong with a message they have not written.
+  it("stays quiet when there is nothing to ask about", () => {
+    const { state } = decidingRecipient(undefined, false);
+    expect(state).toBe("allowed");
+  });
+
+  // And a real allow still reads as one. Without this the fix above could be
+  // "never say allowed", which would take the composer's quiet confirmation
+  // away with it.
+  it("still allows a message every recipient permits", () => {
+    const { state } = decidingRecipient(
+      preview(answer({ decided_by: "machine", verdict: "allow" })),
+      false,
+    );
+    expect(state).toBe("allowed");
+  });
+});

--- a/frontend/src/screens/sendpermission.tsx
+++ b/frontend/src/screens/sendpermission.tsx
@@ -43,7 +43,11 @@ type Recipient = components["schemas"]["SendAuthorizationPreviewRecipient"];
  * render — and so a second surface adopting this component cannot reach a
  * fourth answer by branching on the preview itself.
  */
-export type SendPermissionState = "allowed" | "unproven" | "refused";
+export type SendPermissionState =
+  | "allowed"
+  | "unproven"
+  | "refused"
+  | "checking";
 
 /**
  * The recipient whose answer decides the message, and the state it puts the
@@ -55,10 +59,23 @@ export type SendPermissionState = "allowed" | "unproven" | "refused";
  * and helped once. An absolute refusal outranks an unproven one because it is
  * the one the rep cannot act on.
  */
-export function decidingRecipient(preview: Preview | undefined): {
+export function decidingRecipient(
+  preview: Preview | undefined,
+  asking = false,
+): {
   state: SendPermissionState;
   recipient?: Recipient;
 } {
+  // AN ANSWER THAT HAS NOT ARRIVED IS NOT AN ANSWER. An absent preview used to
+  // read as "allowed", so three situations reached one state: nobody asked, the
+  // asking is in flight, and the answer came back clean. Only the last is
+  // permission, and a rep who pressed Send in the second met the refusal at the
+  // button — the failure this whole surface exists to end.
+  //
+  // An UNASKED question stays quiet rather than warning. A surface with no
+  // recipient yet has nothing to ask about, and a warning there would tell a
+  // rep something is wrong with a message they have not written.
+  if (asking) return { state: "checking" };
   if (!preview) return { state: "allowed" };
 
   let overrulable: Recipient | undefined;
@@ -94,9 +111,17 @@ export function decidingRecipient(preview: Preview | undefined): {
 export function SendPermission({
   preview,
   unanswered = false,
+  asking = false,
   onOverride,
 }: Readonly<{
   preview: Preview | undefined;
+  /**
+   * The question is in flight. Drawn rather than left silent, because silence
+   * here is what a permitted send looks like: the composer said nothing while
+   * it waited and nothing when it was told yes, so a rep read the first as the
+   * second.
+   */
+  asking?: boolean;
   /**
    * The question did not arrive: the preview failed rather than answered. Said
    * out loud, because a surface that fell silent here would look exactly like
@@ -112,12 +137,20 @@ export function SendPermission({
   onOverride?: () => void;
 }>) {
   const t = useT();
-  const { state, recipient } = decidingRecipient(preview);
+  const { state, recipient } = decidingRecipient(preview, asking);
 
   if (unanswered) {
     return (
       <p className="t-caption" role="status">
         {t("sendPermission.unanswered")}
+      </p>
+    );
+  }
+
+  if (state === "checking") {
+    return (
+      <p className="t-caption" role="status">
+        {t("sendPermission.checking")}
       </p>
     );
   }

--- a/scripts/fe-file-length-waivers.txt
+++ b/scripts/fe-file-length-waivers.txt
@@ -58,7 +58,7 @@
 737 frontend/src/screens/companytoday.tsx
 533 frontend/src/screens/companywork.tsx
 3331 frontend/src/screens/compose.test.tsx
-3014 frontend/src/screens/compose.tsx
+2941 frontend/src/screens/compose.tsx
 547 frontend/src/screens/connected-agents.tsx
 1278 frontend/src/screens/connectors.tsx
 1428 frontend/src/screens/contacts.test.tsx


### PR DESCRIPTION
## What was wrong

The function that decides what the composer says answered "allowed" for an absent preview. Three situations reached that one state: nobody asked, the asking is in flight, and the answer came back clean. Only the last is permission.

The composer said nothing while it waited and nothing when it was told yes, so a rep read the first as the second. One who pressed Send in that window met the refusal at the button, which is the failure this surface exists to end.

## What changed

The permission hook already returned an `asking` flag and no caller read it. All three now do: the composer, the scheduled send and the approval card.

An unasked question stays quiet rather than warning. A surface with no recipient yet has nothing to ask about, and a warning there would tell a rep something is wrong with a message they have not written.

## Scope

This is the defect at the centre of the planned adapter slice, not the whole of it. The batched contact-summary endpoint and the presentation adapter are separate work and land separately.

## The file cap did its job

Adding the prop grew `compose.tsx` by one line, which its frozen waiver refused. That is correct: the rule is that the debt may only move shorter, and a waiver that absorbed growth would stop being a ratchet.

Paid by extracting `composereachability.ts`, which answers which addresses would not arrive and whether a channel reply can be offered. Both read off the same person payload the composer already holds, which is why they belong together. 3015 down to 2941, waiver ratcheted to match.

## Proof

Four tests, two mutation-verified. Deleting the checking branch fails both new tests and none of the twenty already there. Full `make check-fe` and `make check-backend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the composer treating an in-flight permission question as an answer. An absent preview previously read as "allowed", so a rep waiting for the engine saw the same silence as one who'd been told yes; now the composer shows a checking state while the question is in flight, and an unasked question still stays quiet.

**Bug Fixes**
- Passes the `asking` flag through the composer, scheduled send, and approval card, which previously ignored it.
- Adds four tests covering the new checking state and the preserved allow case.

**Refactors**
- Extracts `deadRecipientsAmong` and `useChannelReachable` from `compose.tsx` into `composereachability.ts`, unchanged, reducing the file-length waiver from 3015 to 2941.

<sup>Written for commit fe47004ca7fd438fa81cd62cf6319831f19d8e1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

