### PR TITLE
The composer asks about the blind copy too

### DIFF
--- a/frontend/src/screens/compose-permission.test.tsx
+++ b/frontend/src/screens/compose-permission.test.tsx
@@ -213,4 +213,40 @@ describe("the composer asks before anybody presses Send", () => {
 
     expect(await screen.findByText(/could not check/i)).toBeInTheDocument();
   });
+
+  // A BLIND COPY IS BLIND TO THE RECIPIENTS, NEVER TO THE CONSENT GATE.
+  //
+  // The server holds that line — SendEmailInput.Recipients is the merged list of
+  // every To, Cc AND Bcc address, and the send is authorized against all of them.
+  // The composer's preview asked about To and Cc only, so a rep who blind-copied
+  // somebody with a standing objection saw a clean composer and met the refusal
+  // at the Send button, which is the exact silence this surface exists to end.
+  it("asks about a blind copy too", async () => {
+    const asks = stubEngine(allowedPreview);
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+    await screen.findByText(
+      "This continues their own message, so it needs no reason from you.",
+    );
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("To"), "anna@example.test");
+    await user.tab();
+    await user.click(screen.getByRole("button", { name: "Bcc" }));
+    await user.type(screen.getByLabelText("Bcc"), "quiet@example.test");
+    await user.tab();
+
+    await waitFor(() => {
+      const addressed = asks
+        .map((ask) => previewedAddresses(ask.body))
+        .find((addresses) => addresses.includes("quiet@example.test"));
+      expect(addressed).toContain("quiet@example.test");
+    });
+  });
 });

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -2377,11 +2377,12 @@ export function ComposeModal({
     ? { ...account.grounding, projectId: projectFiling.projectId }
     : null;
   // The engine's answer about the message as it stands, asked where the rep is
-  // writing it rather than learned from the Send button's error. Mail only: a
-  // channel reply names no addressee for anybody to ask about, and the preview
-  // doors are the two mail doors.
+  // writing it rather than at the Send button. Mail only: a channel reply names
+  // no addressee. BCC IS IN THE QUESTION — consent is owed to everyone who
+  // receives the message and the server authorizes the merged list, so asking
+  // about two thirds of it let a rep blind-copy an objecting recipient.
   const permission = useSendPermission({
-    recipients: [...to, ...cc],
+    recipients: [...to, ...cc, ...bcc],
     anchorActivityId: answering,
     links: composedLinks(
       { entityType, entityId },


### PR DESCRIPTION
## What was wrong

A blind copy is blind to the recipients, never to the consent gate. The server holds that line: the send input's recipient list is the merged set of every To, Cc and Bcc address, and the send is authorized against all of them.

The composer's preview asked about To and Cc only. So a rep who blind-copied somebody with a standing objection saw a clean composer, pressed Send, and met the refusal at the button. That is the exact silence this surface exists to end.

The dead-address check beside it already covered bcc, which is what made the gap easy to miss.

## Proof

One test, mutation-verified. Dropping bcc from the question fails it and nothing else.

## Not in this slice

The plan's B5 also asks for a visible ready mark replacing the composer's silence on an allowed send, and a send command carrying a draft revision. Both are real, and neither is this defect. The ready mark in particular is a footer layout change that needs room in a file frozen at its line count.

Full `make check-fe` and `make check-backend` green, with the composer landing exactly at its frozen count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the composer's permission preview to include Bcc addresses in the consent question, so reps who blind-copy an objecting recipient see the refusal before pressing Send instead of meeting it at the button.

Previously the preview asked about To and Cc only, while the server authorizes the merged set of all three fields and the dead-address check already covered Bcc.

<sup>Written for commit d0e67f9361a9d07b09bf67ed3b612d439984373d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

