### PR TITLE
A permitted send says so, quietly

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3509,6 +3509,8 @@ export const de = {
     "Wenn Sie den Grund kennen — man hat Sie darum gebeten, Sie hatten ein Treffen, es ist ein Kunde —, halten Sie ihn fest. Er wird unter Ihrem Namen gespeichert.",
   "sendPermission.unprovenRefuses":
     "Der Versand wird abgelehnt, bis Margince einen Nachweis hat.",
+  "sendPermission.ready": "Bereit zum Senden",
+  "sendPermission.markName": "Kommunikationsstatus dieser Nachricht",
   "sendPermission.checking": "Prüfe, ob diese Nachricht gesendet werden darf …",
   "sendPermission.unanswered":
     "Margince konnte nicht prüfen, ob diese Nachricht gesendet werden darf. Beim Senden wird erneut geprüft.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3592,6 +3592,8 @@ export const en = {
     "If you know why — they asked you to, you met, they are a customer — say so and it is recorded against your name.",
   "sendPermission.unprovenRefuses":
     "Sending it will be refused until Margince has a record.",
+  "sendPermission.ready": "Ready to send",
+  "sendPermission.markName": "Communication status for this message",
   "sendPermission.checking": "Checking whether this message may be sent…",
   "sendPermission.unanswered":
     "Margince could not check whether this message may be sent. Sending it asks again.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3466,6 +3466,8 @@ export const vi = {
     "Nếu bạn biết lý do — họ đã đề nghị, bạn đã gặp họ, họ là khách hàng — hãy nêu ra và điều đó được ghi lại dưới tên bạn.",
   "sendPermission.unprovenRefuses":
     "Việc gửi sẽ bị từ chối cho đến khi Margince có ghi nhận.",
+  "sendPermission.ready": "Sẵn sàng gửi",
+  "sendPermission.markName": "Trạng thái liên lạc của tin nhắn này",
   "sendPermission.checking": "Đang kiểm tra xem có thể gửi tin nhắn này không…",
   "sendPermission.unanswered":
     "Margince không kiểm tra được tin nhắn này có được phép gửi hay không. Khi gửi sẽ kiểm tra lại.",

--- a/frontend/src/screens/compose-permission.test.tsx
+++ b/frontend/src/screens/compose-permission.test.tsx
@@ -249,4 +249,43 @@ describe("the composer asks before anybody presses Send", () => {
       expect(addressed).toContain("quiet@example.test");
     });
   });
+
+  // A PERMITTED SEND SAYS SO, QUIETLY.
+  //
+  // SendPermission draws nothing when the engine allows the message, which was
+  // deliberate — the overwhelming majority of sends are allowed and none of them
+  // should cost attention. But silence is also what the composer showed while it
+  // was still asking, and what it showed before anybody had asked at all. Three
+  // different situations, one blank space, and a rep had no way to tell "checked
+  // and fine" from "not asked yet".
+  //
+  // The mark is the smallest thing that separates them: present and quiet on an
+  // allowed send, absent only when there is genuinely nothing to say.
+  it("shows a quiet mark once the engine has allowed the message", async () => {
+    stubEngine(allowedPreview);
+    await openReplyAndAddress("anna@example.test");
+
+    expect(
+      await screen.findByRole("button", { name: /ready to send/i }),
+    ).toBeInTheDocument();
+  });
+
+  // And nothing at all before a recipient exists. A mark drawn over an empty
+  // form would claim an answer about a message nobody has addressed.
+  it("draws no mark before there is anybody to ask about", async () => {
+    stubEngine(allowedPreview);
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+    await screen.findByText(
+      "This continues their own message, so it needs no reason from you.",
+    );
+    expect(screen.queryByRole("button", { name: /ready to send/i })).toBeNull();
+  });
 });

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1,23 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Sparkles } from "lucide-react";
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
-import { Badge, Button } from "../design-system/atoms";
+import { Button } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { ConfirmModal } from "../design-system/confirmmodal";
-import { Eyebrow } from "../design-system/eyebrow";
-import { OpenEmailDrawer } from "../design-system/openemaildrawer";
-import { Panel, PanelBody } from "../design-system/panel";
 import {
   liveProjects,
   type PickableProject,
@@ -29,14 +17,9 @@ import { paragraphsFrom, RichText } from "../design-system/richtext";
 import { Select } from "../design-system/select";
 import { useToast } from "../design-system/toast";
 import type { TokenSuggestion } from "../design-system/tokeninput";
-import {
-  formatDateTime,
-  INTL_LOCALE,
-  identifierNumber,
-} from "../format/format";
+import { formatDateTime, INTL_LOCALE } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, usePlural, useT } from "../i18n";
-import type { MessageKey } from "../i18n/en";
 import { entityTimelineKeys } from "./activitykeys";
 import {
   isConsentNotGranted,
@@ -47,7 +30,7 @@ import {
   useViewerId,
 } from "./common";
 import { recordNamesIn, useOrganization360 } from "./company360";
-import { StaleThreadNotice, VoiceDegradedNotice } from "./compose.notices";
+import { StaleThreadNotice } from "./compose.notices";
 import {
   asksWhy,
   type CommunicationContext,
@@ -61,11 +44,10 @@ import {
   type ChosenFile,
   useCarriageBlocks,
 } from "./composeattachments";
+import { DraftBand, RewriteRow } from "./composedraftband";
 import {
   AccountDraftContext,
   DraftOffer,
-  DraftReasons,
-  openCited,
   type PendingAction,
 } from "./composedraftcontext";
 import {
@@ -93,7 +75,6 @@ import {
   useThreadMessages,
 } from "./composethread";
 import { useRoster } from "./entityref";
-import { useOpenEmail } from "./openemail";
 import { usePerson360 } from "./person360";
 import type { Transport } from "./persontransports";
 import {
@@ -104,7 +85,7 @@ import {
   withSubjectTag,
 } from "./projectrecord";
 import { SCHEDULED_SCREEN } from "./scheduledsends";
-import { SendPermission } from "./sendpermission";
+import { SendMark, SendPermission } from "./sendpermission";
 import { useSendPermission } from "./usesendpermission";
 import { useVoiceProfile } from "./voice-profile";
 import "./compose.css";
@@ -1052,158 +1033,6 @@ export function missingToSend(
     missing.push("context");
   }
   return missing;
-}
-
-// The card that says a MACHINE wrote the words below, and what it wrote them
-// from: to a reader the Art. 50 disclosure and the draft's reasoning are one
-// statement — not your colleague's message, and here is what it stands on.
-//
-// `Panel tone="ai"` draws it, in the colour every other machine-authored
-// surface wears, its title at h3 under the drawer's own h2. Loudest thing in
-// the drawer on purpose: miss it and a model's words go out in a rep's name.
-//
-// The server's disclosure line is a compliance string rendered verbatim, never
-// reworded; a response that omits it still discloses, because a missing line
-// may not silently become a missing disclosure.
-//
-// The voice tag names the PROFILE version that styled the draft; the
-// provisional label reports what that profile is today. Neither implies a
-// weaker draft — nothing gates drafting on maturity. Both hang off the SERVED
-// version, because reporting a maturity over a draft no voice touched would
-// overstate this surface's own provenance, which Art. 50 does not permit.
-function DraftBand({
-  provenance,
-  maturity,
-  reasons,
-  children,
-}: Readonly<{
-  provenance: DraftProvenance;
-  maturity: VoiceProfile["maturity"] | undefined;
-  reasons: components["schemas"]["AccountDraftReason"][];
-  // The steer and the verb that asks for another draft: the card is the
-  // machine's own block, so asking it to write again belongs inside it.
-  children: ReactNode;
-}>) {
-  const t = useT();
-  // One drawer per CARD rather than per reason: a drawer per row would be
-  // several dialogs racing to be the one on top.
-  const [openEmail, setOpenEmail] = useOpenEmail();
-  const zone = useRecordZone();
-  if (!provenance.ai_generated) {
-    return null;
-  }
-  return (
-    <Panel
-      tone="ai"
-      title={t("compose.aiDisclosureTitle")}
-      titleLevel={3}
-      className="compose-band"
-    >
-      <PanelBody className="compose-band-body">
-        <p className="t-body">
-          {provenance.ai_disclosure || t("compose.aiDisclosureFallback")}
-        </p>
-        <DraftReasons
-          reasons={reasons}
-          onOpenRecord={openCited}
-          onOpenEmail={setOpenEmail}
-        />
-        <OpenEmailDrawer
-          activityId={openEmail}
-          zone={zone}
-          onClose={() => setOpenEmail(null)}
-        />
-        <VoiceDegradedNotice degraded={provenance.voice_degraded} />
-        {provenance.voice_profile_version != null && (
-          <>
-            <p className="t-caption">
-              {/* A profile VERSION, never grouped: version 1234 is one
-                  identifier, and "1.234" reads as a different one. */}
-              {t("compose.voiceVersion", {
-                n: identifierNumber(provenance.voice_profile_version),
-              })}
-            </p>
-            {maturity === "provisional" && (
-              <p className="t-caption">
-                <Badge>{t("compose.provisional")}</Badge>{" "}
-                {t("compose.provisionalHint")}
-              </p>
-            )}
-          </>
-        )}
-        {children}
-      </PanelBody>
-    </Panel>
-  );
-}
-
-// The four things a rep asks the machine to do to its own draft, as one press
-// each. Each is an instruction for ONE call — it never becomes the standing
-// steer in the intent field.
-// The label a rep reads and the instruction the model is given are two
-// different strings and both are translated: the button says "Shorter" and the
-// model is asked for it in a sentence, because an instruction of one word is
-// one the model has to guess the scope of.
-const REWRITES = [
-  {
-    key: "shorter",
-    label: "compose.rewriteShorter",
-    instruction: "compose.rewriteShorterAsk",
-  },
-  {
-    key: "warmer",
-    label: "compose.rewriteWarmer",
-    instruction: "compose.rewriteWarmerAsk",
-  },
-  {
-    key: "formal",
-    label: "compose.rewriteFormal",
-    instruction: "compose.rewriteFormalAsk",
-  },
-  {
-    key: "deadline",
-    label: "compose.rewriteDeadline",
-    instruction: "compose.rewriteDeadlineAsk",
-  },
-] as const satisfies readonly {
-  key: string;
-  label: MessageKey;
-  instruction: MessageKey;
-}[];
-
-// Offered only over the machine's OWN untouched words. Once the rep has
-// edited the body, a rewrite would throw their work away to answer a question
-// about text that is no longer there — so the row withdraws rather than
-// growing a confirm nobody would read.
-// `disabled` and not `pending`: these buttons do not report a write of their
-// own, they refuse to start a second one. Named for what it does, because named
-// for a state it does not have it read as the draft button's own spinner and a
-// change to that button silently unblocked these.
-function RewriteRow({
-  onRewrite,
-  disabled,
-}: Readonly<{
-  onRewrite: (instruction: string) => void;
-  disabled: boolean;
-}>) {
-  const t = useT();
-  return (
-    <div className="compose-rewrite">
-      <Eyebrow>{t("compose.rewrite")}</Eyebrow>
-      {REWRITES.map((rewrite) => (
-        <Button
-          key={rewrite.key}
-          small
-          variant="aiQuiet"
-          disabled={disabled}
-          onClick={() => onRewrite(t(rewrite.instruction))}
-        >
-          <Sparkles aria-hidden="true" />
-          {t(rewrite.label)}
-        </Button>
-      ))}
-    </div>
-  );
 }
 
 // The mail-only half of the composer: AI drafting (there is no draft-message
@@ -2560,20 +2389,34 @@ export function ComposeModal({
         }}
         pending={send.isPending}
         error={sendError}
+        // The mark leads the footer row, before discard and the send controls:
+        // it is what a rep checks before pressing anything. The Callout in the
+        // body explains a refusal; this says the engine looked and found
+        // nothing wrong, which the composer used to say by drawing nothing —
+        // indistinguishable from not having asked at all.
         actionsLead={
-          discardControl && (
-            <Button
-              onClick={discardControl.run}
-              disabled={discardControl.disabled}
-              // What discarding DOES, on the control itself: it is not an undo,
-              // it tells the voice profile this draft missed. A rep who reads it
-              // as "clear the box" would train the model on every draft they
-              // merely changed their mind about.
-              title={t("compose.discardDraftHint")}
-            >
-              {t("compose.discardDraft")}
-            </Button>
-          )
+          <>
+            {!isChannelReply && (
+              <SendMark
+                preview={permission.preview}
+                asking={permission.asking}
+                unanswered={permission.unanswered}
+              />
+            )}
+            {discardControl && (
+              <Button
+                onClick={discardControl.run}
+                disabled={discardControl.disabled}
+                // What discarding DOES, on the control itself: it is not an undo,
+                // it tells the voice profile this draft missed. A rep who reads it
+                // as "clear the box" would train the model on every draft they
+                // merely changed their mind about.
+                title={t("compose.discardDraftHint")}
+              >
+                {t("compose.discardDraft")}
+              </Button>
+            )}
+          </>
         }
         confirmMenu={
           isChannelReply ? undefined : (

--- a/frontend/src/screens/composedraftband.tsx
+++ b/frontend/src/screens/composedraftband.tsx
@@ -1,0 +1,182 @@
+import { Sparkles } from "lucide-react";
+import type { ReactNode } from "react";
+import type { components } from "../api/schema";
+import { useRecordZone } from "../app/recordzone";
+import { Badge, Button } from "../design-system/atoms";
+import { Eyebrow } from "../design-system/eyebrow";
+import { OpenEmailDrawer } from "../design-system/openemaildrawer";
+import { Panel, PanelBody } from "../design-system/panel";
+import { identifierNumber } from "../format/format";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { VoiceDegradedNotice } from "./compose.notices";
+import { DraftReasons, openCited } from "./composedraftcontext";
+import { useOpenEmail } from "./openemail";
+
+type EmailDraft = components["schemas"]["EmailDraft"];
+type VoiceProfile = components["schemas"]["VoiceProfile"];
+
+// What the AI band says about a draft nobody typed, and the rewrites offered
+// under it. Extracted from compose.tsx unchanged.
+//
+// The two belong together: the band discloses that a machine wrote the words,
+// and every rewrite row asks that machine to write them again. A surface that
+// showed one without the other would either disclose nothing or offer a rewrite
+// of prose the reader believes they wrote themselves.
+
+type DraftProvenance = Pick<
+  EmailDraft,
+  "ai_generated" | "ai_disclosure" | "voice_profile_version" | "voice_degraded"
+>;
+
+// The card that says a MACHINE wrote the words below, and what it wrote them
+// from: to a reader the Art. 50 disclosure and the draft's reasoning are one
+// statement — not your colleague's message, and here is what it stands on.
+//
+// `Panel tone="ai"` draws it, in the colour every other machine-authored
+// surface wears, its title at h3 under the drawer's own h2. Loudest thing in
+// the drawer on purpose: miss it and a model's words go out in a rep's name.
+//
+// The server's disclosure line is a compliance string rendered verbatim, never
+// reworded; a response that omits it still discloses, because a missing line
+// may not silently become a missing disclosure.
+//
+// The voice tag names the PROFILE version that styled the draft; the
+// provisional label reports what that profile is today. Neither implies a
+// weaker draft — nothing gates drafting on maturity. Both hang off the SERVED
+// version, because reporting a maturity over a draft no voice touched would
+// overstate this surface's own provenance, which Art. 50 does not permit.
+export function DraftBand({
+  provenance,
+  maturity,
+  reasons,
+  children,
+}: Readonly<{
+  provenance: DraftProvenance;
+  maturity: VoiceProfile["maturity"] | undefined;
+  reasons: components["schemas"]["AccountDraftReason"][];
+  // The steer and the verb that asks for another draft: the card is the
+  // machine's own block, so asking it to write again belongs inside it.
+  children: ReactNode;
+}>) {
+  const t = useT();
+  // One drawer per CARD rather than per reason: a drawer per row would be
+  // several dialogs racing to be the one on top.
+  const [openEmail, setOpenEmail] = useOpenEmail();
+  const zone = useRecordZone();
+  if (!provenance.ai_generated) {
+    return null;
+  }
+  return (
+    <Panel
+      tone="ai"
+      title={t("compose.aiDisclosureTitle")}
+      titleLevel={3}
+      className="compose-band"
+    >
+      <PanelBody className="compose-band-body">
+        <p className="t-body">
+          {provenance.ai_disclosure || t("compose.aiDisclosureFallback")}
+        </p>
+        <DraftReasons
+          reasons={reasons}
+          onOpenRecord={openCited}
+          onOpenEmail={setOpenEmail}
+        />
+        <OpenEmailDrawer
+          activityId={openEmail}
+          zone={zone}
+          onClose={() => setOpenEmail(null)}
+        />
+        <VoiceDegradedNotice degraded={provenance.voice_degraded} />
+        {provenance.voice_profile_version != null && (
+          <>
+            <p className="t-caption">
+              {/* A profile VERSION, never grouped: version 1234 is one
+                  identifier, and "1.234" reads as a different one. */}
+              {t("compose.voiceVersion", {
+                n: identifierNumber(provenance.voice_profile_version),
+              })}
+            </p>
+            {maturity === "provisional" && (
+              <p className="t-caption">
+                <Badge>{t("compose.provisional")}</Badge>{" "}
+                {t("compose.provisionalHint")}
+              </p>
+            )}
+          </>
+        )}
+        {children}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+// The four things a rep asks the machine to do to its own draft, as one press
+// each. Each is an instruction for ONE call — it never becomes the standing
+// steer in the intent field.
+// The label a rep reads and the instruction the model is given are two
+// different strings and both are translated: the button says "Shorter" and the
+// model is asked for it in a sentence, because an instruction of one word is
+// one the model has to guess the scope of.
+export const REWRITES = [
+  {
+    key: "shorter",
+    label: "compose.rewriteShorter",
+    instruction: "compose.rewriteShorterAsk",
+  },
+  {
+    key: "warmer",
+    label: "compose.rewriteWarmer",
+    instruction: "compose.rewriteWarmerAsk",
+  },
+  {
+    key: "formal",
+    label: "compose.rewriteFormal",
+    instruction: "compose.rewriteFormalAsk",
+  },
+  {
+    key: "deadline",
+    label: "compose.rewriteDeadline",
+    instruction: "compose.rewriteDeadlineAsk",
+  },
+] as const satisfies readonly {
+  key: string;
+  label: MessageKey;
+  instruction: MessageKey;
+}[];
+
+// Offered only over the machine's OWN untouched words. Once the rep has
+// edited the body, a rewrite would throw their work away to answer a question
+// about text that is no longer there — so the row withdraws rather than
+// growing a confirm nobody would read.
+// `disabled` and not `pending`: these buttons do not report a write of their
+// own, they refuse to start a second one. Named for what it does, because named
+// for a state it does not have it read as the draft button's own spinner and a
+// change to that button silently unblocked these.
+export function RewriteRow({
+  onRewrite,
+  disabled,
+}: Readonly<{
+  onRewrite: (instruction: string) => void;
+  disabled: boolean;
+}>) {
+  const t = useT();
+  return (
+    <div className="compose-rewrite">
+      <Eyebrow>{t("compose.rewrite")}</Eyebrow>
+      {REWRITES.map((rewrite) => (
+        <Button
+          key={rewrite.key}
+          small
+          variant="aiQuiet"
+          disabled={disabled}
+          onClick={() => onRewrite(t(rewrite.instruction))}
+        >
+          <Sparkles aria-hidden="true" />
+          {t(rewrite.label)}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/screens/sendpermission.tsx
+++ b/frontend/src/screens/sendpermission.tsx
@@ -2,6 +2,7 @@ import { ShieldAlert, ShieldQuestion } from "lucide-react";
 import type { components } from "../api/schema";
 import { Button } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
+import { CommunicationStatus } from "../design-system/communicationstatus";
 import { useT } from "../i18n";
 
 // What the engine decided about this message, said where the rep is writing it.
@@ -230,4 +231,52 @@ function reasonKey(recipient: Recipient | undefined) {
     default:
       return "sendPermission.reason.other" as const;
   }
+}
+
+/**
+ * SendMark is the quiet half of the answer: a mark that says the engine has
+ * looked and found nothing wrong.
+ *
+ * SendPermission draws a Callout for the states a rep has to act on and
+ * NOTHING for the state they do not. That silence was deliberate — the
+ * overwhelming majority of sends are allowed and none should cost attention —
+ * but it is also what the composer showed while it was still asking, and before
+ * anybody had asked at all. Three situations, one blank space, and no way to
+ * tell "checked and fine" from "not asked yet".
+ *
+ * So the allowed state gets a mark and the other two keep their Callout: this
+ * renders beside the Send button, where the decision is made, and the Callout
+ * stays in the body where an explanation belongs. A rep who never looks at the
+ * mark loses nothing, which is the test a quiet signal has to pass.
+ *
+ * It draws NOTHING when there is no question yet. A mark over an empty form
+ * would claim an answer about a message nobody has addressed.
+ */
+export function SendMark({
+  preview,
+  asking = false,
+  unanswered = false,
+}: Readonly<{
+  preview: Preview | undefined;
+  asking?: boolean;
+  unanswered?: boolean;
+}>) {
+  const t = useT();
+  const { state } = decidingRecipient(preview, asking);
+  // The refused and unproven states are the Callout's, not the mark's: a
+  // sentence a rep has to read does not belong in a glyph beside a button.
+  if (unanswered || (state === "allowed" && !preview)) return null;
+  if (state !== "allowed" && state !== "checking") return null;
+  const label =
+    state === "checking"
+      ? t("sendPermission.checking")
+      : t("sendPermission.ready");
+  return (
+    <CommunicationStatus
+      state={state === "checking" ? "checking" : "ready"}
+      scope="current_message"
+      label={label}
+      name={`${t("sendPermission.markName")}: ${label}`}
+    />
+  );
 }

--- a/scripts/fe-file-length-waivers.txt
+++ b/scripts/fe-file-length-waivers.txt
@@ -58,7 +58,7 @@
 737 frontend/src/screens/companytoday.tsx
 533 frontend/src/screens/companywork.tsx
 3331 frontend/src/screens/compose.test.tsx
-2941 frontend/src/screens/compose.tsx
+2797 frontend/src/screens/compose.tsx
 547 frontend/src/screens/connected-agents.tsx
 1278 frontend/src/screens/connectors.tsx
 1428 frontend/src/screens/contacts.test.tsx


### PR DESCRIPTION
## What was wrong

The permission component drew nothing when the engine allowed the message. That was deliberate: the overwhelming majority of sends are allowed and none should cost attention. The file's own header already called that state "one quiet line".

But silence was also what the composer showed while it was still asking, and before anybody had asked at all. Three situations, one blank space, and no way to tell "checked and fine" from "not asked yet".

## What changed

A mark in the footer's lead slot, beside the controls a rep is about to press. The explanatory callout stays in the body, where a refusal that needs reading belongs.

A rep who never looks at the mark loses nothing, which is the test a quiet signal has to pass. It draws nothing before a recipient exists, since a mark over an empty form would claim an answer about a message nobody has addressed.

## No new design-system prop

My first attempt invented a `confirmPrefix` prop on the confirm dialog. That dialog already has an `actionsLead` slot, and twenty-eight surfaces build on it. The mark uses the slot that was already there.

## Paying for the lines

The mark cost fourteen lines in a file frozen at its count. `composedraftband.tsx` comes out to pay for it: the AI disclosure band and the rewrites under it, which belong together because every rewrite asks the same machine to write the words the band discloses.

2941 down to 2797, waiver ratcheted to match.

## Proof

Two tests, one mutation-verified. Full `make check-fe` and `make check-backend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a quiet "Ready to send" mark in the composer footer once the engine has allowed a message, so a rep can tell an allowed send from one that is still checking or not yet asked.

- Draws nothing before a recipient exists, since a mark over an empty form would claim an answer about a message nobody has addressed.
- Reuses the footer's existing `actionsLead` slot; no new design-system prop.
- Refusals keep their explanatory callout in the body.
- Moves the AI disclosure band and rewrite row into `composedraftband.tsx` so `compose.tsx` stays within its file-length waiver.

<sup>Written for commit eced29e89312ad814951b5f63f1e4382626808e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

