### PR TITLE
The rep can open the review their refusal named

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -13276,6 +13276,35 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/DataSubjectRequest' }
+  /communication-reviews/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
+    get:
+      tags: [Communication]
+      operationId: getCommunicationReview
+      security: [ { cookieAuth: [] } ]   # human session only — the row names other people's addresses
+      x-agent-access: human-only
+      summary: What a refused send was refused for, and for whom.
+      description: |
+        A send the engine refused leaves a review behind, and the refusal answers its reference. This
+        is how a rep opens it: what was refused, which recipient it was refused for, and the reason
+        each one carries.
+
+        SCOPED TO THE INITIATOR. The row names the recipients of somebody's message and the reason
+        each was refused, which is a fact about those people — so this serves the person who pressed
+        Send and nobody else. A review belonging to somebody else answers 404 rather than 403,
+        because "forbidden" would confirm the id exists and that is itself a disclosure about a
+        message the caller may not see.
+
+        Human-only. An agent that could read these would enumerate one seat's refused correspondence.
+      responses:
+        '200':
+          description: The review.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CommunicationReview' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /data-subject-requests/{id}:
     parameters:
       - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
@@ -39463,6 +39492,46 @@ components:
       properties:
         data: { type: array, items: { $ref: '#/components/schemas/Team' } }
         page: { $ref: '#/components/schemas/PageInfo' }
+
+    RefusedRecipient:
+      type: object
+      description: |
+        One recipient's half of a refusal, as the engine gave it. The ADDRESS is here because a
+        reason code without one says a message was refused and not who for, which is the question
+        the rep is actually asking — and it is why an erasure clears this list.
+      required: [address, reason_code]
+      properties:
+        address: { type: string }
+        subject_kind: { type: string, enum: [person, lead] }
+        subject_id: { type: string, format: uuid }
+        reason_code: { type: string }
+        category: { type: string }
+
+    CommunicationReview:
+      type: object
+      description: |
+        What a refused send left behind. A SNAPSHOT of the engine's answer at the moment it was
+        given — a reader asking why a message was refused on Tuesday needs Tuesday's answer, not
+        what the consent rows say today.
+      required: [id, state, kind, reason_code, refusals]
+      properties:
+        id: { type: string, format: uuid }
+        state:
+          type: string
+          enum: [needs_context, needs_repair, resolved, superseded, cancelled]
+          description: |
+            What is NEEDED rather than who is blocked: `needs_context` is a fact about the message
+            and stays true whoever is looking at it. `needs_repair` is a refusal no evidence can
+            answer — an objection, a dead address — where offering a context form would invite a rep
+            to argue with a withdrawal.
+        kind: { type: string, enum: [single] }
+        reason_code:
+          type: string
+          description: The strongest reason across the recipients, so a queue can order without opening the snapshot.
+        refusals:
+          type: array
+          description: What was refused, per recipient. Empty once an erasure has cleared the subject from it.
+          items: { $ref: '#/components/schemas/RefusedRecipient' }
 
     DataSubjectRequest:
       type: object

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -210,6 +210,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/commissions":                                                {Op: "listCommissionEntries", Access: "tool", Tool: "list_records", RecordType: "commission", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/commissions/summary":                                        {Op: "getCommissionSummary", Access: "tool", Tool: "run_report", RecordType: "commission", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/commissions/{id}":                                           {Op: "getCommissionEntry", Access: "tool", Tool: "read_record", RecordType: "commission", Tier: "auto_execute", Scope: "read"},
+	"GET /v1/communication-reviews/{id}":                                 {Op: "getCommunicationReview", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/company":                                                    {Op: "getCompany", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/company/context":                                            {Op: "getCompanyContext", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/company/context/capabilities":                               {Op: "getCompanyContextCapabilities", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/integration/refused_send_review_integration_test.go
+++ b/backend/internal/compose/integration/refused_send_review_integration_test.go
@@ -195,3 +195,85 @@ func TestErasingASubjectClearsThemFromARefusedSendReview(t *testing.T) {
 		t.Errorf("the review still names the erased subject's address: %s", after[0].refusals)
 	}
 }
+
+// A REFERENCE NOBODY CAN RESOLVE IS BARELY BETTER THAN AN ERROR CODE. The
+// refusal answers a review id and, until this endpoint existed, nothing could
+// open it: the row was written, the rep was handed the id, and there was no
+// door.
+func TestTheRepCanOpenTheReviewTheirRefusalNamed(t *testing.T) {
+	c := setupConsent(t)
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send with no grant → %d, want 409", status)
+	}
+	reviews := openReviews(t, c.AppEnv)
+	if len(reviews) != 1 {
+		t.Fatalf("%d review(s), want 1", len(reviews))
+	}
+
+	var opened struct {
+		ID         string `json:"id"`
+		State      string `json:"state"`
+		ReasonCode string `json:"reason_code"`
+		Refusals   []struct {
+			Address    string `json:"address"`
+			ReasonCode string `json:"reason_code"`
+		} `json:"refusals"`
+	}
+	if status := c.Call(t, "GET", "/v1/communication-reviews/"+reviews[0].id,
+		nil, nil, &opened); status != http.StatusOK {
+		t.Fatalf("opening the review the refusal named → %d, want 200", status)
+	}
+	if opened.ID != reviews[0].id {
+		t.Errorf("opened review %q, want %q", opened.ID, reviews[0].id)
+	}
+	if len(opened.Refusals) != 1 {
+		t.Fatalf("%d refusal(s) in the answer, want 1 — the rep is told a send was refused "+
+			"and not who for", len(opened.Refusals))
+	}
+	if opened.Refusals[0].Address != "subject@consent.test" {
+		t.Errorf("the answer names %q, want the recipient the send was refused for",
+			opened.Refusals[0].Address)
+	}
+	if opened.ReasonCode == "" || opened.State == "" {
+		t.Errorf("the answer carries state=%q reason=%q, want both",
+			opened.State, opened.ReasonCode)
+	}
+}
+
+// A REVIEW BELONGING TO SOMEBODY ELSE IS NOT FOUND, not forbidden. The row
+// names the recipients of another person's message and why each was refused,
+// which is a fact about those people — and "forbidden" would confirm the id
+// exists, which is itself a disclosure about a message the caller may not see.
+func TestAnotherSeatsReviewIsNotFound(t *testing.T) {
+	c := setupConsent(t)
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send with no grant → %d, want 409", status)
+	}
+	reviews := openReviews(t, c.AppEnv)
+	if len(reviews) != 1 {
+		t.Fatalf("%d review(s), want 1", len(reviews))
+	}
+
+	// Reassigned to a seat this caller is not: the same shape as another rep's
+	// refusal, without needing a second logged-in session to produce one.
+	var other string
+	if err := c.Owner.QueryRow(context.Background(), `
+		INSERT INTO app_user (email, display_name)
+		VALUES ('other-' || gen_random_uuid() || '@consent.test', 'Other Seat')
+		RETURNING id::text`).Scan(&other); err != nil {
+		t.Fatalf("seeding another seat: %v", err)
+	}
+	if _, err := c.Owner.Exec(context.Background(),
+		`UPDATE communication_review SET initiated_by = $1 WHERE id = $2`,
+		other, reviews[0].id); err != nil {
+		t.Fatalf("reassigning the review: %v", err)
+	}
+
+	if status := c.Call(t, "GET", "/v1/communication-reviews/"+reviews[0].id,
+		nil, nil, nil); status != http.StatusNotFound {
+		t.Errorf("another seat's review → %d, want 404 — a 403 would confirm the id exists, "+
+			"which is a disclosure about a message this caller may not see", status)
+	}
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -571,6 +571,10 @@ func (stubs) DecideCommissionEntry(w nethttp.ResponseWriter, r *nethttp.Request,
 	httperr.NotImplemented(w, r, "DecideCommissionEntry")
 }
 
+func (stubs) GetCommunicationReview(w nethttp.ResponseWriter, r *nethttp.Request, id openapi_types.UUID) {
+	httperr.NotImplemented(w, r, "GetCommunicationReview")
+}
+
 func (stubs) GetCompany(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetCompany")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3088,6 +3088,48 @@ func (e CommunicationContext) Valid() bool {
 	}
 }
 
+// Defines values for CommunicationReviewKind.
+const (
+	Single CommunicationReviewKind = "single"
+)
+
+// Valid indicates whether the value is a known member of the CommunicationReviewKind enum.
+func (e CommunicationReviewKind) Valid() bool {
+	switch e {
+	case Single:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CommunicationReviewState.
+const (
+	CommunicationReviewStateCancelled    CommunicationReviewState = "cancelled"
+	CommunicationReviewStateNeedsContext CommunicationReviewState = "needs_context"
+	CommunicationReviewStateNeedsRepair  CommunicationReviewState = "needs_repair"
+	CommunicationReviewStateResolved     CommunicationReviewState = "resolved"
+	CommunicationReviewStateSuperseded   CommunicationReviewState = "superseded"
+)
+
+// Valid indicates whether the value is a known member of the CommunicationReviewState enum.
+func (e CommunicationReviewState) Valid() bool {
+	switch e {
+	case CommunicationReviewStateCancelled:
+		return true
+	case CommunicationReviewStateNeedsContext:
+		return true
+	case CommunicationReviewStateNeedsRepair:
+		return true
+	case CommunicationReviewStateResolved:
+		return true
+	case CommunicationReviewStateSuperseded:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CompanyContextSchemaVersion.
 const (
 	N1 CompanyContextSchemaVersion = 1
@@ -10759,6 +10801,24 @@ const (
 func (e RefreshAcceptedStatus) Valid() bool {
 	switch e {
 	case Enqueued:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RefusedRecipientSubjectKind.
+const (
+	RefusedRecipientSubjectKindLead   RefusedRecipientSubjectKind = "lead"
+	RefusedRecipientSubjectKindPerson RefusedRecipientSubjectKind = "person"
+)
+
+// Valid indicates whether the value is a known member of the RefusedRecipientSubjectKind enum.
+func (e RefusedRecipientSubjectKind) Valid() bool {
+	switch e {
+	case RefusedRecipientSubjectKindLead:
+		return true
+	case RefusedRecipientSubjectKindPerson:
 		return true
 	default:
 		return false
@@ -20918,6 +20978,35 @@ type CommunicationEvidence struct {
 	// InvoiceId The invoice or payment event this send is about.
 	InvoiceId *openapi_types.UUID `json:"invoice_id,omitempty"`
 }
+
+// CommunicationReview What a refused send left behind. A SNAPSHOT of the engine's answer at the moment it was
+// given — a reader asking why a message was refused on Tuesday needs Tuesday's answer, not
+// what the consent rows say today.
+type CommunicationReview struct {
+	Id   openapi_types.UUID      `json:"id"`
+	Kind CommunicationReviewKind `json:"kind"`
+
+	// ReasonCode The strongest reason across the recipients, so a queue can order without opening the snapshot.
+	ReasonCode string `json:"reason_code"`
+
+	// Refusals What was refused, per recipient. Empty once an erasure has cleared the subject from it.
+	Refusals []RefusedRecipient `json:"refusals"`
+
+	// State What is NEEDED rather than who is blocked: `needs_context` is a fact about the message
+	// and stays true whoever is looking at it. `needs_repair` is a refusal no evidence can
+	// answer — an objection, a dead address — where offering a context form would invite a rep
+	// to argue with a withdrawal.
+	State CommunicationReviewState `json:"state"`
+}
+
+// CommunicationReviewKind defines model for CommunicationReview.Kind.
+type CommunicationReviewKind string
+
+// CommunicationReviewState What is NEEDED rather than who is blocked: `needs_context` is a fact about the message
+// and stays true whoever is looking at it. `needs_repair` is a refusal no evidence can
+// answer — an objection, a dead address — where offering a context form would invite a rep
+// to argue with a withdrawal.
+type CommunicationReviewState string
 
 // CompanyContext defines model for CompanyContext.
 type CompanyContext struct {
@@ -32026,6 +32115,20 @@ type RefreshAccepted struct {
 
 // RefreshAcceptedStatus defines model for RefreshAccepted.Status.
 type RefreshAcceptedStatus string
+
+// RefusedRecipient One recipient's half of a refusal, as the engine gave it. The ADDRESS is here because a
+// reason code without one says a message was refused and not who for, which is the question
+// the rep is actually asking — and it is why an erasure clears this list.
+type RefusedRecipient struct {
+	Address     string                       `json:"address"`
+	Category    *string                      `json:"category,omitempty"`
+	ReasonCode  string                       `json:"reason_code"`
+	SubjectId   *openapi_types.UUID          `json:"subject_id,omitempty"`
+	SubjectKind *RefusedRecipientSubjectKind `json:"subject_kind,omitempty"`
+}
+
+// RefusedRecipientSubjectKind defines model for RefusedRecipient.SubjectKind.
+type RefusedRecipientSubjectKind string
 
 // RejectOfferRequest defines model for RejectOfferRequest.
 type RejectOfferRequest struct {
@@ -51807,6 +51910,9 @@ type ServerInterface interface {
 	// Approve, pay, or void one entry.
 	// (POST /commissions/{id}/decide)
 	DecideCommissionEntry(w http.ResponseWriter, r *http.Request, id Id, params DecideCommissionEntryParams)
+	// What a refused send was refused for, and for whom.
+	// (GET /communication-reviews/{id})
+	GetCommunicationReview(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// The installation's own company (the anchor organization).
 	// (GET /company)
 	GetCompany(w http.ResponseWriter, r *http.Request)
@@ -54081,6 +54187,12 @@ func (_ Unimplemented) GetCommissionEntry(w http.ResponseWriter, r *http.Request
 // Approve, pay, or void one entry.
 // (POST /commissions/{id}/decide)
 func (_ Unimplemented) DecideCommissionEntry(w http.ResponseWriter, r *http.Request, id Id, params DecideCommissionEntryParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// What a refused send was refused for, and for whom.
+// (GET /communication-reviews/{id})
+func (_ Unimplemented) GetCommunicationReview(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -61960,6 +62072,38 @@ func (siw *ServerInterfaceWrapper) DecideCommissionEntry(w http.ResponseWriter, 
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.DecideCommissionEntry(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetCommunicationReview operation middleware
+func (siw *ServerInterfaceWrapper) GetCommunicationReview(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetCommunicationReview(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -83865,6 +84009,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/commissions/{id}/decide", wrapper.DecideCommissionEntry)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/communication-reviews/{id}", wrapper.GetCommunicationReview)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/company", wrapper.GetCompany)

--- a/backend/internal/modules/consent/handlers_review.go
+++ b/backend/internal/modules/consent/handlers_review.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Opening a review the refusal named.
+//
+// A refused send answers a reference and, until this existed, nothing could
+// resolve it: the row was written, the rep was handed its id, and there was no
+// door. They had a reference to a record they could not read, which is barely
+// better than the bare error code it replaced.
+
+import (
+	"net/http"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// GetCommunicationReview serves GET /communication-reviews/{id}.
+//
+// Wire-only. The store owns who may read which review, and it must: a handler
+// that decided scope here would be a second answer to a question the store
+// already answers, and the two would disagree the first time either changed.
+func (h Handlers) GetCommunicationReview(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
+	review, err := h.store.ReviewForInitiator(r.Context(), ids.UUID(id))
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, wireReview(review))
+}
+
+// wireReview renders a review for the rep who asked for it.
+//
+// The refusals are rendered as an EMPTY LIST rather than omitted when there are
+// none. A review whose subject has since been erased holds no refusals, and a
+// client distinguishing "absent" from "empty" would be reading a difference
+// that means nothing — both say this review no longer names anybody.
+func wireReview(review Review) crmcontracts.CommunicationReview {
+	refusals := make([]crmcontracts.RefusedRecipient, 0, len(review.Refusals))
+	for _, refusal := range review.Refusals {
+		wire := crmcontracts.RefusedRecipient{
+			Address:    refusal.Address,
+			ReasonCode: refusal.ReasonCode,
+		}
+		if refusal.Category != "" {
+			category := refusal.Category
+			wire.Category = &category
+		}
+		if refusal.SubjectKind != "" {
+			kind := crmcontracts.RefusedRecipientSubjectKind(refusal.SubjectKind)
+			wire.SubjectKind = &kind
+		}
+		if subject, err := ids.Parse(refusal.SubjectID); err == nil {
+			id := openapi_types.UUID(subject)
+			wire.SubjectId = &id
+		}
+		refusals = append(refusals, wire)
+	}
+	return crmcontracts.CommunicationReview{
+		Id:         openapi_types.UUID(review.ID),
+		State:      crmcontracts.CommunicationReviewState(review.State),
+		Kind:       crmcontracts.CommunicationReviewKind(review.Kind),
+		ReasonCode: review.ReasonCode,
+		Refusals:   refusals,
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9223,6 +9223,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/communication-reviews/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * What a refused send was refused for, and for whom.
+         * @description A send the engine refused leaves a review behind, and the refusal answers its reference. This
+         *     is how a rep opens it: what was refused, which recipient it was refused for, and the reason
+         *     each one carries.
+         *
+         *     SCOPED TO THE INITIATOR. The row names the recipients of somebody's message and the reason
+         *     each was refused, which is a fact about those people — so this serves the person who pressed
+         *     Send and nobody else. A review belonging to somebody else answers 404 rather than 403,
+         *     because "forbidden" would confirm the id exists and that is itself a disclosure about a
+         *     message the caller may not see.
+         *
+         *     Human-only. An agent that could read these would enumerate one seat's refused correspondence.
+         */
+        get: operations["getCommunicationReview"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/data-subject-requests/{id}": {
         parameters: {
             query?: never;
@@ -29120,6 +29152,43 @@ export interface components {
             data: components["schemas"]["Team"][];
             page: components["schemas"]["PageInfo"];
         };
+        /**
+         * @description One recipient's half of a refusal, as the engine gave it. The ADDRESS is here because a
+         *     reason code without one says a message was refused and not who for, which is the question
+         *     the rep is actually asking — and it is why an erasure clears this list.
+         */
+        RefusedRecipient: {
+            address: string;
+            /** @enum {string} */
+            subject_kind?: "person" | "lead";
+            /** Format: uuid */
+            subject_id?: string;
+            reason_code: string;
+            category?: string;
+        };
+        /**
+         * @description What a refused send left behind. A SNAPSHOT of the engine's answer at the moment it was
+         *     given — a reader asking why a message was refused on Tuesday needs Tuesday's answer, not
+         *     what the consent rows say today.
+         */
+        CommunicationReview: {
+            /** Format: uuid */
+            id: string;
+            /**
+             * @description What is NEEDED rather than who is blocked: `needs_context` is a fact about the message
+             *     and stays true whoever is looking at it. `needs_repair` is a refusal no evidence can
+             *     answer — an objection, a dead address — where offering a context form would invite a rep
+             *     to argue with a withdrawal.
+             * @enum {string}
+             */
+            state: "needs_context" | "needs_repair" | "resolved" | "superseded" | "cancelled";
+            /** @enum {string} */
+            kind: "single";
+            /** @description The strongest reason across the recipients, so a queue can order without opening the snapshot. */
+            reason_code: string;
+            /** @description What was refused, per recipient. Empty once an erasure has cleared the subject from it. */
+            refusals: components["schemas"]["RefusedRecipient"][];
+        };
         /** @description A GDPR data-subject request (Art. 15/16/17) tracked to completion (B-E11.30; data-model §12.5). */
         DataSubjectRequest: {
             /** Format: uuid */
@@ -47797,6 +47866,29 @@ export interface operations {
                     "application/json": components["schemas"]["DataSubjectRequest"];
                 };
             };
+        };
+    };
+    getCommunicationReview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The review. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CommunicationReview"];
+                };
+            };
+            404: components["responses"]["NotFound"];
         };
     };
     updateDataSubjectRequest: {


### PR DESCRIPTION
## What was wrong

A refused send answers a review reference, and nothing could resolve it. The row was written, the rep was handed the id, and there was no door. A reference to a record nobody can read is barely better than the bare error code it replaced.

## What changed

One read endpoint: what was refused, which recipient it was refused for, and the reason each one carries.

**Scoped to the initiator, and 404 rather than 403 for anybody else.** The row names the recipients of somebody's message and why each was refused, which is a fact about those people. A "forbidden" would confirm the id exists, which is itself a disclosure about a message the caller may not see.

Human-only. An agent that could read these would enumerate one seat's refused correspondence.

## Two details

The refusals render as an empty list rather than being omitted when there are none. A review whose subject has been erased holds none, and a client distinguishing absent from empty would read a difference that means nothing.

The refused-recipient item is a named schema rather than an inline object. An anonymous struct is awkward for every consumer, and the shape is one other surfaces will want.

## Not in this slice

B6 also asks for the drawer that renders this, the in-place context form, and the endpoint that records a firsthand statement. The read is what every one of those needs first.

## Proof

Two tests, the scoping one mutation-verified: widening the query to any seat answers 200 where the test demands 404.

Full `make check-backend`, `make check-fe`, and the compose integration lane at zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read endpoint so a rep can open the review a refused send names; before this, the refusal answered a review id nothing could resolve.

**New Features**
- `GET /communication-reviews/{id}` returns the refusal snapshot: what was refused, for which recipient, and the reason.
- Scoped to the initiating rep; another seat's review answers 404, not 403, so callers cannot confirm an id exists.
- Human-only, so an agent cannot enumerate one seat's refused correspondence.
- Refusals render as an empty list, never omitted, so clients don't mistake no-refusals-after-erasure for absence.
- `RefusedRecipient` is a named schema for reuse by other surfaces.

The drawer, context form, and firsthand-statement endpoint are not in this slice; this read is what each needs first.

<sup>Written for commit e6c2835af90edb4a08746551d2608ee88a2b4cd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

