### PR TITLE
Writing is always available

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8144,8 +8144,6 @@ export const de = {
   "person.action.messageOn": "Über {transport} schreiben",
   "person.action.noTransport":
     "Keine Adresse und keine Unterhaltung, auf die sich antworten ließe.",
-  "person.action.consentRefused":
-    "Derzeit erlaubt kein Zweck, ihnen zu schreiben.",
   "person.action.call": "Anrufen",
   "person.action.meetings": "Termine ansehen",
   "person.action.addTask": "Aufgabe",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8241,8 +8241,6 @@ export const en = {
   // Why the lead verb is refused, in two sentences that are never merged: no
   // way to reach them, and consent that says not to.
   "person.action.noTransport": "No address, and no conversation to reply to.",
-  "person.action.consentRefused":
-    "No purpose currently permits writing to them.",
   "person.action.call": "Call",
   "person.action.meetings": "See meetings",
   "person.action.addTask": "Add task",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8024,8 +8024,6 @@ export const vi = {
   "person.action.messageOn": "Nhắn qua {transport}",
   "person.action.noTransport":
     "Không có địa chỉ và không có cuộc trò chuyện nào để trả lời.",
-  "person.action.consentRefused":
-    "Hiện chưa có mục đích nào cho phép viết cho họ.",
   "person.action.call": "Gọi",
   "person.action.meetings": "Xem lịch hẹn",
   "person.action.addTask": "Thêm việc",

--- a/frontend/src/screens/personactions.tsx
+++ b/frontend/src/screens/personactions.tsx
@@ -42,20 +42,13 @@ type Person360 = components["schemas"]["Person360"];
 // without a reason until the verdict is in, because claiming a refusal the
 // server has not made is worse than a control that is briefly quiet.
 function writeRefusal(
-  state: Readonly<{
-    transports: readonly Transport[];
-    consentAllows: boolean;
-    consentKnown: boolean;
-  }>,
+  state: Readonly<{ transports: readonly Transport[] }>,
   t: ReturnType<typeof useT>,
 ): string | undefined {
   if (state.transports.length === 0) {
     return t("person.action.noTransport");
   }
-  if (state.consentAllows || !state.consentKnown) {
-    return undefined;
-  }
-  return t("person.action.consentRefused");
+  return undefined;
 }
 
 // The header's verbs, in the order every record page carries them: writing
@@ -63,8 +56,6 @@ function writeRefusal(
 // worth doing is the one the call names, and that one carries the colour.
 export function PersonActions({
   view,
-  consentAllows,
-  consentKnown,
   personId,
   overlay,
   onWrite,
@@ -74,8 +65,6 @@ export function PersonActions({
   refusedReasonId,
 }: Readonly<{
   view: Person360;
-  consentAllows: boolean;
-  consentKnown: boolean;
   personId: string;
   // LogActivityAction itself renders nothing in overlay — a mirrored
   // workspace has no activity write of its own, the same fact
@@ -115,7 +104,7 @@ export function PersonActions({
   const transports = useTransports(view);
   const write = primaryTransportAction(transports, t);
   const WriteIcon = write.icon;
-  const refusal = writeRefusal({ transports, consentAllows, consentKnown }, t);
+  const refusal = writeRefusal({ transports }, t);
   return (
     <>
       {/* The shared Email verb, wearing the transport it will open when there
@@ -124,7 +113,6 @@ export function PersonActions({
       <EmailVerb
         label={write.label}
         icon={<WriteIcon size={15} aria-hidden="true" />}
-        disabled={!consentKnown}
         reason={refusal}
         onClick={onWrite}
       />

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -385,25 +385,32 @@ describe("the header's writing verb", () => {
     expect(lead.getAttribute("aria-describedby")).toBeTruthy();
   });
 
-  it("refuses under the consent verdict on its own reason", async () => {
+  // WRITING IS ALWAYS AVAILABLE. A contact who stopped the newsletter can still
+  // be sent their invoice, and which purpose applies is a question about the
+  // MESSAGE — which this page does not have. Disabling the verb answered it
+  // anyway, and answered it wrong: a rep with a lawful service message to send
+  // was told the product would not let them write at all, with no way to see
+  // that only marketing was refused.
+  it("opens the composer even where no purpose currently permits writing", async () => {
     mount("overview", view, [mailBlocked]);
 
-    expect(await screen.findByText(CONSENT_REFUSED)).toBeTruthy();
     const lead = await leadVerb("Email");
-    expect(lead.disabled).toBe(true);
-    // The verb still names the transport it would have opened: what changed is
-    // whether it may be pressed, not what pressing it would do.
+    await waitFor(() => {
+      expect(lead.disabled).toBe(false);
+    });
+    expect(screen.queryByText(CONSENT_REFUSED)).toBeNull();
+    // The verb still names the transport it opens.
     expect(lead.querySelector(".lucide-mail")).toBeTruthy();
   });
 
-  it("keeps the two refusals apart when both apply", async () => {
-    // A rep told the wrong one goes looking in the wrong record. Reachability
-    // is the sentence to show, because it is the half that no consent decision
-    // can lift.
+  it("still refuses when there is nowhere to write to", async () => {
+    // Reachability is the half no consent decision can lift: with no transport
+    // the composer has nothing to send on, whatever the verdict says.
     mount("overview", unreachable, [mailBlocked]);
 
     expect(await screen.findByText(NO_TRANSPORT)).toBeTruthy();
-    expect(screen.queryByText(CONSENT_REFUSED)).toBeNull();
+    const lead = await leadVerb("Write");
+    expect(lead.disabled).toBe(true);
   });
 });
 

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -380,15 +380,12 @@ export function PersonPageV2({
 
   const person = view.data.person;
   const firstName = person.full_name.split(" ")[0];
-  // Consent is decided per PURPOSE, so the guard carries one email entry per
-  // purpose. The hero button asks a wider question than any single entry —
-  // "is there anything we may write to them about" — and reading only the
-  // first entry answered it with whichever purpose sorted first, disabling the
-  // button on a contact the product would happily let you mail transactionally.
-  // Which purpose applies is then the composer's own question.
-  const emailAllowed = (guard.data?.entries ?? []).some(
-    (entry) => entry.channel === "email" && entry.verdict === "allowed",
-  );
+  // The guard is the RAIL'S, not the hero button's. It answers one verdict per
+  // purpose, and the button used to refuse when none of them was `allowed` —
+  // which asked a question this page cannot answer, because whether a message
+  // may go depends on what the message IS. A contact who stopped the newsletter
+  // can still be sent their invoice, and telling their rep the product would
+  // not let them write at all is how a lawful message goes out some other way.
 
   // The action loop. Every surface the contract can name routes to
   // `runPersonMomentAction`, a standalone function rather than a closure here
@@ -453,8 +450,6 @@ export function PersonPageV2({
           actions={
             <PersonActions
               view={view.data}
-              consentAllows={emailAllowed}
-              consentKnown={guard.data !== undefined}
               personId={id}
               overlay={overlay}
               onWrite={() => openComposer("")}


### PR DESCRIPTION
## What was wrong

The person page refused its own Email verb when no consent purpose permitted writing. That asks a question the page cannot answer: whether a message may go depends on what the message is, and the page has no message in hand.

A contact who stopped the newsletter can still be sent their invoice. The button told their rep the product would not let them write at all, with nothing saying only marketing was refused. That is how a lawful message goes out some other way.

## What changed

The consent branch of the write refusal is deleted, and with it the disabled-until-the-guard-answers on the verb.

What stays is reachability, which is the half no consent decision can lift: with no transport the composer has nothing to send on, whatever the verdict says. The guard query stays for the rail, which asks a per-purpose question the rail can actually answer.

The now-unread copy key is removed from all three catalogs. A key with no reader is a sentence the next author will find and wonder about.

## Proof

Two tests rewritten rather than deleted: one says the composer opens where no purpose permits writing, the other that it still refuses when there is nowhere to write to. Mutation-verified, and restoring the refusal fails several existing tests.

Full `make check-fe` and `make check-backend` green.

## Note on scope

This is the defect at the centre of the planned contact-surfaces slice. The status mark on each surface and the subject-stop modal are separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the person page's Email verb always available, so a contact who stopped the newsletter can still be sent a lawful service message. The button previously disabled itself when no consent purpose permitted writing, but whether a message may go depends on the message itself, which this page never has.

- Removes the consent-based refusal and the disabled-until-consent-is-known state from the write verb.
- Keeps the reachability refusal: with no address or conversation to reply to, the composer has nothing to send on.
- Leaves the consent guard query on the rail, which asks a per-purpose question it can actually answer.
- Deletes the now-unread `person.action.consentRefused` copy key from all three catalogs.
- Rewrites two tests: one verifies the composer opens with no permitted purpose, the other that it still refuses when unreachable.

<sup>Written for commit c4497f7cd7547f250da206212d17d189e1ae6a9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The “Write” action remains available when no consent purpose currently permits writing.
  - Email is still disabled when the contact has no reachable transport.
  - Consent-based blocking and related refusal messaging were removed from the initial person action flow.
  - Consent details continue to be available in the person view, with final permission handling occurring when composing the message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->