### PR TITLE
Every purpose says why it answers as it does

### DIFF
--- a/frontend/src/screens/personconsentpanel.tsx
+++ b/frontend/src/screens/personconsentpanel.tsx
@@ -1,0 +1,177 @@
+import { Mail, Phone } from "lucide-react";
+import type { ReactNode } from "react";
+import type { components } from "../api/schema";
+import { Panel, PanelBody } from "../design-system/panel";
+import { useT } from "../i18n";
+import { useProviderLabel } from "./channelproviders";
+import { interactionIcon } from "./interactionchrome";
+import { consentWord } from "./personreadings";
+
+type Person360 = components["schemas"]["Person360"];
+type PersonConsentGuard = components["schemas"]["PersonConsentGuard"];
+
+// What may be sent to this contact, and why. Extracted from personrail.tsx
+// unchanged in behaviour.
+//
+// It is the rail's own answer, deliberately narrower than the composer's: the
+// guard answers per PURPOSE about a person, and the composer answers about a
+// message. A panel that collapsed them would print a permission with no scope
+// on it and be contradicted by the drawer a moment later.
+
+// The action guard, not the proof ledger. It renders even on a thin record,
+// because "may I write to this person" is a question with an answer whatever
+// else is missing.
+//
+// Every row answers ONE transport, and it answers reachability before consent.
+// A verdict presupposes somewhere to send: reporting "allowed" against mail and
+// phone for a contact captured over a chat channel — no address, no number —
+// asserted a reachability nothing in the record supports, while the transport
+// the CRM can actually reach them on had no row at all.
+//
+// The channel rows come from `person.reachability`, the record's own read of
+// `person_channel_identity` — the same binding the reply path resolves a
+// recipient from. They carry the correspondence verdict rather than one of
+// their own because the send gate is per PURPOSE: it resolves the person and
+// asks the one question, so the transport never enters the answer.
+export function ConsentAndChannels({
+  view,
+  guard,
+}: Readonly<{ view: Person360; guard: PersonConsentGuard | undefined }>) {
+  const t = useT();
+  const providerLabel = useProviderLabel();
+  const entries = guard?.entries ?? [];
+  // WHICH email purpose. The guard answers one verdict per purpose, and taking
+  // the first of them painted the Email row with whichever the server happened
+  // to list first — a bare "Allowed" that the composer then contradicted with
+  // "sending will be refused until Margince has a record", because the two were
+  // answering about different purposes and neither said which.
+  //
+  // Correspondence is the one a rail can speak for: it is the purpose a reply
+  // rides, and the only one an inbound message can flip on its own. The others
+  // get their own rows below, each carrying its name.
+  const correspondence =
+    entries.find(
+      (entry) => entry.purpose_class === "business_correspondence",
+    ) ?? entries.find((entry) => entry.channel === "email");
+  const otherPurposes = entries.filter(
+    (entry) => entry.channel === "email" && entry !== correspondence,
+  );
+  const phone = entries.find((entry) => entry.channel === "phone");
+  const hasEmail = (view.person.emails?.length ?? 0) > 0;
+  const channels = view.person.reachability ?? [];
+  return (
+    <Panel title={t("person.rail.consentTitle")}>
+      <PanelBody>
+        <ConsentRow
+          icon={<Mail size={15} aria-hidden="true" />}
+          label={correspondence?.purpose_label ?? t("person.rail.email")}
+          reachable={hasEmail}
+          verdict={correspondence?.verdict}
+          reason={correspondence?.reason}
+          unreachableWord={t("person.rail.noEmailAddress")}
+        />
+        <ConsentRow
+          icon={<Phone size={15} aria-hidden="true" />}
+          label={t("person.rail.phone")}
+          reachable={(view.person.phones?.length ?? 0) > 0}
+          verdict={phone?.verdict}
+          unreachableWord={t("person.rail.noPhoneNumber")}
+        />
+        {/* A blocked identity still gets its row, with `reachable: false`: the
+          conversation happened, and hiding the transport it happened on would
+          answer "can I write to them" by pretending they were never here. */}
+        {channels.map((channel) => (
+          <ConsentRow
+            key={channel.provider}
+            icon={interactionIcon("message", 15)}
+            label={providerLabel(channel.provider)}
+            reachable={channel.reachable}
+            verdict={correspondence?.verdict}
+            unreachableWord={t("person.rail.channelNotDeliverable")}
+          />
+        ))}
+        {/* Every OTHER purpose, by name. A rep who reads "Allowed" against
+          Email and is then refused at the composer has been told two true
+          things and no way to reconcile them: the grant they have is for
+          correspondence and the send they tried was something else. Naming
+          each purpose is what makes the two answers agree on screen. */}
+        {/* EACH PURPOSE CARRIES ITS OWN REASON, under the row it explains. The
+          rail used to print one reason — correspondence's — for the whole
+          panel, so a subject who asked us to stop marketing got a blocked row
+          with nothing saying why. A refusal a rep cannot explain to the person
+          in front of them is not usable. */}
+        {hasEmail &&
+          otherPurposes.map((entry) => (
+            <ConsentRow
+              key={entry.purpose_key}
+              icon={<Mail size={15} aria-hidden="true" />}
+              label={entry.purpose_label ?? entry.purpose_key}
+              reachable
+              verdict={entry.verdict}
+              reason={entry.reason}
+              unreachableWord={t("person.rail.noEmailAddress")}
+            />
+          ))}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+// One transport's row. Reachability is a fact about the RECORD and the verdict
+// is a fact about consent, and the row states the first before the second: a
+// permission to send where there is nowhere to send is not one a rep can act
+// on, and colouring it green says they may.
+function ConsentRow({
+  icon,
+  label,
+  reachable,
+  verdict,
+  reason,
+  unreachableWord,
+}: Readonly<{
+  icon: ReactNode;
+  label: string;
+  reachable: boolean;
+  verdict: string | undefined;
+  // Why this purpose answers as it does, under the row it explains. Absent for
+  // the transports, which answer on reachability and need no sentence.
+  reason?: string;
+  unreachableWord: string;
+}>) {
+  const t = useT();
+  return (
+    <>
+      <div className="pe-rail-row">
+        <span className="pe-rail-label">
+          {icon}
+          {label}
+        </span>
+        <span
+          className={
+            reachable
+              ? verdictClass(verdict)
+              : "pe-rail-value pe-rail-value-muted"
+          }
+        >
+          {reachable ? consentWord(verdict, t) : unreachableWord}
+        </span>
+      </div>
+      {/* Only where the row shows a verdict: a sentence explaining an answer
+        the row above replaced with "no address" explains nothing. */}
+      {reachable && reason && (
+        <p className="pe-colleague-proof t-caption">{reason}</p>
+      )}
+    </>
+  );
+}
+
+function verdictClass(verdict: string | undefined): string {
+  switch (verdict) {
+    case "allowed":
+      return "pe-rail-value pe-rail-value-good";
+    case "blocked":
+      return "pe-rail-value pe-rail-value-warn";
+    default:
+      return "pe-rail-value pe-rail-value-muted";
+  }
+}

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -1022,4 +1022,35 @@ describe("the consent rail names the purpose behind each answer", () => {
     const rows = screen.getAllByText(/Allowed|Unknown/);
     expect(rows.length).toBeGreaterThan(1);
   });
+
+  // A REFUSAL A REP CANNOT EXPLAIN IS NOT USABLE. The rail showed the reason
+  // for correspondence alone, so a subject who asked us to stop marketing got a
+  // blocked row with nothing under it saying why — the one fact a rep needs
+  // before they pick up the phone about it.
+  it("says why a marketing purpose is blocked, not only a correspondence one", async () => {
+    const objected: PersonConsentGuardEntry = {
+      purpose_key: "newsletter",
+      purpose_label: "Newsletter",
+      purpose_class: "marketing",
+      channel: "email",
+      verdict: "blocked",
+      reason: "they asked us to stop on 12 July",
+    };
+    mount("overview", view, [objected, correspondence]);
+
+    expect(
+      await screen.findByText("they asked us to stop on 12 July"),
+    ).not.toBeNull();
+  });
+
+  // And the correspondence reason still shows. Without this the fix above
+  // could be "show the last reason", which would take the row a reply rides
+  // out with it.
+  it("still says why correspondence is allowed", async () => {
+    mount("overview", view, [newsletter, correspondence]);
+
+    expect(
+      await screen.findByText("she wrote to you on 1 June"),
+    ).not.toBeNull();
+  });
 });

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -8,7 +8,6 @@ import {
   Phone,
   User,
 } from "lucide-react";
-import type { ReactNode } from "react";
 import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -54,14 +53,12 @@ import {
   usePlural,
   useT,
 } from "../i18n";
-import { useProviderLabel } from "./channelproviders";
 import { problemMessageOf, throwProblem, useSorMode } from "./common";
 import { CounterpartyHoldRow } from "./counterparty-hold";
 import { stillHeld, today } from "./employmentcurrency";
-import { interactionIcon } from "./interactionchrome";
 import { PersonAccess } from "./personaccess";
+import { ConsentAndChannels } from "./personconsentpanel";
 import { daysSinceInbound, isQuiet } from "./personquiet";
-import { consentWord } from "./personreadings";
 import { personTabRoute } from "./persontab";
 import { TagsPanel } from "./tagspanel";
 
@@ -1329,155 +1326,6 @@ function derivedSignals(
 }
 
 // --- Consent and channels --------------------------------------------------
-
-// The action guard, not the proof ledger. It renders even on a thin record,
-// because "may I write to this person" is a question with an answer whatever
-// else is missing.
-//
-// Every row answers ONE transport, and it answers reachability before consent.
-// A verdict presupposes somewhere to send: reporting "allowed" against mail and
-// phone for a contact captured over a chat channel — no address, no number —
-// asserted a reachability nothing in the record supports, while the transport
-// the CRM can actually reach them on had no row at all.
-//
-// The channel rows come from `person.reachability`, the record's own read of
-// `person_channel_identity` — the same binding the reply path resolves a
-// recipient from. They carry the correspondence verdict rather than one of
-// their own because the send gate is per PURPOSE: it resolves the person and
-// asks the one question, so the transport never enters the answer.
-function ConsentAndChannels({
-  view,
-  guard,
-}: Readonly<{ view: Person360; guard: PersonConsentGuard | undefined }>) {
-  const t = useT();
-  const providerLabel = useProviderLabel();
-  const entries = guard?.entries ?? [];
-  // WHICH email purpose. The guard answers one verdict per purpose, and taking
-  // the first of them painted the Email row with whichever the server happened
-  // to list first — a bare "Allowed" that the composer then contradicted with
-  // "sending will be refused until Margince has a record", because the two were
-  // answering about different purposes and neither said which.
-  //
-  // Correspondence is the one a rail can speak for: it is the purpose a reply
-  // rides, and the only one an inbound message can flip on its own. The others
-  // get their own rows below, each carrying its name.
-  const correspondence =
-    entries.find(
-      (entry) => entry.purpose_class === "business_correspondence",
-    ) ?? entries.find((entry) => entry.channel === "email");
-  const otherPurposes = entries.filter(
-    (entry) => entry.channel === "email" && entry !== correspondence,
-  );
-  const phone = entries.find((entry) => entry.channel === "phone");
-  const hasEmail = (view.person.emails?.length ?? 0) > 0;
-  const channels = view.person.reachability ?? [];
-  return (
-    <Panel title={t("person.rail.consentTitle")}>
-      <PanelBody>
-        <ConsentRow
-          icon={<Mail size={15} aria-hidden="true" />}
-          label={correspondence?.purpose_label ?? t("person.rail.email")}
-          reachable={hasEmail}
-          verdict={correspondence?.verdict}
-          unreachableWord={t("person.rail.noEmailAddress")}
-        />
-        <ConsentRow
-          icon={<Phone size={15} aria-hidden="true" />}
-          label={t("person.rail.phone")}
-          reachable={(view.person.phones?.length ?? 0) > 0}
-          verdict={phone?.verdict}
-          unreachableWord={t("person.rail.noPhoneNumber")}
-        />
-        {/* A blocked identity still gets its row, with `reachable: false`: the
-          conversation happened, and hiding the transport it happened on would
-          answer "can I write to them" by pretending they were never here. */}
-        {channels.map((channel) => (
-          <ConsentRow
-            key={channel.provider}
-            icon={interactionIcon("message", 15)}
-            label={providerLabel(channel.provider)}
-            reachable={channel.reachable}
-            verdict={correspondence?.verdict}
-            unreachableWord={t("person.rail.channelNotDeliverable")}
-          />
-        ))}
-        {/* Every OTHER purpose, by name. A rep who reads "Allowed" against
-          Email and is then refused at the composer has been told two true
-          things and no way to reconcile them: the grant they have is for
-          correspondence and the send they tried was something else. Naming
-          each purpose is what makes the two answers agree on screen. */}
-        {hasEmail &&
-          otherPurposes.map((entry) => (
-            <ConsentRow
-              key={entry.purpose_key}
-              icon={<Mail size={15} aria-hidden="true" />}
-              label={entry.purpose_label ?? entry.purpose_key}
-              reachable
-              verdict={entry.verdict}
-              unreachableWord={t("person.rail.noEmailAddress")}
-            />
-          ))}
-        {/* The REASON, in the reader's words. A verdict a rep cannot explain to
-          the person in front of them is not usable — and one explaining a
-          verdict no row above shows explains nothing. */}
-        {(hasEmail || channels.some((channel) => channel.reachable)) &&
-          correspondence?.reason && (
-            <p className="pe-colleague-proof t-caption">
-              {correspondence.reason}
-            </p>
-          )}
-      </PanelBody>
-    </Panel>
-  );
-}
-
-// One transport's row. Reachability is a fact about the RECORD and the verdict
-// is a fact about consent, and the row states the first before the second: a
-// permission to send where there is nowhere to send is not one a rep can act
-// on, and colouring it green says they may.
-function ConsentRow({
-  icon,
-  label,
-  reachable,
-  verdict,
-  unreachableWord,
-}: Readonly<{
-  icon: ReactNode;
-  label: string;
-  reachable: boolean;
-  verdict: string | undefined;
-  unreachableWord: string;
-}>) {
-  const t = useT();
-  return (
-    <div className="pe-rail-row">
-      <span className="pe-rail-label">
-        {icon}
-        {label}
-      </span>
-      <span
-        className={
-          reachable
-            ? verdictClass(verdict)
-            : "pe-rail-value pe-rail-value-muted"
-        }
-      >
-        {reachable ? consentWord(verdict, t) : unreachableWord}
-      </span>
-    </div>
-  );
-}
-
-function verdictClass(verdict: string | undefined): string {
-  switch (verdict) {
-    case "allowed":
-      return "pe-rail-value pe-rail-value-good";
-    case "blocked":
-      return "pe-rail-value pe-rail-value-warn";
-    default:
-      return "pe-rail-value pe-rail-value-muted";
-  }
-}
 
 // --- Recent activity -------------------------------------------------------
 

--- a/scripts/fe-file-length-waivers.txt
+++ b/scripts/fe-file-length-waivers.txt
@@ -111,7 +111,7 @@
 1184 frontend/src/screens/personpage.tsx
 1208 frontend/src/screens/personprovider.test.tsx
 941 frontend/src/screens/personprovider.tsx
-1575 frontend/src/screens/personrail.tsx
+1430 frontend/src/screens/personrail.tsx
 1200 frontend/src/screens/privacy.test.tsx
 1245 frontend/src/screens/privacy.tsx
 573 frontend/src/screens/project360.tsx


### PR DESCRIPTION
## What was wrong

The person rail printed one reason for the whole consent panel, correspondence's. A subject who asked us to stop marketing got a blocked Newsletter row with nothing under it saying why.

The sentence that justifies showing a reason at all was already in the file: a verdict a rep cannot explain to the person in front of them is not usable. It was applied to one row out of several.

## What changed

The reason moves onto the row component, so every purpose carries its own. It draws only where the row shows a verdict, because a sentence explaining an answer the row above replaced with "no address" explains nothing.

## Why a new file

The panel comes out to pay for the lines, and that also gives the rail's narrowest question its own file. It is deliberately narrower than the composer's: the guard answers per purpose about a person, the composer answers about a message. A panel that collapsed them would print a permission with no scope on it and be contradicted by the drawer a moment later.

1575 lines to 1430, waiver ratcheted.

## Proof

Two tests, one mutation-verified. The second says the correspondence reason still shows, so the fix cannot become "print the last reason" and take the row a reply rides out with it.

Full `make check-fe` and `make check-backend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The consent rail now explains each verdict with its own reason.

- Previously only the correspondence reason printed under the whole panel; now each purpose row shows its own reason, only when the row displays a verdict.
- Extracts the consent and channels panel into `personconsentpanel.tsx`, reducing `personrail.tsx` from 1575 to 1430 lines and updating the waiver.
- Adds tests that a blocked marketing purpose shows its reason and that the correspondence reason still appears.

<sup>Written for commit 967d7cb1b00ac120d51e858eecc05a3520b2b302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consent and communication channels panel to person profiles.
  - Displays consent decisions and reasons for email purposes, including business correspondence.
  - Shows phone and reachability details across available communication channels.
  - Clearly indicates when a person cannot be reached because contact information is unavailable.
  - Preserves separate consent reasons for different email purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->