### PR TITLE
A surface that sends says what the message would meet

### DIFF
--- a/frontend/src/screens/send-surface-census.test.ts
+++ b/frontend/src/screens/send-surface-census.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  extensionFrontendFiles,
+  filesUnder,
+} from "../../scripts/lib/source-tree";
+
+// EVERY SURFACE THAT SENDS SAYS WHAT THE MESSAGE WOULD MEET.
+//
+// The composer used to be the only place that asked the engine, and it asked
+// late: a rep learned a send was refused by pressing Send and reading an error.
+// That is fixed, and the fix is one file deep. Nothing stops a second surface —
+// a bulk action, a follow-up card, an extension's own drawer — from posting a
+// send with no mark beside it and reintroducing exactly that silence.
+//
+// So the rule is stated here rather than remembered: a file that POSTs a send
+// renders the status, or names itself below with why it does not.
+//
+// WHY A CENSUS AND NOT A REVIEW. The failure is invisible at the call site.
+// `api.POST("/emails", …)` reads identically whether the surface around it
+// tells the rep anything or not, and the reviewer who would notice is the one
+// who already knows this rule. A list that fails is what carries it to somebody
+// who does not.
+
+const SCREENS = __dirname;
+const EXTENSIONS = join(__dirname, "..", "..", "..", "extensions");
+
+// The three doors a send goes out of. Read as literals rather than derived from
+// the generated schema, because what matters is the STRING a caller typed: a
+// surface that built the path some other way is a surface this census cannot
+// see either way, and pretending otherwise would be worse than saying so.
+const SEND_PATHS = [
+  '"/emails"',
+  '"/activities/{id}/send-email"',
+  '"/activities/{id}/send-message"',
+];
+
+// What counts as saying something. Any of these means the file draws the
+// engine's answer where the rep can see it before they press.
+const SAYS_SOMETHING = [
+  "SendMark",
+  "SendPermission",
+  "CommunicationStatus",
+  "useSendPermission",
+];
+
+// Files that post a send and draw no mark, each with the reason.
+//
+// EMPTY, and that is the point of landing this now rather than later. The tree
+// is clean today, so every entry added here is a deliberate exception somebody
+// wrote a sentence for — where a census introduced after the first violation
+// would have started with that violation already ratified.
+const SILENT_SENDERS: Record<string, string> = {};
+
+function sourceFiles(): string[] {
+  return [...filesUnder(SCREENS), ...extensionFrontendFiles(EXTENSIONS)].filter(
+    (path) => !/\.(test|stories)\.tsx?$/.test(path),
+  );
+}
+
+function postsASend(source: string): boolean {
+  return SEND_PATHS.some(
+    (path) => source.includes(`api.POST(${path}`) || source.includes(path),
+  );
+}
+
+describe("every surface that sends says what the message would meet", () => {
+  it("finds the senders it is meant to judge", () => {
+    // A census that stopped finding its subject would report a clean tree over
+    // one full of silent senders. This is the arity guard every census owes:
+    // the composer posts all three doors, so at least one file must match.
+    const senders = sourceFiles().filter((path) =>
+      postsASend(readFileSync(path, "utf8")),
+    );
+    expect(senders.length).toBeGreaterThan(0);
+  });
+
+  it("draws the engine's answer beside every send", () => {
+    const silent: string[] = [];
+    for (const path of sourceFiles()) {
+      const source = readFileSync(path, "utf8");
+      if (!postsASend(source)) continue;
+      if (SAYS_SOMETHING.some((marker) => source.includes(marker))) continue;
+      const relative = path.slice(path.indexOf("/src/") + 1);
+      if (SILENT_SENDERS[relative]) continue;
+      silent.push(relative);
+    }
+    expect(silent).toEqual([]);
+  });
+
+  it("keeps no ratified exception that has stopped being one", () => {
+    // A waiver outliving its file is a sentence describing a surface nobody can
+    // find, and it makes the next reader trust a list that is already wrong.
+    const present = new Set(
+      sourceFiles().map((path) => path.slice(path.indexOf("/src/") + 1)),
+    );
+    for (const named of Object.keys(SILENT_SENDERS)) {
+      expect(present.has(named)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Why now

The composer used to be the only place that asked the engine, and it asked late: a rep learned a send was refused by pressing Send and reading an error. That is fixed, and the fix is one file deep.

Nothing stopped a second surface, a bulk action or an extension's own drawer, from posting a send with no mark beside it and reintroducing exactly that silence. The failure is invisible at the call site: the post reads identically whether the surface around it tells the rep anything or not.

## What it holds

A file that posts one of the three send doors renders the engine's answer, or names itself with a reason.

**The waiver list is empty**, which is the point of landing this now rather than later. The tree is clean today, so every future entry is a deliberate exception somebody wrote a sentence for. A census added after the first violation would have started with that violation already ratified.

Extensions are walked too, because an extension composes into the same binary and can post the same send.

## Proof

Three tests, two mutation-verified. A file posting a send with no mark is named. A waiver outliving its file fails rather than sitting there describing a surface nobody can find.

The third is the arity guard every census owes: a walk that stopped finding senders would report a clean tree over one full of silent ones.

Full `make check-fe` and `make check-backend` green.

## Scope

This is the census half of the planned rows slice. The marks on scheduled, approval and worklist rows are separate work, and the census will name them if they ever post a send without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a census test that fails when any frontend or extension file posts a send without rendering the engine's answer, so silent send failures can't slip in through a second surface.

Previously only the composer asked the engine, and only at send time. Now the build breaks if a file POSTs to any of the three send paths without referencing a status marker like `SendMark` or `useSendPermission`.

- Scans every file under `frontend/src/screens` and `extensions` for the send paths and the markers.
- Keeps the waiver list intentionally empty; each future exception must name a file and include a reason, and fails if that file disappears.
- Includes an arity guard so the test errors if it stops finding senders instead of reporting a clean tree.

<sup>Written for commit d0a3cf9fa455c978da13e39dd5bf3eb46633b7ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated coverage to identify message and email sending screens.
  - Added checks confirming senders display the corresponding send status or permission result.
  - Added safeguards to detect undocumented silent senders and outdated exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->