### PR TITLE
fix(frontend): a WORK primary and a PERSONAL primary stand independently

### DIFF
--- a/frontend/src/screens/create.test.tsx
+++ b/frontend/src/screens/create.test.tsx
@@ -152,11 +152,7 @@ describe("contact create flow", () => {
 
   // A WORK primary and a PERSONAL primary are independent, matching what the
   // server itself enforces (personformfields.ts's personEditFields: only a
-  // SAME-type primary swap is refused). Regression for margince#5272, where
-  // markPrimary and the radio group's own `name` were both scoped to the
-  // whole field rather than to the row's own email_type/phone_type, so
-  // marking a PERSONAL email primary silently un-primaried an untouched WORK
-  // email.
+  // SAME-type primary swap is refused).
   it("keeps a WORK primary and a PERSONAL primary independent", async () => {
     const captured: Captured[] = [];
     stubApi(
@@ -219,6 +215,65 @@ describe("contact create flow", () => {
         },
       ],
     });
+  });
+
+  // The request mapper's own fallback (asEmailType) resolves an unset type
+  // to "work" — the form has to group rows the same way, or an unset row
+  // and an explicit Work row read as two kinds here and collide once both
+  // reach the server as two primary work emails.
+  it("groups an unset type with the field's own default kind", async () => {
+    const user = userEvent.setup();
+    render(<ContactsScreen />);
+    await user.click(screen.getByText(en["create.contact"]));
+    await user.type(screen.getByLabelText("Full name *"), "Peter Neu");
+
+    await user.click(screen.getByText("Add email"));
+    await user.click(screen.getByText("Add email"));
+    const emailInputs = screen.getAllByLabelText("Email *");
+    await user.type(emailInputs[0], "peter.unset@neu.example");
+    await user.type(emailInputs[1], "peter.work@neu.example");
+    const types = screen.getAllByRole("combobox", { name: "Type" });
+    await pickOption(user, types[1], "Work");
+    // types[0] stays unset on purpose.
+
+    const primaries = screen.getAllByRole("radio", {
+      name: "Primary",
+    }) as HTMLInputElement[];
+    await user.click(primaries[0]);
+    await user.click(primaries[1]);
+
+    expect(primaries[0].checked).toBe(false);
+    expect(primaries[1].checked).toBe(true);
+  });
+
+  it("clears a row's own primary when its kind changes, rather than colliding with the new kind's primary", async () => {
+    const user = userEvent.setup();
+    render(<ContactsScreen />);
+    await user.click(screen.getByText(en["create.contact"]));
+    await user.type(screen.getByLabelText("Full name *"), "Peter Neu");
+
+    await user.click(screen.getByText("Add email"));
+    await user.click(screen.getByText("Add email"));
+    const emailInputs = screen.getAllByLabelText("Email *");
+    await user.type(emailInputs[0], "peter.personal@neu.example");
+    await user.type(emailInputs[1], "peter.work@neu.example");
+    const types = screen.getAllByRole("combobox", { name: "Type" });
+    await pickOption(user, types[0], "Personal");
+    await pickOption(user, types[1], "Work");
+
+    const primaries = screen.getAllByRole("radio", {
+      name: "Primary",
+    }) as HTMLInputElement[];
+    await user.click(primaries[0]);
+    await user.click(primaries[1]);
+    expect(primaries[0].checked).toBe(true);
+    expect(primaries[1].checked).toBe(true);
+
+    // Retype the PERSONAL row as Work — the second row's own kind.
+    await pickOption(user, types[0], "Work");
+
+    expect(primaries[0].checked).toBe(false);
+    expect(primaries[1].checked).toBe(true);
   });
 
   it("renders the server's 422 detail verbatim and stays open", async () => {

--- a/frontend/src/screens/create.test.tsx
+++ b/frontend/src/screens/create.test.tsx
@@ -150,6 +150,77 @@ describe("contact create flow", () => {
     });
   });
 
+  // A WORK primary and a PERSONAL primary are independent, matching what the
+  // server itself enforces (personformfields.ts's personEditFields: only a
+  // SAME-type primary swap is refused). Regression for margince#5272, where
+  // markPrimary and the radio group's own `name` were both scoped to the
+  // whole field rather than to the row's own email_type/phone_type, so
+  // marking a PERSONAL email primary silently un-primaried an untouched WORK
+  // email.
+  it("keeps a WORK primary and a PERSONAL primary independent", async () => {
+    const captured: Captured[] = [];
+    stubApi(
+      {
+        "POST /people": (body) =>
+          jsonResponse(
+            {
+              id: "p-new",
+              full_name: (body as { full_name: string }).full_name,
+              captured_by: "human:u1",
+              source: "manual",
+              version: 1,
+            },
+            201,
+          ),
+      },
+      captured,
+    );
+    const user = userEvent.setup();
+    render(<ContactsScreen />);
+    await user.click(screen.getByText(en["create.contact"]));
+    await user.type(screen.getByLabelText("Full name *"), "Peter Neu");
+
+    await user.click(screen.getByText("Add email"));
+    await user.click(screen.getByText("Add email"));
+    const emailInputs = screen.getAllByLabelText("Email *");
+    await user.type(emailInputs[0], "peter.work@neu.example");
+    await user.type(emailInputs[1], "peter.personal@neu.example");
+
+    const types = screen.getAllByRole("combobox", { name: "Type" });
+    await pickOption(user, types[0], "Work");
+    await pickOption(user, types[1], "Personal");
+
+    const primaries = screen.getAllByRole("radio", {
+      name: "Primary",
+    }) as HTMLInputElement[];
+    await user.click(primaries[0]);
+    await user.click(primaries[1]);
+
+    // Marking the PERSONAL row primary must not have cleared the WORK row's
+    // own primary — the DOM's own radio-group exclusivity, and the state
+    // update, are both scoped by type.
+    expect(primaries[0].checked).toBe(true);
+    expect(primaries[1].checked).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => expect(window.location.hash).toBe("#/contacts/p-new"));
+    const post = captured.find((entry) => entry.key === "POST /people");
+    expect(post?.body).toMatchObject({
+      emails: [
+        {
+          email: "peter.work@neu.example",
+          email_type: "work",
+          is_primary: true,
+        },
+        {
+          email: "peter.personal@neu.example",
+          email_type: "personal",
+          is_primary: true,
+        },
+      ],
+    });
+  });
+
   it("renders the server's 422 detail verbatim and stays open", async () => {
     stubApi({
       "POST /people": () =>

--- a/frontend/src/screens/create.tsx
+++ b/frontend/src/screens/create.tsx
@@ -22,7 +22,7 @@ import {
   problemMessageOf,
   useSorMode,
 } from "./common";
-import { withPrimaryMarked } from "./createrows";
+import { kindOf, withPrimaryMarked, withRowUpdated } from "./createrows";
 
 // The record screens whose entities are served from the incumbent mirror in
 // overlay mode. Creating one there answers unsupported_by_sor, so CreateAction
@@ -100,6 +100,9 @@ export type CreateField = {
   addLabel?: MessageKey;
   primaryKey?: string;
   typeKey?: string;
+  // typeKey's value when unanswered — must match the request mapper's own
+  // fallback, or an unset row groups differently here than once submitted.
+  typeDefault?: string;
   // A non-input group divider (renders its labelText as a heading, holds no
   // value) — used to set custom fields apart from core fields.
   divider?: boolean;
@@ -576,20 +579,17 @@ function RepeatableRowsField({
   const rowFields = field.rowFields ?? [];
   const primaryKey = field.primaryKey;
   const typeKey = field.typeKey;
+  const typeDefault = field.typeDefault ?? "";
 
   function updateRow(index: number, key: string, value: string) {
-    setRows(
-      rows.map((row, rowIndex) =>
-        rowIndex === index ? { ...row, [key]: value } : row,
-      ),
-    );
+    setRows(withRowUpdated(rows, index, key, value, primaryKey, typeKey));
   }
 
   function markPrimary(index: number) {
     if (!primaryKey) {
       return;
     }
-    setRows(withPrimaryMarked(rows, index, primaryKey, typeKey));
+    setRows(withPrimaryMarked(rows, index, primaryKey, typeKey, typeDefault));
   }
 
   function removeRow(index: number) {
@@ -638,7 +638,7 @@ function RepeatableRowsField({
             <Radio
               className="t-label"
               // Scoped by kind so the native radio group itself cannot enforce exclusivity across kinds.
-              name={`${formId}-${field.key}-${typeKey ? (row[typeKey] ?? "") : ""}-primary`}
+              name={`${formId}-${field.key}-${kindOf(row, typeKey, typeDefault)}-primary`}
               checked={row[primaryKey] === "true"}
               onChange={() => markPrimary(index)}
               label={t("field.primary")}

--- a/frontend/src/screens/create.tsx
+++ b/frontend/src/screens/create.tsx
@@ -22,6 +22,7 @@ import {
   problemMessageOf,
   useSorMode,
 } from "./common";
+import { withPrimaryMarked } from "./createrows";
 
 // The record screens whose entities are served from the incumbent mirror in
 // overlay mode. Creating one there answers unsupported_by_sor, so CreateAction
@@ -93,10 +94,12 @@ export type CreateField = {
    */
   validate?: (value: string) => string | undefined;
   // repeatable-only: the subfields each row renders, the "add row" button's
-  // label, and (if set) which subfield key holds the row's primary flag.
+  // label, which subfield key holds the row's primary flag, and (if set)
+  // which one holds its kind — scoping primaryKey to same-kind rows.
   rowFields?: SubField[];
   addLabel?: MessageKey;
   primaryKey?: string;
+  typeKey?: string;
   // A non-input group divider (renders its labelText as a heading, holds no
   // value) — used to set custom fields apart from core fields.
   divider?: boolean;
@@ -572,6 +575,7 @@ function RepeatableRowsField({
   const t = useT();
   const rowFields = field.rowFields ?? [];
   const primaryKey = field.primaryKey;
+  const typeKey = field.typeKey;
 
   function updateRow(index: number, key: string, value: string) {
     setRows(
@@ -585,12 +589,7 @@ function RepeatableRowsField({
     if (!primaryKey) {
       return;
     }
-    setRows(
-      rows.map((row, rowIndex) => ({
-        ...row,
-        [primaryKey]: rowIndex === index ? "true" : "",
-      })),
-    );
+    setRows(withPrimaryMarked(rows, index, primaryKey, typeKey));
   }
 
   function removeRow(index: number) {
@@ -638,7 +637,8 @@ function RepeatableRowsField({
           {primaryKey && (
             <Radio
               className="t-label"
-              name={`${formId}-${field.key}-primary`}
+              // Scoped by kind so the native radio group itself cannot enforce exclusivity across kinds.
+              name={`${formId}-${field.key}-${typeKey ? (row[typeKey] ?? "") : ""}-primary`}
               checked={row[primaryKey] === "true"}
               onChange={() => markPrimary(index)}
               label={t("field.primary")}

--- a/frontend/src/screens/createrows.ts
+++ b/frontend/src/screens/createrows.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { FormRow } from "./create";
+
+// Marks one row primary among the rows that share its kind — "" (untyped)
+// counts as its own kind — leaving every other kind's rows untouched. Kept
+// out of create.tsx because that file is already at its size ceiling; this
+// is the one place a WORK/PERSONAL split (or none, when typeKey is unset)
+// decides which rows a primary swap may touch.
+export function withPrimaryMarked(
+  rows: FormRow[],
+  index: number,
+  primaryKey: string,
+  typeKey: string | undefined,
+): FormRow[] {
+  const kindOf = (row: FormRow) => (typeKey ? (row[typeKey] ?? "") : "");
+  const targetKind = kindOf(rows[index] ?? {});
+  return rows.map((row, rowIndex) => {
+    if (typeKey && kindOf(row) !== targetKind) {
+      return row;
+    }
+    return { ...row, [primaryKey]: rowIndex === index ? "true" : "" };
+  });
+}

--- a/frontend/src/screens/createrows.ts
+++ b/frontend/src/screens/createrows.ts
@@ -3,21 +3,55 @@
 
 import type { FormRow } from "./create";
 
-// Marks one row primary among the rows that share its kind — "" (untyped)
-// counts as its own kind — leaving every other kind's rows untouched. Kept
-// out of create.tsx because that file is already at its size ceiling; this
-// is the one place a WORK/PERSONAL split (or none, when typeKey is unset)
-// decides which rows a primary swap may touch.
+// A row's own kind for grouping primaries. An unanswered row resolves to
+// typeDefault rather than its own "" bucket — personformfields.ts passes
+// the same default its asEmailType/asPhoneType request mapper falls back
+// to, so an unset row and an explicit default-kind row are one kind on
+// both sides of the wire, never two kinds that collide once submitted.
+export function kindOf(
+  row: FormRow,
+  typeKey: string | undefined,
+  typeDefault: string,
+): string {
+  return typeKey ? row[typeKey] || typeDefault : "";
+}
+
+// One row's value change, plus the primary bookkeeping a kind change owes:
+// a row that changes kind stops claiming a primary it held under its OLD
+// kind, so it never silently contends for the new kind's primary slot
+// without the reader choosing it again.
+export function withRowUpdated(
+  rows: FormRow[],
+  index: number,
+  key: string,
+  value: string,
+  primaryKey: string | undefined,
+  typeKey: string | undefined,
+): FormRow[] {
+  return rows.map((row, rowIndex) => {
+    if (rowIndex !== index) {
+      return row;
+    }
+    const next = { ...row, [key]: value };
+    if (primaryKey && key === typeKey && row[primaryKey] === "true") {
+      next[primaryKey] = "";
+    }
+    return next;
+  });
+}
+
+// Marks one row primary among the rows sharing its kind, leaving every
+// other kind's rows untouched.
 export function withPrimaryMarked(
   rows: FormRow[],
   index: number,
   primaryKey: string,
   typeKey: string | undefined,
+  typeDefault: string,
 ): FormRow[] {
-  const kindOf = (row: FormRow) => (typeKey ? (row[typeKey] ?? "") : "");
-  const targetKind = kindOf(rows[index] ?? {});
+  const targetKind = kindOf(rows[index] ?? {}, typeKey, typeDefault);
   return rows.map((row, rowIndex) => {
-    if (typeKey && kindOf(row) !== targetKind) {
+    if (typeKey && kindOf(row, typeKey, typeDefault) !== targetKind) {
       return row;
     }
     return { ...row, [primaryKey]: rowIndex === index ? "true" : "" };

--- a/frontend/src/screens/personformfields.ts
+++ b/frontend/src/screens/personformfields.ts
@@ -148,6 +148,7 @@ export function contactCreateFields(t: ReturnType<typeof useT>): CreateField[] {
       ],
       primaryKey: "is_primary",
       typeKey: "email_type",
+      typeDefault: "work", // matches asEmailType's own fallback
     },
     {
       key: "phones",
@@ -170,6 +171,7 @@ export function contactCreateFields(t: ReturnType<typeof useT>): CreateField[] {
       ],
       primaryKey: "is_primary",
       typeKey: "phone_type",
+      typeDefault: "work", // matches asPhoneType's own fallback
     },
   ];
 }

--- a/frontend/src/screens/personformfields.ts
+++ b/frontend/src/screens/personformfields.ts
@@ -147,6 +147,7 @@ export function contactCreateFields(t: ReturnType<typeof useT>): CreateField[] {
         },
       ],
       primaryKey: "is_primary",
+      typeKey: "email_type",
     },
     {
       key: "phones",
@@ -168,6 +169,7 @@ export function contactCreateFields(t: ReturnType<typeof useT>): CreateField[] {
         },
       ],
       primaryKey: "is_primary",
+      typeKey: "phone_type",
     },
   ];
 }


### PR DESCRIPTION
## Summary

Closes margince#5272 — editing one WORK-type primary contact (email or phone) on the person edit form silently un-primaried an unrelated PERSONAL-type primary, both at the React state level and at the DOM level (the native radio group's own `name` was field-wide, not scoped by kind).

Root cause: `RepeatableRowsField`'s `markPrimary` cleared the primary flag across every row in the field, and the radio inputs all shared one native `name`, so the browser itself enforced the same field-wide exclusivity. This is a regression surfaced by margince#4823's own fix (PR #5181), which introduced the shared `PersonEditMergeArchive` component reusing this same `RepeatableRowsField`/`create.tsx` code for both `PersonScreen` and `PersonPageV2`.

Fixed by scoping both the state update and the native radio group's `name` to the row's own kind (`email_type`/`phone_type`), added as a new `typeKey` field alongside the existing `primaryKey`. New logic lives in `frontend/src/screens/createrows.ts` rather than growing `create.tsx`, which is already at its frozen file-length waiver (982 lines).

**Two review passes (a fresh `code-review` pass and an independent Codex pass) both caught the same follow-on gap** in the first version of this fix: an unset row's kind ("") and an explicit "Work" row's kind were treated as different kinds client-side, but the request mapper's own `asEmailType`/`asPhoneType` normalize an unset type to `"work"` at submit time — so an unset row and an explicit Work row could both end up `is_primary: true` and both submit as `email_type: "work"`, the exact same-kind collision this fix exists to prevent. Fixed with a `typeDefault` (declared once per field, `"work"` for both emails and phones, matching the request mapper's own fallback exactly) that folds an unset row into its default kind everywhere a kind is computed. Separately, changing an already-primary row's own type via the ordinary Type select never reconciled its primary flag against the row's new kind — fixed by clearing a row's own primary the moment its type changes, so it never silently contends for a kind it didn't choose.

## What's covered

- WORK primary and PERSONAL primary stay independent (state + DOM radio grouping)
- An unset-type row groups with the field's own default kind (`work`), matching the server's own fallback
- Changing a primary row's type clears its own primary rather than colliding with the new kind's primary
- 100% line/function coverage on the new logic (`createrows.ts`)

## Scope boundary

Does not touch the edit-flow's own test suite (`edit.test.tsx`) — the new `RepeatableRowsField`/`createrows.ts` logic is shared code exercised identically from the create flow, which is what the new tests drive; a full edit-flow duplicate would prove the same logic twice for no new coverage.

## UAT

Live-walked on an isolated `DEV_SLUG` dev stack: created a contact with one unset-type primary email and one explicit Personal-type primary email, confirmed both radios stay checked through the whole flow, submitted, and read the stored record back via the API — both emails persisted as `is_primary: true` with their own correct `email_type` (`work`, `personal`), no 409, no collision. Recording attached below.

## Review

Two independent passes before push (`code-review` skill, `codex:rescue`) both found the same real gap in the first commit (unset-vs-explicit-default-kind collision, plus the type-change-reconciliation gap); both fixed and reflected in the final commit, verified by two new regression tests plus the live UAT above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkdtztRqyypJufL6VTE2Vs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes margince#5272: a WORK primary email or phone and a PERSONAL primary no longer clear each other on the person edit form. Marking one type primary used to un-primary the other type's primary in both React state and the browser's native radio group; now each kind's primary is scoped independently and both can submit as primary.

- Scopes primary exclusivity to same-kind rows via a new `typeKey`, matching the server's own same-kind rule (only a same-kind primary swap is refused).
- Groups an unset row type with the field's default (`work`), matching the request mapper's fallback, so an unset row and an explicit Work row can't collide as two primary work emails on submit.
- Clears a row's own primary when its type changes, so it never silently contends for the new kind's primary slot.

<sup>Written for commit 8f1824bd365443f73dbe11e8128a65dede25cf77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

