### PR TITLE
claim: main-red — TestSweepTargetsCarryNoDeleteBlockingTrigger

### DIFF
--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -96,6 +96,26 @@ var preservedResetTables = map[string]bool{
 	// It is still cleared by a reset — `activity` is swept, and the cascade takes
 	// the evidence with it. Preserved here means "not a target", never "kept".
 	"activity_retention_evidence": true,
+	// A directed-send decision (migration 1789048392): the record of who
+	// overrode a refusal, when, and under what reason. Its own trigger refuses
+	// EVERY delete unconditionally ("a communication instruction is the record
+	// of a decision and is never deleted") — unlike activity_retention_evidence
+	// above, there is no row-conditional carve-out for a cascade to pass
+	// through, so this is the audit_log/system_log shape, not that one.
+	//
+	// Not yet reachable in practice: nothing seeds a communication_instruction
+	// row today, so the sweep has never actually met one. The obligation this
+	// leaves standing: communication_review references this table with ON
+	// DELETE CASCADE, and that cascade would hit the same unconditional
+	// refusal the direct DELETE above does — sweeping communication_review
+	// will abort on the first row once an instruction is ever attached to
+	// one. Filed as margince#5287 (needs a product decision: whether a
+	// directed-send decision should outlive a reset the way this table's own
+	// preservation already says, in which case communication_review needs the
+	// same preservation, or whether the reset is entitled to clear it, in
+	// which case the trigger needs the row-conditional shape
+	// activity_retention_evidence's own guard has).
+	"communication_instruction": true,
 }
 
 // resetTargetTables lists every public base table a reset sweeps: all of them,

--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -105,16 +105,20 @@ var preservedResetTables = map[string]bool{
 	//
 	// Not yet reachable in practice: nothing seeds a communication_instruction
 	// row today, so the sweep has never actually met one. The obligation this
-	// leaves standing: communication_review references this table with ON
-	// DELETE CASCADE, and that cascade would hit the same unconditional
-	// refusal the direct DELETE above does — sweeping communication_review
-	// will abort on the first row once an instruction is ever attached to
-	// one. Filed as margince#5287 (needs a product decision: whether a
-	// directed-send decision should outlive a reset the way this table's own
-	// preservation already says, in which case communication_review needs the
-	// same preservation, or whether the reset is entitled to clear it, in
-	// which case the trigger needs the row-conditional shape
-	// activity_retention_evidence's own guard has).
+	// leaves standing, for THIS path only: communication_review references
+	// this table with ON DELETE CASCADE, and that cascade would hit the same
+	// unconditional refusal the direct DELETE above does — sweeping
+	// communication_review will abort on the first row once an instruction is
+	// ever attached to one, because this path runs as the application role
+	// and cannot disable the trigger the way scripts/seed-reset.sql's own
+	// replica-mode session can (that script clears the same orphan risk with
+	// its own explicit DELETE, the same way it already does for
+	// activity_retention_evidence). Filed as margince#5287 (needs a product
+	// decision: whether a directed-send decision should outlive a reset the
+	// way this table's own preservation already says, in which case
+	// communication_review needs the same preservation, or whether the reset
+	// is entitled to clear it, in which case the trigger needs the
+	// row-conditional shape activity_retention_evidence's own guard has).
 	"communication_instruction": true,
 }
 

--- a/scripts/seed-reset.sql
+++ b/scripts/seed-reset.sql
@@ -43,6 +43,7 @@ DECLARE
     'audit_log',
     'auth_token',
     'channel_provider',
+    'communication_instruction',
     'currency_minor_digits',
     'embed_store_binding',
     'consent_text_version',

--- a/scripts/seed-reset.sql
+++ b/scripts/seed-reset.sql
@@ -109,6 +109,24 @@ BEGIN
   DELETE FROM activity_retention_evidence are
    WHERE NOT EXISTS (SELECT 1 FROM activity a WHERE a.id = are.activity_id);
 
+  -- communication_instruction is the SAME shape one column over: preserved
+  -- above because its own trigger refuses every direct DELETE unconditionally
+  -- ("a communication instruction is the record of a decision and is never
+  -- deleted") — but that trigger is suppressed by replica mode exactly like
+  -- activity_retention_evidence's own, and so is communication_review's
+  -- ON DELETE CASCADE into it. Without this statement, sweeping
+  -- communication_review above would leave every instruction behind, now
+  -- naming a review that no longer exists — silently, since replica mode
+  -- means neither the FK nor the trigger would raise to say so.
+  --
+  -- The in-product reset has no equivalent answer: it runs as the
+  -- application role, which cannot disable the trigger, so the same cascade
+  -- there aborts the whole reset instead of orphaning anything — tracked as
+  -- margince#5287, a product decision this script is not the place to make
+  -- on its own.
+  DELETE FROM communication_instruction ci
+   WHERE NOT EXISTS (SELECT 1 FROM communication_review cr WHERE cr.id = ci.review_id);
+
   -- event_outbox is preserved the same way: "not a target" of the generic
   -- sweep, never "kept" outright. Clearing it here removes only the DATABASE
   -- rows — it is not the guarantee the in-product reset gives. The relay


### PR DESCRIPTION
## Summary

Fixes the main-red `TestSweepTargetsCarryNoDeleteBlockingTrigger` (backend/internal/compose/datareset_integration_test.go), introduced by PR #5284's `communication_instruction` table — its trigger refuses every DELETE unconditionally ("a communication instruction is the record of a decision and is never deleted"), the same shape `audit_log`/`system_log` already have, and the gate exists precisely to force a new table like this to be classified rather than discovered at runtime.

Classified into `preservedResetTables` (and its `scripts/seed-reset.sql` mirror — `backend/gates/seedresetparity_test.go` holds the two equal) rather than `deleteGuardedSweepTargets`: the guard has no row-conditional carve-out for a legitimate cascade to pass through, unlike `activity_retention_evidence` beside it.

Filed margince#5287 for the obligation this leaves standing: `communication_review` references `communication_instruction` with `ON DELETE CASCADE`, and that cascade will hit the same unconditional refusal once an instruction is ever attached to a review. Not reachable today (nothing seeds one yet), and it needs a product decision (should a directed-send decision outlive a reset, or should the reset be entitled to clear it) this fix is not the place to guess at.

## Test plan

- [x] `make check-go` (build, vet, lint, unit, gates, contract drift, composition)
- [x] `make test-integration` (0 skips, 51 packages)
- [x] `TestSweepTargetsCarryNoDeleteBlockingTrigger` and `TestPreserveSetIntegrity` pass
- [x] `TestTheTwoResetsPreserveTheSameTables` (seedresetparity_test.go) passes
- [x] `craft static --strict` on the changed Go file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkdtztRqyypJufL6VTE2Vs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Communication instructions are now preserved when resetting seeded data.
  - Reset operations no longer target communication instructions for deletion, helping retain existing instruction content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->