### PR TITLE
A settled screen is one that has stopped moving, not one that is merely visible

### DIFF
--- a/frontend/e2e/perf-mobile.spec.ts
+++ b/frontend/e2e/perf-mobile.spec.ts
@@ -40,8 +40,26 @@ const FAST_3G = {
 const SAMPLES = 20;
 const PERCEIVED_BUDGET_MS = 300;
 
-/** One measured open: the click, the heading, and what sat between them. */
-type Open = { from: number; to: number; ms: number };
+/**
+ * One measured open, split into the phases the single number used to hide.
+ *
+ * `clickMs` is Playwright's actionability plus the dispatch — a click does not
+ * land until the target is STABLE (its box unchanged across two consecutive
+ * animation frames), so a screen still moving is paid here. `renderMs` is what
+ * the app then took to put the record's own heading on screen, which is the
+ * cost MOBILE-AC-2 is actually about. `settleMs` is outside the window entirely
+ * and is reported as evidence rather than measured as latency: it says how long
+ * the screen went on moving AFTER the row appeared, which is what used to be
+ * charged to the open that followed.
+ */
+type Open = {
+  from: number;
+  to: number;
+  ms: number;
+  clickMs: number;
+  renderMs: number;
+  settleMs: number;
+};
 
 /** One request's LIFE on the wire, rather than the moment it was issued. */
 type Exchange = { path: string; from: number; to: number };
@@ -183,9 +201,28 @@ async function openOneRecord(page: Page): Promise<Open> {
   // of it joined and the person's name is a fragment of that by construction.
   const row = page.getByRole("row", { name: "Anna Weber" });
   await expect(row).toBeVisible();
+  // A VISIBLE screen is not yet a settled one, and the difference is the whole
+  // of this lane's reported breach. The shell transitions the rail's width over
+  // `--dur-move` on a route change (src/app/shell.css), which relayouts every
+  // row of the table under it; a click dispatched while that is travelling
+  // waits out the remainder as actionability, inside the measured window, as
+  // neither a request nor a long task. This file already says it anchors on a
+  // settled screen — `networkidle` and a visible row were the wrong two tests
+  // for that, because neither of them is about MOVEMENT.
+  //
+  // Timed out loudly rather than bounded and ignored: nothing on this screen
+  // animates forever, so a wait that does not finish is a finding.
+  const settleFrom = Date.now();
+  await page.waitForFunction(
+    () => document.getAnimations().every((a) => a.playState !== "running"),
+    undefined,
+    { timeout: 5_000 },
+  );
+  const settleMs = Date.now() - settleFrom;
 
   const from = Date.now();
   await row.click();
+  const clicked = Date.now();
   // The record's OWN header, not the shell's: the head shows only the trail
   // on a record route and renders from the router before any record read
   // returns, so waiting on it would measure routing rather than the open.
@@ -200,7 +237,14 @@ async function openOneRecord(page: Page): Promise<Open> {
   // drop is what the click issued in its first milliseconds, which is precisely
   // what the window is being measured to catch.
   const to = Date.now();
-  return { from, to, ms: to - from };
+  return {
+    from,
+    to,
+    ms: to - from,
+    clickMs: clicked - from,
+    renderMs: to - clicked,
+    settleMs,
+  };
 }
 
 /**
@@ -242,6 +286,19 @@ function report(
     `perfbench [fast-3g/390px]: record_open_perceived ` +
       `span_ms=${opens[opens.length - 1].to - opens[0].from} ` +
       `in_order=${JSON.stringify(samples)}`,
+  );
+  // WHERE in the open the time went, aligned index-for-index with `in_order`.
+  // This is the reading that separates a cost the product pays from a cost the
+  // harness pays: `click_ms` is Playwright waiting for the screen to hold still
+  // before it may click, `render_ms` is the app drawing the record. A step that
+  // lands in the first is the anchor; a step that lands in the second is the
+  // product. `settle_ms` sits OUTSIDE the window and says how long the screen
+  // kept moving after the row appeared — the movement this anchor now absorbs.
+  console.log(
+    `perfbench [fast-3g/390px]: record_open_perceived ` +
+      `click_ms=${JSON.stringify(opens.map((o) => o.clickMs))} ` +
+      `render_ms=${JSON.stringify(opens.map((o) => o.renderMs))} ` +
+      `settle_ms=${JSON.stringify(opens.map((o) => o.settleMs))}`,
   );
   // The two things an open can WAIT for, aligned index-for-index with
   // `in_order` above: requests in flight across the window, and milliseconds


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/margince/margince/pull/5289, which gave this lane
instruments that could finally say what a slow open was waiting for. The answer
was **nothing the product does** — no request in flight, no main-thread work —
so this tests the remaining candidate: the lane's own anchor.

### The measurement that prompted it

MOBILE-AC-2 says in its own comments that it anchors on a settled screen before
starting the clock, and tests that with `networkidle` and a visible row.
**Neither of those is about movement.**

This branch reports `settle_ms` — how long the screen goes on animating *after*
the row is visible. Locally, on every one of the twenty samples:

```
settle_ms=[400,406,399,404,401,393,403,399,402,401,409,402,400,406,413,409,398,411,405,404]
```

~400 ms, every time, previously running underneath the timer. That is the list's
own arrival animation (`--dur-enter` is 360 ms). A click dispatched into it waits
for the target to be **stable** — Playwright will not land a click until the
element's box is unchanged across two consecutive animation frames — and that
wait is layout rather than script, so it appears as **neither a request nor a
long task**.

That is precisely the shape of the last five breaches: a clean ~240 ms step,
`in_flight=0`, `blocked_ms=0`, alternating with the phase of the animation
against the loop.

## What changes

1. **The wait happens before the clock rather than under it.** Navigating back to
   the list is test scaffolding — a user opening records does not re-enter the
   list and pay its arrival animation each time — so charging it to the open that
   follows measured the harness, not the product. It is timed out loudly rather
   than bounded and ignored: nothing here animates forever, so a wait that does
   not finish is a finding.
2. **The window is split into the phases one number hid**: `click_ms`
   (Playwright waiting for the screen to hold still) and `render_ms` (the app
   drawing the record). A step landing in the first is the anchor; a step landing
   in the second is the product. This is what makes the next run conclusive
   either way, instead of leaving a green lane with an unexplained cause.

## What this does NOT change

The budget, the sample count, the throttling profile and the assertion are
untouched. Nothing is recorded to the published page.

**And it is not yet a demonstrated fix.** Local runs cannot exhibit the slow mode
at all — the whole loop finishes in seconds, and `click_ms` here is a flat ~20 ms
because nothing on this machine ever made the click wait. Whether the anchor is
what CI was paying is what the next dispatch on `main` answers, and `click_ms`
is the line that answers it:

- the step was in `click_ms` and is now gone → the anchor was the cause, and
  PERF-1's budget was never in question (p50 has been 82 ms against 300 ms);
- the step moves to `render_ms` → it is the product after all, and now bisectable;
- the step survives in `click_ms` → the anchor is not enough and the measurement
  path itself is next.

## Local numbers, before and after

| | before | after |
|---|---|---|
| p95 | 64 ms | 63 ms |
| p50 | 46 ms | 54 ms |
| `click_ms` | — | flat ~20 ms |
| `render_ms` | — | 27–43 ms |
| `span_ms` | 1 340 ms | 9 103 ms |

The loop is slower by the settle waits, which is the point of them, and stays far
inside both the 30 s stale window and the 300 s test timeout.

## Test plan

- [x] `make fe-unit` — 657 files, 8801 passed
- [x] `make check-fe` — one unrelated flake in `src/screens/onboarding.test.tsx` (passes alone and in a clean full re-run; `fe clock drift (main)` and the frontend legs are green on `main`), everything else green
- [x] `CI=true MARGINCE_BENCH_MOBILE=1 pnpm exec playwright test` — 1 passed, p95=63 ms
- [x] `biome check` on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
