### PR TITLE
Publish MOBILE-AC-2's number now that the breach is understood

### DIFF
--- a/docs/reference/perfbench/bench-mobile.json
+++ b/docs/reference/perfbench/bench-mobile.json
@@ -1,13 +1,13 @@
 {
   "target": "bench-mobile",
-  "measured_on": "2026-08-21",
+  "measured_on": "2026-09-11",
   "machine": {
     "os": "darwin",
     "arch": "arm64",
-    "cpu": "Apple M4 Pro",
-    "cores": 12,
-    "memory_gib": 24,
-    "toolchain": "node 24.16.0",
+    "cpu": "Apple M1 Pro",
+    "cores": 8,
+    "memory_gib": 16,
+    "toolchain": "node 24.19.0",
     "network": "throttled Fast-3G (MOBILE-PARAM-2)",
     "viewport": "390x844"
   },
@@ -15,9 +15,9 @@
     {
       "id": "MOBILE-AC-2",
       "name": "record_open_perceived",
-      "p50_ms": 45,
-      "p95_ms": 49,
-      "p99_ms": 843,
+      "p50_ms": 48,
+      "p95_ms": 61,
+      "p99_ms": 65,
       "budget_ms": 300,
       "samples": 20
     }

--- a/docs/reference/performance-budgets.md
+++ b/docs/reference/performance-budgets.md
@@ -30,7 +30,7 @@ them runs in CI, so nothing here changes unless somebody chooses to measure.
 | `PERF-6` | Cold start (single binary) | < 2 s | — | **not measured** | — |
 | `PERF-7` | Context-graph assembly | < 300 ms at mid-market | 9.9 ms | within budget | 2026-08-15 |
 | `CAP-PARAM-1` | Capture to timeline | 60 s p95 | 39.2 ms | within budget | 2026-08-15 |
-| `MOBILE-AC-2` | Record open, perceived, Fast-3G | < 300 ms perceived | 49.0 ms | within budget | 2026-08-21 |
+| `MOBILE-AC-2` | Record open, perceived, Fast-3G | < 300 ms perceived | 61.0 ms | within budget | 2026-09-11 |
 
 ### Still unmeasured
 
@@ -55,20 +55,20 @@ A latency is only true of the machine that produced it.
 |---|---|---|---|---|---|
 | `capture_to_timeline` | 27.8 ms | 39.2 ms | 42.9 ms | 60000 ms | 20 |
 
-### `make bench-mobile` · measured 2026-08-21
+### `make bench-mobile` · measured 2026-09-11
 
 | | |
 |---|---|
 | os / arch | darwin / arm64 |
-| cpu | Apple M4 Pro (12 cores) |
-| memory | 24 GiB |
-| toolchain | node 24.16.0 |
+| cpu | Apple M1 Pro (8 cores) |
+| memory | 16 GiB |
+| toolchain | node 24.19.0 |
 | network | throttled Fast-3G (MOBILE-PARAM-2) |
 | viewport | 390x844 |
 
 | measurement | p50 | p95 | p99 | budget | samples |
 |---|---|---|---|---|---|
-| `record_open_perceived` | 45.0 ms | 49.0 ms | 843 ms | 300 ms | 20 |
+| `record_open_perceived` | 48.0 ms | 61.0 ms | 65.0 ms | 300 ms | 20 |
 
 ### `make bench-perf` · measured 2026-08-15
 


### PR DESCRIPTION
## Summary

Closes out https://github.com/margince/margince/issues/4804 by doing what its
body asks for once the breach is understood: publish a fresh record.

The page has carried `p99_ms: 843` since 2026-08-21. That is the same measurement
artifact which later presented as five consecutive p95 breaches — the lane
started its clock while the list's arrival animation (`--dur-enter`, 360 ms) was
still running, and Playwright will not land a click until the target's box holds
still across two animation frames. One sample catching that wait is an 843 ms
p99; several catching it is a 326 ms p95.

With the anchor moved ahead of the clock
(https://github.com/margince/margince/pull/5291), the tail is gone rather than
merely smaller:

| | before (2026-08-21) | now |
|---|---|---|
| p50 | 45 ms | 48 ms |
| p95 | 49 ms | 61 ms |
| **p99** | **843 ms** | **65 ms** |

**p50 is unchanged, and that is the point.** Nothing about opening a record got
faster. The number stopped including a wait that was never the product's.

The machine block changes because a record is a human's to publish and this one
was measured on a different laptop than the last — which is exactly why the
record carries the machine.

## Test plan

- [x] `make bench-mobile` — 1 passed, p95=61 ms, `click_ms` flat 19–22 ms, `render_ms` 13–44 ms
- [x] `make perfdoc` regenerated `docs/reference/performance-budgets.md` (run by the same target); diff is the two numbers and the machine block, nothing else
- [x] Verified green on CI first: https://github.com/margince/margince/actions/runs/34559775341 reports p95=74 ms on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
