### PR TITLE
A calendar day is derived in one place, in the installation's zone

### DIFF
--- a/backend/gates/calendarday_test.go
+++ b/backend/gates/calendarday_test.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// A calendar day is one derivation, and this is the census that keeps it one.
+//
+// "What day is this instant?" was answered five times by `X.UTC().Truncate(24 *
+// time.Hour)` — UTC's midnight wherever the installation is — and the invariant
+// was re-broken three times by call-site discipline alone. storekit.WorkspaceDay
+// now holds the reading (the local day of an instant), storekit.AsDate holds the
+// other (the calendar date a value already names), and this gate fails the
+// moment a sixth site spells the truncation itself.
+//
+// WHAT THIS DOES NOT COVER, so the absence of findings is not read wider than it
+// is: the OTHER spelling of a day, `time.Date(t.Year(), t.Month(), t.Day(), 0,
+// 0, 0, 0, ...)`, which is how storekit itself builds the value and which a
+// dozen tests use to name a specific date — matching it would report far more
+// correct sites than wrong ones, the noise that teaches a reader to skip a
+// census. The `Truncate(24 * time.Hour)` idiom is the one every drift used, and
+// the one a fourth author reaches for next; that is what this holds.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// calendarDayOwner is the package that may hold the day derivation. Its own
+// spelling is time.Date, not Truncate, so it never trips this — but it is named
+// so the failure can point a new site at the primitive rather than at a rule.
+const calendarDayOwner = "internal/platform/database/storekit"
+
+// deferred sites still truncate a day in UTC, each for a reason that is not "not
+// yet done": converting them needs a zone the module cannot currently reach, or
+// would be wrong. Ratified by name so a NEW truncation fails loudly while these
+// stay described where the next reader sees them, not in a PR they will not open.
+var deferred = gatekit.Waive(map[string]string{
+	"internal/modules/finance/offline.go":           "the offline ledger's demonstration anchor: a fixed instant reduced to a stable date ORIGIN for reproducible synthetic invoices, never a business calendar day to localise. UTC is the whole point — a moving or zoned anchor would rewrite every generated row.",
+	"internal/modules/ai/ratewrite.go":              "the ai_model_rate sheet's effective-day guard and cutoff, the fx_rate sibling. It is an operator-set business day and belongs in the installation zone, but RateStore carries no installation handle to resolve one; giving it the seam deals.Store has is its own change.",
+	"internal/modules/ai/pricing.go":                "normalises the seed price sheet's effective date, the same ai_model_rate day as ratewrite.go. It moves in lockstep with that seam, not before it.",
+	"internal/modules/people/rollupclock.go":        "the open-pipeline rollup's FX as-of day, deliberately UTC today so two readers of one account agree on a rate. A workspace zone meets that goal too and is the right answer, but the pure clock helper must first be threaded a zone.",
+	"internal/modules/automation/handlers_clock.go": "the renewal-reminder window compares a DATE column scanned as UTC midnight against today; today is truncated the SAME way ON PURPOSE so both sides agree. Converting today alone would reintroduce the same-day miss — this moves only in lockstep with the anchor scan in candidates.go.",
+})
+
+// isDayTruncation reports whether a call is `X.Truncate(24 * time.Hour)` — the
+// one idiom every calendar-day drift used, in either operand order.
+func isDayTruncation(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Truncate" || len(call.Args) != 1 {
+		return false
+	}
+	bin, ok := call.Args[0].(*ast.BinaryExpr)
+	if !ok || bin.Op != token.MUL {
+		return false
+	}
+	return (isIntLit(bin.X, "24") && isTimeHour(bin.Y)) ||
+		(isTimeHour(bin.X) && isIntLit(bin.Y, "24"))
+}
+
+func isIntLit(expr ast.Expr, value string) bool {
+	lit, ok := expr.(*ast.BasicLit)
+	return ok && lit.Kind == token.INT && lit.Value == value
+}
+
+func isTimeHour(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Hour" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "time"
+}
+
+// TestTheMatcherSeesWhatItClaimsTo pins what the idiom catches and what it must
+// let through — a census asserting a shape is ABSENT passes identically over a
+// clean tree and over a matcher that has quietly stopped matching.
+func TestTheMatcherSeesWhatItClaimsTo(t *testing.T) {
+	t.Parallel()
+	caught := []string{
+		"x.Truncate(24 * time.Hour)",
+		"x.UTC().Truncate(24 * time.Hour)",
+		"clock().UTC().Truncate(24 * time.Hour)",
+		"t.Truncate(time.Hour * 24)",
+	}
+	for _, src := range caught {
+		if !exprIsDayTruncation(t, src) {
+			t.Errorf("the matcher does not see a day truncation it must:\n\t%s", src)
+		}
+	}
+	missed := []string{
+		"x.Truncate(time.Hour)",
+		"x.Truncate(30 * time.Minute)",
+		"x.Truncate(48 * time.Hour)",
+		"x.Round(24 * time.Hour)",
+		"time.Date(x.Year(), x.Month(), x.Day(), 0, 0, 0, 0, time.UTC)",
+	}
+	for _, src := range missed {
+		if exprIsDayTruncation(t, src) {
+			t.Errorf("the matcher reports something that is not a day truncation:\n\t%s", src)
+		}
+	}
+}
+
+// exprIsDayTruncation parses one expression and runs the matcher over its
+// outermost call, the shape the tree walk inspects.
+func exprIsDayTruncation(t *testing.T, src string) bool {
+	t.Helper()
+	expr, err := parser.ParseExpr(src)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", src, err)
+	}
+	call, ok := expr.(*ast.CallExpr)
+	return ok && isDayTruncation(call)
+}
+
+func TestOnlyOnePlaceDerivesACalendarDay(t *testing.T) {
+	t.Parallel()
+	// A ratification that stops matching is one for a site that moved or was
+	// converted; leaving it re-exempts whatever takes its place.
+	defer deferred.AssertAllMatched(t)
+
+	var sites []string
+	judged := 0
+	fset := token.NewFileSet()
+	for _, root := range []string{"internal", "../extensions"} {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if name := entry.Name(); name == "testdata" || name == "node_modules" {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
+				strings.HasSuffix(path, "_gen.go") {
+				return nil
+			}
+			rel := filepath.ToSlash(path)
+			if strings.Contains(rel, calendarDayOwner) {
+				return nil
+			}
+			source, readErr := os.ReadFile(path) // #nosec G304 -- a *.go path from walking the trusted source tree
+			if readErr != nil {
+				return readErr
+			}
+			judged++
+			file, parseErr := parser.ParseFile(fset, path, source, 0)
+			if parseErr != nil {
+				return parseErr
+			}
+			ast.Inspect(file, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok || !isDayTruncation(call) {
+					return true
+				}
+				if !deferred.Waived(t, rel) {
+					sites = append(sites, rel)
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	if judged < 500 {
+		t.Fatalf("the census read only %d Go files, so it covered almost nothing", judged)
+	}
+	sort.Strings(sites)
+	if len(sites) > 0 {
+		t.Errorf("%d site(s) truncate a calendar day themselves.\n\n"+
+			"Which day an instant falls on is one derivation, in the installation's zone, and it "+
+			"was re-broken three times by spelling Truncate(24 * time.Hour) at a fresh call site. "+
+			"Use storekit.WorkspaceDay (the local day of an instant) or storekit.AsDate (the date a "+
+			"value already names).\n\n\t%s", len(sites), strings.Join(sites, "\n\t"))
+	}
+}

--- a/backend/gates/calendarday_test.go
+++ b/backend/gates/calendarday_test.go
@@ -62,7 +62,7 @@ func isDayTruncation(call *ast.CallExpr, timeName string) bool {
 	if !ok || sel.Sel.Name != "Truncate" || len(call.Args) != 1 {
 		return false
 	}
-	bin, ok := call.Args[0].(*ast.BinaryExpr)
+	bin, ok := unparen(call.Args[0]).(*ast.BinaryExpr)
 	if !ok || bin.Op != token.MUL {
 		return false
 	}
@@ -70,13 +70,27 @@ func isDayTruncation(call *ast.CallExpr, timeName string) bool {
 		(isTimeHour(bin.X, timeName) && isIntLit(bin.Y, "24"))
 }
 
+// unparen strips redundant parentheses, so `(24)` and `(time.Hour)` and a whole
+// parenthesised `(24 * time.Hour)` match the same as the bare forms. A census
+// that let a parenthesised operand slip would fail short (rule 8), and gofmt
+// does not remove parentheses a writer put there.
+func unparen(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
+}
+
 func isIntLit(expr ast.Expr, value string) bool {
-	lit, ok := expr.(*ast.BasicLit)
+	lit, ok := unparen(expr).(*ast.BasicLit)
 	return ok && lit.Kind == token.INT && lit.Value == value
 }
 
 func isTimeHour(expr ast.Expr, timeName string) bool {
-	sel, ok := expr.(*ast.SelectorExpr)
+	sel, ok := unparen(expr).(*ast.SelectorExpr)
 	if !ok || sel.Sel.Name != "Hour" {
 		return false
 	}
@@ -115,6 +129,11 @@ func TestTheMatcherSeesWhatItClaimsTo(t *testing.T) {
 		"x.UTC().Truncate(24 * time.Hour)",
 		"clock().UTC().Truncate(24 * time.Hour)",
 		"t.Truncate(time.Hour * 24)",
+		// Parentheses a writer added, which gofmt keeps: the census must see
+		// through them or it fails short.
+		"x.Truncate((24) * time.Hour)",
+		"x.Truncate(24 * (time.Hour))",
+		"x.Truncate((24 * time.Hour))",
 	}
 	for _, src := range caught {
 		if !exprIsDayTruncation(t, src) {
@@ -216,7 +235,10 @@ func TestOnlyOnePlaceDerivesACalendarDay(t *testing.T) {
 				return nil
 			}
 			rel := filepath.ToSlash(path)
-			if strings.Contains(rel, calendarDayOwner) {
+			// Exactly the owner package, by directory prefix — Contains would also
+			// exempt a sibling like storekitlegacy/ whose path merely spells the
+			// owner's, letting a truncation there pass unseen.
+			if rel == calendarDayOwner || strings.HasPrefix(rel, calendarDayOwner+"/") {
 				return nil
 			}
 			source, readErr := os.ReadFile(path) // #nosec G304 -- a *.go path from walking the trusted source tree

--- a/backend/gates/calendarday_test.go
+++ b/backend/gates/calendarday_test.go
@@ -54,8 +54,10 @@ var deferred = gatekit.Waive(map[string]string{
 })
 
 // isDayTruncation reports whether a call is `X.Truncate(24 * time.Hour)` — the
-// one idiom every calendar-day drift used, in either operand order.
-func isDayTruncation(call *ast.CallExpr) bool {
+// one idiom every calendar-day drift used, in either operand order. timeName is
+// the local name the file binds the standard "time" package to, so a truncation
+// written through an aliased import is still seen.
+func isDayTruncation(call *ast.CallExpr, timeName string) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || sel.Sel.Name != "Truncate" || len(call.Args) != 1 {
 		return false
@@ -64,8 +66,8 @@ func isDayTruncation(call *ast.CallExpr) bool {
 	if !ok || bin.Op != token.MUL {
 		return false
 	}
-	return (isIntLit(bin.X, "24") && isTimeHour(bin.Y)) ||
-		(isTimeHour(bin.X) && isIntLit(bin.Y, "24"))
+	return (isIntLit(bin.X, "24") && isTimeHour(bin.Y, timeName)) ||
+		(isTimeHour(bin.X, timeName) && isIntLit(bin.Y, "24"))
 }
 
 func isIntLit(expr ast.Expr, value string) bool {
@@ -73,13 +75,34 @@ func isIntLit(expr ast.Expr, value string) bool {
 	return ok && lit.Kind == token.INT && lit.Value == value
 }
 
-func isTimeHour(expr ast.Expr) bool {
+func isTimeHour(expr ast.Expr, timeName string) bool {
 	sel, ok := expr.(*ast.SelectorExpr)
 	if !ok || sel.Sel.Name != "Hour" {
 		return false
 	}
 	pkg, ok := sel.X.(*ast.Ident)
-	return ok && pkg.Name == "time"
+	return ok && timeName != "" && pkg.Name == timeName
+}
+
+// timeImportName is the local name this file binds the standard "time" package
+// to — "time" normally, or the alias in `import clock "time"`. Empty when the
+// file does not import time at all, in which case no `time.Hour` can appear.
+//
+// Resolving the alias is what keeps the census from failing SHORT (rule 8): a
+// truncation written through an aliased import would otherwise pass unseen. A
+// LOCAL value shadowing `time` is deliberately NOT resolved — it would be
+// over-reported, the safe direction, an extra waiver rather than a missed site.
+func timeImportName(file *ast.File) string {
+	for _, imp := range file.Imports {
+		if imp.Path.Value != `"time"` {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name
+		}
+		return "time"
+	}
+	return ""
 }
 
 // TestTheMatcherSeesWhatItClaimsTo pins what the idiom catches and what it must
@@ -121,7 +144,51 @@ func exprIsDayTruncation(t *testing.T, src string) bool {
 		t.Fatalf("parsing %q: %v", src, err)
 	}
 	call, ok := expr.(*ast.CallExpr)
-	return ok && isDayTruncation(call)
+	return ok && isDayTruncation(call, "time")
+}
+
+// TestTheMatcherResolvesTheTimeImportAlias plants the case a static review named:
+// a truncation written through an aliased `time` import is a real day derivation
+// the census MUST still see (the false-NEGATIVE rule 8 forbids), while a file
+// that never imports time has no truncation to find.
+func TestTheMatcherResolvesTheTimeImportAlias(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"plain import", "package p\nimport \"time\"\nfunc f(x time.Time) { _ = x.Truncate(24 * time.Hour) }\n", true},
+		{"aliased import", "package p\nimport clock \"time\"\nfunc f(x clock.Time) { _ = x.Truncate(24 * clock.Hour) }\n", true},
+		{"no time import is nothing to find", "package p\nfunc f() { _ = 24 }\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fileHasDayTruncation(t, tc.src); got != tc.want {
+				t.Errorf("day truncation seen = %v, want %v in:\n%s", got, tc.want, tc.src)
+			}
+		})
+	}
+}
+
+// fileHasDayTruncation parses a whole file and runs the census's own logic —
+// resolve the time import, then inspect — so the alias resolution is exercised
+// exactly as the walk exercises it.
+func fileHasDayTruncation(t *testing.T, src string) bool {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), "fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parsing fixture: %v", err)
+	}
+	timeName := timeImportName(file)
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		if call, ok := node.(*ast.CallExpr); ok && isDayTruncation(call, timeName) {
+			found = true
+		}
+		return true
+	})
+	return found
 }
 
 func TestOnlyOnePlaceDerivesACalendarDay(t *testing.T) {
@@ -161,9 +228,10 @@ func TestOnlyOnePlaceDerivesACalendarDay(t *testing.T) {
 			if parseErr != nil {
 				return parseErr
 			}
+			timeName := timeImportName(file)
 			ast.Inspect(file, func(node ast.Node) bool {
 				call, ok := node.(*ast.CallExpr)
-				if !ok || !isDayTruncation(call) {
+				if !ok || !isDayTruncation(call, timeName) {
 					return true
 				}
 				if !deferred.Waived(t, rel) {

--- a/backend/gates/calendarday_test.go
+++ b/backend/gates/calendarday_test.go
@@ -177,8 +177,15 @@ func TestOnlyOnePlaceDerivesACalendarDay(t *testing.T) {
 			t.Fatalf("walking %s: %v", root, err)
 		}
 	}
-	if judged < 500 {
-		t.Fatalf("the census read only %d Go files, so it covered almost nothing", judged)
+	// The floor sits just under the real corpus (~2800 non-test .go files), not
+	// at a token 500: under-recognition is the one way this must not break
+	// (rule 8), and a walk that silently stopped reading internal/compose —
+	// where org360 and briefs live — would still clear a low floor and report
+	// PASS over a planted truncation. If a refactor legitimately drops the count
+	// below this, lower it deliberately rather than widening the blind spot.
+	if judged < 2500 {
+		t.Fatalf("the census read only %d Go files, far below the ~2800 it should — it covered "+
+			"a fraction of the tree and a truncation outside what it read would pass unseen", judged)
 	}
 	sort.Strings(sites)
 	if len(sites) > 0 {

--- a/backend/internal/compose/attention/dayboundary.go
+++ b/backend/internal/compose/attention/dayboundary.go
@@ -69,7 +69,7 @@ func WithNoticeCases(n NoticeCases) Option {
 // THE INSTALLATION'S midnight, not UTC's — storekit.StartOfNextDay derives it
 // in the installation's zone, exact on the two mornings a year the clocks move
 // where a truncated 24 hours would land an hour off. The same primitive backs
-// every calendar-day surface, so this feed cannot drift from the rest.
+// every calendar-day surface the product derives.
 //
 // ONCE PER ASSEMBLY, and the answer is carried to every lane that needs it. An
 // operator moving the installation mid-read would otherwise give one lane
@@ -93,8 +93,8 @@ func (s *Service) endOfDay(ctx context.Context, asOf time.Time) (time.Time, *tim
 // The forward lanes ask what is still coming and stop at endOfDay; a lane about
 // what already happened needs where today began, and "today" has to mean the
 // same thing at both ends or a meeting at 08:00 falls between them. Both ends
-// are the storekit primitive's, so a backward lane and a forward one cannot
-// disagree about where the day is.
+// come from the storekit primitive, so a backward lane and a forward one
+// measure the day by one rule.
 func (s *Service) startOfDay(ctx context.Context, asOf time.Time) (time.Time, error) {
 	loc, err := s.location(ctx)
 	if err != nil {

--- a/backend/internal/compose/attention/dayboundary.go
+++ b/backend/internal/compose/attention/dayboundary.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
 )
 
@@ -65,14 +66,11 @@ func WithNoticeCases(n NoticeCases) Option {
 // endOfDay is the boundary every due-dated lane stops at, so a promise, a task
 // and a meeting falling on the same afternoon are judged against one instant.
 //
-// THE INSTALLATION'S midnight, not UTC's. Truncating the clock to 24 hours
-// answers UTC midnight wherever the installation is, which put a UTC+7 seat's
-// "today" through 07:00 tomorrow and cut a UTC-4 seat's short at 20:00 — the
-// same convention error the morning brief's local_day exists to avoid.
+// THE INSTALLATION'S midnight, not UTC's — storekit.StartOfNextDay derives it
+// in the installation's zone, exact on the two mornings a year the clocks move
+// where a truncated 24 hours would land an hour off. The same primitive backs
+// every calendar-day surface, so this feed cannot drift from the rest.
 //
-// AddDate over the local date, not Add(24h) over the instant: a day is 23 or 25
-// hours where clocks change, and adding a fixed span lands an hour off on those
-// two mornings a year — in the direction that drops work the reader is owed.
 // ONCE PER ASSEMBLY, and the answer is carried to every lane that needs it. An
 // operator moving the installation mid-read would otherwise give one lane
 // yesterday's boundary and the next one today's, inside a single response — and
@@ -87,26 +85,22 @@ func (s *Service) endOfDay(ctx context.Context, asOf time.Time) (time.Time, *tim
 	if err != nil {
 		return time.Time{}, nil, err
 	}
-	return startOfNextDay(asOf.In(loc), loc), loc, nil
+	return storekit.StartOfNextDay(asOf, loc), loc, nil
 }
 
 // startOfDay is the other end of the same day, for a lane that looks BACK.
 //
 // The forward lanes ask what is still coming and stop at endOfDay; a lane about
 // what already happened needs where today began, and "today" has to mean the
-// same thing at both ends or a meeting at 08:00 falls between them.
-//
-// It is startOfNextDay asked about YESTERDAY, rather than a second walk: that
-// function's whole subtlety is the zones where local midnight does not exist,
-// and a midnight built here directly would be wrong on exactly the mornings
-// that comment describes.
+// same thing at both ends or a meeting at 08:00 falls between them. Both ends
+// are the storekit primitive's, so a backward lane and a forward one cannot
+// disagree about where the day is.
 func (s *Service) startOfDay(ctx context.Context, asOf time.Time) (time.Time, error) {
 	loc, err := s.location(ctx)
 	if err != nil {
 		return time.Time{}, err
 	}
-	local := asOf.In(loc)
-	return startOfNextDay(local.AddDate(0, 0, -1), loc), nil
+	return storekit.StartOfDay(asOf, loc), nil
 }
 
 // location resolves the installation's zone, or UTC when none is bound.
@@ -129,43 +123,6 @@ func (s *Service) location(ctx context.Context) (*time.Location, error) {
 		return nil, errors.New("attention: the installation timezone resolved to no location")
 	}
 	return resolved, nil
-}
-
-// startOfNextDay is the first instant of the day after local's, in loc.
-//
-// NOT local midnight constructed directly, because in some zones it does not
-// exist. Havana and Santiago spring forward AT midnight, and Go normalises the
-// missing 00:00 BACKWARD — to 23:00 on the previous date, an hour before the day
-// this bounds has even ended, so the last hour's work would fall off today's
-// lane. Beirut springs forward at midnight too and normalises FORWARD, to 01:00,
-// which is right by luck rather than by rule.
-//
-// So the rule is asked directly: the first instant whose local date is
-// tomorrow's. Noon is the anchor because no zone shifts its clock at midday, so
-// "tomorrow" is never ambiguous to begin with, and the walk back from it stops
-// at the transition on the days there is one. At most a few hundred steps, once
-// per assembly, and exact on every day of the year rather than on most of them.
-func startOfNextDay(local time.Time, loc *time.Location) time.Time {
-	noon := time.Date(local.Year(), local.Month(), local.Day(), 12, 0, 0, 0, loc).AddDate(0, 0, 1)
-	year, month, day := noon.Date()
-	if midnight := time.Date(year, month, day, 0, 0, 0, 0, loc); sameDate(midnight, noon) {
-		return midnight
-	}
-	first := noon
-	for {
-		earlier := first.Add(-time.Minute)
-		if !sameDate(earlier, noon) {
-			return first
-		}
-		first = earlier
-	}
-}
-
-// sameDate compares two instants by the LOCAL calendar date they fall on.
-func sameDate(a, b time.Time) bool {
-	ay, am, ad := a.Date()
-	by, bm, bd := b.Date()
-	return ay == by && am == bm && ad == bd
 }
 
 // The five runs a dated row can fall into. Named rather than spelled at each
@@ -206,7 +163,7 @@ func dueGroup(deadlineAt, asOf, until time.Time, loc *time.Location) string {
 	// The rest compare against DAY BOUNDARIES rather than against the clock,
 	// which is a different question and one this file owns: where today ends,
 	// where tomorrow ends, and how far "this week" reaches.
-	tomorrowEnds := startOfNextDay(until.In(loc), loc)
+	tomorrowEnds := storekit.StartOfNextDay(until, loc)
 	weekEnds := until.AddDate(0, 0, upcomingWeekDays)
 	switch {
 	case deadlineAt.Before(until):

--- a/backend/internal/compose/attention/dayboundary_test.go
+++ b/backend/internal/compose/attention/dayboundary_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 )
 
 func zoneNamed(t *testing.T, name string) Zone {
@@ -18,6 +20,15 @@ func zoneNamed(t *testing.T, name string) Zone {
 		t.Fatalf("loading %s: %v", name, err)
 	}
 	return func(context.Context) (*time.Location, error) { return loc, nil }
+}
+
+// sameDate compares two instants by the LOCAL calendar date they fall on — a
+// test assertion, distinct from the DST day-boundary walk these tests exercise
+// through storekit.
+func sameDate(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
 }
 
 // THE DAY ENDS AT THE INSTALLATION'S MIDNIGHT, not UTC's.
@@ -175,7 +186,7 @@ func TestADayWhoseMidnightDoesNotExistEndsAtItsFirstInstant(t *testing.T) {
 				// these zones sit hours apart, and the same instant is morning
 				// in one and evening in another.
 				asOf := time.Date(day.Year(), day.Month(), day.Day(), 15, 0, 0, 0, loc).AddDate(0, 0, -1)
-				local := startOfNextDay(asOf.In(loc), loc).In(loc)
+				local := storekit.StartOfNextDay(asOf, loc).In(loc)
 				if !sameDate(local, day) {
 					t.Fatalf("the day ends at %s, which is not the start of %s", local, day.Format(time.DateOnly))
 				}
@@ -315,7 +326,7 @@ func TestADayWhoseMidnightDoesNotExistBeginsAtItsFirstInstant(t *testing.T) {
 func TestADatedRowFallsInTheRunItsDeadlineNames(t *testing.T) {
 	loc := time.FixedZone("Europe/Berlin", 2*60*60)
 	asOf := time.Date(2026, 9, 10, 14, 0, 0, 0, loc)
-	until := startOfNextDay(asOf, loc)
+	until := storekit.StartOfNextDay(asOf, loc)
 
 	cases := []struct {
 		name string

--- a/backend/internal/compose/briefs/briefday.go
+++ b/backend/internal/compose/briefs/briefday.go
@@ -13,7 +13,6 @@ package briefs
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -41,9 +40,9 @@ func LocalDayAt(ctx context.Context, tx pgx.Tx, now time.Time) (day time.Time, l
 	if err != nil {
 		return time.Time{}, time.Time{}, err
 	}
-	loc, err := time.LoadLocation(zone)
+	loc, err := storekit.LoadZone(zone)
 	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("brief: the installation timezone %q does not resolve: %w", zone, err)
+		return time.Time{}, time.Time{}, err
 	}
 	return storekit.WorkspaceDay(now, loc), now.In(loc), nil
 }

--- a/backend/internal/compose/briefs/briefday.go
+++ b/backend/internal/compose/briefs/briefday.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 )
 
 // LocalDayAt is the calendar date the given instant falls on in the
@@ -44,8 +45,7 @@ func LocalDayAt(ctx context.Context, tx pgx.Tx, now time.Time) (day time.Time, l
 	if err != nil {
 		return time.Time{}, time.Time{}, fmt.Errorf("brief: the installation timezone %q does not resolve: %w", zone, err)
 	}
-	local = now.In(loc)
-	return time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, time.UTC), local, nil
+	return storekit.WorkspaceDay(now, loc), now.In(loc), nil
 }
 
 // localDay is LocalDayAt for the callers in this package, which need only the

--- a/backend/internal/compose/briefs/brieflineage.go
+++ b/backend/internal/compose/briefs/brieflineage.go
@@ -21,12 +21,12 @@ package briefs
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -61,9 +61,9 @@ func briefLineage(
 	if err != nil {
 		return nil, err
 	}
-	loc, err := time.LoadLocation(zone)
+	loc, err := storekit.LoadZone(zone)
 	if err != nil {
-		return nil, fmt.Errorf("brief: the installation timezone %q does not resolve: %w", zone, err)
+		return nil, err
 	}
 
 	// The most recent mark per deal, whatever it is — then lineage only when
@@ -112,9 +112,8 @@ func briefLineage(
 		if err := rows.Scan(&dealID, &dismissedAt, &returnedWith); err != nil {
 			return nil, err
 		}
-		local := dismissedAt.In(loc)
 		out[dealID] = dealLineage{
-			dismissedOn:  time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, time.UTC),
+			dismissedOn:  storekit.WorkspaceDay(dismissedAt, loc),
 			returnedWith: returnedWith,
 		}
 	}

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -108,6 +108,11 @@ type briefFacts struct {
 	// read needs. False is NOT "this rep's deals have no stakeholders": it
 	// floors the warmth factor for every deal, which reorders the queue.
 	seatsReadable bool
+	// today is the installation-zone calendar day the timing factor measures
+	// "days until expected close" from — the SAME day brief_run.local_day is
+	// stamped in, resolved once in the gather transaction so the score and the
+	// run it belongs to cannot disagree about which morning it is.
+	today time.Time
 }
 
 // gather reads one transaction's worth of ranking facts.
@@ -122,6 +127,13 @@ func (e *BriefEngine) gather(ctx context.Context, now time.Time, userID ids.UUID
 		// The rep's last brief view: the previous run's data cutoff. No
 		// previous run → the overnight window is all-time.
 		lastView, err := briefLastView(ctx, tx, userID)
+		if err != nil {
+			return err
+		}
+
+		// The installation-zone day the timing factor measures against,
+		// resolved in this transaction so it is the same day the run is stamped.
+		out.today, err = localDay(ctx, tx, now)
 		if err != nil {
 			return err
 		}
@@ -188,7 +200,7 @@ func (e *BriefEngine) Rank(ctx context.Context, now time.Time) (BriefRanking, er
 
 	scored := make([]BriefQueueItem, 0, len(order))
 	for _, dealID := range order {
-		item := briefScore(facts[dealID], revenueNorm, now)
+		item := briefScore(facts[dealID], revenueNorm, gathered.today)
 		// Attached AFTER scoring, never inside it. briefScore is a pure
 		// function of the ranking facts and is tested as one; lineage explains
 		// why a deal is in the queue and must not be able to change where it

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -110,8 +110,8 @@ type briefFacts struct {
 	seatsReadable bool
 	// today is the installation-zone calendar day the timing factor measures
 	// "days until expected close" from — the SAME day brief_run.local_day is
-	// stamped in, resolved once in the gather transaction so the score and the
-	// run it belongs to cannot disagree about which morning it is.
+	// stamped in, resolved once in the gather transaction so the score reads the
+	// morning the run belongs to.
 	today time.Time
 }
 

--- a/backend/internal/compose/briefs/briefrank_test.go
+++ b/backend/internal/compose/briefs/briefrank_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// briefTestClock is the fixed evaluation instant of every fold below.
-var briefTestClock = time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+// briefTestClock is the fixed evaluation DAY every fold scores against — the
+// installation-zone calendar day Rank resolves and hands the scorer, at UTC
+// midnight the way localDay returns it.
+var briefTestClock = time.Date(2026, 6, 4, 0, 0, 0, 0, time.UTC)
 
 func datePtr(t time.Time) *time.Time { return &t }
 

--- a/backend/internal/compose/briefs/briefscore.go
+++ b/backend/internal/compose/briefs/briefscore.go
@@ -122,11 +122,11 @@ type briefDealFacts struct {
 // I/O. Every factor that lacks evidence sits at its floor by
 // construction — momentum is 1.0 only over overnight rows, warmth only
 // over §4 contributing interactions, revenue only over a real base value.
-func briefScore(f briefDealFacts, revenueNormMinor int64, now time.Time) BriefQueueItem {
+func briefScore(f briefDealFacts, revenueNormMinor int64, today time.Time) BriefQueueItem {
 	features := BriefFeatureVector{
 		Winnability: float64(f.winProbability) / 100,
 		Revenue:     briefRevenueScore(f.baseValueMinor, revenueNormMinor),
-		Timing:      briefTimingScore(f.expectedClose, now),
+		Timing:      briefTimingScore(f.expectedClose, today),
 		Momentum:    briefMomentumUnchanged,
 		Warmth:      float64(f.warmthStrength) / 100,
 	}
@@ -169,14 +169,19 @@ func briefRevenueScore(baseValueMinor *int64, revenueNormMinor int64) float64 {
 	return math.Min(1.0, float64(*baseValueMinor)/float64(revenueNormMinor))
 }
 
-// briefTimingScore buckets whole calendar days until the expected close
-// (UTC dates, like the column's date type): overdue is urgent, this week
-// is hottest, and no date at all reads as the mild-uncertainty midpoint.
-func briefTimingScore(expectedClose *time.Time, now time.Time) float64 {
+// briefTimingScore buckets whole calendar days until the expected close:
+// overdue is urgent, this week is hottest, and no date at all reads as the
+// mild-uncertainty midpoint.
+//
+// today is the installation-zone calendar day the caller resolved (Rank, via
+// localDay), not a UTC truncation: a rep east of UTC in her local evening would
+// otherwise read a day behind and see every close a day less urgent than it is.
+// expectedClose is the deal's own date column, already a calendar date, so the
+// two subtract as whole days.
+func briefTimingScore(expectedClose *time.Time, today time.Time) float64 {
 	if expectedClose == nil {
 		return 0.3
 	}
-	today := now.UTC().Truncate(24 * time.Hour)
 	d := expectedClose.Sub(today).Hours() / 24
 	switch {
 	case d < 0:

--- a/backend/internal/compose/handlersets.go
+++ b/backend/internal/compose/handlersets.go
@@ -171,7 +171,7 @@ func (s *Server) wireProject360(pool *pgxpool.Pool) {
 		deals.NewStore(InstallationDB(pool), DealsInstallation()).WithFieldCatalog(customfields.NewService(pool, nil)),
 		ProjectsStore(pool),
 		s.peopleStore,
-		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)),
+		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool), ContractTimezone()),
 		activities.NewStore(InstallationDB(pool)),
 		time.Now,
 	)

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -184,7 +184,8 @@ func ContractsStore(db *database.DB, dealStore *deals.Store) *contracts.Store {
 	return contracts.NewStore(db,
 		func(ctx context.Context, tx pgx.Tx, currency string, asOf time.Time) (string, time.Time, error) {
 			return dealStore.FreezeRateAt(ctx, tx, currency, asOf)
-		})
+		},
+		identity.TimezoneAppliedTx)
 }
 
 // SchemaPool opens the owner-privileged schema-change pool the

--- a/backend/internal/compose/integration/installationseam_integration_test.go
+++ b/backend/internal/compose/integration/installationseam_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/margince/margince/backend/internal/modules/contracts"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -130,6 +131,37 @@ func TestTodayIsComputedInTheZoneTheSettingNames(t *testing.T) {
 	}); err == nil {
 		t.Fatal("the close-date check resolved a today with an unresolvable zone stored; " +
 			"it is still reading workspace.timezone")
+	} else if !strings.Contains(err.Error(), "Margince/Nowhere") {
+		t.Errorf("the failure should name the zone it tried, got %v", err)
+	}
+}
+
+// A CONTRACT's under-contract "today" is computed in the same zone, by the same
+// technique. Under the old spelling it truncated the store clock in UTC and
+// never consulted the setting, so this create would succeed whatever the zone —
+// the unresolvable zone is what proves the reader now reads it, and the
+// installation_settings gate is not in the way (the admin here does hold it, but
+// the seam reads ungated so a contract writer holding only `contract` also can).
+func TestAContractsTodayIsComputedInTheZoneTheSettingNames(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+	e.WsExec(t, `UPDATE setting SET value = '"Margince/Nowhere"'::jsonb WHERE key = 'installation.timezone'`)
+
+	org := ids.NewV7()
+	e.WsExec(t, `INSERT INTO organization (id, owner_id, display_name, source, captured_by)
+		VALUES ($1, $2, 'Anchor GmbH', 'manual', 'human:x')`, org, e.AdminUser)
+
+	starts := time.Date(2026, time.January, 5, 0, 0, 0, 0, time.UTC)
+	_, err := ContractsStore(e.DB(), e.Deals).CreateContract(admin, contracts.CreateContractInput{
+		OrganizationID: ids.From[ids.OrganizationKind](org),
+		Title:          "Framework agreement",
+		StartsOn:       &starts,
+		ValueBasis:     "total",
+		Source:         "manual",
+	})
+	if err == nil {
+		t.Fatal("the under-contract today resolved with an unresolvable zone stored; " +
+			"the contract store is not reading the installation timezone")
 	} else if !strings.Contains(err.Error(), "Margince/Nowhere") {
 		t.Errorf("the failure should name the zone it tried, got %v", err)
 	}

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -217,7 +217,11 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// the attachment count above and for the same reason. Flat in the size of
 	// the account — twenty emails and two cost the one statement — which is
 	// the property this budget protects rather than the absolute number.
-	const budget = 46
+	// 47 since the under-contract strip judges "active today" on the
+	// installation's calendar day rather than UTC's (#3266): one read of the
+	// installation timezone, flat in the size of the account — the same one
+	// statement whether the account holds two contracts or two hundred.
+	const budget = 47
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}

--- a/backend/internal/compose/org360/contracts.go
+++ b/backend/internal/compose/org360/contracts.go
@@ -20,6 +20,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/margince/margince/backend/internal/modules/contracts"
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -55,11 +56,21 @@ func readContractStrip(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	orgPos := arg(orgID)
-	// The as-of is the DATE, not the instant. The columns are dates, and an
-	// aggregate evaluated at a timestamp drops a contract ending today the
-	// moment midnight passes while the contract's own read still calls it
-	// active all day — two surfaces disagreeing about the same row.
-	asOfPos := arg(asOf.UTC().Truncate(24 * time.Hour))
+	// The as-of is the DATE, not the instant, and derived in the installation's
+	// zone — the SAME day the contracts module's single read computes. The
+	// columns are dates, and an aggregate evaluated at a timestamp drops a
+	// contract ending today the moment UTC midnight passes while the contract's
+	// own read still calls it active all local day — two surfaces disagreeing
+	// about the same row.
+	tzName, err := identity.TimezoneAppliedTx(ctx, tx)
+	if err != nil {
+		return contractStrip{}, fmt.Errorf("resolve the installation's timezone: %w", err)
+	}
+	loc, err := time.LoadLocation(tzName)
+	if err != nil {
+		return contractStrip{}, fmt.Errorf("the installation's timezone %q: %w", tzName, err)
+	}
+	asOfPos := arg(storekit.WorkspaceDay(asOf, loc))
 
 	// The SAME predicate the contracts module applies to a single read. An
 	// aggregate that skipped it would leak through its total: a reader who

--- a/backend/internal/compose/org360/contracts.go
+++ b/backend/internal/compose/org360/contracts.go
@@ -66,9 +66,9 @@ func readContractStrip(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
 	if err != nil {
 		return contractStrip{}, fmt.Errorf("resolve the installation's timezone: %w", err)
 	}
-	loc, err := time.LoadLocation(tzName)
+	loc, err := storekit.LoadZone(tzName)
 	if err != nil {
-		return contractStrip{}, fmt.Errorf("the installation's timezone %q: %w", tzName, err)
+		return contractStrip{}, err
 	}
 	asOfPos := arg(storekit.WorkspaceDay(asOf, loc))
 
@@ -99,6 +99,14 @@ func readContractStrip(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID,
 	}
 	defer rows.Close()
 
+	return scanContractStrip(rows, baseCcy)
+}
+
+// scanContractStrip folds the active-contract rows into the strip: it counts
+// every agreement, tracks the nearest renewal and any pending cancellation, and
+// sums the ones it can price by basis (a row it cannot convert is counted but
+// not summed, so the two figures stay honest about what they cover).
+func scanContractStrip(rows pgx.Rows, baseCcy string) (contractStrip, error) {
 	strip := contractStrip{baseCurrency: baseCcy}
 	var totalBasis, annualized int64
 	var haveTotal, haveAnnualized bool

--- a/backend/internal/compose/project360seam.go
+++ b/backend/internal/compose/project360seam.go
@@ -33,7 +33,7 @@ func project360Reader(pool *pgxpool.Pool) agents.Project360Reader {
 		deals.NewStore(InstallationDB(pool), DealsInstallation()).WithFieldCatalog(catalog),
 		ProjectsStore(pool),
 		people.NewStore(InstallationDB(pool)).WithFieldCatalog(catalog),
-		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)),
+		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool), ContractTimezone()),
 		activities.NewStore(InstallationDB(pool)),
 		clockNow,
 	)

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -80,7 +80,7 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 		BaseURL: httpserver.BaseURL,
 		Middlewares: []crmcontracts.MiddlewareFunc{
 			agentGate(registry, staging, provider, provider, fieldOwnership{pool: pool}, importsFor(&srv), tagSeam(pool), gate),
-			idempotency(pool, replayProbes(staging.svc, contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)), dealrooms.NewStore(InstallationDB(pool)))),
+			idempotency(pool, replayProbes(staging.svc, contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool), ContractTimezone()), dealrooms.NewStore(InstallationDB(pool)))),
 			// Outermost: an overlay-mode SoR write is refused before it can
 			// be recorded under an idempotency key or staged as an agent
 			// approval — the honest unsupported_by_sor, for every principal.

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -133,7 +133,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		peopleHandlers:      newPeopleHandlers(pool).WithUploadLimit(limits.LinkedInImport),
 		dealsHandlers:       dealsH,
 		projectsHandlers:    projects.HandlersOver(ProjectsStore(pool)),
-		contractsHandlers:   contracts.NewHandlers(InstallationDB(pool), ContractFreezeRate(pool)),
+		contractsHandlers:   contracts.NewHandlers(InstallationDB(pool), ContractFreezeRate(pool), ContractTimezone()),
 		dealroomsHandlers:   dealrooms.NewHandlers(InstallationDB(pool)),
 		commissionsHandlers: commissions.NewHandlers(InstallationDB(pool)),
 		activitiesHandlers:  newActivitiesHandlers(pool).WithUploadLimit(limits.Attachment),

--- a/backend/internal/compose/settingswiring.go
+++ b/backend/internal/compose/settingswiring.go
@@ -19,6 +19,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/modules/contracts"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/integrations"
@@ -149,3 +150,12 @@ func yamlPaths(t reflect.Type, prefix string) map[string]bool {
 // The wiring itself lives in installseam, which the integration harness can
 // also reach; this stays as the name compose's own call sites use.
 func DealsInstallation() deals.Installation { return installseam.Deals() }
+
+// ContractTimezone is the installation timezone seam the contracts module reads
+// its calendar "today" through — the SAME setting deals resolves, so a contract
+// and a deal cannot disagree about which day it is.
+//
+// The UNGATED reader: deriving "today" is internal to a write the caller is
+// already authorized for, and a contract writer holds `contract`, not
+// `installation_settings` (identity.TimezoneAppliedTx says why).
+func ContractTimezone() contracts.TimezoneFunc { return identity.TimezoneAppliedTx }

--- a/backend/internal/compose/settingswiring.go
+++ b/backend/internal/compose/settingswiring.go
@@ -153,7 +153,7 @@ func DealsInstallation() deals.Installation { return installseam.Deals() }
 
 // ContractTimezone is the installation timezone seam the contracts module reads
 // its calendar "today" through — the SAME setting deals resolves, so a contract
-// and a deal cannot disagree about which day it is.
+// and a deal read one installation day.
 //
 // The UNGATED reader: deriving "today" is internal to a write the caller is
 // already authorized for, and a contract writer holds `contract`, not

--- a/backend/internal/modules/contracts/contract_lifecycle.go
+++ b/backend/internal/modules/contracts/contract_lifecycle.go
@@ -210,7 +210,9 @@ func (s *Store) freezeRateForActivation(ctx context.Context, tx pgx.Tx,
 	if existing.FxRateToBase != nil {
 		return nil, nil
 	}
-	rate, on, err := s.freezeRate(ctx, tx, *existing.Currency, s.today())
+	// The clock, not s.today(): the seam resolves the calendar day in the
+	// installation's zone, and a day truncated here would be UTC's.
+	rate, on, err := s.freezeRate(ctx, tx, *existing.Currency, s.clock())
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/modules/contracts/contract_lifecycle.go
+++ b/backend/internal/modules/contracts/contract_lifecycle.go
@@ -87,7 +87,11 @@ func (s *Store) ChangeStatus(ctx context.Context, id ids.ContractID, to string, 
 
 	var out crmcontracts.Contract
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		existing, err := writableContract(ctx, tx, id, s.today())
+		today, err := s.today(ctx, tx)
+		if err != nil {
+			return err
+		}
+		existing, err := writableContract(ctx, tx, id, today)
 		if err != nil {
 			return err
 		}
@@ -98,7 +102,7 @@ func (s *Store) ChangeStatus(ctx context.Context, id ids.ContractID, to string, 
 		if err != nil {
 			return err
 		}
-		out, err = applyStatusTx(ctx, tx, id, existing, to, nil, ifVersion, s.today(), frozen)
+		out, err = applyStatusTx(ctx, tx, id, existing, to, nil, ifVersion, today, frozen)
 		return err
 	})
 	return out, err
@@ -230,7 +234,11 @@ func (s *Store) Cancel(ctx context.Context, id ids.ContractID, noticeOn, effecti
 
 	var out crmcontracts.Contract
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		existing, err := writableContract(ctx, tx, id, s.today())
+		today, err := s.today(ctx, tx)
+		if err != nil {
+			return err
+		}
+		existing, err := writableContract(ctx, tx, id, today)
 		if err != nil {
 			return err
 		}
@@ -244,7 +252,7 @@ func (s *Store) Cancel(ctx context.Context, id ids.ContractID, noticeOn, effecti
 		if err := applyContractUpdate(ctx, tx, id, patch, ifVersion, "contract cancellation"); err != nil {
 			return err
 		}
-		out, err = readContractForCaller(ctx, tx, id, s.today())
+		out, err = readContractForCaller(ctx, tx, id, today)
 		return err
 	})
 	return out, err
@@ -268,7 +276,11 @@ func (s *Store) Renew(ctx context.Context, id ids.ContractID, successor CreateCo
 
 	var out crmcontracts.Contract
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		predecessor, err := writableContract(ctx, tx, id, s.today())
+		today, err := s.today(ctx, tx)
+		if err != nil {
+			return err
+		}
+		predecessor, err := writableContract(ctx, tx, id, today)
 		if err != nil {
 			return err
 		}
@@ -284,12 +296,12 @@ func (s *Store) Renew(ctx context.Context, id ids.ContractID, successor CreateCo
 		}
 		successor.OrganizationID = ids.OrganizationID{UUID: anchor}
 
-		created, err := createContractTx(ctx, tx, successor, by, s.today())
+		created, err := createContractTx(ctx, tx, successor, by, today)
 		if err != nil {
 			return err
 		}
 		successorID := ids.ContractID{UUID: ids.UUID(created.Id)}
-		if _, err := applyStatusTx(ctx, tx, id, predecessor, StatusSuperseded, &successorID, ifVersion, s.today(), nil); err != nil {
+		if _, err := applyStatusTx(ctx, tx, id, predecessor, StatusSuperseded, &successorID, ifVersion, today, nil); err != nil {
 			return err
 		}
 		out = created

--- a/backend/internal/modules/contracts/contract_list.go
+++ b/backend/internal/modules/contracts/contract_list.go
@@ -47,8 +47,11 @@ func (s *Store) ListOrganizationContracts(ctx context.Context, in ListContractsI
 		if err := auth.EnsureLinkTarget(ctx, tx, organizationTable, in.OrganizationID.UUID); err != nil {
 			return err
 		}
-		var err error
-		out, err = listContractsTx(ctx, tx, in, s.today())
+		today, err := s.today(ctx, tx)
+		if err != nil {
+			return err
+		}
+		out, err = listContractsTx(ctx, tx, in, today)
 		return err
 	})
 	return out, err
@@ -144,9 +147,13 @@ func (s *Store) ListProjectContractsTx(ctx context.Context, tx pgx.Tx, projectID
 	if err := auth.EnsureLinkTarget(ctx, tx, projectTable, projectID.UUID); err != nil {
 		return crmcontracts.ContractListResponse{}, err
 	}
+	today, err := s.today(ctx, tx)
+	if err != nil {
+		return crmcontracts.ContractListResponse{}, err
+	}
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
-	asOfPos := arg(s.today())
+	asOfPos := arg(today)
 	where := []string{storekit.SQLf("project_id = $%d", arg(projectID)), "archived_at IS NULL"}
 	scope, err := VisibleClause(ctx, "", arg)
 	if err != nil {

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -56,8 +56,11 @@ func (s *Store) CreateContract(ctx context.Context, in CreateContractInput) (crm
 
 	var out crmcontracts.Contract
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		var err error
-		out, err = createContractTx(ctx, tx, in, by, s.today())
+		today, err := s.today(ctx, tx)
+		if err != nil {
+			return err
+		}
+		out, err = createContractTx(ctx, tx, in, by, today)
 		return err
 	})
 	return out, err
@@ -129,9 +132,13 @@ func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcon
 
 	var out crmcontracts.Contract
 	err := s.tx(ctx, func(tx pgx.Tx) error {
+		today, err := s.today(ctx, tx)
+		if err != nil {
+			return err
+		}
 		// The patch is a write, so the row must first be visible as a read —
 		// otherwise a caller learns a contract exists by patching it.
-		existing, err := writableContract(ctx, tx, id, s.today())
+		existing, err := writableContract(ctx, tx, id, today)
 		if err != nil {
 			return err
 		}
@@ -161,7 +168,7 @@ func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcon
 		if err := applyContractUpdate(ctx, tx, id, patch, ifVersion, "contract update"); err != nil {
 			return err
 		}
-		out, err = readContractForCaller(ctx, tx, id, s.today())
+		out, err = readContractForCaller(ctx, tx, id, today)
 		return err
 	})
 	return out, err
@@ -211,7 +218,11 @@ func (s *Store) ArchiveContract(ctx context.Context, id ids.ContractID) error {
 		return err
 	}
 	return s.tx(ctx, func(tx pgx.Tx) error {
-		existing, err := writableContract(ctx, tx, id, s.today())
+		today, err := s.today(ctx, tx)
+		if err != nil {
+			return err
+		}
+		existing, err := writableContract(ctx, tx, id, today)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/contracts/handlers.go
+++ b/backend/internal/modules/contracts/handlers.go
@@ -24,8 +24,8 @@ type Handlers struct {
 }
 
 // NewHandlers builds the contract handler set.
-func NewHandlers(db *database.DB, freezeRate FreezeRateFunc) Handlers {
-	return Handlers{store: NewStore(db, freezeRate)}
+func NewHandlers(db *database.DB, freezeRate FreezeRateFunc, timezone TimezoneFunc) Handlers {
+	return Handlers{store: NewStore(db, freezeRate, timezone)}
 }
 
 // pathID converts a contract path parameter into its typed id.

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -90,9 +90,12 @@ type Store struct {
 }
 
 // FreezeRateFunc answers what one currency converts to the installation's base
-// at, as of a day, inside a transaction the caller already holds. It reports
-// the rate and the day it is the rate FOR, which are two facts: the rate a
-// contract froze and the date that rate was published on.
+// at, as of an INSTANT, inside a transaction the caller already holds. The
+// calendar day the rate is looked up against is that instant read in the
+// installation's zone — resolved by the seam, because a contract does not know
+// the zone and must not compute the day in UTC. It reports the rate and the day
+// it is the rate FOR, which are two facts: the rate a contract froze and the
+// date that rate was published on.
 type FreezeRateFunc func(ctx context.Context, tx pgx.Tx, currency string, asOf time.Time) (string, time.Time, error)
 
 // NewStore builds the contract store.

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -130,9 +130,9 @@ func (s *Store) today(ctx context.Context, tx pgx.Tx) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("resolve the installation's timezone: %w", err)
 	}
-	loc, err := time.LoadLocation(tzName)
+	loc, err := storekit.LoadZone(tzName)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("the installation's timezone %q: %w", tzName, err)
+		return time.Time{}, err
 	}
 	return storekit.WorkspaceDay(s.clock(), loc), nil
 }

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -87,7 +87,20 @@ type Store struct {
 	// contract by its frozen rate, so a NULL one is a contract the guard
 	// cannot see and an installation can restate underneath.
 	freezeRate FreezeRateFunc
+	// timezone resolves the IANA zone the store's "today" is computed in, read
+	// from the installation inside the caller's tx. REQUIRED, and injected for
+	// the reason freezeRate is: the zone is a setting another module owns, and
+	// contracts takes a seam rather than that module. Without it, the
+	// under-contract reading would judge a date column against UTC's midnight
+	// rather than the installation's, so a contract's first and last day would
+	// begin hours early or late for anyone not on UTC.
+	timezone TimezoneFunc
 }
+
+// TimezoneFunc answers the installation's IANA timezone name inside a
+// transaction the caller already holds — the zone a calendar "today" is derived
+// in. Bound in the composition root to the setting the identity module owns.
+type TimezoneFunc func(ctx context.Context, tx pgx.Tx) (string, error)
 
 // FreezeRateFunc answers what one currency converts to the installation's base
 // at, as of an INSTANT, inside a transaction the caller already holds. The
@@ -99,17 +112,29 @@ type Store struct {
 type FreezeRateFunc func(ctx context.Context, tx pgx.Tx, currency string, asOf time.Time) (string, time.Time, error)
 
 // NewStore builds the contract store.
-func NewStore(db *database.DB, freezeRate FreezeRateFunc) *Store {
-	return &Store{db: db, clock: time.Now, freezeRate: freezeRate}
+func NewStore(db *database.DB, freezeRate FreezeRateFunc, timezone TimezoneFunc) *Store {
+	return &Store{db: db, clock: time.Now, freezeRate: freezeRate, timezone: timezone}
 }
 
 func (s *Store) tx(ctx context.Context, fn func(pgx.Tx) error) error {
 	return s.db.Tx(ctx, fn)
 }
 
-// today is the date the derived reading is computed against.
-func (s *Store) today() time.Time {
-	return s.clock().UTC().Truncate(24 * time.Hour)
+// today is the calendar day the under-contract reading is computed against, in
+// the installation's zone rather than UTC: a contract's start and end are DATE
+// columns, and "in force today" has to mean the reader's today, not a boundary
+// hours away. The clock is injected so a date-boundary test stays deterministic;
+// the zone is read inside the caller's tx.
+func (s *Store) today(ctx context.Context, tx pgx.Tx) (time.Time, error) {
+	tzName, err := s.timezone(ctx, tx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("resolve the installation's timezone: %w", err)
+	}
+	loc, err := time.LoadLocation(tzName)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("the installation's timezone %q: %w", tzName, err)
+	}
+	return storekit.WorkspaceDay(s.clock(), loc), nil
 }
 
 // contractColumns is the select list every read shares, in the order
@@ -226,8 +251,11 @@ func (s *Store) GetContract(ctx context.Context, id ids.ContractID) (crmcontract
 	}
 	var out crmcontracts.Contract
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		var err error
-		out, err = readContractForCaller(ctx, tx, id, s.today())
+		today, err := s.today(ctx, tx)
+		if err != nil {
+			return err
+		}
+		out, err = readContractForCaller(ctx, tx, id, today)
 		return err
 	})
 	return out, err

--- a/backend/internal/modules/deals/basecurrencyfreezewrite.go
+++ b/backend/internal/modules/deals/basecurrencyfreezewrite.go
@@ -195,16 +195,30 @@ func (s *Store) freezeBaseRate(ctx context.Context, tx pgx.Tx, p *storekit.Patch
 
 // freezeFx resolves the frozen currency→base conversion for a closed
 // deal: the latest fx_rate on or before asOf. Used at close (asOf = now)
-// and when a closed deal is re-priced (asOf = its close date), so the
+// and when a closed deal is re-priced (asOf = its close instant), so the
 // frozen rate always reflects the deal's close, never the edit.
+//
+// asOf is an INSTANT — a close moment or the clock — and the calendar day it
+// freezes against is that instant read in the installation's zone, not UTC: an
+// installation ahead of UTC closing in its local morning would otherwise freeze
+// the previous day's rate, and a frozen rate is a business and audit fact that
+// is never recomputed. The day is derived HERE, so every caller passes a raw
+// instant rather than a second spelling of "which day".
 func (s *Store) freezeFx(ctx context.Context, tx pgx.Tx,
 	base, currency string, asOf time.Time,
 ) (string, time.Time, error) {
-	asOfDate := asOf.UTC().Truncate(24 * time.Hour)
+	tzName, err := s.installation.Timezone(ctx, tx)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("resolve the installation's timezone: %w", err)
+	}
+	loc, err := installationZone(tzName)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	asOfDate := storekit.WorkspaceDay(asOf, loc)
 	if currency == base {
 		return "1", asOfDate, nil
 	}
-	var err error
 	var rate string
 	err = tx.QueryRow(ctx,
 		`SELECT rate::text FROM fx_rate

--- a/backend/internal/modules/deals/closedatesweep.go
+++ b/backend/internal/modules/deals/closedatesweep.go
@@ -147,8 +147,7 @@ func (c *CloseDateCorrector) sweepWorkspace(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		asOf := now.In(loc)
-		asOf = time.Date(asOf.Year(), asOf.Month(), asOf.Day(), 0, 0, 0, 0, time.UTC)
+		asOf := storekit.WorkspaceDay(now, loc)
 
 		// A pass already open for this local day is resumed, not duplicated:
 		// the retry after a worker deadline is the same pass continuing. No

--- a/backend/internal/modules/deals/dealfigures.go
+++ b/backend/internal/modules/deals/dealfigures.go
@@ -205,10 +205,10 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 // (closedatesweep.go's nightly pass, this file's batched overdue read).
 // Split from the Timezone fetch itself: closedatesweep.go still needs the
 // raw name on its own, to bind into the same transaction's pre-filter query.
+//
+// The load-and-wrap is storekit.LoadZone, the same one contracts and the org360
+// strip resolve their day's zone through, so an unresolvable zone reads alike
+// wherever a day is derived.
 func installationZone(tzName string) (*time.Location, error) {
-	loc, err := time.LoadLocation(tzName)
-	if err != nil {
-		return nil, fmt.Errorf("the installation's timezone %q: %w", tzName, err)
-	}
-	return loc, nil
+	return storekit.LoadZone(tzName)
 }

--- a/backend/internal/modules/deals/fxrate_store.go
+++ b/backend/internal/modules/deals/fxrate_store.go
@@ -30,10 +30,10 @@ type FxRateRow struct {
 	RateDate     time.Time
 }
 
-// SetFxRateInput sets one effective-dated rate. EffectiveDate is the UTC
-// day the rate takes effect; it may be today or later, never the past
-// (strict append-forward — a past-dated row prices historical rollups and
-// must never change).
+// SetFxRateInput sets one effective-dated rate. EffectiveDate is the calendar
+// day the rate takes effect, read in the installation's zone; it may be today
+// or later, never the past (strict append-forward — a past-dated row prices
+// historical rollups and must never change).
 type SetFxRateInput struct {
 	FromCurrency  string
 	Rate          string
@@ -59,12 +59,26 @@ func fxInvalid(field, code, message string) error {
 	return &FxRateValidationError{Field: field, Code: code, Message: message}
 }
 
-func (s *Store) todayUTC() time.Time {
-	return s.clock().UTC().Truncate(24 * time.Hour)
+// effectiveToday is the calendar day the sheet's append-forward guard and "in
+// force today" cutoff are judged against, in the installation's zone rather than
+// UTC: an operator east of UTC scheduling a rate in their local morning must not
+// have it read as yesterday's. The store clock is sampled inside the caller's
+// transaction, so a write that waited for the pool across the local day boundary
+// judges the day it commits.
+func (s *Store) effectiveToday(ctx context.Context, tx pgx.Tx) (time.Time, error) {
+	tzName, err := s.installation.Timezone(ctx, tx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("resolve the installation's timezone: %w", err)
+	}
+	loc, err := installationZone(tzName)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return storekit.WorkspaceDay(s.clock(), loc), nil
 }
 
-// SetFxRate appends (or corrects, same UTC day) one effective-dated FX
-// rate. Admin/ops-gated; append-forward (rejects a past effective date);
+// SetFxRate appends (or corrects, same installation-zone day) one effective-
+// dated FX rate. Admin/ops-gated; append-forward (rejects a past effective date);
 // resolves ToCurrency to the workspace base and rejects from == base.
 func (s *Store) SetFxRate(ctx context.Context, in SetFxRateInput) (FxRateRow, error) {
 	// RBAC + pure shape validation BEFORE acquiring a connection, so a denied
@@ -149,8 +163,8 @@ func fxRateImage(from, base, rate string, effDate time.Time) map[string]any {
 
 // writeFxRate does the transactional body: resolve and guard the effective day
 // against a clock sampled INSIDE the tx (so a write that waited for the pool
-// across UTC midnight is stored against the day it commits — append-forward
-// stays true at write time), resolve the workspace base, reject from == base,
+// across the installation's midnight is stored against the day it commits —
+// append-forward stays true at write time), resolve the workspace base, reject from == base,
 // require the grant the upsert turns out to need, then upsert the
 // append-forward row and audit — all in the caller-owned tx.
 func (s *Store) writeFxRate(ctx context.Context, tx pgx.Tx, from string, in SetFxRateInput) (FxRateRow, error) {
@@ -160,14 +174,18 @@ func (s *Store) writeFxRate(ctx context.Context, tx pgx.Tx, from string, in SetF
 	if err := storekit.LockWriteIdentity(ctx, tx, "fx_rate", from); err != nil {
 		return FxRateRow{}, err
 	}
-	today := s.todayUTC()
-	eff := in.EffectiveDate
-	if eff.IsZero() {
-		eff = today
+	today, err := s.effectiveToday(ctx, tx)
+	if err != nil {
+		return FxRateRow{}, err
 	}
-	// Persist the same UTC-truncated day the past-date guard checks, so a
-	// sub-day offset can never store a calendar date different from the validated one.
-	effDate := eff.UTC().Truncate(24 * time.Hour)
+	// The chosen effective date is a calendar day the operator named, taken as
+	// itself; only an unset date falls back to today (derived from the clock).
+	// Projecting a chosen date through the zone would slip it a day west of UTC —
+	// the off-by-one a calendar date must never take.
+	effDate := today
+	if !in.EffectiveDate.IsZero() {
+		effDate = storekit.AsDate(in.EffectiveDate)
+	}
 	if effDate.Before(today) {
 		return FxRateRow{}, fxInvalid("effective_date", "fx_rate_past", "effective_date cannot be in the past")
 	}
@@ -293,14 +311,18 @@ func (s *Store) ListEffectiveFxRates(ctx context.Context) ([]FxRateRow, error) {
 		if err != nil {
 			return err
 		}
-		// Sample "today" inside the transaction: a wait for a pooled
-		// connection across UTC midnight must not list yesterday's cutoff.
+		// Sample "today" inside the transaction: a wait for a pooled connection
+		// across the installation's midnight must not list yesterday's cutoff.
+		today, err := s.effectiveToday(ctx, tx)
+		if err != nil {
+			return err
+		}
 		r, err := tx.Query(ctx, `
 			SELECT DISTINCT ON (from_currency) from_currency, to_currency, rate::text, rate_date
 			FROM fx_rate
 			 WHERE rate_date <= $1
 			   AND to_currency = $2
-			ORDER BY from_currency, rate_date DESC`, s.todayUTC(), base)
+			ORDER BY from_currency, rate_date DESC`, today, base)
 		if err != nil {
 			return fmt.Errorf("list effective fx_rate: %w", err)
 		}
@@ -316,8 +338,8 @@ func (s *Store) ListEffectiveFxRates(ctx context.Context) ([]FxRateRow, error) {
 // must see the same state the apply writes into. It takes the currency's
 // write-identity lock (so no standalone write can commit between this read
 // and the dependent write) and returns the day it sampled: the caller pins
-// its write to that SAME day, so a transaction that crosses UTC midnight
-// fails the append-forward guard instead of overwriting the new day's
+// its write to that SAME day, so a transaction that crosses the installation's
+// midnight fails the append-forward guard instead of overwriting the new day's
 // scheduled row. found=false means no rate is in force, a materially
 // different answer from any value. Admin/ops read gate.
 func (s *Store) EffectiveFxRateInTx(ctx context.Context, tx pgx.Tx, fromCurrency string) (rate string, asOf time.Time, found bool, err error) {
@@ -328,7 +350,9 @@ func (s *Store) EffectiveFxRateInTx(ctx context.Context, tx pgx.Tx, fromCurrency
 	if err := storekit.LockWriteIdentity(ctx, tx, "fx_rate", from); err != nil {
 		return "", time.Time{}, false, err
 	}
-	asOf = s.todayUTC()
+	if asOf, err = s.effectiveToday(ctx, tx); err != nil {
+		return "", time.Time{}, false, err
+	}
 	err = tx.QueryRow(ctx, `
 		SELECT rate::text FROM fx_rate
 		WHERE from_currency = $1 AND rate_date <= $2

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -338,6 +338,20 @@ func TimezoneOf(ctx context.Context, tx pgx.Tx) (string, error) {
 	return settings.RequireTx(ctx, tx, Timezone)
 }
 
+// TimezoneAppliedTx resolves the installation's zone for an INTERNAL date
+// derivation — a "today" computed while executing an operation the caller is
+// already authorized for — WITHOUT the installation_settings.read gate.
+//
+// ApplyTx, not the gated TimezoneOf: deriving which calendar day it is is
+// infrastructure, not the settings-management surface the object gate protects.
+// A contract writer holds `contract`, not `installation_settings`, and the zone
+// is disclosed by every date it is ever shown anyway — WorkingHoursOf reads it
+// the same way for the same reason. An unset zone reads as the registered UTC
+// default rather than erroring, so a fresh installation still writes.
+func TimezoneAppliedTx(ctx context.Context, tx pgx.Tx) (string, error) {
+	return settings.ApplyTx(ctx, tx, Timezone)
+}
+
 // NameOf resolves the installation's display name inside a transaction the
 // caller already holds.
 //

--- a/backend/internal/platform/database/storekit/workspaceday.go
+++ b/backend/internal/platform/database/storekit/workspaceday.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+import "time"
+
+// Where a calendar day comes from, spelled once.
+//
+// An instant is zone-independent; the day it falls on is not. Truncating the
+// clock to 24 hours answers UTC's midnight wherever the installation is, which
+// puts a seat east of UTC on yesterday for its whole local morning and a seat
+// west of UTC on tomorrow for its whole local evening. Every "what day is it"
+// on a business surface — the day a rate takes effect, the day a contract is
+// judged against, the day a close is scored from — derives here instead, in the
+// installation's own zone, so a fourth caller cannot re-break the invariant by
+// reaching for Truncate again.
+
+// WorkspaceDay is the calendar day the instant falls on in loc, as a DATE:
+// the local year-month-day re-anchored at UTC midnight.
+//
+// A date, not an instant, because that is what a `date` column and a `::date`
+// bind read back unchanged. A value carrying the local wall time would bind as
+// a different day west of UTC — the exact off-by-one this helper exists to end.
+func WorkspaceDay(t time.Time, loc *time.Location) time.Time {
+	local := t.In(loc)
+	return time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// AsDate reduces a value to the calendar date it ALREADY names — its UTC
+// year-month-day at UTC midnight — projecting through no zone.
+//
+// The counterpart to WorkspaceDay, and not interchangeable with it. WorkspaceDay
+// answers "what day is this INSTANT, locally"; AsDate answers "normalise this
+// DATE the caller already chose". Passing a chosen date through WorkspaceDay
+// would slip it a day west of UTC — the off-by-one a calendar date must never
+// take. Use AsDate for an operator-selected effective date; use WorkspaceDay for
+// the clock.
+func AsDate(t time.Time) time.Time {
+	utc := t.UTC()
+	return time.Date(utc.Year(), utc.Month(), utc.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// StartOfNextDay is the first instant of the day after t's, in loc.
+//
+// NOT local midnight constructed directly, because in some zones it does not
+// exist. Havana and Santiago spring forward AT midnight, and Go normalises the
+// missing 00:00 BACKWARD — to 23:00 on the previous date, an hour before the day
+// this bounds has even begun. So the rule is asked directly: the first instant
+// whose local date is tomorrow's. Noon is the anchor because no zone shifts its
+// clock at midday, so "tomorrow" is never ambiguous, and the walk back from it
+// stops at the transition on the days there is one.
+func StartOfNextDay(t time.Time, loc *time.Location) time.Time {
+	local := t.In(loc)
+	noon := time.Date(local.Year(), local.Month(), local.Day(), 12, 0, 0, 0, loc).AddDate(0, 0, 1)
+	year, month, day := noon.Date()
+	if midnight := time.Date(year, month, day, 0, 0, 0, 0, loc); sameLocalDate(midnight, noon) {
+		return midnight
+	}
+	first := noon
+	for {
+		earlier := first.Add(-time.Minute)
+		if !sameLocalDate(earlier, noon) {
+			return first
+		}
+		first = earlier
+	}
+}
+
+// StartOfDay is the first instant of t's OWN calendar day, in loc.
+//
+// It is StartOfNextDay asked about yesterday rather than a second midnight walk:
+// that function's whole subtlety is the zones where local midnight does not
+// exist, and a midnight built here directly would be wrong on exactly those
+// mornings.
+func StartOfDay(t time.Time, loc *time.Location) time.Time {
+	return StartOfNextDay(t.In(loc).AddDate(0, 0, -1), loc)
+}
+
+// sameLocalDate compares two instants by the LOCAL calendar date they fall on.
+func sameLocalDate(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}

--- a/backend/internal/platform/database/storekit/workspaceday.go
+++ b/backend/internal/platform/database/storekit/workspaceday.go
@@ -3,7 +3,25 @@
 
 package storekit
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+// LoadZone resolves an IANA zone name to a *time.Location, wrapping the failure
+// with the name so an operator sees which zone did not resolve.
+//
+// The one place the installation's zone STRING becomes a location: WorkspaceDay
+// and the boundary helpers all take the *time.Location it returns, so every
+// module that derives a day loads the zone the same way and reports an
+// unresolvable one in the same words.
+func LoadZone(name string) (*time.Location, error) {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return nil, fmt.Errorf("the installation's timezone %q does not resolve: %w", name, err)
+	}
+	return loc, nil
+}
 
 // Where a calendar day comes from, spelled once.
 //

--- a/backend/internal/platform/database/storekit/workspaceday_test.go
+++ b/backend/internal/platform/database/storekit/workspaceday_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// The calendar day an instant falls on is the installation's, not UTC's: a seat
+// east of UTC closing at 01:30 local is on today, not yesterday.
+func TestWorkspaceDayTakesTheLocalDayEastOfUTC(t *testing.T) {
+	saigon, err := time.LoadLocation("Asia/Ho_Chi_Minh")
+	if err != nil {
+		t.Fatalf("load zone: %v", err)
+	}
+	// 18:30Z is 01:30 the next morning in a +7 zone.
+	instant := time.Date(2026, 3, 15, 18, 30, 0, 0, time.UTC)
+
+	day := storekit.WorkspaceDay(instant, saigon)
+
+	if y, m, d := day.Date(); y != 2026 || m != time.March || d != 16 {
+		t.Fatalf("workspace day = %04d-%02d-%02d, want 2026-03-16", y, m, d)
+	}
+}
+
+// And west of UTC the same instant is the previous day.
+func TestWorkspaceDayTakesTheLocalDayWestOfUTC(t *testing.T) {
+	newYork, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load zone: %v", err)
+	}
+	// 02:30Z is 22:30 the previous evening in New York (EDT, -4, in March).
+	instant := time.Date(2026, 3, 15, 2, 30, 0, 0, time.UTC)
+
+	day := storekit.WorkspaceDay(instant, newYork)
+
+	if y, m, d := day.Date(); y != 2026 || m != time.March || d != 14 {
+		t.Fatalf("workspace day = %04d-%02d-%02d, want 2026-03-14", y, m, d)
+	}
+}
+
+// The result is a DATE, not an instant: local Y-M-D re-anchored at UTC midnight,
+// which is the shape a `date` column or a `::date` bind reads back unchanged. A
+// value carrying the local wall time would bind as a different day west of UTC.
+func TestWorkspaceDayIsADateAtUTCMidnight(t *testing.T) {
+	saigon, err := time.LoadLocation("Asia/Ho_Chi_Minh")
+	if err != nil {
+		t.Fatalf("load zone: %v", err)
+	}
+	day := storekit.WorkspaceDay(time.Date(2026, 3, 15, 18, 30, 0, 0, time.UTC), saigon)
+
+	if loc := day.Location(); loc != time.UTC {
+		t.Fatalf("location = %v, want UTC", loc)
+	}
+	if h, m, s := day.Clock(); h != 0 || m != 0 || s != 0 {
+		t.Fatalf("clock = %02d:%02d:%02d, want 00:00:00", h, m, s)
+	}
+}
+
+// AsDate takes the calendar day a value ALREADY names — its own year-month-
+// day — and must not project through any zone. A date the admin chose as
+// 2026-03-16 stays the 16th, where WorkspaceDay of that same UTC-midnight instant
+// west of UTC would slip it to the 15th. Two different questions, two primitives.
+func TestAsDateKeepsTheChosenDayWithoutZoneShift(t *testing.T) {
+	chosen := time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC)
+
+	day := storekit.AsDate(chosen)
+
+	if y, m, d := day.Date(); y != 2026 || m != time.March || d != 16 {
+		t.Fatalf("plain date = %04d-%02d-%02d, want 2026-03-16", y, m, d)
+	}
+	if loc := day.Location(); loc != time.UTC {
+		t.Fatalf("location = %v, want UTC", loc)
+	}
+}
+
+// A value carrying a wall time is reduced to its date, so a sub-day offset can
+// never store a calendar day different from the one it names.
+func TestAsDateDropsTheTimeOfDay(t *testing.T) {
+	day := storekit.AsDate(time.Date(2026, 3, 16, 14, 30, 0, 0, time.UTC))
+
+	if h, m, s := day.Clock(); h != 0 || m != 0 || s != 0 {
+		t.Fatalf("clock = %02d:%02d:%02d, want 00:00:00", h, m, s)
+	}
+}
+
+// The day boundary is asked directly rather than truncated, because in some
+// zones local midnight does not exist. Havana springs forward AT midnight on
+// 2026-03-08, so that day's first instant is 01:00 local — Truncate/Add would
+// land an hour before the day it bounds has even begun.
+func TestStartOfNextDayIsExactWhereMidnightDoesNotExist(t *testing.T) {
+	havana, err := time.LoadLocation("America/Havana")
+	if err != nil {
+		t.Fatalf("load zone: %v", err)
+	}
+	// Noon on the 7th: unambiguous, and the next day is the one that skips 00:00.
+	asOf := time.Date(2026, 3, 7, 12, 0, 0, 0, havana)
+
+	start := storekit.StartOfNextDay(asOf, havana)
+
+	local := start.In(havana)
+	if y, m, d := local.Date(); y != 2026 || m != time.March || d != 8 {
+		t.Fatalf("start date = %04d-%02d-%02d, want 2026-03-08", y, m, d)
+	}
+	if h := local.Hour(); h != 1 {
+		t.Fatalf("start hour = %02d, want 01 (00:00 does not exist that day)", h)
+	}
+	// It is the FIRST such instant: a minute earlier is still the 7th.
+	if before := start.Add(-time.Minute).In(havana); before.Day() != 7 {
+		t.Fatalf("a minute before start fell on day %d, want the 7th", before.Day())
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -329,7 +329,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 | `writeliveness_test.go` | H2 | The LIVENESS obligation as a fitness function: a write that targets one standing row of a table which can be archived either REFUSES an archived row, DECLARES that it deliberately reaches one, or is ratified with a reason. |
 
-## Prohibition (53)
+## Prohibition (54)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -337,6 +337,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `arch_test.go` | H2 | Structural fitness functions (architecture/03 §1): these tests make the boundary rules mechanical, and they derive the package list from the tree instead of maintaining it by hand — a new package is enrolled the moment it exists (fitness function over point fix). |
 | `authzmetriclabels_test.go` | H2 | The outbound decision counter labels only closed vocabularies, and never the recipient. |
 | `backfillledgerlock_test.go` | H2 | A transaction that writes the backfill creation ledger locks the run row first. |
+| `calendarday_test.go` | H2 | A calendar day is one derivation, and this is the census that keeps it one. |
 | `capabilitypathlog_test.go` | H2 | A request path reaches a log line through capabilitypath.Redact, never raw. |
 | `commentnamedtests_test.go` | H1 | A test named in a comment exists. |
 | `connectoractor_test.go` | H1 | A connector's actor id is DERIVED from the work, never written down. |


### PR DESCRIPTION
## What this does

A calendar day was derived from `X.UTC().Truncate(24 * time.Hour)` at several sites — UTC's midnight wherever the installation runs — and the invariant had been re-broken three times by call-site discipline alone. This makes the derivation single-sourced and gated.

**The primitive.** `storekit.WorkspaceDay` (the local day of an instant), `storekit.AsDate` (the calendar date a value already names, no zone shift), and the DST-correct `StartOfNextDay`/`StartOfDay` are one home for turning an instant into a day in the installation's zone. `attention` delegates its day boundary to it rather than keeping a second copy of the spring-forward-at-midnight walk.

**Converted to the installation's zone:**
- **FX** — the `fx_rate` sheet's append-forward guard and "in force today" cutoff, and the rate a closing deal freezes (`deal.fx_rate_date`). The freeze seam now takes an instant and resolves the day, so a contract stops truncating its activation day in UTC. `closedatesweep` routes its inline derivation through the primitive.
- **Contracts** — the under-contract "today" (a real UTC-truncation bug: a contract's first/last day began hours early or late off-UTC), via a new timezone seam read **ungated** (deriving today is internal to a write the caller is already authorized for; a contract writer holds `contract`, not `installation_settings`).
- **org360** — the account state strip's active-contract as-of day, so the headline and a single contract read agree.
- **Morning brief** — the timing factor's "days until expected close" now measures from the installation-zone local day the run is stamped with.

**The gate.** `backend/gates/calendarday_test.go` is an AST census over `internal/` + `extensions/` that fails the moment a new `Truncate(24 * time.Hour)` appears outside `storekit`, with a corpus floor and a matcher self-test.

**Waived, by name with reasons** (a follow-up converts them): the AI `ai_model_rate` sheet + seed (needs an installation seam on `RateStore`), the open-pipeline rollup as-of (thread a zone into the clock helper), the renewal reminder (lockstep with a UTC-scanned DATE column in `candidates.go`), and the offline-ledger demo anchor (legitimately UTC forever).

Closes #3266. Closes #2673 (its surface — `feed.go`'s day boundary — now delegates to the primitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calendar-day derivation now lives in `storekit` and uses the installation's timezone instead of UTC midnight. This fixes off-by-one behavior for FX rates, contract dates and status, company360 active-contract state, and morning-brief scoring, and gives attention's day boundary one shared implementation.

**Changes**
- `WorkspaceDay`, `AsDate`, `StartOfDay`, `StartOfNextDay`, and `LoadZone` handle the conversion, including DST transitions and missing midnights.
- Contract and FX stores resolve the timezone inside their existing transactions; contracts read it ungated because deriving "today" is internal to an already-authorized write.
- The company360 strip adds one flat timezone query, raising its query budget from 47 to 48.
- Contract link validation moves to `contract_links.go` so `contract_write.go` stays under the file ceiling.
- Closes #3266 and #2673.

**Guardrails**
- An AST gate scans `internal/` and `extensions/` and fails on any new `Truncate(24 * time.Hour)` outside `storekit`, resolving aliased `time` imports and parenthesised operands; a corpus floor and matcher self-tests keep it from failing short.
- Five named UTC sites remain waived with documented reasons: four need seams or lockstep handling, and one is UTC by design.

<sup>Written for commit e6b303181887d831904d3fd181f3f499c54e93c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added timezone-aware calendar-day handling for contracts, deals, briefs, FX rates, and company views.
  - “Today,” contract status, renewals, due groups, scoring, and rate calculations now follow the installation’s configured timezone.
  - Added reliable day-boundary handling for daylight-saving and other timezone transitions.
  - Contract links now validate visibility and company consistency across supported record types.

- **Bug Fixes**
  - Corrected date-based filtering and calculations that could use the wrong UTC day.
  - Unconfigured timezones now fall back to UTC, while invalid settings report an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->