### PR TITLE
feat(rail): one website read is one line, not four (#2272)

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -37644,10 +37644,16 @@ components:
         Four names come from a durable carrier that owns its own occurrence and can say
         queued and running: the two scheduled kinds match a name in runner.Catalog(),
         `document_extract` is a reading of an attached document a human asked for, and
-        `site_read` is a deep read of a company's website — one occurrence for the whole crawl,
-        where the site tasks below are the individual model calls it makes. Every other
-        name is an api/ai-tasks.yaml task announced by the router on the task's own behalf —
+        `site_read` is a deep read of a company's website. Every other name is an
+        api/ai-tasks.yaml task announced by the router on the task's own behalf —
         settled when it appears, because the router learns of a call once the call is over.
+
+        `site_extract`, `site_fact_extract` and `site_triage` are RETIRED names: a website
+        read runs those three passes and is one occurrence of the read, so the passes report
+        none of their own. Nothing writes them any more. They stay in this list because it is
+        also what a caller may FILTER on, and rows written before they were retired are served
+        until the projection's retention window closes over them — narrowing the filter would
+        refuse a query that still has answers.
 
         Its own schema because the item that reports a kind and the query that asks for kinds
         must be ONE list — two copies of a vocabulary are two vocabularies as soon as somebody

--- a/backend/gates/aiactivitycatalogparity_test.go
+++ b/backend/gates/aiactivitycatalogparity_test.go
@@ -115,17 +115,43 @@ func producedKinds() []string {
 	return out
 }
 
+// namesRowsMayStillCarry is every task that USED to announce under its own name
+// and no longer does.
+//
+// Derived from the registry rather than listed, because the registry is where
+// the retirement is decided: a task moved to SourceNoOccurrence is one whose
+// work is now reported under the unit it serves. Its name stays valid on the
+// wire for two reasons, and both outlive the change — the projection serves
+// rows written before it until the retention window closes over them, and the
+// enum is also what a caller may FILTER on, so narrowing it would refuse a
+// query that still has answers.
+//
+// This is the one direction of the parity that must NOT fail on such a name.
+// The other direction is untouched: nothing here lets a name be announced.
+func namesRowsMayStillCarry() []string {
+	var out []string
+	for task, source := range ai.RailOwners() {
+		if source == ai.SourceNoOccurrence {
+			out = append(out, task)
+		}
+	}
+	return out
+}
+
 // The reverse: a kind nothing can produce is copy three locales carry, a line
 // no reader will see, and a promise the server cannot keep.
 func TestEveryContractKindHasSomethingThatProducesIt(t *testing.T) {
 	t.Parallel()
 	produced := producedKinds()
+	retired := namesRowsMayStillCarry()
 	for _, kind := range crmYAMLNamedEnum(t, "AiActivityKind") {
-		if !slices.Contains(produced, kind) {
-			t.Errorf("the contract declares kind %q and nothing announces it — either an emitter was "+
-				"removed and the enum kept its name, or the name is aspirational. Drop it, or point this "+
-				"gate at what produces it", kind)
+		if slices.Contains(produced, kind) || slices.Contains(retired, kind) {
+			continue
 		}
+		t.Errorf("the contract declares kind %q and nothing announces it — either an emitter was "+
+			"removed and the enum kept its name, or the name is aspirational. Drop it, point this "+
+			"gate at what produces it, or retire the task in ai.railOwners so the name is one rows "+
+			"may still carry rather than one nothing ever wrote", kind)
 	}
 }
 

--- a/backend/gates/aiactivitycatalogparity_test.go
+++ b/backend/gates/aiactivitycatalogparity_test.go
@@ -115,8 +115,8 @@ func producedKinds() []string {
 	return out
 }
 
-// namesRowsMayStillCarry is every task that USED to announce under its own name
-// and no longer does.
+// namesRowsMayStillCarry reads the registry for tasks that used to announce
+// under their own name and no longer do.
 //
 // Derived from the registry rather than listed, because the registry is where
 // the retirement is decided: a task moved to SourceNoOccurrence is one whose

--- a/backend/internal/compose/integration/aiactivity_router_integration_test.go
+++ b/backend/internal/compose/integration/aiactivity_router_integration_test.go
@@ -194,25 +194,28 @@ func TestARouterReportedTaskReachesTheProjection(t *testing.T) {
 	}
 }
 
-// One request's calls for one task are ONE line. Forty page reads under a
-// single job pass must not become forty rows on somebody's rail, and the second
-// call must WIN rather than be refused as a redelivery of the first — otherwise
-// a failure a retry has already corrected is reported forever.
+// One request's calls for one task are ONE line. A hundred candidates enriched
+// under a single job pass must not become a hundred rows on somebody's rail,
+// and the second call must WIN rather than be refused as a redelivery of the
+// first — otherwise a failure a retry has already corrected is reported forever.
+//
+// `enrich` is the example because it is the shape: one correlation id per job
+// pass, a call per candidate in series, and the router owns it.
 func TestOneRequestsCallsForOneTaskAreOneOccurrence(t *testing.T) {
 	f := newRouterFixture(t)
-	f.call(t, ai.TaskSiteFactExtract, func(c *ai.Call) { c.ErrorSentinel = "provider_unavailable" })
+	f.call(t, ai.TaskEnrich, func(c *ai.Call) { c.ErrorSentinel = "provider_unavailable" })
 	f.drain(t)
-	if got := f.row(t, ai.TaskSiteFactExtract); got.State != "failed" || got.Attempt != 1 {
+	if got := f.row(t, ai.TaskEnrich); got.State != "failed" || got.Attempt != 1 {
 		t.Fatalf("first call projected (%s, attempt %d), want (failed, attempt 1)", got.State, got.Attempt)
 	}
 
-	f.call(t, ai.TaskSiteFactExtract, nil)
+	f.call(t, ai.TaskEnrich, nil)
 	f.drain(t)
 
 	if n := f.env.WsCount(t, `SELECT count(*) FROM ai_task_run WHERE source = 'ai_router'`); n != 1 {
 		t.Errorf("ai_router occurrences = %d, want 1 — the two calls are one piece of work", n)
 	}
-	got := f.row(t, ai.TaskSiteFactExtract)
+	got := f.row(t, ai.TaskEnrich)
 	if got.Attempt != 2 {
 		t.Errorf("attempt = %d, want 2 — a second call under one key that reused attempt 1 would be refused by the projection's guard", got.Attempt)
 	}
@@ -392,7 +395,7 @@ func TestConcurrentCallsOfOneTaskAllReachTheProjection(t *testing.T) {
 			<-start
 			errs <- meter.Record(f.ctx, []ai.Call{{
 				LogicalCallID: ids.NewV7(), Attempt: 1, IsTerminal: true, Kind: "completion",
-				CorrelationID: &f.corr, Task: ai.TaskSiteFactExtract, Tier: ai.TierCheapCloud,
+				CorrelationID: &f.corr, Task: ai.TaskEnrich, Tier: ai.TierCheapCloud,
 				Provider: "anthropic", ModelID: "claude-cheap", ServedIdentitySource: "response",
 				// The last one to land wins the row, so every worker carries a
 				// distinguishable outcome rather than all of them agreeing.
@@ -432,7 +435,7 @@ func TestConcurrentCallsOfOneTaskAllReachTheProjection(t *testing.T) {
 	if n := f.env.WsCount(t, `SELECT count(*) FROM ai_task_run WHERE source = 'ai_router'`); n != 1 {
 		t.Errorf("ai_router occurrences = %d, want 1 — they are one piece of work", n)
 	}
-	if got := f.row(t, ai.TaskSiteFactExtract); got.Attempt != racingCalls {
+	if got := f.row(t, ai.TaskEnrich); got.Attempt != racingCalls {
 		t.Errorf("attempt = %d, want %d — an outcome was refused as a redelivery and lost", got.Attempt, racingCalls)
 	}
 }

--- a/backend/internal/compose/integration/aiactivity_siteread_integration_test.go
+++ b/backend/internal/compose/integration/aiactivity_siteread_integration_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/aiactivity"
 	"github.com/margince/margince/backend/internal/modules/people"
 	kevents "github.com/margince/margince/backend/internal/shared/kernel/events"
@@ -364,5 +365,44 @@ func TestARetryableFailureReclaimedIsALiveSecondAttempt(t *testing.T) {
 	if got.FinishedAt != nil || got.DegradeReason != nil || got.StaleAfter == nil {
 		t.Fatalf("the retry carried the failure with it: finished_at %v, reason %v, stale_after %v — want none, none, a lease",
 			got.FinishedAt, got.DegradeReason, got.StaleAfter)
+	}
+}
+
+// A read's own model calls announce nothing, so one read is ONE occurrence.
+//
+// The three passes a crawl runs used to be reported by the router, and the
+// router keys on correlation id plus task — a read's correlation id being its
+// own row id. So one thing a rep asked for once filed four lines: the dossier's,
+// and one per pass, at a grain nobody asked about. The passes are still TRACED;
+// what they no longer do is claim to be work of their own.
+func TestOneWebsiteReadIsOneOccurrenceWhateverItRunsInside(t *testing.T) {
+	f := newWebsiteReadFixture(t)
+	f.drain(t)
+
+	meter := ai.NewCallMeter(f.env.DB()).WithLogger(testLogger(t))
+	for _, task := range []ai.Task{ai.TaskSiteTriage, ai.TaskSiteExtract, ai.TaskSiteFactExtract} {
+		// Under the READ's own correlation, which is what compose binds for the
+		// crawl — the id the router would key each pass's occurrence on.
+		if err := meter.Record(f.worker, []ai.Call{{
+			LogicalCallID: ids.NewV7(), Attempt: 1, IsTerminal: true, Kind: "completion",
+			CorrelationID: &f.readID, Task: task, Tier: ai.TierCheapCloud,
+			Provider: "anthropic", ModelID: "claude-cheap",
+			ServedIdentitySource: "response", RequestFingerprint: "fp", LatencyMS: 900,
+		}}); err != nil {
+			t.Fatalf("recording the %s pass: %v", task, err)
+		}
+	}
+
+	if n := f.env.WsCount(t, `SELECT count(*) FROM ai_call`); n != 3 {
+		t.Fatalf("ai_call rows = %d, want 3 — the passes must still be TRACED, only unannounced", n)
+	}
+	if n := f.env.WsCount(t,
+		`SELECT count(*) FROM event_outbox
+		  WHERE envelope->>'type' = 'ai_task.state_changed'
+		    AND envelope->'payload'->>'source' = 'ai_router'`); n != 0 {
+		t.Errorf("the router staged %d announcements for passes inside a read that announces itself", n)
+	}
+	if n := f.env.WsCount(t, `SELECT count(*) FROM ai_task_run`); n != 1 {
+		t.Errorf("ai_task_run rows = %d, want 1 — a rep who clicked read this site is owed one line", n)
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17573,10 +17573,16 @@ type AiActivityItem struct {
 	// Four names come from a durable carrier that owns its own occurrence and can say
 	// queued and running: the two scheduled kinds match a name in runner.Catalog(),
 	// `document_extract` is a reading of an attached document a human asked for, and
-	// `site_read` is a deep read of a company's website — one occurrence for the whole crawl,
-	// where the site tasks below are the individual model calls it makes. Every other
-	// name is an api/ai-tasks.yaml task announced by the router on the task's own behalf —
+	// `site_read` is a deep read of a company's website. Every other name is an
+	// api/ai-tasks.yaml task announced by the router on the task's own behalf —
 	// settled when it appears, because the router learns of a call once the call is over.
+	//
+	// `site_extract`, `site_fact_extract` and `site_triage` are RETIRED names: a website
+	// read runs those three passes and is one occurrence of the read, so the passes report
+	// none of their own. Nothing writes them any more. They stay in this list because it is
+	// also what a caller may FILTER on, and rows written before they were retired are served
+	// until the projection's retention window closes over them — narrowing the filter would
+	// refuse a query that still has answers.
 	//
 	// Its own schema because the item that reports a kind and the query that asks for kinds
 	// must be ONE list — two copies of a vocabulary are two vocabularies as soon as somebody
@@ -17646,10 +17652,16 @@ type AiActivityItemState string
 // Four names come from a durable carrier that owns its own occurrence and can say
 // queued and running: the two scheduled kinds match a name in runner.Catalog(),
 // `document_extract` is a reading of an attached document a human asked for, and
-// `site_read` is a deep read of a company's website — one occurrence for the whole crawl,
-// where the site tasks below are the individual model calls it makes. Every other
-// name is an api/ai-tasks.yaml task announced by the router on the task's own behalf —
+// `site_read` is a deep read of a company's website. Every other name is an
+// api/ai-tasks.yaml task announced by the router on the task's own behalf —
 // settled when it appears, because the router learns of a call once the call is over.
+//
+// `site_extract`, `site_fact_extract` and `site_triage` are RETIRED names: a website
+// read runs those three passes and is one occurrence of the read, so the passes report
+// none of their own. Nothing writes them any more. They stay in this list because it is
+// also what a caller may FILTER on, and rows written before they were retired are served
+// until the projection's retention window closes over them — narrowing the filter would
+// refuse a query that still has answers.
 //
 // Its own schema because the item that reports a kind and the query that asks for kinds
 // must be ONE list — two copies of a vocabulary are two vocabularies as soon as somebody

--- a/backend/internal/modules/ai/railowner.go
+++ b/backend/internal/modules/ai/railowner.go
@@ -73,6 +73,12 @@ var railOwners = map[Task]string{
 
 	TaskEmbeddings: SourceNoOccurrence,
 
+	// The three passes of one website read. The read itself is a carrier and
+	// announces the occurrence; these run inside it.
+	TaskSiteTriage:      SourceNoOccurrence,
+	TaskSiteExtract:     SourceNoOccurrence,
+	TaskSiteFactExtract: SourceNoOccurrence,
+
 	// A planned task: nothing calls it yet, and when something does the call
 	// will be one interactive completion the router reports after the fact —
 	// there is no durable row to say queued and running for a read a human
@@ -98,9 +104,6 @@ var railOwners = map[Task]string{
 	TaskRateExtract:                   SourceRouter,
 	TaskSignalExtract:                 SourceRouter,
 	TaskStageEvidenceExtract:          SourceRouter,
-	TaskSiteExtract:                   SourceRouter,
-	TaskSiteFactExtract:               SourceRouter,
-	TaskSiteTriage:                    SourceRouter,
 	TaskSummarize:                     SourceRouter,
 	TaskTranscript:                    SourceRouter,
 	TaskVoiceBuild:                    SourceRouter,
@@ -113,7 +116,20 @@ var railOwners = map[Task]string{
 // to defend. A reason that is really an editorial preference ("no rep wants to
 // see it") belongs in the CLIENT, which decides what to draw — this map is only
 // for work that has no unit of its own to be an occurrence of.
+// siteReadPassesReason answers for all three passes of one website read,
+// because the reason is the same sentence about the same piece of work.
+const siteReadPassesReason = "a website read runs all three of these passes, and the READ is the " +
+	"occurrence: it is what a person asked for, it owns the row that is queued before any worker " +
+	"sees it, and it already announces itself. The router keys on correlation id plus task, and a " +
+	"read's correlation id is its own row id — so leaving these to the router files three more " +
+	"lines for one thing somebody asked for once, at a grain nobody asked about: a rep who clicked " +
+	"\"read this site\" has no use for the news that its triage pass finished."
+
 var railNoOccurrenceReasons = map[Task]string{
+	TaskSiteTriage:      siteReadPassesReason,
+	TaskSiteExtract:     siteReadPassesReason,
+	TaskSiteFactExtract: siteReadPassesReason,
+
 	TaskEmbeddings: "an embedding is a step inside another piece of work, never one of its own: " +
 		"every call happens in service of a search, an enrich or a reindex, and that is the " +
 		"occurrence. Reporting it separately would report one piece of work twice at two grains — " +

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -27517,10 +27517,16 @@ export interface components {
          *     Four names come from a durable carrier that owns its own occurrence and can say
          *     queued and running: the two scheduled kinds match a name in runner.Catalog(),
          *     `document_extract` is a reading of an attached document a human asked for, and
-         *     `site_read` is a deep read of a company's website — one occurrence for the whole crawl,
-         *     where the site tasks below are the individual model calls it makes. Every other
-         *     name is an api/ai-tasks.yaml task announced by the router on the task's own behalf —
+         *     `site_read` is a deep read of a company's website. Every other name is an
+         *     api/ai-tasks.yaml task announced by the router on the task's own behalf —
          *     settled when it appears, because the router learns of a call once the call is over.
+         *
+         *     `site_extract`, `site_fact_extract` and `site_triage` are RETIRED names: a website
+         *     read runs those three passes and is one occurrence of the read, so the passes report
+         *     none of their own. Nothing writes them any more. They stay in this list because it is
+         *     also what a caller may FILTER on, and rows written before they were retired are served
+         *     until the projection's retention window closes over them — narrowing the filter would
+         *     refuse a query that still has answers.
          *
          *     Its own schema because the item that reports a kind and the query that asks for kinds
          *     must be ONE list — two copies of a vocabulary are two vocabularies as soon as somebody

--- a/frontend/src/app/ai-activity-lines.ts
+++ b/frontend/src/app/ai-activity-lines.ts
@@ -35,17 +35,24 @@ const SYSTEM_SWEEP = notDisplayed(
 
 // The site-read lanes, which do NOT belong above however much they look like it.
 //
-// Their attribution is a property of the READ, not of the task: compose binds
-// the requester as OnBehalfOf when a human asked (deepreadprincipal.go), so
-// those occurrences resolve to that person and land in their personal feed —
-// while a read requested by domain triage or the auto-enrich sweep names no
-// human, yields the zero uuid, and is workspace-scoped like any sweep. Calling
-// all three "work that belongs to nobody" is therefore false for the commonest
+// They are RETIRED names. A read runs all three as model calls and is one
+// occurrence of the read, so nothing announces them any more — but the wire can
+// still carry them, from rows written before that and from a caller filtering on
+// the name, so the rail still has to answer for what it draws. Nothing, as
+// before.
+//
+// Their attribution is why this is a reason of its own rather than the sweep's:
+// compose binds the requester as OnBehalfOf when a human asked
+// (deepreadprincipal.go), so those occurrences resolve to that person and land
+// in their personal feed — while a read requested by domain triage or the
+// auto-enrich sweep names no human and is workspace-scoped like any sweep.
+// Calling all three "work that belongs to nobody" is false for the commonest
 // case, and a kind-level map cannot say "sometimes personal" in the SYSTEM_SWEEP
-// sentence — which is why they get their own reason instead of sharing one.
+// sentence.
 const SITE_READ_WATCHED_WHERE_IT_RUNS = notDisplayed(
-  "the site-read lanes, which are the individual model calls a website read makes, and the read narrates itself: `site_read` below is one occurrence for the whole crawl, announced by the dossier row from the moment it is queued to the moment it settles, so a line per call would tell one reading several times over — and at a grain the rail could not render honestly, because the occurrence key is correlation+task and one read's correlation is its site_read row id, so a single read files one occurrence PER LANE it runs. Their attribution is a fact about the READ rather than the task: a human-requested read carries that person as on_behalf_of and IS personal to them, while a domain-triage or auto-enrich read names no human and is workspace-scoped, exactly like the sweeps above",
+  "the site-read lanes, which are the individual model calls a website read makes. The read narrates itself: `site_read` below is one occurrence for the whole crawl, announced by the dossier row from the moment it is queued to the moment it settles, so a line per call would tell one reading several times over. These three no longer report at all — the rail registry has them as steps inside the read — and the names survive here because rows written before that are served until the projection's retention window closes over them, and because the same list is what a caller may filter on. Their attribution was never the task's either: a human-requested read carries that person as on_behalf_of and IS personal to them, while a domain-triage or auto-enrich read names no human and is workspace-scoped, exactly like the sweeps above",
 );
+
 /**
  * The line for one (kind, state), by literal key — or the reason there is none.
  *


### PR DESCRIPTION
The remaining half of #2272 step 1 — the **grain question**, which the issue calls the sharper half. The carrier itself landed in #4392 and #4545; what was left is that the read's own model calls were still reporting as work of their own.

## The defect

A website read runs three passes — `site_triage`, `site_extract`, `site_fact_extract` — and the router reported each one. The router keys an occurrence on **correlation id + task**, and a read's correlation id is its own row id (`compose/deepreadprincipal.go`). So one thing a rep asked for once filed **four** lines: the dossier's own, which can say queued and running, and three more at a grain nobody asked about.

The frontend had already refused to draw them, citing exactly this. The rows were still being written.

## The fix

The three move to `SourceNoOccurrence` with one reason shared between them: the READ is the occurrence and these are passes inside it. Both router paths (`AnnounceRailStart`, `announceRailBestEffort`) gate on `RouterReports`, so this is a registry edit. The calls are still traced — `ai_call`, cost, certification unchanged.

## Why the enum keeps the retired names

`AiActivityKind` is also the vocabulary of the `kinds` **query filter** on `GET /me/ai-activity`. Removing the three narrows a request parameter, which the breaking-change gate catches and is right to: a client filtering on `site_triage` mid-upgrade would start getting 422, and the projection still serves rows carrying those kinds until the fourteen-day retention window closes over them. So the names stay and the contract says they are retired.

The catalog parity gate had no word for that — its reverse direction asks whether anything announces each declared kind. It now derives the difference from the registry: a task the registry retires is a name rows may still carry. **Derived, not listed** — the registry is where the retirement is decided, so a name cannot be excused here without being retired there. The forward direction is untouched: nothing in this lets a name be announced.

## Proof

`TestOneWebsiteReadIsOneOccurrenceWhateverItRunsInside` — a real read through `people.Store`, its three passes recorded through the real `ai.CallMeter` under the read's own correlation, asserting three `ai_call` rows, zero router announcements, and **one** `ai_task_run`.

Mutation-verified: putting `site_triage` back on the router fails it at the announcement count.

`make check` green; `make craft-static` clean whole-tree.

## What is left on #2272

Step 2, voice build: one task, and the carrier it needs does not exist — `voice_build` has no `attempt`, no `attempt_at` and no lease, so it needs an additive migration before it can say anything but settled. Step 3 landed in #5161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC