### PR TITLE
feat(lists): a deal sorts by the company and the stage its list draws (#2090)

### DIFF
--- a/backend/internal/compose/integration/dealsortvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/dealsortvocabulary_integration_test.go
@@ -14,16 +14,19 @@ package integration
 // columns were. Lars ruled on 2026-08-21 that the rule is the columns, for
 // every list in the product.
 //
-// Two of the four are reachable today and are held here. The other two are
-// JOINED columns — a stage orders by its position in its pipeline, a partner by
-// the organization's name — and the list machinery renders one quoted
-// identifier of the row's own table, so they need the sort model to take an
-// expression first. That is why this file pins two rather than four, and it is
-// stated so a reader does not read the gap as an oversight.
+// Three of them are not columns of `deal` at all. A stage orders by its
+// position in its PIPELINE — alphabetical stages are the funnel shuffled — and
+// the two organizations order by the referenced company's name. Each is held
+// here, and so is the rule that makes a reference sort safe to offer: ordering
+// by a value is reading it, so a company this reader may not open must not
+// order the page by the name it is being refused.
 
 import (
+	"context"
+	"slices"
 	"testing"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -99,5 +102,206 @@ func TestTheDealsListStillRefusesAFieldItDoesNotPublish(t *testing.T) {
 	notPublished := "captured_by"
 	if _, _, err := f.store.ListDeals(f.ctx, deals.ListDealsInput{Sort: &notPublished}); err == nil {
 		t.Fatal("the list sorted by a column it does not publish — the vocabulary has stopped being one, and a caller can now order by anything the table holds")
+	}
+}
+
+// dealsIn lists the deals this caller sees under one sort spec, in order.
+func dealsIn(ctx context.Context, t *testing.T, e *Env, spec string) []ids.UUID {
+	t.Helper()
+	rows, _, err := e.Deals.ListDeals(ctx, deals.ListDealsInput{Sort: &spec})
+	if err != nil {
+		t.Fatalf("ListDeals(sort=%s): %v", spec, err)
+	}
+	out := make([]ids.UUID, len(rows))
+	for i, d := range rows {
+		out[i] = ids.UUID(d.Id)
+	}
+	return out
+}
+
+// A stage sorts by its place in the pipeline, which is the only order anybody
+// sorting by stage means.
+//
+// The seeded pipeline's stages are deliberately NOT in alphabetical order, so a
+// sort that fell back to the name would put them the other way round — which is
+// how the assertion tells the two apart.
+func TestTheDealsListSortsStagesByPipelineOrderAndNotByName(t *testing.T) {
+	e := Setup(t)
+	pipeline, _, _ := DealFixture(t, e)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, dealCFVPerms)
+
+	stages, err := e.Deals.DefaultPipeline(e.Admin())
+	if err != nil {
+		t.Fatalf("reading the seeded pipeline: %v", err)
+	}
+	// Open stages only: a deal cannot be created on Won or Lost, which are
+	// reached by advancing rather than by filing.
+	var open []crmcontracts.Stage
+	for _, st := range *stages.Stages {
+		if st.Semantic == "open" {
+			open = append(open, st)
+		}
+	}
+	if len(open) < 3 {
+		t.Fatalf("the seeded pipeline has %d open stages; this case needs three", len(open))
+	}
+	// The case turns on the two orders disagreeing. Asserted rather than
+	// assumed: rename the seeded stages into alphabetical order and this test
+	// would pass over a sort that had fallen back to the name.
+	byName := make([]string, 0, len(open))
+	for _, st := range open {
+		byName = append(byName, st.Name)
+	}
+	if slices.IsSorted(byName) {
+		t.Fatalf("the seeded open stages %v are already in alphabetical order, so this case "+
+			"cannot tell pipeline order from name order", byName)
+	}
+
+	// One deal per stage, seeded LAST-stage-first so insertion order is the
+	// reverse of the answer and the default sort cannot produce it either.
+	want := make([]ids.UUID, len(open))
+	for i := len(open) - 1; i >= 0; i-- {
+		st := ids.From[ids.StageKind](ids.UUID(open[i].Id))
+		want[i] = e.SeedDeal(t, "Deal in "+open[i].Name, pipeline, st, &e.Rep1)
+	}
+
+	assertIDOrder(t, dealsIn(ctx, t, e, "stage_id"), want, "stage ascending (pipeline order)")
+
+	reversed := make([]ids.UUID, 0, len(want))
+	for i := len(want) - 1; i >= 0; i-- {
+		reversed = append(reversed, want[i])
+	}
+	assertIDOrder(t, dealsIn(ctx, t, e, "-stage_id"), reversed, "stage descending")
+}
+
+// A reference sorts by the referenced company's NAME, which is what a reader
+// clicking the column is asking for — the id it is named after orders nothing
+// anybody can see.
+func TestTheDealsListSortsItsCompanyColumnsByTheCompanyName(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, dealCFVPerms)
+
+	// Named so that ordering by the company disagrees with ordering by the
+	// deal's own name, which is the only way to tell which one answered.
+	zeta := e.SeedOrg(t, "Zeta Holding", &e.Rep1)
+	alma := e.SeedOrg(t, "Alma Werke", &e.Rep1)
+	first := seedDealForCompany(t, e, "A deal", pipeline, open, zeta)
+	second := seedDealForCompany(t, e, "B deal", pipeline, open, alma)
+
+	assertIDOrder(t, dealsIn(ctx, t, e, "organization_id"),
+		[]ids.UUID{second, first}, "company ascending — Alma before Zeta")
+	assertIDOrder(t, dealsIn(ctx, t, e, "-organization_id"),
+		[]ids.UUID{first, second}, "company descending")
+}
+
+// A company this reader may not open orders the page by NOTHING.
+//
+// Ordering by a value is reading it. A page ordered by a name the reader is
+// refused would disclose it through the order — read the list ascending and
+// descending and the hidden company's position tells you where its name falls
+// in the alphabet. It sorts into the NULL tail instead, which is where every
+// deal whose company the reader cannot see lands together, and which says the
+// same thing the row itself says: nothing.
+func TestAnUnreadableCompanyOrdersTheDealsListByNothing(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, dealCFVPerms)
+
+	// "Alma" sorts first of the three by name. Hidden from this reader, it must
+	// sort last instead — with the deal that names no company at all.
+	hidden := e.SeedOrg(t, "Alma Werke", &e.Rep3)
+	mid := e.SeedOrg(t, "Mercator", &e.Rep1)
+	last := e.SeedOrg(t, "Zeta Holding", &e.Rep1)
+
+	secret := seedDealForCompany(t, e, "Deal with the hidden company", pipeline, open, hidden)
+	// Made private AFTER the deal is filed, which is the real sequence: a
+	// company goes capture-private while the deals naming it stay where they
+	// were.
+	e.MakeCapturePrivate(t, "organization", hidden, e.Rep3)
+	middle := seedDealForCompany(t, e, "Deal with Mercator", pipeline, open, mid)
+	zeta := seedDealForCompany(t, e, "Deal with Zeta", pipeline, open, last)
+
+	// Admitted first: the reader must SEE all three deals, so what the sort
+	// does below is the company's visibility and not the deal's.
+	if got := dealsIn(ctx, t, e, "name"); len(got) != 3 {
+		t.Fatalf("the reader sees %d deals, want 3 — this case would prove nothing about the ordering", len(got))
+	}
+
+	ascending := dealsIn(ctx, t, e, "organization_id")
+	assertIDOrder(t, ascending, []ids.UUID{middle, zeta, secret},
+		"company ascending — the unreadable one in the tail, not first")
+
+	// And the same position under the other direction. A name that really was
+	// ordering the page would move to the other end.
+	assertIDOrder(t, dealsIn(ctx, t, e, "-organization_id"), []ids.UUID{zeta, middle, secret},
+		"company descending — still the tail, because there is nothing to order by")
+}
+
+// seedDealForCompany creates a deal filed under one company, through the real
+// writer.
+func seedDealForCompany(
+	t *testing.T, e *Env, name string, pipeline ids.PipelineID, stage ids.StageID, org ids.UUID,
+) ids.UUID {
+	t.Helper()
+	orgID := ids.From[ids.OrganizationKind](org)
+	d, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: name, PipelineID: pipeline, StageID: stage,
+		OrganizationID: &orgID, OwnerID: userIDPtr(&e.Rep1),
+	})
+	if err != nil {
+		t.Fatalf("creating %q: %v", name, err)
+	}
+	return ids.UUID(d.Id)
+}
+
+// The page continues under a reference sort, including across the NULL tail.
+//
+// The keyset cursor carries the sort field's key and continues strictly past
+// it, so an expression sort has to render the SAME expression in the ORDER BY
+// and in the continuation — order by one and continue by another and a page
+// boundary repeats rows or skips them. One row at a time is the setting that
+// makes every boundary a boundary.
+func TestAReferenceSortPagesWithoutRepeatingOrSkipping(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, dealCFVPerms)
+
+	hidden := e.SeedOrg(t, "Alma Werke", &e.Rep3)
+	named := []ids.UUID{
+		seedDealForCompany(t, e, "Deal with the hidden company", pipeline, open, hidden),
+		seedDealForCompany(t, e, "Deal with Mercator", pipeline, open, e.SeedOrg(t, "Mercator", &e.Rep1)),
+		seedDealForCompany(t, e, "Deal with Zeta", pipeline, open, e.SeedOrg(t, "Zeta Holding", &e.Rep1)),
+	}
+	// Two rows in the NULL tail — the hidden company and a deal filed under no
+	// company at all — because the tail is where the continuation changes shape.
+	bare := e.SeedDeal(t, "Deal with nobody", pipeline, open, &e.Rep1)
+	e.MakeCapturePrivate(t, "organization", hidden, e.Rep3)
+
+	spec, one := "organization_id", 1
+	var walked []ids.UUID
+	var cursor *string
+	for range len(named) + 2 {
+		rows, page, err := e.Deals.ListDeals(ctx, deals.ListDealsInput{Sort: &spec, Limit: &one, Cursor: cursor})
+		if err != nil {
+			t.Fatalf("paging by company: %v", err)
+		}
+		for _, d := range rows {
+			walked = append(walked, ids.UUID(d.Id))
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		next := page.NextCursor
+		cursor = &next
+	}
+
+	// Every deal once, in the same order the unpaged read gives.
+	assertIDOrder(t, walked, dealsIn(ctx, t, e, spec), "paged one at a time by company")
+	if len(walked) != len(named)+1 {
+		t.Fatalf("walked %d deals, want %d — a boundary repeated or skipped one", len(walked), len(named)+1)
+	}
+	if walked[len(walked)-1] != bare && walked[len(walked)-2] != bare {
+		t.Errorf("the company-less deal landed at %v, not in the NULL tail", walked)
 	}
 }

--- a/backend/internal/modules/activities/documents.go
+++ b/backend/internal/modules/activities/documents.go
@@ -82,7 +82,7 @@ func (s *Store) ListOrganizationDocuments(
 		// Keyset, not offset: the library is ordered pinned-then-newest and a
 		// page boundary has to survive a pin being added between two reads.
 		if in.Cursor != nil && *in.Cursor != "" {
-			sort, err := documentSort()
+			sort, err := documentSort(ctx)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ func (s *Store) ListOrganizationDocuments(
 		}
 		if len(out) > lim {
 			out = out[:lim]
-			p, err := documentPage(out[len(out)-1])
+			p, err := documentPage(ctx, out[len(out)-1])
 			if err != nil {
 				return err
 			}
@@ -154,9 +154,9 @@ func (s *Store) ListOrganizationDocuments(
 // fixed here and ParseListSort is only the constructor — which is why the error
 // is returned rather than swallowed: the alternative to a parseable sort is an
 // unordered library, not a default one.
-func documentSort() (*storekit.ListSort, error) {
+func documentSort(ctx context.Context) (*storekit.ListSort, error) {
 	spec := "-pinned"
-	sort, err := storekit.ParseListSort(&spec, map[string]string{"pinned": fieldcatalog.TypeBoolean})
+	sort, err := storekit.ParseListSort(ctx, &spec, map[string]storekit.SortField{"pinned": storekit.Column(fieldcatalog.TypeBoolean)}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("activities: the document library's fixed sort no longer parses: %w", err)
 	}
@@ -448,8 +448,8 @@ func documentMetadataPatch(before crmcontracts.Attachment, in DocumentMetadata) 
 // the PINNED half as well as the house (created_at, id) tuple, because the
 // library orders on all three — a token that dropped it would strand every
 // newer unpinned document behind the pinned group.
-func documentPage(last crmcontracts.Attachment) (storekit.Page, error) {
-	sort, err := documentSort()
+func documentPage(ctx context.Context, last crmcontracts.Attachment) (storekit.Page, error) {
+	sort, err := documentSort(ctx)
 	if err != nil {
 		return storekit.Page{}, err
 	}

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -120,23 +120,56 @@ const dealNameColumn = "name"
 // the columns, for every list in the product; where that and the older set
 // disagree, this follows the rule.
 //
-// `name` and `status` are the two the ruling reaches today, because they are
-// columns of `deal` and the list machinery orders by a base column. `stage` and
-// the two organization columns are joined — a stage sorts by its POSITION in
-// its pipeline rather than by its name, and a partner sorts by the
-// organization's — and storekit's ORDER BY renders one quoted identifier, so
-// those three need the sort model to take an expression before they can be
-// offered. Named here rather than left as an unexplained gap: the frontend
-// columns cite this vocabulary by name, so a reader who finds two of the four
-// fixed needs to know why the others were not.
-var dealListFields = map[string]string{
-	"created_at":          storekit.KindTimestamp,
-	"updated_at":          storekit.KindTimestamp,
-	"last_activity_at":    storekit.KindTimestamp,
-	"amount_minor":        fieldcatalog.TypeCurrency,
-	"expected_close_date": fieldcatalog.TypeDate,
-	dealNameColumn:        fieldcatalog.TypeText,
-	"status":              fieldcatalog.TypeText,
+// Three of the eight are not columns of `deal` at all: a stage and the two
+// organizations are references, so each carries the expression that orders it.
+var dealListFields = map[string]storekit.SortField{
+	"created_at":         storekit.Column(storekit.KindTimestamp),
+	"updated_at":         storekit.Column(storekit.KindTimestamp),
+	"last_activity_at":   storekit.Column(storekit.KindTimestamp),
+	"amount_minor":       storekit.Column(fieldcatalog.TypeCurrency),
+	closeDateField:       storekit.Column(fieldcatalog.TypeDate),
+	dealNameColumn:       storekit.Column(fieldcatalog.TypeText),
+	"status":             storekit.Column(fieldcatalog.TypeText),
+	filterStageID:        {Kind: fieldcatalog.TypeNumber, Expr: orderByStagePosition},
+	filterOrganizationID: {Kind: fieldcatalog.TypeText, Expr: orderByReadableOrgName(filterOrganizationID)},
+	filterPartnerOrgID:   {Kind: fieldcatalog.TypeText, Expr: orderByReadableOrgName(filterPartnerOrgID)},
+}
+
+// orderByStagePosition orders by a stage's place in its PIPELINE, not by its
+// name.
+//
+// Alphabetical is almost never what somebody sorting by stage means: they want
+// the funnel, and "Discovery, Negotiation, Proposal" is the funnel shuffled.
+// `stage` is workspace configuration and carries no row scope, so the position
+// is the same number for every reader.
+func orderByStagePosition(context.Context, func(any) int) (string, error) {
+	return "(SELECT stage_sort.position FROM stage stage_sort WHERE stage_sort.id = deal.stage_id)", nil
+}
+
+// orderByReadableOrgName orders by the referenced organization's name, and by
+// NOTHING for a reference this caller may not read.
+//
+// Ordering by a value is reading it — the rule refuseMaskedSort already applies
+// to masked amounts — so a page ordered by names the caller is refused would
+// disclose them through its order. The row scope goes INSIDE the subquery
+// rather than beside it: a reference outside the caller's scope then answers
+// NULL, which the ORDER BY already puts last, so those deals land in the tail
+// together and the order says nothing about which company they name. That is
+// the same answer the row itself gives, where the reference is withheld.
+func orderByReadableOrgName(column string) func(context.Context, func(any) int) (string, error) {
+	return func(ctx context.Context, arg func(any) int) (string, error) {
+		scope, err := auth.ScopeClauseFor(ctx, "organization", "org_sort", arg)
+		if err != nil {
+			return "", err
+		}
+		if scope != "" {
+			scope = " AND " + scope
+		}
+		// The column is one of this map's own keys, never a caller's string.
+		return storekit.SQLf(
+			"(SELECT org_sort.display_name FROM organization org_sort WHERE org_sort.id = deal.%s%s)",
+			column, scope), nil
+	}
 }
 
 // wireRowTags renders one deal row's tag chips. A twin of the people module's:

--- a/backend/internal/modules/deals/offer_template.go
+++ b/backend/internal/modules/deals/offer_template.go
@@ -239,12 +239,12 @@ const (
 	offerTemplateDefaultColumn = "is_default"
 )
 
-var offerTemplateListFields = map[string]string{
-	listCreatedAtColumn:        storekit.KindTimestamp,
-	listUpdatedAtColumn:        storekit.KindTimestamp,
-	offerTemplateNameField:     fieldcatalog.TypeText,
-	offerTemplateLocaleColumn:  fieldcatalog.TypeText,
-	offerTemplateDefaultColumn: fieldcatalog.TypeBoolean,
+var offerTemplateListFields = map[string]storekit.SortField{
+	listCreatedAtColumn:        storekit.Column(storekit.KindTimestamp),
+	listUpdatedAtColumn:        storekit.Column(storekit.KindTimestamp),
+	offerTemplateNameField:     storekit.Column(fieldcatalog.TypeText),
+	offerTemplateLocaleColumn:  storekit.Column(fieldcatalog.TypeText),
+	offerTemplateDefaultColumn: storekit.Column(fieldcatalog.TypeBoolean),
 }
 
 // ListOfferTemplates pages the workspace's templates keyset-style

--- a/backend/internal/modules/deals/product.go
+++ b/backend/internal/modules/deals/product.go
@@ -221,13 +221,13 @@ const (
 	productActiveField = "active"
 )
 
-var productListFields = map[string]string{
-	listCreatedAtColumn: storekit.KindTimestamp,
-	listUpdatedAtColumn: storekit.KindTimestamp,
-	productNameColumn:   fieldcatalog.TypeText,
-	productSkuColumn:    fieldcatalog.TypeText,
-	productPriceColumn:  fieldcatalog.TypeCurrency,
-	productActiveField:  fieldcatalog.TypeBoolean,
+var productListFields = map[string]storekit.SortField{
+	listCreatedAtColumn: storekit.Column(storekit.KindTimestamp),
+	listUpdatedAtColumn: storekit.Column(storekit.KindTimestamp),
+	productNameColumn:   storekit.Column(fieldcatalog.TypeText),
+	productSkuColumn:    storekit.Column(fieldcatalog.TypeText),
+	productPriceColumn:  storekit.Column(fieldcatalog.TypeCurrency),
+	productActiveField:  storekit.Column(fieldcatalog.TypeBoolean),
 }
 
 func (s *Store) ListProducts(ctx context.Context, in ListProductsInput) ([]crmcontracts.Product, storekit.Page, error) {

--- a/backend/internal/modules/people/lead_list.go
+++ b/backend/internal/modules/people/lead_list.go
@@ -49,14 +49,14 @@ const (
 // name. That header no longer offers a sort, and
 // TestEverySortAListOffersIsOneItsResourceAccepts is what keeps the two
 // answering together.
-var leadListFields = map[string]string{
-	createdAtColumn:   storekit.KindTimestamp,
-	updatedAtColumn:   storekit.KindTimestamp,
-	leadNameColumn:    fieldcatalog.TypeText,
-	leadCompanyColumn: fieldcatalog.TypeText,
-	leadStatusColumn:  fieldcatalog.TypeText,
-	leadScoreColumn:   fieldcatalog.TypeNumber,
-	ownerIDColumn:     storekit.KindUUID,
+var leadListFields = map[string]storekit.SortField{
+	createdAtColumn:   storekit.Column(storekit.KindTimestamp),
+	updatedAtColumn:   storekit.Column(storekit.KindTimestamp),
+	leadNameColumn:    storekit.Column(fieldcatalog.TypeText),
+	leadCompanyColumn: storekit.Column(fieldcatalog.TypeText),
+	leadStatusColumn:  storekit.Column(fieldcatalog.TypeText),
+	leadScoreColumn:   storekit.Column(fieldcatalog.TypeNumber),
+	ownerIDColumn:     storekit.Column(storekit.KindUUID),
 }
 
 // ListLeads is the row-scoped lead list read: quick-find, the status and

--- a/backend/internal/modules/people/leadworkqueue.go
+++ b/backend/internal/modules/people/leadworkqueue.go
@@ -116,7 +116,7 @@ func leadQueueWhere(ctx context.Context, in ListLeadsInput, active []fieldcatalo
 	if scope != "" {
 		where = append(where, scope)
 	}
-	defaultSort, err := storekit.ParseListSort(nil, leadListFields)
+	defaultSort, err := storekit.ParseListSort(ctx, nil, leadListFields, arg)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/backend/internal/modules/people/listpage.go
+++ b/backend/internal/modules/people/listpage.go
@@ -38,7 +38,7 @@ type listPageSpec[T any] struct {
 	columns string
 	// fields is the core sortable vocabulary (data-model §13.5); active
 	// cf_ columns join it per request.
-	fields map[string]string
+	fields map[string]storekit.SortField
 	// filters appends the request's optional WHERE clauses (their
 	// arguments through arg) — typically listFilters.clauses plus any
 	// type-specific extras.
@@ -63,15 +63,18 @@ func listPage[T any](ctx context.Context, s *Store, sortSpec *string, limitIn *i
 	if err != nil {
 		return nil, storekit.Page{}, err
 	}
-	sorted, err := storekit.ParseListSort(sortSpec, storekit.SortVocabulary(spec.fields, active))
-	if err != nil {
-		return nil, storekit.Page{}, err
-	}
 	limit := storekit.ClampLimit(limitIn)
 
 	where := []string{whereAlways}
 	args := []any{}
 	arg := func(v any) int { args = append(args, v); return len(args) }
+
+	// The sort first, because a reference sort binds parameters of its own and
+	// every clause below binds through the same counter.
+	sorted, err := storekit.ParseListSort(ctx, sortSpec, storekit.SortVocabulary(spec.fields, active), arg)
+	if err != nil {
+		return nil, storekit.Page{}, err
+	}
 
 	scope, err := auth.ScopeClauseFor(ctx, spec.entity, "", arg)
 	if err != nil {

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -75,12 +75,12 @@ type ListOrganizationsInput struct {
 // organizationListFields is the organization list's core sortable
 // vocabulary — exactly the data-model §13.5 DM-VOCAB-2 set; active cf_
 // columns join it per request.
-var organizationListFields = map[string]string{
-	createdAtColumn:    storekit.KindTimestamp,
-	updatedAtColumn:    storekit.KindTimestamp,
-	orgNameColumn:      fieldcatalog.TypeText,
-	ownerIDColumn:      storekit.KindUUID,
-	lastActivityColumn: storekit.KindTimestamp,
+var organizationListFields = map[string]storekit.SortField{
+	createdAtColumn:    storekit.Column(storekit.KindTimestamp),
+	updatedAtColumn:    storekit.Column(storekit.KindTimestamp),
+	orgNameColumn:      storekit.Column(fieldcatalog.TypeText),
+	ownerIDColumn:      storekit.Column(storekit.KindUUID),
+	lastActivityColumn: storekit.Column(storekit.KindTimestamp),
 }
 
 // organizationDomainClause narrows the page to the account that lists one

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -65,12 +65,12 @@ type ListPeopleInput struct {
 // personListFields is the person list's core sortable vocabulary —
 // exactly the data-model §13.5 DM-VOCAB-1 set; active cf_ columns join
 // it per request.
-var personListFields = map[string]string{
-	createdAtColumn:    storekit.KindTimestamp,
-	updatedAtColumn:    storekit.KindTimestamp,
-	personNameColumn:   fieldcatalog.TypeText,
-	ownerIDColumn:      storekit.KindUUID,
-	lastActivityColumn: storekit.KindTimestamp,
+var personListFields = map[string]storekit.SortField{
+	createdAtColumn:    storekit.Column(storekit.KindTimestamp),
+	updatedAtColumn:    storekit.Column(storekit.KindTimestamp),
+	personNameColumn:   storekit.Column(fieldcatalog.TypeText),
+	ownerIDColumn:      storekit.Column(storekit.KindUUID),
+	lastActivityColumn: storekit.Column(storekit.KindTimestamp),
 }
 
 // personTagClause narrows the page to the people carrying the named tags.

--- a/backend/internal/modules/projects/read.go
+++ b/backend/internal/modules/projects/read.go
@@ -111,17 +111,17 @@ const projectQuickFindExpr = `(coalesce(name,'') || ' ' || coalesce(key,''))`
 const projectNameField = "name"
 
 // projectListFields is the project list's core sortable vocabulary.
-var projectListFields = map[string]string{
-	"created_at":       storekit.KindTimestamp,
-	"updated_at":       storekit.KindTimestamp,
-	"last_activity_at": storekit.KindTimestamp,
-	projectNameField:   fieldcatalog.TypeText,
-	"target_end_date":  fieldcatalog.TypeDate,
+var projectListFields = map[string]storekit.SortField{
+	"created_at":        storekit.Column(storekit.KindTimestamp),
+	"updated_at":        storekit.Column(storekit.KindTimestamp),
+	"last_activity_at":  storekit.Column(storekit.KindTimestamp),
+	projectNameField:    storekit.Column(fieldcatalog.TypeText),
+	targetEndDateColumn: storekit.Column(fieldcatalog.TypeDate),
 	// The Owner header has offered this sort for as long as the list has drawn
 	// the column, and the server refused it: `project.owner_id` is a column of
 	// the row like any other, so the refusal was the vocabulary's omission
 	// rather than anything about the field.
-	filterOwnerID: storekit.KindUUID,
+	filterOwnerID: storekit.Column(storekit.KindUUID),
 }
 
 // ListProjects answers one page under the caller's row scope.

--- a/backend/internal/platform/database/storekit/listpage.go
+++ b/backend/internal/platform/database/storekit/listpage.go
@@ -55,20 +55,23 @@ func (p *ListPrelude) Arg(v any) int { return p.arg(v) }
 func BuildListPrelude(
 	ctx context.Context,
 	object string,
-	fields map[string]string,
+	fields map[string]SortField,
 	active []fieldcatalog.Column,
 	sort *string,
 	limit *int,
 	cursor *string,
 	customFilters map[string]string,
 ) (*ListPrelude, error) {
-	sorted, err := ParseListSort(sort, SortVocabulary(fields, active))
+	p := &ListPrelude{limit: ClampLimit(limit), where: []string{ListWhereSeed}}
+	p.arg = func(v any) int { p.args = append(p.args, v); return len(p.args) }
+
+	// The sort first, because a reference sort binds parameters of its own and
+	// every clause below binds through the same counter.
+	sorted, err := ParseListSort(ctx, sort, SortVocabulary(fields, active), p.arg)
 	if err != nil {
 		return nil, err
 	}
-
-	p := &ListPrelude{sorted: sorted, limit: ClampLimit(limit), where: []string{ListWhereSeed}}
-	p.arg = func(v any) int { p.args = append(p.args, v); return len(p.args) }
+	p.sorted = sorted
 
 	// A row-scoped record narrows to what this reader may see. The
 	// workspace-shared catalogues (products, offer templates) have no such

--- a/backend/internal/platform/database/storekit/listquery.go
+++ b/backend/internal/platform/database/storekit/listquery.go
@@ -20,6 +20,7 @@ package storekit
 // cf_<name>=<value> list parameters.
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -62,16 +63,38 @@ const (
 	CodeSortUnsupported     = "sort_unsupported"
 )
 
-// SortVocabulary merges a resource's fixed core sortable fields (name →
-// kind) with the workspace's active custom columns. Retired columns left
-// ActiveColumns, so they leave the vocabulary — and its 422 — for free.
-func SortVocabulary(core map[string]string, active []fieldcatalog.Column) map[string]string {
-	vocab := make(map[string]string, len(core)+len(active))
-	for name, kind := range core {
-		vocab[name] = kind
+// SortField is one field a resource will order by: the kind its cursor key
+// round-trips as, and — when the ordering is not the row's own column — the
+// expression that renders it.
+type SortField struct {
+	Kind string
+	// Expr renders the ORDER BY and cursor-key expression. Nil is the ordinary
+	// case: the column of this field's own name.
+	//
+	// A FUNCTION rather than a string because the sorts that need one are
+	// reference sorts, and a reference the caller may not read must not order
+	// the page by a name it is refusing to show — so the expression asks the
+	// caller's own row scope, which needs the context and binds parameters.
+	//
+	// Whatever it renders is used for the ordering AND for the keyset
+	// continuation, so a page cannot be ordered by one expression and
+	// continued by another.
+	Expr func(ctx context.Context, arg func(any) int) (string, error)
+}
+
+// Column is the ordinary sortable field: the row's own column of that name.
+func Column(kind string) SortField { return SortField{Kind: kind} }
+
+// SortVocabulary merges a resource's fixed core sortable fields with the
+// workspace's active custom columns. Retired columns left ActiveColumns, so
+// they leave the vocabulary — and its 422 — for free.
+func SortVocabulary(core map[string]SortField, active []fieldcatalog.Column) map[string]SortField {
+	vocab := make(map[string]SortField, len(core)+len(active))
+	for name, field := range core {
+		vocab[name] = field
 	}
 	for _, c := range active {
-		vocab[c.Name] = c.Type
+		vocab[c.Name] = Column(c.Type)
 	}
 	return vocab
 }
@@ -84,6 +107,10 @@ type ListSort struct {
 	name string
 	kind string
 	desc bool
+	// expr is the rendered ordering expression, empty for a plain column.
+	// Rendered ONCE, at parse time, because it may bind parameters and every
+	// clause that orders or continues this page has to name the same ones.
+	expr string
 }
 
 // ParseListSort validates a list's sort spec against the resource's
@@ -92,7 +119,7 @@ type ListSort struct {
 // spec the keyset cursor cannot continue — is a typed refusal.
 //
 //nolint:nilnil // the nil *ListSort IS the default sort by design: every ListSort method answers its default shape on a nil receiver, so callers thread one value unconditionally
-func ParseListSort(spec *string, vocab map[string]string) (*ListSort, error) {
+func ParseListSort(ctx context.Context, spec *string, vocab map[string]SortField, arg func(any) int) (*ListSort, error) {
 	if spec == nil {
 		return nil, nil
 	}
@@ -107,14 +134,37 @@ func ParseListSort(spec *string, vocab map[string]string) (*ListSort, error) {
 		}
 	}
 	name := strings.TrimPrefix(raw, "-")
-	kind, ok := vocab[name]
+	field, ok := vocab[name]
 	if !ok || name == "" {
 		return nil, &SortError{
 			Code:    CodeSortFieldNotAllowed,
 			Message: fmt.Sprintf("field %q is not sortable on this resource", name),
 		}
 	}
-	return &ListSort{name: name, kind: kind, desc: strings.HasPrefix(raw, "-")}, nil
+	sorted := &ListSort{name: name, kind: field.Kind, desc: strings.HasPrefix(raw, "-")}
+	if field.Expr != nil {
+		// A caller with no binder is one whose vocabulary is plain columns —
+		// a fixed internal sort, not a client's. Reaching an expression there
+		// is a wiring mistake, and saying so beats a nil call.
+		if arg == nil {
+			return nil, fmt.Errorf("storekit: sort %q renders an expression and this caller binds no parameters", name)
+		}
+		rendered, err := field.Expr(ctx, arg)
+		if err != nil {
+			return nil, err
+		}
+		sorted.expr = rendered
+	}
+	return sorted, nil
+}
+
+// orderExpr is what this sort orders and continues by: the field's own
+// expression, or the column of its name.
+func (s *ListSort) orderExpr() string {
+	if s.expr != "" {
+		return s.expr
+	}
+	return quoteColumnIdentifier(s.name)
 }
 
 // OrderBy renders the ORDER BY clause: the sort field first (NULLS LAST
@@ -129,7 +179,7 @@ func (s *ListSort) OrderBy() string {
 	if s.desc {
 		dir = "DESC"
 	}
-	return " ORDER BY " + quoteColumnIdentifier(s.name) + " " + dir + " NULLS LAST, created_at DESC, id DESC"
+	return " ORDER BY " + s.orderExpr() + " " + dir + " NULLS LAST, created_at DESC, id DESC"
 }
 
 // CursorKeySuffix is the trailing SELECT expression a sorted list scans
@@ -143,7 +193,7 @@ func (s *ListSort) CursorKeySuffix() string {
 	if s == nil {
 		return ""
 	}
-	return ", (" + quoteColumnIdentifier(s.name) + `)::text AS "__cursor_key"`
+	return ", (" + s.orderExpr() + `)::text AS "__cursor_key"`
 }
 
 // EncodePageCursor mints the next-page token: the house (created_at, id)
@@ -182,7 +232,7 @@ func (s *ListSort) KeysetClause(token string, arg func(any) int) (string, error)
 		return "", &CursorSortMismatchError{}
 	}
 
-	col := quoteColumnIdentifier(s.name)
+	col := s.orderExpr()
 	if c.SortKey == nil {
 		return SQLf("(%s IS NULL AND (created_at, id) < ($%d, $%d))", col, arg(c.CreatedAt), arg(c.ID)), nil
 	}

--- a/backend/internal/platform/database/storekit/listquery_test.go
+++ b/backend/internal/platform/database/storekit/listquery_test.go
@@ -11,6 +11,7 @@ package storekit
 // parameter.
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -20,9 +21,9 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
-var testVocab = SortVocabulary(map[string]string{
-	"created_at": KindTimestamp,
-	"full_name":  fieldcatalog.TypeText,
+var testVocab = SortVocabulary(map[string]SortField{
+	"created_at": Column(KindTimestamp),
+	"full_name":  Column(fieldcatalog.TypeText),
 }, []fieldcatalog.Column{
 	{Name: "cf_score", Type: fieldcatalog.TypeNumber},
 	{Name: "cf_strategic", Type: fieldcatalog.TypeBoolean},
@@ -30,21 +31,28 @@ var testVocab = SortVocabulary(map[string]string{
 
 func sortSpec(s string) *string { return &s }
 
+// noArgs is the binder for a vocabulary of plain columns: nothing in it renders
+// an expression, so nothing here binds a parameter. A call means the fixture
+// grew a reference sort and this file has to say what it binds.
+//
+//craft:ignore naked-any the parameter type is ParseListSort's own binder shape, which takes any bind value
+func noArgs(any) int { panic("a plain-column vocabulary binds no sort parameters") }
+
 func TestParseListSort_DefaultSpellings(t *testing.T) {
 	for _, spec := range []*string{nil, sortSpec(""), sortSpec("-created_at,id")} {
-		got, err := ParseListSort(spec, testVocab)
+		got, err := ParseListSort(context.Background(), spec, testVocab, noArgs)
 		if err != nil || got != nil {
-			t.Fatalf("ParseListSort(%v) = %v, %v — want the nil default sort", spec, got, err)
+			t.Fatalf("ParseListSort(context.Background(), %v) = %v, %v — want the nil default sort", spec, got, err)
 		}
 	}
 }
 
 func TestParseListSort_SingleField(t *testing.T) {
-	asc, err := ParseListSort(sortSpec("cf_score"), testVocab)
+	asc, err := ParseListSort(context.Background(), sortSpec("cf_score"), testVocab, noArgs)
 	if err != nil || asc == nil || asc.desc || asc.name != "cf_score" {
 		t.Fatalf("ascending cf_score: got %+v, %v", asc, err)
 	}
-	desc, err := ParseListSort(sortSpec("-full_name"), testVocab)
+	desc, err := ParseListSort(context.Background(), sortSpec("-full_name"), testVocab, noArgs)
 	if err != nil || desc == nil || !desc.desc || desc.name != "full_name" {
 		t.Fatalf("descending full_name: got %+v, %v", desc, err)
 	}
@@ -52,16 +60,16 @@ func TestParseListSort_SingleField(t *testing.T) {
 
 func TestParseListSort_OutOfVocabularyRefused(t *testing.T) {
 	for _, spec := range []string{"owner_id", "cf_retired_or_unknown", "-cf_retired_or_unknown", "-"} {
-		_, err := ParseListSort(sortSpec(spec), testVocab)
+		_, err := ParseListSort(context.Background(), sortSpec(spec), testVocab, noArgs)
 		var sortErr *SortError
 		if !errors.As(err, &sortErr) || sortErr.Code != CodeSortFieldNotAllowed {
-			t.Fatalf("ParseListSort(%q) err = %v, want SortError %s", spec, err, CodeSortFieldNotAllowed)
+			t.Fatalf("ParseListSort(context.Background(), %q) err = %v, want SortError %s", spec, err, CodeSortFieldNotAllowed)
 		}
 	}
 }
 
 func TestParseListSort_MultiFieldRefused(t *testing.T) {
-	_, err := ParseListSort(sortSpec("-created_at,full_name"), testVocab)
+	_, err := ParseListSort(context.Background(), sortSpec("-created_at,full_name"), testVocab, noArgs)
 	var sortErr *SortError
 	if !errors.As(err, &sortErr) || sortErr.Code != CodeSortUnsupported {
 		t.Fatalf("multi-field sort err = %v, want SortError %s", err, CodeSortUnsupported)
@@ -73,14 +81,14 @@ func TestListSort_OrderBy(t *testing.T) {
 	if got := def.OrderBy(); got != " ORDER BY created_at DESC, id DESC" {
 		t.Fatalf("default OrderBy = %q", got)
 	}
-	asc, err := ParseListSort(sortSpec("cf_score"), testVocab)
+	asc, err := ParseListSort(context.Background(), sortSpec("cf_score"), testVocab, noArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got := asc.OrderBy(); got != ` ORDER BY "cf_score" ASC NULLS LAST, created_at DESC, id DESC` {
 		t.Fatalf("ascending OrderBy = %q", got)
 	}
-	desc, err := ParseListSort(sortSpec("-cf_score"), testVocab)
+	desc, err := ParseListSort(context.Background(), sortSpec("-cf_score"), testVocab, noArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +102,7 @@ func TestListSort_CursorKeySuffix(t *testing.T) {
 	if got := def.CursorKeySuffix(); got != "" {
 		t.Fatalf("default CursorKeySuffix = %q, want empty", got)
 	}
-	s, err := ParseListSort(sortSpec("cf_score"), testVocab)
+	s, err := ParseListSort(context.Background(), sortSpec("cf_score"), testVocab, noArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +137,7 @@ func TestKeysetClause_DefaultCursorRoundTrip(t *testing.T) {
 }
 
 func TestKeysetClause_SortedCursorRoundTrip(t *testing.T) {
-	s, err := ParseListSort(sortSpec("cf_score"), testVocab)
+	s, err := ParseListSort(context.Background(), sortSpec("cf_score"), testVocab, noArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +161,7 @@ func TestKeysetClause_SortedCursorRoundTrip(t *testing.T) {
 }
 
 func TestKeysetClause_DescendingComparesBelow(t *testing.T) {
-	s, err := ParseListSort(sortSpec("-cf_score"), testVocab)
+	s, err := ParseListSort(context.Background(), sortSpec("-cf_score"), testVocab, noArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +178,7 @@ func TestKeysetClause_DescendingComparesBelow(t *testing.T) {
 }
 
 func TestKeysetClause_NullKeyContinuesInsideNullTail(t *testing.T) {
-	s, err := ParseListSort(sortSpec("cf_score"), testVocab)
+	s, err := ParseListSort(context.Background(), sortSpec("cf_score"), testVocab, noArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,11 +199,11 @@ func TestKeysetClause_NullKeyContinuesInsideNullTail(t *testing.T) {
 // distinct from an undecodable token) rather than silently misordering
 // the page.
 func TestKeysetClause_SortMismatchIsTypedMismatch(t *testing.T) {
-	sorted, err := ParseListSort(sortSpec("cf_score"), testVocab)
+	sorted, err := ParseListSort(context.Background(), sortSpec("cf_score"), testVocab, noArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
-	descending, err := ParseListSort(sortSpec("-cf_score"), testVocab)
+	descending, err := ParseListSort(context.Background(), sortSpec("-cf_score"), testVocab, noArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,9 +237,9 @@ func TestKeysetClause_SortMismatchIsTypedMismatch(t *testing.T) {
 // the client-fault type, never reach the typed bind cast where Postgres
 // would fail the whole query (22P02 → 500).
 func TestKeysetClause_UnparseableSortKeyIsMalformed(t *testing.T) {
-	vocab := SortVocabulary(map[string]string{
-		"created_at": KindTimestamp,
-		"owner_id":   KindUUID,
+	vocab := SortVocabulary(map[string]SortField{
+		"created_at": Column(KindTimestamp),
+		"owner_id":   Column(KindUUID),
 	}, []fieldcatalog.Column{
 		{Name: "cf_score", Type: fieldcatalog.TypeNumber},
 		{Name: "cf_budget", Type: fieldcatalog.TypeCurrency},
@@ -249,7 +257,7 @@ func TestKeysetClause_UnparseableSortKeyIsMalformed(t *testing.T) {
 		"created_at":   "yesterday",
 	} {
 		t.Run(field, func(t *testing.T) {
-			s, err := ParseListSort(sortSpec(field), vocab)
+			s, err := ParseListSort(context.Background(), sortSpec(field), vocab, noArgs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -269,9 +277,9 @@ func TestKeysetClause_UnparseableSortKeyIsMalformed(t *testing.T) {
 // cursor keys and bind under their own casts, so a legitimately minted
 // token round-trips.
 func TestKeysetClause_CoreKindKeysRoundTrip(t *testing.T) {
-	vocab := SortVocabulary(map[string]string{
-		"updated_at": KindTimestamp,
-		"owner_id":   KindUUID,
+	vocab := SortVocabulary(map[string]SortField{
+		"updated_at": Column(KindTimestamp),
+		"owner_id":   Column(KindUUID),
 	}, nil)
 	at, id := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC), ids.NewV7()
 
@@ -280,7 +288,7 @@ func TestKeysetClause_CoreKindKeysRoundTrip(t *testing.T) {
 		"updated_at": {key: "2026-07-11 12:00:00.123456+00", wantCast: "::timestamptz"},
 	} {
 		t.Run(field, func(t *testing.T) {
-			s, err := ParseListSort(sortSpec(field), vocab)
+			s, err := ParseListSort(context.Background(), sortSpec(field), vocab, noArgs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -396,7 +404,7 @@ func TestSortError_NamesTheFieldAndTheCode(t *testing.T) {
 // of them was covered: DecodeCursor rejects this one before KeysetClause has a
 // sort to compare against, so a nil ListSort reaches it too.
 func TestKeysetClause_UndecodableTokenIsMalformed(t *testing.T) {
-	sorted, err := ParseListSort(sortSpec("cf_score"), testVocab)
+	sorted, err := ParseListSort(context.Background(), sortSpec("cf_score"), testVocab, noArgs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/platform/database/storekit/nextpage_test.go
+++ b/backend/internal/platform/database/storekit/nextpage_test.go
@@ -12,6 +12,7 @@ package storekit
 // fetch it with. Silent on the server, permanent for that list.
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ import (
 var beyondJSON = time.Date(294276, 1, 1, 0, 0, 0, 0, time.UTC)
 
 func TestAPageWhoseCursorWillNotMintIsAnErrorNotAnEmptyPromise(t *testing.T) {
-	sorted, err := ParseListSort(sortSpec("full_name"), testVocab)
+	sorted, err := ParseListSort(context.Background(), sortSpec("full_name"), testVocab, noArgs)
 	if err != nil {
 		t.Fatalf("building a non-default sort: %v", err)
 	}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -1478,12 +1478,13 @@ function dealColumns(
       // apart from a deal nobody has linked.
       //
       // No `sort`, for the reason the partner column below carries none: the
-      // company is a JOINED column and the list machinery orders by one column
-      // of the row's own table, so the API cannot offer it yet. A header that
-      // looked sortable and refused would be worse than one that never
-      // offered.
+      // Ordered by the company's NAME, not by the id the field is called
+      // after: the sort vocabulary names the reference and the server decides
+      // what ordering it means. A company this reader may not open sorts last,
+      // with the rest, because ordering by a name is reading it.
       key: "company",
       header: t("create.organization"),
+      sort: "organization_id",
       cell: (deal) => <CompanyCell deal={deal} field="organization_id" />,
     },
     {
@@ -1492,18 +1493,18 @@ function dealColumns(
       // per-row is worse in a list than an empty cell — a column that comes
       // and goes cannot be scanned down.
       //
-      // It carries no `sort` because the partner is a JOINED column: ordering
-      // by it means ordering by the organization's name, and the list
-      // machinery renders one quoted identifier of the row's own table. That
-      // limitation is not this column's to fix, and a header that looked
-      // sortable and refused would be worse than one that never offered.
       key: "partner",
       header: t("deal.partnerOrg"),
+      sort: "partner_org_id",
       cell: (deal) => <CompanyCell deal={deal} field="partner_org_id" />,
     },
     {
       key: "stage",
       header: t("deals.stage"),
+      // Ordered by the stage's place in its PIPELINE. Alphabetical stages are
+      // the funnel shuffled, which is never what somebody sorting by stage
+      // means.
+      sort: "stage_id",
       // stage_id is null for an overlay-mirror deal (OVA-MAP-6) — no native
       // stage row to name; a native deal always has one.
       cell: (deal) =>


### PR DESCRIPTION
The rest of #2090 for deals. #5213 built the gate that catches a dead header; this removes the three that were left.

## What was dead

The deals list draws eight columns. Five sorted. `company`, `partner` and `stage` did not, and the screen said why in a comment beside each one:

> the list machinery orders by one column of the row's own table, so the API cannot offer it yet

All three are **references**. That is the limitation this removes.

## A sortable field can carry the expression that orders it

`storekit.SortField` gains an optional `Expr`. Nil is still the ordinary case — the column of the field's own name, which is what every existing entry is (`storekit.Column(kind)`). A reference renders a correlated subquery instead.

The expression is rendered **once**, at parse time, and used for the `ORDER BY`, the cursor key and the keyset continuation alike — so a page cannot be ordered by one expression and continued by another. It is a function rather than a string because a reference sort has to ask the caller's own row scope, which needs the context and binds parameters.

No join: a correlated subquery leaves `RunListPage`'s one-table shape untouched.

## The two rulings the issue asked for

**A stage orders by its POSITION in its pipeline.** Alphabetical stages are the funnel shuffled — "Discovery, Negotiation, Proposal, Qualified" for a pipeline that runs Qualified → Discovery → Proposal → Negotiation — and nobody sorting by stage means that. `stage` is workspace configuration and carries no row scope, so the position is the same number for every reader.

**A company orders by its name, and a company this reader may not open orders the page by NOTHING.** Ordering by a value is reading it — the rule `refuseMaskedSort` already applies to masked amounts — so a page ordered by names the caller is refused would disclose them through its order: read it ascending and descending and the hidden company's position tells you where its name falls in the alphabet. The row scope goes **inside** the subquery, so such a reference answers NULL, lands in the tail the `ORDER BY` already puts last with every other deal whose company this reader cannot see, and says exactly what the row itself says about it: nothing.

## Proof

Four integration cases over a real Postgres, each mutation-verified against the arm it names:

- stage sorts by pipeline order, not by name — and the case **fails loudly** if the seeded stages ever become alphabetical, since it could not tell the two apart then. Mutating the expression to `stage_sort.name` fails it.
- a company column sorts by the company's name.
- an unreadable company sorts into the tail under **both** directions — a name that was really ordering the page would move to the other end. Dropping the scope from the subquery fails it, with the hidden company first.
- a reference sort pages one row at a time without repeating or skipping, across the NULL tail. Continuing by the column instead of the expression fails it.

`make check` green, `make craft-static` clean whole-tree, the full compose integration lane and the four touched module lanes green.

## What is left on #2090

The other lists, one entity at a time — the machinery they need is now here. `status` still sorts by its stored value rather than by lifecycle; that is a vocabulary question of its own and the issue names it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deal lists now support sorting by company, partner, and stage.
  - Stage sorting follows pipeline order, while company and partner sorting uses display names.
  - Sorting respects visibility permissions for referenced companies and partners.

- **Bug Fixes**
  - Improved deal-list pagination when sorting by referenced fields, preventing skipped or repeated results.
  - Deals linked to unreadable companies are placed consistently at the end of results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->