### PR TITLE
feat(lists): an account sorts by the columns its list draws (#2090)

### DIFF
--- a/backend/internal/compose/integration/orgsortvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/orgsortvocabulary_integration_test.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A column the accounts list SHOWS is a column the accounts list SORTS BY.
+//
+// The list draws eight columns and its vocabulary reached three of them, so
+// five headers were dead controls a reader had to learn to ignore. Three of the
+// five are DERIVED — the website comes off the primary domain row and the two
+// counts are read per page rather than stored — so each is asserted the way
+// that matters: the order the list gives agrees with the values it prints.
+// That is what makes the count in the ORDER BY the same count as the one on
+// screen rather than a second derivation that will drift.
+//
+// The relationship column is deliberately absent. An account can be a partner
+// AND a customer, so there is no single value to order by.
+
+import (
+	"context"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// orgsIn lists the accounts this caller sees under one sort spec, in order.
+func orgsIn(ctx context.Context, t *testing.T, e *Env, spec string) []crmcontracts.Organization {
+	t.Helper()
+	rows, _, err := e.People.ListOrganizations(ctx, people.ListOrganizationsInput{Sort: &spec})
+	if err != nil {
+		t.Fatalf("ListOrganizations(sort=%s): %v", spec, err)
+	}
+	return rows
+}
+
+func orgIDsIn(ctx context.Context, t *testing.T, e *Env, spec string) []ids.UUID {
+	t.Helper()
+	rows := orgsIn(ctx, t, e, spec)
+	out := make([]ids.UUID, len(rows))
+	for i, o := range rows {
+		out[i] = ids.UUID(o.Id)
+	}
+	return out
+}
+
+// The two plain columns the vocabulary simply did not name.
+func TestTheAccountsListSortsByTheDescriptionAndLifecycleItDraws(t *testing.T) {
+	e := Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+
+	// Seeded so that neither answer can come from insertion order or from the
+	// name, which is the sort the list already had.
+	zeta := seedAccount(t, e, people.CreateOrganizationInput{
+		DisplayName: "Zeta Holding", Description: strPtr("An early note"),
+	})
+	alma := seedAccount(t, e, people.CreateOrganizationInput{
+		DisplayName: "Alma Werke", Description: strPtr("Zero interest so far"),
+	})
+	setLifecycle(t, e, zeta, "customer")
+	setLifecycle(t, e, alma, "target")
+
+	assertIDOrder(t, orgIDsIn(ctx, t, e, "description"), []ids.UUID{zeta, alma},
+		"description ascending")
+	assertIDOrder(t, orgIDsIn(ctx, t, e, "lifecycle"), []ids.UUID{zeta, alma},
+		"lifecycle ascending — customer before target")
+}
+
+// The Website header orders by the HOST it prints, off the primary domain row
+// that website_url is derived from.
+func TestTheAccountsListSortsByTheWebsiteItDraws(t *testing.T) {
+	e := Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+
+	// Names and hosts deliberately disagree, so the answer cannot come from the
+	// sort this list already had.
+	// TWO domains, the non-primary one created first and sorting last: the
+	// column prints the PRIMARY host, so a sort that read any live domain —
+	// or read them oldest-first — would key this account on "zzz.example" and
+	// put it the other side of the account below.
+	zeta := seedAccount(t, e, people.CreateOrganizationInput{
+		DisplayName: "Zeta Holding",
+		Domains: []people.OrgDomainInput{
+			{Domain: "zzz.example"},
+			{Domain: "alma.example", IsPrimary: true},
+		},
+	})
+	alma := seedAccount(t, e, people.CreateOrganizationInput{
+		DisplayName: "Alma Werke",
+		Domains:     []people.OrgDomainInput{{Domain: "zeta.example", IsPrimary: true}},
+	})
+	// No domain at all: nothing to print and nothing to order by, so it sits in
+	// the tail rather than ahead of every named host.
+	nameless := e.SeedOrg(t, "Mercator", &e.Rep1)
+
+	assertIDOrder(t, orgIDsIn(ctx, t, e, "website_url"), []ids.UUID{zeta, alma, nameless},
+		"website ascending — alma.example before zeta.example, no host last")
+
+	// And the order agrees with what the rows print, which is the claim that
+	// makes the expression the same derivation rather than a second one.
+	rows := orgsIn(ctx, t, e, "website_url")
+	if len(rows) != 3 || rows[0].WebsiteUrl == nil || *rows[0].WebsiteUrl != "https://alma.example" {
+		t.Fatalf("the first row prints %v, and the page was ordered by the host it comes from", rows[0].WebsiteUrl)
+	}
+}
+
+// The Contacts header orders by the number it prints — counted per row, under
+// the same scope the page's own count applies.
+func TestOrderingAccountsByContactsAgreesWithTheCountTheyShow(t *testing.T) {
+	e := Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+
+	busy := e.SeedOrg(t, "Alma Werke", &e.Rep1)
+	quiet := e.SeedOrg(t, "Zeta Holding", &e.Rep1)
+	for _, name := range []string{"One", "Two", "Three"} {
+		employPerson(t, e, e.SeedPerson(t, name+" at Alma", &e.Rep1), busy, nil)
+	}
+	employPerson(t, e, e.SeedPerson(t, "Only at Zeta", &e.Rep1), quiet, nil)
+
+	// Ascending puts the quieter account first, which is the reverse of the
+	// name order the list already had.
+	assertIDOrder(t, orgIDsIn(ctx, t, e, "contact_count"), []ids.UUID{quiet, busy},
+		"contacts ascending")
+
+	rows := orgsIn(ctx, t, e, "-contact_count")
+	if len(rows) != 2 {
+		t.Fatalf("listed %d accounts, want 2", len(rows))
+	}
+	// The ordering and the printed number are the same number.
+	if rows[0].ContactCount == nil || *rows[0].ContactCount != 3 {
+		t.Errorf("the account the page put first prints %v contacts, not the 3 it was ordered by",
+			rows[0].ContactCount)
+	}
+	if rows[1].ContactCount == nil || *rows[1].ContactCount != 1 {
+		t.Errorf("the second account prints %v contacts, not 1", rows[1].ContactCount)
+	}
+}
+
+// A count this reader is not shown orders the page by NOTHING.
+//
+// The open-pipeline figure is withheld from a role without computed_field:read
+// (STATE-4), and a page ordered by a number they are refused would disclose it
+// through the order — read it both ways and the largest pipeline is at whichever
+// end. Every such row sits in the tail instead.
+func TestAWithheldCountOrdersTheAccountsListByNothing(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+
+	big := e.SeedOrg(t, "Alma Werke", &e.Rep1)
+	small := e.SeedOrg(t, "Zeta Holding", &e.Rep1)
+	for i := range 3 {
+		seedDealForCompany(t, e, "Alma deal "+string(rune('A'+i)), pipeline, open, big)
+	}
+	seedDealForCompany(t, e, "Zeta deal", pipeline, open, small)
+
+	// Admitted first: a reader who IS shown the count is ordered by it, so the
+	// silence below is the grant's doing and not a sort that never worked. The
+	// admin holds computed_field:read; AccountRepPerms deliberately does not.
+	assertIDOrder(t, orgIDsIn(e.Admin(), t, e, "-open_deal_count"), []ids.UUID{big, small},
+		"open deals descending, for a reader who may see them")
+
+	blind := e.As(e.Rep1, []ids.UUID{e.Team1}, AccountRepPerms)
+	rows := orgsIn(blind, t, e, "-open_deal_count")
+	if len(rows) != 2 {
+		t.Fatalf("listed %d accounts, want 2", len(rows))
+	}
+	for _, o := range rows {
+		if o.OpenDealCount != nil {
+			t.Fatalf("the reader without computed_field:read was shown a count of %d", *o.OpenDealCount)
+		}
+	}
+	// Both rows in the tail, so the page falls back to its tie-breaker and the
+	// order says nothing about the pipelines behind it. Newest first is what
+	// that tie-breaker gives, and Zeta was seeded last.
+	assertIDOrder(t, []ids.UUID{ids.UUID(rows[0].Id), ids.UUID(rows[1].Id)},
+		[]ids.UUID{small, big}, "open deals descending, for a reader shown none")
+}
+
+// seedAccount creates one account through the real writer, owned by Rep1.
+func seedAccount(t *testing.T, e *Env, in people.CreateOrganizationInput) ids.UUID {
+	t.Helper()
+	in.OwnerID, in.Source = userIDPtr(&e.Rep1), "manual"
+	org, err := e.People.CreateOrganization(e.Admin(), in)
+	if err != nil {
+		t.Fatalf("seeding %q: %v", in.DisplayName, err)
+	}
+	return ids.UUID(org.Id)
+}
+
+// setLifecycle moves an account's stage through the real update path, so the
+// column the sort reads holds a value a writer really put there.
+func setLifecycle(t *testing.T, e *Env, org ids.UUID, to string) {
+	t.Helper()
+	if _, err := e.People.UpdateOrganization(e.Admin(), ids.From[ids.OrganizationKind](org),
+		people.UpdateOrganizationInput{Lifecycle: &to}); err != nil {
+		t.Fatalf("setting the lifecycle to %q: %v", to, err)
+	}
+}

--- a/backend/internal/modules/people/opendealcount_test.go
+++ b/backend/internal/modules/people/opendealcount_test.go
@@ -51,7 +51,11 @@ var dealStatusConstraint = regexp.MustCompile(`(?i)\bstatus\b\s*(=|<>|!=|\bIN\b|
 func TestEveryOpenDealCountComesFromTheRollup(t *testing.T) {
 	counts, dealReads := 0, 0
 	for _, sql := range moduleSQLLiterals(t) {
-		if strings.Contains(sql.text, "open_deal_count") {
+		// A literal that is EXACTLY the column name is a NAME — the sort
+		// vocabulary's key for the column, say — and names no population.
+		// Exempted at exactly that width and no wider: one more character and
+		// the literal is assembling something, which is what this arm reads.
+		if strings.Contains(sql.text, "open_deal_count") && sql.text != "open_deal_count" {
 			counts++
 			if !gatekit.TableReadPattern(openPipelineRollupView).MatchString(sql.text) {
 				t.Errorf("%s reads open_deal_count without reading %s:\n\n\t%s\n\n"+

--- a/backend/internal/modules/people/organization_counts.go
+++ b/backend/internal/modules/people/organization_counts.go
@@ -105,32 +105,53 @@ func grantVisible(ctx context.Context, object string) bool {
 func fillContactCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUID]*crmcontracts.Organization, orgIDs []ids.UUID) error {
 	args := []any{orgIDs}
 	arg := func(v any) int { args = append(args, v); return len(args) }
-	// attachOrgCounts admitted the object; this bounds WHICH edges are counted,
-	// so a count never includes an edge whose endpoint the caller cannot reach.
-	edgeBound, err := auth.RelationshipEndpointScope(ctx, "rel", arg)
+	// attachOrgCounts admitted the object; the helper bounds which edges and
+	// people are counted, so a count never includes an edge whose endpoint the
+	// caller cannot reach.
+	from, err := countedEmploymentFrom(ctx, "rel.organization_id = ANY($1)", arg)
 	if err != nil {
 		return err
+	}
+	return fillCount(ctx, tx, idx,
+		`SELECT rel.organization_id, count(*)`+from+`
+		 GROUP BY rel.organization_id`, args,
+		func(o *crmcontracts.Organization, n int) { o.ContactCount = &n })
+}
+
+// countedEmploymentFrom is the FROM and WHERE of "which contacts work here that
+// this caller may see", with the organization binding left to the caller.
+//
+// Both the count the page PRINTS and the expression it ORDERS BY build their
+// statement from here — the page counts the whole set at once, the sort counts
+// per row — so a reader sees the number the list was arranged by rather than a
+// second reading of the same question.
+//
+// It takes the gates itself rather than being handed them: which employment
+// EDGES this caller may traverse bounds the count as much as which PEOPLE they
+// may see, and a caller that had to remember to pass either could forget one
+// and get a counting oracle over edges it is refused everywhere else.
+func countedEmploymentFrom(ctx context.Context, orgBinding string, arg func(any) int) (string, error) {
+	edgeBound, err := auth.RelationshipEndpointScope(ctx, "rel", arg)
+	if err != nil {
+		return "", err
 	}
 	if edgeBound != "" {
 		edgeBound = " AND " + edgeBound
 	}
 	scope, err := auth.ScopeClauseFor(ctx, "person", "p", arg)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if scope != "" {
 		scope = " AND " + scope
 	}
-	return fillCount(ctx, tx, idx,
-		`SELECT rel.organization_id, count(*)
+	return `
 		 FROM relationship rel
 		 JOIN person p ON p.id = rel.person_id AND p.archived_at IS NULL
-		 WHERE rel.organization_id = ANY($1)
+		 WHERE ` + orgBinding + `
 		   AND rel.kind = 'employment'
-		   AND `+employment.CurrentPrimarySQL("rel")+`
-		   AND rel.archived_at IS NULL`+edgeBound+scope+`
-		 GROUP BY rel.organization_id`, args,
-		func(o *crmcontracts.Organization, n int) { o.ContactCount = &n })
+		   AND ` + employment.CurrentPrimarySQL("rel") + `
+		   AND rel.archived_at IS NULL` + edgeBound + scope, nil
 }
 
 // fillOpenDealCounts reads the 0065 organization_open_pipeline_rollup view

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -81,6 +81,16 @@ var organizationListFields = map[string]storekit.SortField{
 	orgNameColumn:      storekit.Column(fieldcatalog.TypeText),
 	ownerIDColumn:      storekit.Column(storekit.KindUUID),
 	lastActivityColumn: storekit.Column(storekit.KindTimestamp),
+	columnDescription:  storekit.Column(fieldcatalog.TypeText),
+	// classification is retired and the column the list draws is lifecycle, so
+	// this is the one the header offers. By the stored value, which groups the
+	// seven states together; the funnel's own order is a question of its own
+	// and the deals list answers `status` the same way today.
+	filterLifecycle: storekit.Column(fieldcatalog.TypeText),
+	// The three the list draws and does not store (organization_sorts.go).
+	"website_url":     {Kind: fieldcatalog.TypeText, Expr: orderByPrimaryDomain},
+	"contact_count":   {Kind: fieldcatalog.TypeNumber, Expr: orderByContactCount},
+	"open_deal_count": {Kind: fieldcatalog.TypeNumber, Expr: orderByOpenDealCount},
 }
 
 // organizationDomainClause narrows the page to the account that lists one

--- a/backend/internal/modules/people/organization_sorts.go
+++ b/backend/internal/modules/people/organization_sorts.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// What the accounts list orders by when the column it draws is not a column of
+// `organization`.
+//
+// A column the list SHOWS is a column the list SORTS BY (Lars, 2026-08-21), and
+// half of what this list shows is derived: the website comes off the primary
+// domain row, and the two counts are read per page rather than stored. Each is
+// spelled here as the expression that orders it, beside the rule it mirrors.
+
+import (
+	"context"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// orderByPrimaryDomain orders by the host the Website column draws.
+//
+// website_url is DERIVED, never stored (ADR-0085): the primary domain row is
+// the canonical fact. This picks the same row attachOrgDomains renders from —
+// live, primary, oldest first — so the order the reader sees is the order of
+// the values on screen. An account with no primary domain shows nothing and
+// orders by nothing, which is the same answer.
+//
+// The domain rather than the rendered URL, because the scheme is a constant
+// this product adds and sorting by "https://" tells nobody anything.
+func orderByPrimaryDomain(context.Context, func(any) int) (string, error) {
+	return `(SELECT wd.domain FROM organization_domain wd
+	          WHERE wd.organization_id = organization.id
+	            AND wd.archived_at IS NULL AND wd.is_primary
+	          ORDER BY wd.created_at LIMIT 1)`, nil
+}
+
+// orderByContactCount orders by how many contacts this caller may see at the
+// account — the number the Contacts column prints, counted per row.
+//
+// A role that may not read people, or may not traverse employment edges, sees
+// no count and orders by NOTHING: the column is absent for them, and a page
+// ordered by a number they are refused would disclose it through the order.
+func orderByContactCount(ctx context.Context, arg func(any) int) (string, error) {
+	if !grantVisible(ctx, "person") || !grantVisible(ctx, "relationship") {
+		return withheldSortValue, nil
+	}
+	from, err := countedEmploymentFrom(ctx, "rel.organization_id = organization.id", arg)
+	if err != nil {
+		return "", err
+	}
+	return "(SELECT count(*)" + from + ")", nil
+}
+
+// orderByOpenDealCount orders by the account's open pipeline, read from the
+// 0065 rollup, where "open deal" is defined — so the order and the number on
+// screen come from the same rows.
+//
+// Held by: TestEveryOpenDealCountComesFromTheRollup (backend/internal/modules/people/opendealcount_test.go)
+//
+// The as-of date is rollupAsOf(), which the page's own count already uses and
+// which truncates to the day: the sort and the figure beside it cannot land on
+// two different instants.
+//
+// A role without computed_field:read is shown NO count (STATE-4) and orders by
+// nothing — same rule as the contacts column above, for the same reason.
+func orderByOpenDealCount(ctx context.Context, arg func(any) int) (string, error) {
+	if !grantVisible(ctx, "deal") || !computedFieldsVisible(ctx) {
+		return withheldSortValue, nil
+	}
+	return storekit.SQLf(
+		`(SELECT pipeline_sort.open_deal_count
+		    FROM organization_open_pipeline_rollup($%d) pipeline_sort
+		   WHERE pipeline_sort.organization_id = organization.id)`, arg(rollupAsOf())), nil
+}
+
+// withheldSortValue is what a column this caller may not see orders by: NULL,
+// which the list's ORDER BY already puts last. Every row then sits in the tail
+// together and the page falls back to its tie-breaker, so the order says
+// nothing at all about the figures behind it.
+//
+// CAST, because Postgres reads a bare NULL in an ORDER BY as a constant and
+// refuses the statement. Both columns this answers for are counts, so the type
+// is the one their cursor keys already round-trip through.
+const withheldSortValue = "NULL::numeric"
+
+// Compile-time proof that each of these is the shape a sortable field takes.
+var _ = []func(context.Context, func(any) int) (string, error){
+	orderByPrimaryDomain, orderByContactCount, orderByOpenDealCount,
+}

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -310,11 +310,14 @@ export function CompaniesScreen() {
             key: "description",
             header: t("org.description"),
             cell: (org: Organization) => org.description ?? "",
+            sort: "description",
           },
           tagsColumn<Organization>(t),
           {
             key: "website",
             header: t("org.website"),
+            // By the HOST the cell prints — the scheme is a constant.
+            sort: "website_url",
             cell: (org: Organization) =>
               org.website_url ? (
                 <a
@@ -335,6 +338,8 @@ export function CompaniesScreen() {
             header: t("org.contactCount"),
             numeric: true,
             cell: (org: Organization) => org.contact_count ?? "",
+            // A reader shown no count is ordered by none: such rows go last.
+            sort: "contact_count",
           },
           {
             // Withheld (absent key), not zero, for a role without
@@ -344,10 +349,12 @@ export function CompaniesScreen() {
             header: t("org.openDealCount"),
             numeric: true,
             cell: (org: Organization) => org.open_deal_count ?? "",
+            sort: "open_deal_count",
           },
           {
             key: "class",
             header: t("org.lifecycle"),
+            sort: "lifecycle",
             // classification is retired and no longer written by anything,
             // so a column reading it would show whatever it happened to
             // hold when the split shipped, forever.
@@ -359,6 +366,10 @@ export function CompaniesScreen() {
           {
             key: "relationship",
             header: t("org.relationshipTypes"),
+            // NO `sort`, and not a gap: an account can be a partner AND a
+            // customer, so ordering by the first member of a set would read as
+            // an answer without being one. The filter above narrows instead.
+            //
             // A filter with no column to read it back on is a list that cannot
             // say why a row matched. Multi-valued on purpose (ADR-0079):
             // an account can be a partner AND a customer, and showing only the

--- a/scripts/fe-file-length-waivers.txt
+++ b/scripts/fe-file-length-waivers.txt
@@ -101,7 +101,7 @@
 856 frontend/src/screens/onboarding-gate.tsx
 995 frontend/src/screens/onboarding-read.tsx
 2534 frontend/src/screens/organizations.test.tsx
-2589 frontend/src/screens/organizations.tsx
+2587 frontend/src/screens/organizations.tsx
 984 frontend/src/screens/overlay-usermap.tsx
 648 frontend/src/screens/partners.tsx
 513 frontend/src/screens/person360.tsx


### PR DESCRIPTION
#2090 for the accounts list. #5304 built the machinery on deals; this is the next entity.

## What was dead

Eight columns, three sortable. Five headers did nothing — and three of those five are not columns of `organization` at all:

| column | what it draws | now orders by |
|---|---|---|
| Description | `description` | the column |
| Lifecycle | `lifecycle` | the column |
| Website | derived from the primary domain row (ADR-0085) | that row's host |
| Contacts | counted per page under the caller's scope | the same count, per row |
| Open deals | the 0065 open-pipeline rollup | the same rollup |
| Relationship types | a SET | **nothing, deliberately** |

## The derived three

**Website** picks the same row `attachOrgDomains` renders from — live, primary, oldest first — so the order is the order of the values on screen. The domain rather than the URL: the scheme is a constant this product adds. An account with no primary domain shows nothing and orders by nothing.

**Contacts** is the number the column prints. The page counts the whole set at once, the sort counts per row, and both build their statement from one helper — which now takes its own gates rather than being handed them. That is not tidying: which employment **edges** a caller may traverse bounds the count as much as which **people** they may see, and a caller who had to remember to pass either could forget one and get a counting oracle over edges it is refused on every other surface. The `edgereaders` gate catches exactly that, and did.

**Open deals** reads the 0065 rollup, where "open deal" is defined, at `rollupAsOf()` — the same as-of date the page's own figure uses, truncated to the day, so the sort and the number beside it cannot land on two instants.

## A count this reader is not shown orders the page by nothing

The open-pipeline figure is withheld from a role without `computed_field:read` (STATE-4). A page ordered by a number they are refused would disclose it through the order: read it ascending and descending and the largest pipeline is at whichever end. Those rows sort into the tail instead, all of them, and the page falls back to its tie-breaker.

The same rule covers the contacts count for a role without `person.read` or `relationship.read`.

## The relationship column keeps no sort

An account can be a partner AND a customer. Ordering by the first member of a set would read as an answer without being one — the filter is how a reader narrows to a type. Said in the column, so the next reader does not take it for the gap the other five were.

## One gate learned something

`TestEveryOpenDealCountComesFromTheRollup` walks every string literal in the module and refuses one that names `open_deal_count` without reading the rollup. The sort vocabulary's KEY is that string. It now exempts a literal that is **exactly** the column name — a name, not a query — and nothing wider: one character more and the literal is assembling something. Mutation-verified by giving the sort its own count off the `deal` table, which the gate still catches.

## Proof

Four integration cases over a real Postgres, each mutation-verified:

- the two plain columns order by their values, seeded so neither answer can come from insertion order or the name.
- the website orders by the primary host — the account under test carries a **second, non-primary domain created first and sorting last**, so a sort reading any live domain, or reading them oldest-first, puts it the other side of its neighbour. Both mutations fail it.
- the contacts order agrees with the counts the same rows print, asserted on the rows themselves rather than on ids alone.
- a withheld count orders by nothing, admitted first as a reader who may see it.

`make check` green, `make craft-static` clean whole-tree, the compose integration lane and the people module lane green.

## What is left on #2090

Contacts (email by the primary address, company by the employer), leads (status is already in the vocabulary and just needs the header; next task and source are references) and projects (company, phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC