### PR TITLE
fix(rail): the address grid keeps the panel's left edge

### DIFF
--- a/frontend/src/design-system/disclosure-inset.test.ts
+++ b/frontend/src/design-system/disclosure-inset.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { withoutComments } from "../testing/css";
+
+// Fitness function for a disclosure nested inside a disclosure.
+//
+// A screen that draws its sections as `Disclosure`s gives the section's body
+// the pane's inset — that is how a slice's rows sit on the panel's gutter. Spelt
+// as a DESCENDANT (`.co-rail .co-sect .disclosure-body`), that inset also
+// reaches every disclosure nested inside the slice, which pays it a second time:
+// the company rail's Details slice draws the postal address behind a disclosure
+// of its own, and its six rows started a full pane-padding right of the nine
+// rows above them, with the value column losing that width at both ends — long
+// enough to break a street name mid-syllable while the fields above it did not.
+//
+// The invariant, then: a section's inset belongs to that section's OWN body, so
+// a nested disclosure keeps the atom's body and both grids share one left edge.
+// Scoped with `>` it does; there is no other way to spell it that a reader can
+// see at the call site, which is why this asks about the combinator rather than
+// about any one screen's rule.
+//
+// WHAT IT CANNOT SEE, deliberately:
+//
+//   - Paint. It reads what the sheets declare; jsdom applies no stylesheet, so
+//     no test in this suite measures a left edge.
+//   - An inset put on the nested disclosure by any other selector — a screen
+//     class on the `<details>` itself, or padding on the grid inside it. The
+//     descendant `.disclosure-body` is the shape that actually regressed, twice
+//     in this tree.
+
+const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function stylesheets(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === "node_modules" || entry.name === "dist"
+        ? []
+        : stylesheets(path);
+    }
+    return entry.name.endsWith(".css") ? [path] : [];
+  });
+}
+
+/** One selector mentioning `.disclosure-body`, and where it was written. */
+type Mention = Readonly<{ sheet: string; selector: string }>;
+
+// Every selector in the tree that reaches a disclosure's body. Selector
+// preludes, one per comma, comments blanked first — a rule spelt out in the
+// paragraph above it is prose, and a commented-out rule styles nothing.
+const mentions: Mention[] = stylesheets(srcRoot).flatMap((sheet) => {
+  const css = withoutComments(readFileSync(sheet, "utf8"));
+  return [...css.matchAll(/([^{}]+)\{[^{}]*\}/g)].flatMap((rule) =>
+    rule[1]
+      .split(",")
+      .map((one) => one.trim().replace(/\s+/g, " "))
+      .filter((one) => one.includes(".disclosure-body"))
+      .map((selector) => ({ sheet: relative(srcRoot, sheet), selector })),
+  );
+});
+
+// The atom's own rule is the one selector that names the body with nothing to
+// its left; every other mention scopes it to something, and scoping is what
+// this gate is about.
+const scoped = mentions.filter(
+  (one) => !/^\.disclosure-body\b/.test(one.selector),
+);
+
+describe("a section's inset stops at that section's own body", () => {
+  // A scan that reads a smaller tree than it thinks reports PASS with no
+  // failing assertion to notice, so the corpus is asserted before it is judged:
+  // the sheets, the atom's own rule, and the scoped mentions the rule below
+  // exists for.
+  it("reads the whole tree of stylesheets", () => {
+    expect(stylesheets(srcRoot).length).toBeGreaterThan(20);
+    expect(
+      mentions.some((one) => /^\.disclosure-body\b/.test(one.selector)),
+      "the scan did not find the atom's own `.disclosure-body` rule, so it is " +
+        "reading something other than this tree's stylesheets",
+    ).toBe(true);
+    expect(scoped.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("scopes every inset to a direct child", () => {
+    for (const { sheet, selector } of scoped) {
+      expect(
+        selector,
+        `${sheet} insets \`.disclosure-body\` by descent, so a disclosure ` +
+          "nested inside that section pays the inset a second time and its " +
+          "rows start right of the rows above them; scope it with `>`",
+      ).toMatch(/>\s*\.disclosure-body\b/);
+    }
+  });
+});

--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -1159,7 +1159,14 @@
 .co-rail .co-sect > summary .badge {
   margin-left: auto;
 }
-.co-rail .co-sect .disclosure-body {
+/* The SECTION's own body, by child combinator rather than by descent: a
+   disclosure nested inside a slice — the Details grid's postal address is one —
+   took this inset a second time as a descendant, so its labels and values
+   started a pane's padding right of the rows above them and the value column
+   lost that width twice over, breaking a street name mid-syllable. A nested
+   disclosure keeps the atom's own body, which is what puts both grids on one
+   left edge. */
+.co-rail .co-sect > .disclosure-body {
   margin-top: 0;
   padding: 0 var(--padPanel) var(--padPanel);
 }

--- a/frontend/src/screens/companyraildetails.tsx
+++ b/frontend/src/screens/companyraildetails.tsx
@@ -640,8 +640,8 @@ function DetailsGridBody({
       {/* The address block sits last rather than in its old slot between the
           domain and the industry: it is its own grid now, and two grids with a
           third between them put two seams through a panel that reads best as
-          one block. Both grids stand on the same 112px label rung, so the
-          values still share one left edge down the whole panel. */}
+          one block. Both are the same `FieldGrid icons`, so the values share one
+          left edge — which no screen may inset away (disclosure-inset.test.ts). */}
       <FieldGrid icons>
         <LegalNameRow {...row} />
         {/* Beside the legal name, not with the postal address below: a VAT

--- a/frontend/src/screens/person360.css
+++ b/frontend/src/screens/person360.css
@@ -411,7 +411,7 @@
   top: var(--space-2);
   right: var(--space-5);
 }
-.pe-rail .pe-sect .disclosure-body {
+.pe-rail .pe-sect > .disclosure-body {
   margin-top: 0;
   padding: 0 var(--padPanel) var(--padPanel);
 }


### PR DESCRIPTION
## What

In the company rail's Details slice, the postal address rows sat a full pane-padding to the right of every field above them, and their value column was ~40px narrower at the same time — narrow enough to break a street name mid-word ("Zitadellenstr / aße 14a") while "Company Consulting" two rows up held one line. After this PR both grids stand on one label rung and one value edge down the whole panel.

## Why

The rail draws each slice as a `Disclosure`, and `company360.css` gave the slice's body the pane's inset by DESCENT (`.co-rail .co-sect .disclosure-body`). The address is a disclosure nested inside that slice, so its body matched the same rule and paid the inset a second time — on both sides, which is why the value column lost width twice over.

The invariant: a section's inset belongs to that section's OWN body, so a disclosure nested inside it keeps the atom's body and both grids share one left edge. Scoped with a child combinator it does. The person rail carried the same descendant spelling, so it is scoped too rather than left as a second copy waiting for its first nested disclosure.

A new gate reads every stylesheet under `frontend/src` and fails any selector that insets `.disclosure-body` by descent. It asserts its corpus before it judges it — the sheets it found, the atom's own unscoped rule, and the scoped mentions the rule exists for — so a scan that reads less than the tree cannot report a silent PASS.

## How verified

- `make check-fe` green end to end (ds-gates, drift, lint, 659 test files / 8818 tests, build, composed typecheck).
- The gate was proved to fail: reverting `company360.css` to the descendant spelling turns it red naming that sheet; restoring it turns it green.
- Measured in Chromium (Playwright, rail markup against the real sheets) rather than asserted by eye, since jsdom applies no stylesheet. Before: outer label x=49 / inner x=69, outer value 193–323 / inner 213–303, street wrapping to two lines. After: labels both x=49, values both 193–323, street on one line.

- [ ] `make check` is green — its frontend half (`make check-fe`) is green as above; the backend half was not run because this diff contains no Go and no backend file. CI runs both.
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — three CSS/TSX-comment lines and one frontend gate; no tenant data, no RLS, no write path.
- [x] `make craft-static` reports no new blockers — it reads Go, and this diff changes no Go file.
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by Claude Code end to end: the diagnosis, the two CSS scopings, the gate, and this description. The browser measurement above was run against the real sheets rather than reasoned about, and the gate was checked for its ability to fail before it was kept.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjwfmytcE2YEDTQd5yC5wF

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjwfmytcE2YEDTQd5yC5wF)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the company rail's postal address grid so it sits on the same left edge as the fields above it, instead of starting a full pane padding right with a value column ~40px narrower.

- `company360.css` and `person360.css` now scope the section inset to a direct child (`.co-rail .co-sect > .disclosure-body`), so a disclosure nested inside a section no longer pays the inset a second time.
- The new gate `frontend/src/design-system/disclosure-inset.test.ts` reads every stylesheet under `frontend/src` and fails any selector that insets `.disclosure-body` by descent; it asserts its corpus first, so a scan that reads less than the tree can't report a silent pass.

<sup>Written for commit 43ba95e166c3f8566a76ec48d213b042b397e88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

