### PR TITLE
feat(shell): the agent panel's recap names the record it worked on

### DIFF
--- a/docs/explanation/ai-activity-rail.md
+++ b/docs/explanation/ai-activity-rail.md
@@ -203,6 +203,30 @@ ticker's own `enrich` key names DIFFERENT work — a provider run on a person
 runs `cold_start`, not this task. The deep read rides its own `site-read` ticker
 key, not this one.
 
+### Where a narrated line lands
+
+Three places, and each answers a different question.
+
+- **The panel's running section** lists what is LIVE, and only that.
+- **The panel's recap** ("What it has done") lists what SETTLED today, newest
+  first, at most five. Same copy table, so one occurrence is told in one
+  vocabulary from start to finish — "I'm reading the Acme website" while it runs
+  and "I've read the Acme website" once it is done — and the record's name is a
+  LINK, which is the half of the row a reader can act on. It reads THIS feed
+  rather than the model-call trace deliberately: `ai_call` is telemetry and
+  carries no subject (`Call.Subject` reaches the occurrence and never the trace),
+  so a recap read from there could report that something happened and nothing
+  about what it happened to. The trace is still one click away, behind
+  "Full log".
+- **The card's resting line** rotates the newest settled occurrence among the
+  agent's other standing facts, because the rail is 235px wide and carries one
+  line.
+
+A kind with no copy draws nothing in any of the three. The recap says "nothing
+has finished today" only once the feed has ANSWERED: an unread feed draws no
+sentence at all, because "nothing finished" is a claim about a day somebody
+looked at.
+
 ### The ask: what this tab knows before the feed does
 
 The feed arrives on a poll, so between a person pressing "Draft with AI" and

--- a/frontend/src/app/agentrail-copy.ts
+++ b/frontend/src/app/agentrail-copy.ts
@@ -12,52 +12,6 @@ import type { MarginceCoreState } from "../design-system/margince-core";
  * here is the words those readings are said in.
  */
 
-/**
- * The agent's tasks, in words a person who does not work on this product can
- * read.
- *
- * The wire carries `growth_fit` and `site_fact_extract`, which are the names of
- * INVOCATION SITES — correct for a trace, and meaningless to the salesperson
- * whose company page they ran on. A recap that prints them is a log with a
- * friendlier heading: the reader learns that something happened five times and
- * nothing about what.
- *
- * Each line says what the agent DID, in the past tense, from the reader's side
- * rather than the pipeline's. A task with no entry falls back to its token with
- * the underscores opened up, so a task added upstream degrades to something
- * readable instead of disappearing.
- */
-export const TASK_SAID: Readonly<Record<string, string>> = {
-  account_scan: "Read what an account needs",
-  agent_loop: "Worked through a request",
-  brief_ranking: "Ranked your morning brief",
-  capture_classify: "Sorted captured mail",
-  owed_verdict: "Read which messages are waiting on you",
-  capture_counterparty_verdict: "Decided who a message was with",
-  cert_judge: "Checked its own answer",
-  cold_start: "Set up your workspace",
-  corpus_ask: "Answered from your documents",
-  deal_health: "Read the health of a deal",
-  document_extract: "Pulled fields out of a document",
-  draft_reply: "Drafted a reply",
-  embeddings: "Indexed records for search",
-  enrich: "Filled in contact details",
-  growth_fit: "Scored how well a company fits",
-  nl_search: "Answered a search",
-  offer_draft: "Drafted an offer",
-  rate_extract: "Read pricing off a page",
-  signal_extract: "Found signals in a thread",
-  stage_evidence_extract: "Checked what a deal still needs",
-  site_extract: "Read a company website",
-  site_fact_extract: "Pulled facts off a web page",
-  site_triage: "Picked which pages to read",
-  summarize: "Wrote a summary",
-  transcript: "Processed a call transcript",
-  propose_roles: "Read the buying roles from their messages",
-  transcript_propose: "Proposed next steps from a call",
-  voice_build: "Learned your writing voice",
-};
-
 export const LABELS = {
   /** The month's estimated spend, and it says estimated by saying "so far":
    *  the server prices on read, so the figure moves as rates change. */
@@ -76,7 +30,10 @@ export const LABELS = {
   recap: "What it has done",
   justNow: "just now",
   fullLog: "Full log",
-  logUnreadable: "The call log is not readable on this seat",
+  /** The recap when the feed answered and this person's day holds nothing yet.
+   *  It is bounded to what SETTLED today, so an empty list is a quiet morning
+   *  rather than an agent that has never run. */
+  nothingToday: "nothing has finished today",
   model: "model",
   sources: "sources",
   tools: "tools",

--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -1007,6 +1007,17 @@
   font-style: italic;
 }
 
+/* The recap's sentence, as ONE flex item.
+ *
+ * A recap line can carry a link around the record it names, and the line is
+ * rendered as a fragment — dropped straight into the row it would make that
+ * link a flex child of its own, with the row's gap opened between the words
+ * and the name. `min-width: 0` is what lets a long company name wrap inside
+ * the sentence instead of pushing the stamp out of the panel. */
+.arsaid {
+  min-width: 0;
+}
+
 .armuted {
   margin-left: auto;
   padding-left: var(--space-2);

--- a/frontend/src/app/agentrail.recap.test.tsx
+++ b/frontend/src/app/agentrail.recap.test.tsx
@@ -1,0 +1,173 @@
+/** @vitest-environment jsdom */
+
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { AgentRail } from "./agentrail";
+import { LABELS } from "./agentrail-copy";
+import { meFixture } from "./mefixture";
+
+// The panel's recap: what the agent has done, and WHICH RECORD it did it on.
+//
+// The claim under every case here is that the recap reads the AI-activity feed
+// rather than the model-call trace. The trace is telemetry and carries no
+// subject by design (`Call.Subject` never reaches ai_call), so a recap drawn
+// from it could only ever report that something happened; the occurrence is the
+// half that knows what the work was about, and the name it carries is the way
+// back to the account.
+//
+// They live apart from agentrail.test.tsx because that file is at the size a
+// test file may grow to.
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const emptyPage = { has_more: false, next_cursor: null };
+
+type AiActivityItem = components["schemas"]["AiActivityItem"];
+
+/** A website read that finished, naming the company it was about: the label is
+ *  the name the source knew when it emitted, and the type and id are what turn
+ *  that name into a way back to the record. */
+const SETTLED_SITE_READ: AiActivityItem = {
+  id: "019f7e65-0000-7000-8000-0000000000a1",
+  kind: "site_read",
+  state: "done",
+  started_at: "2026-08-01T09:00:00Z",
+  finished_at: "2026-08-01T09:01:00Z",
+  subject_label: "Acme GmbH",
+  subject_type: "organization",
+  subject_id: "019f7e65-0000-7000-8000-0000000000b2",
+};
+
+/**
+ * Every read the section makes, answered with the least the panel needs, and
+ * the feed answered by the case itself.
+ *
+ * The seat holds nothing: the recap is a rep's surface, so a case that granted
+ * `ai_diagnostics:read` would be proving the recap on the one seat that also
+ * gets the runtime row — and the rows this file is about would be the only
+ * thing an ordinary seat could not see.
+ */
+function stubRail(feed: () => Response | Promise<Response>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      const { pathname } = new URL(request.url);
+      if (pathname.endsWith("/me/ai-activity")) {
+        return feed();
+      }
+      if (pathname.endsWith("/me")) {
+        return jsonResponse(meFixture({ allow: {} }));
+      }
+      if (pathname.endsWith("/assistant/profile")) {
+        return jsonResponse({ state: "configured" });
+      }
+      if (pathname.endsWith("/connectors")) {
+        return jsonResponse({ data: [] });
+      }
+      return jsonResponse({ data: [], page: emptyPage });
+    }),
+  );
+}
+
+function mount() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider>
+        <AgentRail route={{ screen: "companies" }} />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** The panel is portalled to the body once open, never inside the container. */
+const panel = () => {
+  const el = document.querySelector(".arloose");
+  if (!el) throw new Error("no .arloose panel on the document");
+  return el;
+};
+
+async function openPanel(container: HTMLElement) {
+  const user = userEvent.setup();
+  const trigger = container.querySelector(".arhit");
+  if (!trigger) throw new Error("no .arhit trigger in the rendered tree");
+  await user.click(trigger);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the agent panel's recap", () => {
+  // The case the recap exists for: the record's name is IN the sentence, and it
+  // is the way back to the record rather than a word in it.
+  it("names the record a settled run was about, and links to it", async () => {
+    stubRail(() =>
+      jsonResponse({ running: [], recent: [SETTLED_SITE_READ], faults: [] }),
+    );
+    const { container } = mount();
+    await openPanel(container);
+    const row = await waitFor(() => {
+      const found = panel().querySelector(".aritem:not(.arempty)");
+      if (!found) throw new Error("no recap row on the panel yet");
+      return found as HTMLElement;
+    });
+    expect(row.textContent).toContain("I've read the");
+    expect(
+      within(row).getByRole("link", { name: "Acme GmbH" }).getAttribute("href"),
+    ).toBe(`#/companies/${SETTLED_SITE_READ.subject_id}`);
+    // The kind is an invocation-site token, and a recap that leaked one would
+    // say something happened and nothing about what.
+    expect(panel().textContent).not.toContain("site_read");
+  });
+
+  // A read that has not answered is ABSENT, never a zero: the empty sentence
+  // claims a day somebody looked at, and nobody has.
+  it("draws neither a row nor an empty line while the feed read is in flight", async () => {
+    stubRail(() => new Promise<Response>(() => {}));
+    const { container } = mount();
+    await openPanel(container);
+    await waitFor(() => expect(panel().textContent).toContain(LABELS.recap));
+    expect(panel().querySelector(".aritem")).toBeNull();
+  });
+
+  // The server reports every AI task, because a task that reports nothing is AI
+  // work the product performed and then denied; what a reader is SHOWN is the
+  // client's decision. A background sweep the copy map does not narrate draws no
+  // row rather than an invented sentence — it stays in the full log, which is
+  // what the heading links to — and a day of nothing else earns the sentence
+  // that says so.
+  it("says nothing has finished today for a day the rail narrates none of", async () => {
+    stubRail(() =>
+      jsonResponse({
+        running: [],
+        recent: [{ ...SETTLED_SITE_READ, kind: "capture_classify" }],
+        faults: [],
+      }),
+    );
+    const { container } = mount();
+    await openPanel(container);
+    await waitFor(() =>
+      expect(panel().querySelector(".arempty")?.textContent).toBe(
+        LABELS.nothingToday,
+      ),
+    );
+    expect(panel().querySelector(".aritem:not(.arempty)")).toBeNull();
+    expect(panel().textContent).not.toContain("capture_classify");
+  });
+});

--- a/frontend/src/app/agentrail.stories.tsx
+++ b/frontend/src/app/agentrail.stories.tsx
@@ -29,6 +29,9 @@ type Answers = Readonly<{
   connectorStatus: "connected" | "reauth_required";
   licenseState: "valid" | "absent" | "rejected";
   approvals: number;
+  /** What `/ai/calls` answers. It feeds the runtime row's served model and
+   *  nothing else — the recap is the feed's, below — so one row is the whole
+   *  fixture and an empty list is the installation that has never called. */
   calls: readonly Readonly<{ task: string; minutesAgo: number }>[];
   /** What `/me/ai-activity` answers. The agent's own states come from here and
    *  from nowhere else, so a story for one is a story about this feed. */
@@ -52,6 +55,16 @@ function occurrence(over: Readonly<Record<string, unknown>>) {
     started_at: new Date(NOW - 4 * 60_000).toISOString(),
     ...over,
   };
+}
+
+/** A settled occurrence, as the recap reads them: finished, and newest first. */
+function settled(minutesAgo: number, over: Readonly<Record<string, unknown>>) {
+  return occurrence({
+    state: "done",
+    started_at: new Date(NOW - (minutesAgo + 1) * 60_000).toISOString(),
+    finished_at: new Date(NOW - minutesAgo * 60_000).toISOString(),
+    ...over,
+  });
 }
 
 // The two objects the section actually asks about: `license` gates the posture
@@ -223,12 +236,36 @@ const HEALTHY: Answers = {
   connectorStatus: "connected",
   licenseState: "valid",
   approvals: 0,
-  calls: [
-    { task: "growth_fit", minutesAgo: 12 },
-    { task: "summarize", minutesAgo: 47 },
-    { task: "brief_ranking", minutesAgo: 190 },
-  ],
+  calls: [{ task: "summarize", minutesAgo: 12 }],
 };
+
+/**
+ * A day of finished work, as the panel's recap reads it.
+ *
+ * Two of the three name the record they were about, which is the half of a
+ * recap row a reader can act on — the name is the way back to the account. The
+ * third names none, because most occurrences are about no single record and the
+ * row has to read well without one.
+ *
+ * It is the PanelOpen story's alone rather than HEALTHY's: `recent` also feeds
+ * the card's resting rotation, so putting it in the shared fixture would put a
+ * finished run into the line of every story in this file.
+ */
+const A_DAYS_WORK = [
+  settled(12, {
+    kind: "site_read",
+    subject_label: "Acme GmbH",
+    subject_type: "organization",
+    subject_id: "019f7e65-0000-7000-8000-0000000000b2",
+  }),
+  settled(47, {
+    kind: "summarize",
+    subject_label: "Ana Roth",
+    subject_type: "person",
+    subject_id: "019f7e65-0000-7000-8000-0000000000b3",
+  }),
+  settled(190, { kind: "morning_brief" }),
+];
 
 const meta: Meta<typeof AgentRail> = {
   title: "Shell/Agent rail",
@@ -388,7 +425,7 @@ export const LeveledRail: Story = {
  * story in the catalog after it. Its two appearances are `Switch`'s own.
  */
 export const PanelOpen: Story = {
-  render: story({ ...HEALTHY, approvals: 3 }),
+  render: story({ ...HEALTHY, approvals: 3, recent: A_DAYS_WORK }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -32,7 +32,7 @@ import {
   currentAgentEdge,
 } from "./agent-edge-signal";
 import { AgentRail } from "./agentrail";
-import { LABELS, TASK_SAID, VOCABULARY } from "./agentrail-copy";
+import { LABELS, VOCABULARY } from "./agentrail-copy";
 import { type GrantSpec, meFixture } from "./mefixture";
 import type { Route } from "./router";
 import { stubPhoneViewport } from "./testing/shellharness";
@@ -908,52 +908,6 @@ describe("AgentRail", () => {
     ).toBe(false);
   });
 
-  // The wire carries the invocation-site token (`capture_classify`); the
-  // recap owes the reader the plain-language line, never the token itself —
-  // a recap that leaked the token would tell a salesperson something ran five
-  // times and nothing about what.
-  it("recaps a call in plain words, not the raw task token", async () => {
-    const user = userEvent.setup();
-    stubAgentRailApi({
-      aiCalls: () =>
-        jsonResponse({
-          data: [AI_CALL],
-          page: emptyPage,
-          payload_capture_enabled: false,
-          tasks: [AI_CALL.task],
-        }),
-    });
-    const { container } = render(ROUTE);
-    await openPanel(user, container);
-    await waitFor(() =>
-      expect(screen.getByText(TASK_SAID.capture_classify)).toBeTruthy(),
-    );
-    expect(panel().textContent).not.toContain("capture_classify");
-    expect(
-      screen.getByRole("link", { name: LABELS.fullLog }).getAttribute("href"),
-    ).toBe("#/settings/ai");
-  });
-
-  // A task named `constructor` is a plain string off the wire, but a bare
-  // lookup into an object answers it from `Object.prototype` with a function
-  // React then tries to render — `saidFor` guards with `Object.hasOwn`
-  // precisely so the recap still shows the humanised token.
-  it("shows the humanised token, not a function, for a task named constructor", async () => {
-    const user = userEvent.setup();
-    stubAgentRailApi({
-      aiCalls: () =>
-        jsonResponse({
-          data: [{ ...AI_CALL, task: "constructor" }],
-          page: emptyPage,
-          payload_capture_enabled: false,
-          tasks: ["constructor"],
-        }),
-    });
-    const { container } = render(ROUTE);
-    await openPanel(user, container);
-    await waitFor(() => expect(screen.getByText("constructor")).toBeTruthy());
-  });
-
   // Only a company record serves a 360 read; every other screen must not ask
   // for one at all, not just decline to show it.
   it("never asks for the 360 read when the route is not a company record", async () => {
@@ -1467,22 +1421,22 @@ describe("AgentRail", () => {
     expect(panel().textContent).not.toContain("telepathic_prospecting");
   });
 
-  // A settled run reaches the reader through the RESTING ROTATION on the card
-  // and nowhere else: the panel lists live work only, so a day of finished
-  // runs draws no list there. `recent` is bounded to today, so the rotation
-  // never pins a "ready" that would still be announcing this morning at six
-  // in the evening.
-  it("reads a run that finished today in the resting line, not as a panel list", async () => {
+  // A settled run reaches the reader twice, answering two questions: the
+  // RESTING ROTATION on the card says the one true thing this installation has
+  // to say now, and the recap lists what got done. It reaches the RUNNING
+  // section in neither case. `recent` is bounded to today, so the rotation
+  // never pins a "ready" still announcing this morning at six in the evening.
+  it("reads a run that finished today in the resting line and in the recap, never as live work", async () => {
     withSettled(RUN({ state: "done" }));
     const user = userEvent.setup();
     const { container } = render(ROUTE);
-    // Nothing is live, so the orb rests — and the line is the settled run,
-    // which is the only true thing this installation has to say.
     await settlesOnLine(container, "Your morning brief is ready.");
     expect(block(container).getAttribute("data-core-state")).toBe("idle");
     await openPanel(user, container);
     expect(runLines()).toEqual([]);
-    expect(panel().textContent).not.toContain("Finished today");
     expect(panel().textContent).not.toContain("Running now");
+    expect(
+      panel().querySelector(".aritem:not(.arempty)")?.textContent,
+    ).toContain("Your morning brief is ready.");
   });
 });

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -38,13 +38,7 @@ import {
   publishAgentEdge,
 } from "./agent-edge-signal";
 import { type AgentFault, useAgentFault } from "./agent-fault";
-import {
-  IDLE_ORDER,
-  type IdleKind,
-  LABELS,
-  RUNNING,
-  TASK_SAID,
-} from "./agentrail-copy";
+import { IDLE_ORDER, type IdleKind, LABELS, RUNNING } from "./agentrail-copy";
 import { EdgeLightSetting } from "./agentrail-edgelight";
 import { RailLine } from "./agentrail-line";
 import { useAgentTicker } from "./agentrail-ticker";
@@ -253,43 +247,35 @@ function useLicensePosture(): LicensePosture | undefined {
     : "ok";
 }
 
+/** One terminal attempt of the model-call trace, as `/ai/calls` reports it. */
+type AiCall = components["schemas"]["AiCallSummary"];
+
 /**
  * The model the agent last actually ran on — the SERVED one, not the configured
  * one, because a fallback ladder makes those two differ exactly when it matters.
  *
- * Operator-only: `/ai/calls` sits behind `automation:update`, so a sales seat
- * gets nothing and the runtime row says the seat cannot read it rather than
- * printing a model nobody on that seat could verify. One call, because the panel
- * shows one line.
- */
-type AiCall = components["schemas"]["AiCallSummary"];
-
-/**
- * The last few things the agent actually did, newest first.
+ * ONE row, because the runtime strip shows one model and nothing else here
+ * reads the trace: the recap below is drawn from the AI-activity feed, which is
+ * the projection that knows what each occurrence was ABOUT. Asking for five
+ * would be four rows nothing renders.
  *
- * This is the recap the panel owes a reader: not what the agent IS, but what it
- * has been doing — the task, the model it ran on, when. The full trace, with the
- * attempt ladder and the payloads, lives on the AI settings tab, and the panel
- * links to it rather than reproducing it. A recap that grows into a log is a
- * second log to keep correct.
- *
- * Operator-only, because `/ai/calls` sits behind `automation:update`. A seat
- * without it gets no rows and is told why, rather than an empty section that
- * reads as an agent which has never run.
+ * Operator-only, because `/ai/calls` sits behind `ai_diagnostics:read`. A seat
+ * without it is told the runtime row is not readable rather than shown a model
+ * nobody on that seat could verify.
  */
-function useRecentCalls(): Readonly<{
+function useLastCall(): Readonly<{
   allowed: boolean;
   calls: readonly AiCall[];
 }> {
   // GET /ai/calls asks for ai_diagnostics:read (ai/callread.go).
   const allowed = useCan("ai_diagnostics", "read");
   const recent = useQuery({
-    queryKey: ["ai-calls", "agentrail-recent"],
+    queryKey: ["ai-calls", "agentrail-served-model"],
     enabled: allowed,
     staleTime: 30_000,
     queryFn: async () => {
       const { data, error } = await api.GET("/ai/calls", {
-        params: { query: { limit: RECAP_ROWS } },
+        params: { query: { limit: 1 } },
       });
       if (error) {
         // Chrome must not take a page down over telemetry: an unreadable log is
@@ -385,22 +371,6 @@ function modelText(
 }
 
 /**
- * The recap: what the agent has done lately, and the door to the whole trace.
- *
- * Five rows at most. The question a person asks of a background agent is "what
- * have you been doing", and five answers it — a sixth turns the panel into a log
- * viewer, which already exists and is better at it.
- */
-/** The task in the reader's words, or the token opened up if it is a new one. */
-function saidFor(task: string): string {
-  // `task` comes off the wire, and a bare lookup answers `constructor` from the
-  // prototype chain with a function that React then tries to render.
-  return Object.hasOwn(TASK_SAID, task)
-    ? TASK_SAID[task]
-    : task.replaceAll("_", " ");
-}
-
-/**
  * When it happened, as a person would say it.
  *
  * A wall-clock stamp answers "at what time", and the question a recap answers is
@@ -430,25 +400,57 @@ function agoFor(iso: string, locale: Locale, now: number): string {
   return format.format(Math.max(0, Math.floor(seconds / size)));
 }
 
+/**
+ * The recap: what the agent has done lately, and the door to the whole trace.
+ *
+ * Five rows at most. The question a person asks of a background agent is "what
+ * have you been doing", and five answers it — a sixth turns the panel into a log
+ * viewer, which already exists and is better at it.
+ *
+ * It is drawn from the AI-activity feed rather than from the model-call trace,
+ * and the difference is what a row can SAY. The trace knows the task and the
+ * tokens; it is telemetry, and it deliberately carries no record — a call's
+ * subject travels to the occurrence and never to `ai_call`. The occurrence is
+ * the half that knows what the work was ABOUT, so a recap read from it names
+ * the account that was read and links to it, where a recap read from the trace
+ * could only ever say that something happened five times.
+ *
+ * That makes these rows the settled counterpart of the running section above,
+ * in one vocabulary rather than two: the same `speak` table says "I'm reading
+ * the Acme website" while it runs and "I've read the Acme website" once it is
+ * done. A kind the table has no words for draws NOTHING, for the reason
+ * `RunSection` gives — an invented sentence costs the rows that are real.
+ */
 function Recap({
-  recent,
+  settled,
 }: Readonly<{
-  recent: Readonly<{ allowed: boolean; calls: readonly AiCall[] }>;
+  /** Today's settled occurrences, or undefined while no read has answered. */
+  settled: readonly AiActivityItem[] | undefined;
 }>) {
   const { locale } = useLocale();
+  const t = useT();
   // Read once per open, so five rows share one reading of the clock and cannot
   // disagree about what "now" is.
   const now = Date.now();
-  if (!recent.allowed) {
-    return <p className="aritem arempty">{LABELS.logUnreadable}</p>;
+  if (settled === undefined) {
+    // Nothing, not a sentence: the panel cannot tell a read still in flight
+    // from one that failed, and both would be libelled by "nothing has
+    // finished today".
+    return null;
   }
-  if (recent.calls.length === 0) {
-    return <p className="aritem arempty">{LABELS.noCallsYet}</p>;
+  const said = settled
+    .flatMap((item) => {
+      const line = speak(item, t);
+      return line === null ? [] : [{ item, line }];
+    })
+    .slice(0, RECAP_ROWS);
+  if (said.length === 0) {
+    return <p className="aritem arempty">{LABELS.nothingToday}</p>;
   }
   return (
     <>
-      {recent.calls.map((call, index) => (
-        <p className="aritem" key={call.id}>
+      {said.map(({ item, line }, index) => (
+        <p className="aritem" key={item.id}>
           {/* The mark fades down the list, so the newest thing the agent did is
               the brightest thing in it. Position IS the age here: the rows are
               newest first, and a reader takes the gradient before they read a
@@ -458,9 +460,14 @@ function Recap({
             aria-hidden="true"
             style={{ opacity: Math.max(0.3, 1 - index * MARK_FADE) }}
           />
-          {saidFor(call.task)}
+          <span className="arsaid">
+            <RailLine line={line} />
+          </span>
+          {/* A settled occurrence has a finish — the projection's own CHECK
+              says so — and `started_at` is what is left if a server ever sends
+              one that does not. */}
           <span className="armuted">
-            {agoFor(call.occurred_at, locale, now)}
+            {agoFor(item.finished_at ?? item.started_at, locale, now)}
           </span>
         </p>
       ))}
@@ -579,6 +586,7 @@ function AgentPanel({
   state,
   line,
   running,
+  settled,
   signals,
   model,
   spend,
@@ -590,6 +598,8 @@ function AgentPanel({
   line: SpokenLine;
   /** The scheduled runs the server reports as live. */
   running: readonly AiActivityItem[];
+  /** What settled today, or undefined while no read of the feed has answered. */
+  settled: readonly AiActivityItem[] | undefined;
   signals: Signals;
   model: Readonly<{ allowed: boolean; calls: readonly AiCall[] }>;
   spend: Readonly<{
@@ -640,10 +650,10 @@ function AgentPanel({
       </header>
 
       {/* Above the counts: a run happening this second outranks a queue that
-          has been waiting since yesterday. Only live work is listed — a settled
-          run reaches the reader through the resting rotation on the card, not
-          as a list here. The section is absent when its list is, rather than
-          drawn empty. */}
+          has been waiting since yesterday. Only live work is listed here — what
+          settled belongs to the recap further down, so an occurrence is in one
+          section or the other and never both. The section is absent when its
+          list is, rather than drawn empty. */}
       <RunSection heading={PANEL_HEADING.running} items={running} />
 
       {/* The one count somebody opens this panel to act on, as a tile rather
@@ -694,7 +704,7 @@ function AgentPanel({
             {LABELS.fullLog}
           </a>
         </h2>
-        <Recap recent={model} />
+        <Recap settled={settled} />
       </div>
 
       {/* What it is standing on, in one strip. Not a section of its own: it is
@@ -1357,7 +1367,7 @@ export function AgentRail({
   const block = useRef<HTMLElement>(null);
   const phone = usePhoneViewport();
   const signals = useSignals();
-  const model = useRecentCalls();
+  const model = useLastCall();
   const server = useAiActivity();
   const ticker = useAgentTicker();
   const spend = useAiSpend();
@@ -1467,6 +1477,7 @@ export function AgentRail({
               frame={frame}
               line={line}
               running={server.running}
+              settled={server.answered ? server.recent : undefined}
               spend={spend}
             />
           </div>,

--- a/frontend/src/app/ai-activity.ts
+++ b/frontend/src/app/ai-activity.ts
@@ -101,6 +101,16 @@ export type AiActivity = Readonly<{
   /** Occurrences that settled since local midnight, newest first. */
   recent: readonly AiActivityItem[];
   /**
+   * Whether a read of the feed has actually ANSWERED.
+   *
+   * The three lists above coalesce an absent read to empty, which is the right
+   * default for anything that counts them and the wrong one for anything that
+   * would SAY so: "nothing has finished today" claims a day nobody read. A
+   * surface that draws an empty state needs the two apart, and nothing else in
+   * the shape can tell them apart.
+   */
+  answered: boolean;
+  /**
    * What went wrong today — failed and degraded runs, newest first.
    *
    * Beside `recent` rather than filtered out of it, and the difference is the
@@ -239,15 +249,16 @@ export function useAiActivity(): AiActivity {
   // off the body: a 200 whose shape is not the one the contract promises is
   // another absent read, and reaching into it for a length is how the rail's
   // whole section throws instead of reporting nothing.
-  const answered = query.data;
-  const running = answered?.running ?? NOTHING;
-  const recent = answered?.recent ?? NOTHING;
-  const faults = answered?.faults ?? NOTHING;
+  const feed = query.data;
+  const running = feed?.running ?? NOTHING;
+  const recent = feed?.recent ?? NOTHING;
+  const faults = feed?.faults ?? NOTHING;
   const asking = useLingeringAsk(open, recent[0]?.id);
   return {
     running,
     recent,
     faults,
+    answered: feed !== undefined,
     // STALLED is not working. The server derives that state for an occurrence
     // whose own source says it should have finished by now, and the chrome that
     // reads `working` pulses to say the AI is busy — so counting a stalled item

--- a/scripts/fe-file-length-waivers.txt
+++ b/scripts/fe-file-length-waivers.txt
@@ -11,7 +11,7 @@
 # Format: <frozen-line-count> <path>
 1035 frontend/src/App.tsx
 612 frontend/src/app/account.tsx
-1488 frontend/src/app/agentrail.test.tsx
+1442 frontend/src/app/agentrail.test.tsx
 1571 frontend/src/app/agentrail.tsx
 589 frontend/src/app/palette.tsx
 1031 frontend/src/app/shell.tsx


### PR DESCRIPTION
## What

The agent panel's "What it has done" now names the record each finished run was
about, and links to it — "I've read the Acme GmbH website." rather than a list of
task labels. It reads the AI-activity feed (`/me/ai-activity`'s settled arm)
instead of the model-call trace (`/ai/calls`).

Three behaviours change with it:

- The rows say what the **Running now** section above them says, in one
  vocabulary from start to finish: "I'm reading the Acme website" while it runs,
  "I've read the Acme website" once it is done. The name is a link where the
  record kind has a page.
- **Every seat can read it.** `/ai/calls` sits behind `ai_diagnostics:read`, so a
  sales rep opening the panel was told the call log is not readable on their
  seat. The feed is their own.
- A kind the rail has no copy for draws **no row** rather than an invented
  sentence, so the background sweeps it deliberately does not narrate stay in the
  full log — which the heading still links to. An empty day says so only once the
  feed has ANSWERED; an unread feed draws nothing.

`/ai/calls` still serves the runtime strip's served model, and now asks for the
one row that line needs rather than five.

## Why

The recap could not name a record because the trace it read does not carry one,
by design: `ai_call` is telemetry, `Call.Subject` reaches the occurrence and
never the trace, and `privacy/retention.go` leans on exactly that ("ai_call
carries no subject content"). So a recap read from there could only ever report
that something happened five times and nothing about what it happened to.

The subject was one layer away the whole time. `ai_task_run` stores
`subject_type` / `subject_id` / `subject_label` — the name the emitting source
knew when it emitted — and the panel's running section already draws it as a
linked name through `speak()` / `RailLine`. Reading the recap from the same
projection is reuse of the one thing that knows what the work was ABOUT, not a
second copy of it.

The absent-vs-empty split is the rail's standing doctrine applied to a new empty
state: `useAiActivity` coalesces an unanswered read to an empty list, which is
right for anything that counts it and wrong for anything that would say so, so
the hook now reports `answered` beside the lists and the recap draws nothing
until a read comes back.

## How verified

- `make check-fe` green end to end locally (11m21s: ds-gates, drift, file-length,
  lint, unit — 659 files / 8817 tests — and build).
- New `frontend/src/app/agentrail.recap.test.tsx`, in its own file because
  `agentrail.test.tsx` is at the size a test file may grow to (the pattern its
  three existing siblings follow). Three cases: the record named and linked to
  `#/companies/<id>`; nothing drawn at all while the feed read is in flight; and
  the empty sentence for a day whose only occurrence is a kind the rail does not
  narrate. The seat in that file holds no grants, which is the point — the recap
  has to work for the seat that cannot read the trace.
- `agentrail.test.tsx`'s settled-run case updated to the behaviour it now has
  (the resting line AND the recap, never the running section), and the file
  ratcheted down in `scripts/fe-file-length-waivers.txt` from 1488 to 1442.
- The backend half of `make check` could not run in the working container: its
  pre-built `golangci-lint` is a go1.25 binary and the modules target go1.26, so
  `lint-modules` exits 3 before reading anything — it fails identically on a
  clean checkout there. **CI settled it instead**: `craftsmanship`,
  `deterministic-gates`, `govulncheck`, all six integration shards and the
  isolation/erasure/HTTP e2e lane are green on `d97f6a1`, which is the same
  question that lane answers. The diff contains no Go, no contract and no
  migration.

- [x] `make check` is green — the frontend half locally, the backend half on CI
      for the reason above
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — green on CI; no backend change at all
- [x] `make craft-static` reports no new blockers — no Go in the diff, and the `craftsmanship` check is green
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

AI-assisted end to end under review: the data-source choice, the code, the tests,
the story fixture and the `docs/explanation/ai-activity-rail.md` section were
drafted by Claude Code in a working session and read line by line before commit.
The product fork — recap from occurrences (records named, sweep rows drop out)
versus keeping the trace and plumbing subjects into it — was put to and decided
by a human before any code was written.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VenH6ukQMiDwzSyeG6Ekyd
