### PR TITLE
fix(frontend): the company screen is back under its frozen ceiling

### DIFF
--- a/frontend/src/screens/companycitations.ts
+++ b/frontend/src/screens/companycitations.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// WHERE A CITED RECORD OPENS.
+//
+// The brief, the prepared answers and the suggestions all cite the same
+// records, so they share one route: a second copy would drift and send one
+// card's reader to the wrong screen. Its own file because it is that one route
+// and nothing else — the screen that used to hold it is five times the file
+// ceiling, and this is a concept that comes out whole.
+
+import { navigate } from "../app/router";
+import type { CitedRecord } from "./companyevidence";
+
+// openCitation routes a cited record to its own screen. The brief, the
+// prepared answers and the suggestions all cite the same records, so they
+// share one route — a second copy would drift and send one card's reader to
+// the wrong screen.
+// A citation goes to one of two places. A deal or a person has a screen of its
+// own; a fact or a profile field has no screen, but it does have a receipt —
+// where the value came from and what could not be recorded about it — which is
+// what the reader wanted when they clicked the chip.
+export function citationOpensRecord(entityType: string): boolean {
+  return entityType === "deal" || entityType === "person";
+}
+
+// An activity opens the MESSAGE, in the account page's own email drawer.
+//
+// The kinds a receipt can be written for. Narrowing HERE rather than asserting
+// at the fetch is what keeps the modal's contract honest: a kind that grows a
+// receipt upstream fails to compile until this decision learns about it.
+export function citationHasReceipt(
+  entityType: string,
+): entityType is CitedRecord["entityType"] {
+  return entityType === "fact" || entityType === "profile_field";
+}
+
+export function openCitation(entityType: string, entityId: string) {
+  if (entityType === "deal") {
+    navigate({ screen: "deals", id: entityId });
+  }
+  if (entityType === "person") {
+    navigate({ screen: "contacts", id: entityId });
+  }
+}

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -64,6 +64,11 @@ import {
 } from "./company360";
 import { NewDealAction } from "./companyactions";
 import { CompanyApprovalsPanel } from "./companyapprovals";
+import {
+  citationHasReceipt,
+  citationOpensRecord,
+  openCitation,
+} from "./companycitations";
 import { CompanyContractState, CompanyLastOffer } from "./companycommercial";
 import { CompanyContractsCard } from "./companycontracts";
 import { CompanyDocumentsCard } from "./companydocuments";
@@ -2465,38 +2470,6 @@ function CompanyTasksTab({
       }
     />
   );
-}
-
-// openCitation routes a cited record to its own screen. The brief, the
-// prepared answers and the suggestions all cite the same records, so they
-// share one route — a second copy would drift and send one card's reader to
-// the wrong screen.
-// A citation goes to one of two places. A deal or a person has a screen of its
-// own; a fact or a profile field has no screen, but it does have a receipt —
-// where the value came from and what could not be recorded about it — which is
-// what the reader wanted when they clicked the chip.
-function citationOpensRecord(entityType: string): boolean {
-  return entityType === "deal" || entityType === "person";
-}
-
-// An activity opens the MESSAGE, in the account page's own email drawer.
-//
-// The kinds a receipt can be written for. Narrowing HERE rather than asserting
-// at the fetch is what keeps the modal's contract honest: a kind that grows a
-// receipt upstream fails to compile until this decision learns about it.
-function citationHasReceipt(
-  entityType: string,
-): entityType is CitedRecord["entityType"] {
-  return entityType === "fact" || entityType === "profile_field";
-}
-
-function openCitation(entityType: string, entityId: string) {
-  if (entityType === "deal") {
-    navigate({ screen: "deals", id: entityId });
-  }
-  if (entityType === "person") {
-    navigate({ screen: "contacts", id: entityId });
-  }
 }
 
 // The reference material a reader opens when the summary above is not enough.

--- a/scripts/fe-file-length-waivers.txt
+++ b/scripts/fe-file-length-waivers.txt
@@ -101,7 +101,7 @@
 856 frontend/src/screens/onboarding-gate.tsx
 995 frontend/src/screens/onboarding-read.tsx
 2534 frontend/src/screens/organizations.test.tsx
-2587 frontend/src/screens/organizations.tsx
+2562 frontend/src/screens/organizations.tsx
 984 frontend/src/screens/overlay-usermap.tsx
 648 frontend/src/screens/partners.tsx
 513 frontend/src/screens/person360.tsx


### PR DESCRIPTION
`make check-backend` fails on `main`:

```
FAIL: frontend/src/screens/organizations.tsx grew to 2589 lines
      (waiver froze it at 2587) — shrink it, never grow it
```

`fe-file-length` is one of the root script gates the `deterministic-gates` job
fans out, so **every open PR fails it**, whatever it touched. Reproduced on a
pristine checkout of `3bef98c25` before touching anything.

#5307 took the file two lines over — through formatting rather than through new
behaviour: a destructuring and a props list that wrapped at 80 columns.

## The fix, and why this piece

The waiver's own header says regenerating it is for establishing the baseline
*"never to absorb a file that grew"*, so the number goes **down**, not up.

The citation route comes out whole. `citationOpensRecord`, `citationHasReceipt`
and `openCitation` are one concept — where a cited record opens — reached from
exactly one place, and their existing comment already argues they are one route
rather than three: *"the brief, the prepared answers and the suggestions all cite
the same records, so they share one route — a second copy would drift and send
one card's reader to the wrong screen."* That is a file's worth of reason.

2589 → 2562, and the waiver moves down with it.

The file is still five times the 500-line cap and this does not pretend
otherwise. It is the ratchet doing what it is for.

## Checks

`make check-fe` green, `check-fe-file-length` green, `tsc` clean.