### PR TITLE
main is red: fe-file-length (organizations.tsx over its waiver)

### DIFF
--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1280,12 +1280,10 @@ function useChronologySlots({
       />
     ),
   });
-  // An evidence mark asks "where did this value come from" — the answer is
-  // the record's change history, so the mark turns the timeline to Changes
-  // rather than opening a screen of its own.
-  // Through the same opener a pill press goes through: a cut opened from the
-  // side of the page and one opened from the pills is the same act, and a
-  // second way in is a second set of rules about what opening a cut does.
+  // An evidence mark asks "where did this value come from", and the answer
+  // is the record's change history: the mark turns the timeline to Changes
+  // through the opener a pill press uses — one act, one set of rules about
+  // opening a cut, and no screen of its own.
   const showChanges = () => openCut("changes");
 
   if (!active) {


### PR DESCRIPTION
Claiming:
- `make fe-file-length` (deterministic-gates → `check-backend` → `fe-file-length`)

Cause: #5307 (ae97d9137) grew `frontend/src/screens/organizations.tsx` from 2587 to 2589 lines; `scripts/fe-file-length-waivers.txt` froze it at 2587, so every open pull request's merge commit fails the ratchet.

Fix in progress: condense two adjacent comment blocks above `showChanges` back to the frozen length, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqEF4mbX4owQwtGBKnDiPw

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings `frontend/src/screens/organizations.tsx` back under its `fe-file-length` waiver by condensing two adjacent comment blocks, with no behavior change.

#5307 grew the screen two lines past the frozen length, failing the ratchet on every open pull request's merge commit. The comments above `showChanges` now say the same thing in four lines instead of six.

<sup>Written for commit 715f35f337685c17ca28ed0c784d5e1b44e75d4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified comments describing evidence-mark behavior, including that opening the Changes timeline follows the shared navigation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->