### PR TITLE
fix(compose): the release record is ordered by the lock that serialises it

### DIFF
--- a/backend/internal/compose/integration/releaseversion_integration_test.go
+++ b/backend/internal/compose/integration/releaseversion_integration_test.go
@@ -194,3 +194,62 @@ func TestReleaseGuardIgnoresAPredecessorsRelease(t *testing.T) {
 		t.Fatal("a role matched the PREDECESSOR's release; that row is not this installation's")
 	}
 }
+
+// "LATEST" MEANS LAST COMMITTED, not first begun.
+//
+// system_log.occurred_at defaults to now(), which is the TRANSACTION timestamp,
+// and the advisory lock this write takes is inside the transaction. So a replica
+// that begins first, is descheduled, and commits second carries the OLDER stamp
+// — and a read ordered by occurred_at returns the other replica's row although
+// this one committed last. The lock serialises the writes; the key did not
+// observe it.
+//
+// That is ordinary during a rollout, when replicas from two releases are alive
+// at once, and what it costs is which release the whole fleet is held to: every
+// role that disagrees with the winning row refuses to boot.
+//
+// The two rows are written directly rather than raced, because a race
+// reproduces this about as often as the scheduler happens to interleave that
+// way — the shape is what is under test, and a case that reproduces it
+// sometimes is one that reports a regression as a flake. What IS production's
+// here is the read: the assertion goes through AssertInstallationRelease, which
+// is what every non-api role boots on.
+func TestTheRecordedReleaseIsTheOneCommittedLast(t *testing.T) {
+	env := Setup(t)
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// The api records once, so the installation marker and the row shape are
+	// production's rather than this test's guess at them.
+	if err := compose.RecordInstallationRelease(ctx, env.Pool, logger, "1970.42"); err != nil {
+		t.Fatalf("recording the first release: %v", err)
+	}
+
+	// The straggler: it BEGAN before the row above (older occurred_at) and got
+	// its turn under the lock after it (later observed_at). Copied from the
+	// recorded row so every other field — the marker especially — is the one
+	// production wrote.
+	if _, err := env.Pool.Exec(ctx, `
+		INSERT INTO system_log (id, actor_type, actor_id, action, detail, occurred_at)
+		SELECT uuidv7(), actor_type, actor_id, action,
+		       jsonb_set(
+		           jsonb_set(detail, '{release_version}', '"1970.43"'),
+		           '{observed_at}', to_jsonb(to_char(occurred_at + interval '1 hour',
+		                                             'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'))),
+		       occurred_at - interval '1 hour'
+		  FROM system_log
+		 WHERE action = 'release.version_observed'`); err != nil {
+		t.Fatalf("seeding the late-committing replica's row: %v", err)
+	}
+
+	// The row that committed last is the one the fleet is held to, even though
+	// its transaction began first.
+	if err := compose.AssertInstallationRelease(ctx, env.Pool, logger, "1970.43"); err != nil {
+		t.Errorf("a role at the last-committed release refused to start: %v — the read is ordering by "+
+			"when a writer BEGAN, so whichever replica was descheduled longest wins the record", err)
+	}
+	if err := compose.AssertInstallationRelease(ctx, env.Pool, logger, "1970.42"); err == nil {
+		t.Error("a role at the superseded release started — with the ordering wrong in the other " +
+			"direction this passes for free, so both halves are asserted")
+	}
+}

--- a/backend/internal/compose/releaseversion.go
+++ b/backend/internal/compose/releaseversion.go
@@ -58,6 +58,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -93,16 +94,35 @@ const releaseLedgerFact = "release-version"
 // ledger, so the api's own row is the newest as soon as it boots. The window is
 // a worker booting against residue before that api boot, which is #2196.
 //
-// occurred_at leads the ordering, with id as the deterministic tiebreak, for the
-// reason extensioninventory spells out: uuidv7 ids are monotonic only within one
-// process, and concurrently booting replicas mint theirs independently. COALESCE
-// because an absent key must read as the empty string — the same value "no
+// THE ORDERING KEY OBSERVES THE LOCK, which occurred_at does not.
+//
+// system_log.occurred_at defaults to now(), the TRANSACTION timestamp, and the
+// advisory lock above is taken inside the transaction. So a replica that begins
+// first, is descheduled, and commits second carries the OLDER stamp — and this
+// read would return the other replica's row although this one committed last.
+// The lock serialises the write correctly; the key simply did not observe that.
+//
+// `observed_at` is clock_timestamp() read after the lock is held, so it orders
+// by the moment the writer actually got its turn. Rows written before it exists
+// fall back to occurred_at, which is what they were ordered by anyway: the
+// coalesce makes this a strict improvement rather than a cliff at the deploy
+// that introduces it.
+//
+// Cast rather than compared as text. A timestamp rendered one way sorts
+// lexicographically and rendered another does not, and nothing here would say
+// which it got.
+//
+// id stays the deterministic tiebreak, for the reason extensioninventory spells
+// out: uuidv7 ids are monotonic only within one process, and concurrently
+// booting replicas mint theirs independently. The outer COALESCE is a different
+// one — an absent release key must read as the empty string, the same value "no
 // record at all" produces, since both mean there is nothing to compare.
 const lastObservedReleaseQuery = `
 	SELECT COALESCE(detail->>'release_version', '')
 	  FROM system_log
 	 WHERE action = $1 AND detail->>'installation' = $2
-	 ORDER BY occurred_at DESC, id DESC LIMIT 1`
+	 ORDER BY COALESCE((detail->>'observed_at')::timestamptz, occurred_at) DESC, id DESC
+	 LIMIT 1`
 
 // RecordInstallationRelease records the release this api was built from as the
 // installation's release, when it differs from the last one recorded.
@@ -151,9 +171,19 @@ func RecordInstallationRelease(ctx context.Context, pool *pgxpool.Pool, log *slo
 		if last == version {
 			return nil
 		}
+		// The instant this writer got its turn, read from the database AFTER the
+		// lock is held. It is what the read above orders by, and taking it here
+		// rather than at transaction start is the whole of the fix: a replica
+		// descheduled between BEGIN and the lock would otherwise stamp a moment
+		// earlier than a replica that started later and finished first.
+		var observedAt time.Time
+		if err := tx.QueryRow(ctx, `SELECT clock_timestamp()`).Scan(&observedAt); err != nil {
+			return fmt.Errorf("compose: reading the instant this release observation got its turn: %w", err)
+		}
 		if _, err := storekit.LogSystem(ctx, tx, installationReleaseObserved, map[string]any{
 			"release_version": version,
 			"installation":    installationMarker(ctx),
+			"observed_at":     observedAt.UTC().Format(time.RFC3339Nano),
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
Refs #1735. Builds finding 2 of the ruling. Finding 1 is **not** built, and the
reason is a conflict the ruling did not have in front of it — see the end.

## Finding 2: "latest" now means last committed

`system_log.occurred_at` defaults to `now()`, the **transaction** timestamp, and
the advisory lock this write takes is *inside* the transaction. So a replica that
begins first, is descheduled, and commits second carries the **older** stamp, and
the read returns the other replica's row although this one committed last. The
lock serialises the writes correctly; the ordering key simply did not observe it.

That is ordinary during a rollout — replicas from two releases alive at once —
and what it decides is which release the whole fleet is held to, since every role
disagreeing with the winning row refuses to boot.

`observed_at` is `clock_timestamp()` read **after the lock is held**, so the order
is the order writers got their turn.

Two details worth stating:

- **Rows written before it exists fall back to `occurred_at`**, which is what
  they were ordered by anyway. A strict improvement rather than a cliff at the
  deploy that introduces it.
- **Cast, not compared as text.** A timestamp rendered one way sorts
  lexicographically and rendered another does not, and nothing here would say
  which it got.

## The test

`TestTheRecordedReleaseIsTheOneCommittedLast`. The two rows are **written rather
than raced**: a race reproduces this about as often as the scheduler happens to
interleave that way, and a case that reproduces sometimes reports a regression as
a flake. What is production's is the **read** — the assertion goes through
`AssertInstallationRelease`, which every non-api role boots on — and both
directions are asserted, since with the ordering wrong the other way the first
half passes for free.

Mutation-checked: restoring `ORDER BY occurred_at DESC` fails both halves.

## Finding 1 is not built, and should not be as written

The ruling says the write should *"refuse to record a release older than the one
already recorded"*. Two things block that, and I would rather raise them than
guess:

**1. There is no order to compare on, deliberately.** `buildinfo`'s own comment:

> *The value is the constellation release version (`YYYY.<edition>`; the PoC
> pipeline cuts `1970.<build>`). It is compared for EQUALITY only — never
> ordered. A set is either one release or it is not.*

The package exposes `Comparable` and `SkewBetween` and nothing that orders. So
"older" would mean either inventing a version grammar, or defining it as
ledger order — "a release this installation has already moved on from".

**2. Either definition breaks rollback, which is currently tested.**
`TestReleaseGuardStopsATornSetAndLetsAnUpgradeThrough` asserts in as many words
that *"an upgrade and a rollback have to get through"*. Under a monotonic rule a
deliberate rollback to `1970.42` is refused, the record stays `1970.43`, and
**every rolled-back role then refuses to boot** — worse than the bug, and
reached by the operator action taken when things are already wrong.

The ticket anticipated this — *"Rollback would then need an explicit operator
override"* — and the ruling's "what to build" does not include one. That override
is the actual decision, and it is product surface rather than a clause in this
query.

Recorded on the issue with the evidence; leaving it open for that half.

## Checks

`make check-backend`, `craft static --strict` (0/0/0), and the full release-guard
integration suite.

**Note:** `make check-backend` also fails on `main` for an unrelated reason —
`organizations.tsx` is two lines over its frozen waiver, from #5307. #5314 fixes
that; this branch is green apart from it.