### PR TITLE
feat(rail): a voice build says it is running (#2272)

### DIFF
--- a/backend/gates/aiactivitycatalogparity_test.go
+++ b/backend/gates/aiactivitycatalogparity_test.go
@@ -46,6 +46,7 @@ const (
 	documentReadingKind = activities.ExtractionAITask
 	websiteReadingKind  = people.SiteReadActivityKind
 	transcriptReadKind  = activities.TranscriptAITask
+	voiceBuildKind      = ai.VoiceBuildAITask
 )
 
 func TestEveryKindSomethingProducesIsOneTheContractCanExpress(t *testing.T) {
@@ -103,7 +104,7 @@ func alignEnum(missing []string) string {
 // direction is a producer half-gated, and the half that is missing is whichever
 // one nobody thought about.
 func producedKinds() []string {
-	out := []string{documentReadingKind, websiteReadingKind, transcriptReadKind, orgscan.ActivityKind}
+	out := []string{documentReadingKind, websiteReadingKind, transcriptReadKind, voiceBuildKind, orgscan.ActivityKind}
 	for _, spec := range runner.Catalog() {
 		out = append(out, spec.Name)
 	}

--- a/backend/gates/aitaskrailcensus_test.go
+++ b/backend/gates/aitaskrailcensus_test.go
@@ -51,6 +51,7 @@ var carrierSources = map[string]string{
 	"attachment_extraction": activities.ExtractionActivitySource,
 	"account_scan":          orgscan.ActivitySource,
 	"transcript_read":       activities.TranscriptActivitySource,
+	"voice_build":           ai.VoiceBuildActivitySource,
 }
 
 func TestEveryAITaskNamesTheSourceThatReportsIt(t *testing.T) {

--- a/backend/internal/compose/integration/aiactivity_voicebuild_integration_test.go
+++ b/backend/internal/compose/integration/aiactivity_voicebuild_integration_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A voice build as the rail sees it, end to end: the store moves the row, the
+// move announces itself, and the projection holds what a rep's feed would draw.
+//
+// The router used to report this task, so the occurrence was settled the moment
+// it appeared — a rep asked the product to learn their writing voice, saw
+// nothing while the model worked, and then found it already done. These are the
+// states that were unreachable before, and the deferral, which is the one that
+// needs the attempt.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/modules/aiactivity"
+	kevents "github.com/margince/margince/backend/internal/shared/kernel/events"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// voiceBuildReclaim stands in for the worker's reclaim window, which compose
+// computes from the job's own timeout. Any positive value proves the shape.
+const voiceBuildReclaim = 10 * time.Minute
+
+// voiceBuildFixture is one owner's profile with a real corpus, the build they
+// asked for, and the consumer that projects what the build announces.
+type voiceBuildFixture struct {
+	env      *Env
+	owner    context.Context
+	store    *ai.VoiceStore
+	consumer *aiactivity.Consumer
+	profile  ids.UUID
+	buildID  ids.UUID
+	// delivered is how far this subscriber has got, so drain hands over only
+	// what is new — replaying the queued event would paper over a later one.
+	delivered int
+}
+
+func newVoiceBuildFixture(t *testing.T) *voiceBuildFixture {
+	t.Helper()
+	e := Setup(t)
+	store := ai.NewVoiceStore(e.DB())
+	owner := e.As(e.Rep1, []ids.UUID{e.Team1}, voiceRepPerms)
+	profile, err := store.CreateProfile(owner, ai.CreateVoiceProfileInput{})
+	if err != nil {
+		t.Fatalf("creating the profile: %v", err)
+	}
+	if _, _, _, err := store.IngestSource(owner, profile.ID, ai.IngestSourceInput{
+		Kind: "document", SourceLabel: "seed", SourceRef: "seed", Content: strings.Repeat("word ", 800),
+	}); err != nil {
+		t.Fatalf("seeding the corpus: %v", err)
+	}
+	build, err := store.CreateBuild(owner, profile.ID, ai.CreateVoiceBuildInput{Reason: "manual"})
+	if err != nil {
+		t.Fatalf("asking for the build: %v", err)
+	}
+	return &voiceBuildFixture{
+		env: e, owner: owner, store: store,
+		consumer: aiactivity.NewConsumer(aiactivity.NewStore(e.DB()), testLogger(t)),
+		profile:  profile.ID, buildID: build.ID,
+	}
+}
+
+// drain hands the consumer every ai_task.state_changed this build staged and
+// has not yet delivered, oldest first.
+func (f *voiceBuildFixture) drain(t *testing.T) {
+	t.Helper()
+	var raws [][]byte
+	err := f.env.DB().Tx(context.Background(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(context.Background(), `
+			SELECT envelope FROM event_outbox
+			 WHERE envelope->>'type' = 'ai_task.state_changed'
+			   AND envelope->'payload'->>'occurrence_key' = $1
+			 ORDER BY seq
+			 OFFSET $2`, f.buildID.String(), f.delivered)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var raw []byte
+			if err := rows.Scan(&raw); err != nil {
+				return err
+			}
+			raws = append(raws, raw)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		t.Fatalf("reading the staged envelopes: %v", err)
+	}
+	if len(raws) == 0 {
+		t.Fatal("the build staged no new ai_task.state_changed — the transition happened and nothing downstream could learn of it")
+	}
+	for _, raw := range raws {
+		var env kevents.Envelope
+		if err := json.Unmarshal(raw, &env); err != nil {
+			t.Fatalf("decoding a staged envelope: %v", err)
+		}
+		if err := f.consumer.HandleEvent(context.Background(), env); err != nil {
+			t.Fatalf("the projection refused envelope %s: %v", env.EventID, err)
+		}
+		f.delivered++
+	}
+}
+
+func (f *voiceBuildFixture) projection(t *testing.T) projectedOccurrence {
+	t.Helper()
+	var got projectedOccurrence
+	err := f.env.Pool.QueryRow(context.Background(), `
+		SELECT kind, ai_task, state, attempt, actor_scope, actor_user_id,
+		       started_at, stale_after, subject_type
+		  FROM ai_task_run WHERE source = $1 AND occurrence_key = $2`,
+		ai.VoiceBuildActivitySource, f.buildID.String()).
+		Scan(&got.Kind, &got.AITask, &got.State, &got.Attempt, &got.ActorScope,
+			&got.ActorUserID, &got.StartedAt, &got.StaleAfter, &got.SubjectType)
+	if err != nil {
+		t.Fatalf("reading the projected occurrence: %v", err)
+	}
+	return got
+}
+
+// claim takes the build the way the worker does, and reports the instant the
+// claim was stamped — the fence every terminal transition is written against.
+func (f *voiceBuildFixture) claim(t *testing.T) time.Time {
+	t.Helper()
+	input, claimed, err := f.store.ClaimBuild(f.owner, f.profile, f.buildID, voiceBuildReclaim)
+	if err != nil || !claimed {
+		t.Fatalf("claiming the build: claimed=%v err=%v", claimed, err)
+	}
+	if input.Build.StartedAt == nil {
+		t.Fatal("a claimed build carries no started_at, so no terminal write could fence against it")
+	}
+	return *input.Build.StartedAt
+}
+
+// The line the router could never draw: a build is live and the rep's own from
+// the moment they ask for it, not from the moment it finishes.
+func TestAQueuedVoiceBuildIsProjectedAsThePersonsOwnLiveWork(t *testing.T) {
+	f := newVoiceBuildFixture(t)
+	f.drain(t)
+
+	got := f.projection(t)
+	if got.State != "queued" || got.Attempt != 1 {
+		t.Fatalf("state/attempt = %s/%d, want queued/1", got.State, got.Attempt)
+	}
+	if got.ActorScope != "personal" || got.ActorUserID == nil || *got.ActorUserID != f.env.Rep1 {
+		t.Fatalf("actor = %s/%v, want personal/%s — the human who asked owns the occurrence",
+			got.ActorScope, got.ActorUserID, f.env.Rep1)
+	}
+	if got.Kind != ai.VoiceBuildAITask || got.AITask == nil || *got.AITask != ai.VoiceBuildAITask {
+		t.Fatalf("kind/ai_task = %s/%v, want %s", got.Kind, got.AITask, ai.VoiceBuildAITask)
+	}
+	if got.StaleAfter == nil {
+		t.Fatal("a queued occurrence carries no stale_after, so a queue nobody drains would render as live forever")
+	}
+	// NO subject: a build is about the reader's own writing voice, and there is
+	// no second party to name.
+	if got.SubjectType != nil {
+		t.Errorf("the build named subject %q; it is about the reader's own voice", *got.SubjectType)
+	}
+}
+
+// The claim moves the same occurrence to running, carrying the window a
+// replacement worker may take it in — and the outcome settles it.
+func TestAVoiceBuildRunsAndSettlesInTheProjection(t *testing.T) {
+	f := newVoiceBuildFixture(t)
+	claimedAt := f.claim(t)
+	f.drain(t)
+
+	running := f.projection(t)
+	if running.State != "running" || running.Attempt != 1 {
+		t.Fatalf("after the claim, state/attempt = %s/%d, want running/1", running.State, running.Attempt)
+	}
+	if running.StartedAt == nil || running.StaleAfter == nil {
+		t.Fatalf("a claimed build carries started_at %v and stale_after %v; a worker that dies must become stalled",
+			running.StartedAt, running.StaleAfter)
+	}
+
+	if err := f.store.FailBuild(f.owner, f.buildID, claimedAt,
+		"model_unavailable", "The model was unavailable. Try again shortly."); err != nil {
+		t.Fatalf("failing the build: %v", err)
+	}
+	f.drain(t)
+
+	settled := f.projection(t)
+	if settled.State != "failed" {
+		t.Fatalf("state = %s, want failed", settled.State)
+	}
+	if settled.StaleAfter != nil {
+		t.Error("a settled occurrence still carries a lease; a closed line has nothing to go stale")
+	}
+}
+
+// A build parked for budget SETTLES rather than staying live, and the next
+// claim reopens it under a new attempt.
+//
+// The attempt is what the migration is for: the projection orders two events
+// for one occurrence by it, and a `running` that supersedes a settled deferral
+// is indistinguishable from a stale redelivery without one.
+func TestADeferredVoiceBuildSettlesAndTheNextClaimReopensIt(t *testing.T) {
+	f := newVoiceBuildFixture(t)
+	claimedAt := f.claim(t)
+	f.drain(t)
+
+	due := time.Now().Add(-time.Second)
+	if err := f.store.DeferBuild(f.owner, f.buildID, claimedAt,
+		"The workspace is out of AI credit until the window reopens.", due); err != nil {
+		t.Fatalf("deferring the build: %v", err)
+	}
+	f.drain(t)
+
+	parked := f.projection(t)
+	if parked.State != "degraded" || parked.Attempt != 1 {
+		t.Fatalf("after the deferral, state/attempt = %s/%d, want degraded/1 — the build is not being worked",
+			parked.State, parked.Attempt)
+	}
+	if parked.StaleAfter != nil {
+		t.Error("a deferred build still carries a lease, so an orb would report work that is not happening")
+	}
+
+	f.claim(t)
+	f.drain(t)
+
+	resumed := f.projection(t)
+	if resumed.State != "running" || resumed.Attempt != 2 {
+		t.Fatalf("after the next claim, state/attempt = %s/%d, want running/2 — the same build on a new attempt",
+			resumed.State, resumed.Attempt)
+	}
+	if resumed.StaleAfter == nil {
+		t.Error("the resumed build carries no lease, so a worker that dies on the second attempt renders as live forever")
+	}
+}

--- a/backend/internal/modules/ai/railowner.go
+++ b/backend/internal/modules/ai/railowner.go
@@ -48,6 +48,7 @@ const (
 	sourceAttachmentExtraction = "attachment_extraction"
 	sourceAccountScan          = "account_scan"
 	sourceTranscriptRead       = "transcript_read"
+	sourceVoiceBuild           = "voice_build"
 )
 
 // railOwners answers who reports each task. TOTAL over the contract's task
@@ -70,6 +71,13 @@ var railOwners = map[Task]string{
 	// is worse than silence: it looks like nothing happened and then it is
 	// done.
 	TaskTranscriptPropose: sourceTranscriptRead,
+
+	// Learning a rep's writing voice, which they press a button and wait for.
+	// The build row is queued before any worker sees it, carries the claim's
+	// reclaim window as its lease, and counts its own attempts across a budget
+	// deferral — so it can say queued and running, which the router reporting
+	// the model call afterwards never could.
+	TaskVoiceBuild: sourceVoiceBuild,
 
 	TaskEmbeddings: SourceNoOccurrence,
 
@@ -106,7 +114,6 @@ var railOwners = map[Task]string{
 	TaskStageEvidenceExtract:          SourceRouter,
 	TaskSummarize:                     SourceRouter,
 	TaskTranscript:                    SourceRouter,
-	TaskVoiceBuild:                    SourceRouter,
 }
 
 // railNoOccurrenceReasons says why a task is a step rather than an occurrence.

--- a/backend/internal/modules/ai/voice_build_complete.go
+++ b/backend/internal/modules/ai/voice_build_complete.go
@@ -128,7 +128,7 @@ func (s *VoiceStore) CompleteBuild(ctx context.Context, buildID ids.UUID, claime
 		if err != nil {
 			return err
 		}
-		return emitVoiceBuild(ctx, tx, auditID, finished)
+		return emitVoiceBuild(ctx, tx, auditID, finished, 0)
 	})
 	return result, err
 }

--- a/backend/internal/modules/ai/voice_build_run.go
+++ b/backend/internal/modules/ai/voice_build_run.go
@@ -90,7 +90,12 @@ func (s *VoiceStore) ClaimBuild(ctx context.Context, profileID, buildID ids.UUID
 		build, err := scanVoiceBuild(tx.QueryRow(ctx, storekit.SQLf(`
 			UPDATE voice_build
 			SET status = 'running', stage = 'snapshot', status_code = NULL, status_detail = NULL,
-			    next_attempt_at = NULL, started_at = $3, version = version + 1, updated_at = $3
+			    next_attempt_at = NULL, started_at = $3, version = version + 1, updated_at = $3,
+			    -- Taking a QUEUED build is the attempt that was already
+			    -- queued; taking a deferred one back, or reclaiming one whose
+			    -- worker died, starts a new attempt at the same build.
+			    attempt    = attempt + CASE WHEN status = 'queued' THEN 0 ELSE 1 END,
+			    attempt_at = CASE WHEN status = 'queued' THEN attempt_at ELSE $3 END
 			WHERE id = $1 AND voice_profile_id = $2 AND archived_at IS NULL
 			  AND (status = 'queued'
 			       OR (status = 'deferred' AND next_attempt_at <= $3)
@@ -133,6 +138,23 @@ func (s *VoiceStore) ClaimBuild(ctx context.Context, profileID, buildID ids.UUID
 		}
 		samples, err := loadVoiceSamples(ctx, tx, profileID)
 		if err != nil {
+			return err
+		}
+		// The claim is the only transition that makes the rail say `running`,
+		// and it publishes from inside the claiming transaction: a worker that
+		// takes the row and dies before announcing would leave a build the rail
+		// still calls queued until its lease ran out.
+		//
+		// The lease is the caller's reclaim window — the instant a replacement
+		// may take this row — which is exactly when the claim stops being
+		// believable.
+		auditID, err := storekit.Audit(ctx, tx, "update", "voice_build", build.ID,
+			map[string]any{voiceKeyStatus: voiceBuildStatusRunning},
+			map[string]any{voiceKeyStatus: build.Status, "attempt": build.Attempt})
+		if err != nil {
+			return err
+		}
+		if err := emitVoiceBuild(ctx, tx, auditID, build, reclaimAfter); err != nil {
 			return err
 		}
 		input = VoiceBuildInput{Build: build, Profile: profile, Personality: profile.PersonalityMD, Samples: samples}
@@ -209,7 +231,9 @@ func (s *VoiceStore) DeferBuild(ctx context.Context, buildID ids.UUID, claimedAt
 		if err != nil {
 			return err
 		}
-		return emitVoiceBuild(ctx, tx, auditID, build)
+		// The deferral is SETTLED on the rail: the build is not being
+		// worked and the window may reopen hours later.
+		return emitVoiceBuild(ctx, tx, auditID, build, 0)
 	})
 }
 
@@ -255,7 +279,7 @@ func (s *VoiceStore) finishBuildTx(ctx context.Context, tx pgx.Tx, build VoiceBu
 	if err != nil {
 		return err
 	}
-	return emitVoiceBuild(ctx, tx, auditID, finished)
+	return emitVoiceBuild(ctx, tx, auditID, finished, 0)
 }
 
 func nullIfEmpty(s string) *string {

--- a/backend/internal/modules/ai/voice_lifecycle.go
+++ b/backend/internal/modules/ai/voice_lifecycle.go
@@ -43,6 +43,14 @@ type VoiceBuild struct {
 	CompletedAt     *time.Time
 	UpdatedAt       *time.Time
 	ArchivedAt      *time.Time
+	// Attempt is which claim of this build is current, and AttemptAt when it
+	// became current. A build deferred for a budget window and re-claimed, or
+	// reclaimed from a dead worker, is the same build on a new attempt — and
+	// the AI-activity projection orders two events for one occurrence by this,
+	// because status cannot tell a 'queued' that supersedes a 'running' from a
+	// stale redelivery of an earlier one.
+	Attempt   int
+	AttemptAt time.Time
 }
 
 // CreateVoiceBuildInput identifies the human-approved reason for a build.
@@ -50,14 +58,15 @@ type CreateVoiceBuildInput struct {
 	Reason string
 }
 
-const voiceBuildColumns = `id, voice_profile_id, reason, status, stage, source_hash, source_count, result_version, candidate_action, status_code, status_detail, next_attempt_at, version, created_at, started_at, completed_at, updated_at, archived_at`
+const voiceBuildColumns = `id, voice_profile_id, reason, status, stage, source_hash, source_count, result_version, candidate_action, status_code, status_detail, next_attempt_at, version, created_at, started_at, completed_at, updated_at, archived_at, attempt, attempt_at`
 
 func scanVoiceBuild(row pgx.Row) (VoiceBuild, error) {
 	var build VoiceBuild
 	err := row.Scan(&build.ID, &build.ProfileID, &build.Reason, &build.Status, &build.Stage,
 		&build.SourceHash, &build.SourceCount, &build.ResultVersion, &build.CandidateAction,
 		&build.StatusCode, &build.StatusDetail, &build.NextAttemptAt, &build.Version,
-		&build.CreatedAt, &build.StartedAt, &build.CompletedAt, &build.UpdatedAt, &build.ArchivedAt)
+		&build.CreatedAt, &build.StartedAt, &build.CompletedAt, &build.UpdatedAt, &build.ArchivedAt,
+		&build.Attempt, &build.AttemptAt)
 	return build, err
 }
 
@@ -139,7 +148,7 @@ func (s *VoiceStore) CreateBuild(ctx context.Context, profileID ids.UUID, in Cre
 		if err != nil {
 			return err
 		}
-		if err := emitVoiceBuild(ctx, tx, auditID, build); err != nil {
+		if err := emitVoiceBuild(ctx, tx, auditID, build, voiceBuildQueuedLease); err != nil {
 			return err
 		}
 		if s.enqueueBuild != nil {
@@ -172,8 +181,20 @@ func (s *VoiceStore) GetBuild(ctx context.Context, profileID, buildID ids.UUID) 
 	return build, err
 }
 
-func emitVoiceBuild(ctx context.Context, tx pgx.Tx, auditID ids.UUID, build VoiceBuild) error {
-	return storekit.EmitEvent(ctx, tx, auditID, build.ProfileID, voiceBuildChangedPayload(build))
+// emitVoiceBuild publishes one state change BOTH ways: the public
+// voice.build_changed a subscriber reads, and the AI-activity occurrence a rep
+// watches. Every status write funnels through here, so the rail cannot fall
+// behind the event by one transition.
+//
+// lease is how long this state stays believable, and applies only to a live
+// one. A caller that has just settled the build passes none.
+func emitVoiceBuild(
+	ctx context.Context, tx pgx.Tx, auditID ids.UUID, build VoiceBuild, lease time.Duration,
+) error {
+	if err := storekit.EmitEvent(ctx, tx, auditID, build.ProfileID, voiceBuildChangedPayload(build)); err != nil {
+		return err
+	}
+	return emitVoiceBuildActivity(ctx, tx, auditID, build, lease)
 }
 
 // voiceBuildChangedPayload builds voice.build_changed's typed payload.

--- a/backend/internal/modules/ai/voicebuildactivity.go
+++ b/backend/internal/modules/ai/voicebuildactivity.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// A voice build reporting itself to the AI-activity projection.
+//
+// The router can only speak once a model call is over, so a task it reports is
+// settled the moment it appears: a rep asks the product to learn their writing
+// voice, sees nothing for as long as it takes, and then finds it already done.
+// For work a person waits on, settled-only is worse than silence — it looks
+// like nothing happened.
+//
+// A build has what a live line needs and the router does not: a durable row
+// that is queued before any worker sees it, an attributable requester, a claim
+// with a reclaim window that says when a worker has died, and an attempt that
+// survives a deferral. So it carries its own occurrence and railowner.go hands
+// the task here.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// VoiceBuildActivitySource names this carrier to the projection. It is
+// IDENTITY, not display: two sources must never collide on one occurrence key,
+// and the display kind is a separate string that may be re-pointed without
+// re-keying every row.
+const VoiceBuildActivitySource = "voice_build"
+
+// VoiceBuildAITask is the api/ai-tasks.yaml task a build runs. Exported so a
+// root-package fitness test can hold it to the generated task set — a module
+// may not import the rail registry's own neighbours to assert that about
+// itself.
+const VoiceBuildAITask = string(TaskVoiceBuild)
+
+// voiceBuildQueuedLease is how long a queued build stays believable before the
+// projection reports it stalled.
+//
+// A queued row is waiting for a worker, not held by one, so it carries no
+// reclaim window of its own — and a queue nobody drains must not render as live
+// forever. Generous against the job runner's own backlog and short enough that
+// a runner that is not running shows as stalled within the hour.
+const voiceBuildQueuedLease = 30 * time.Minute
+
+// activityStateDegraded is the projection's word for work that settled short of
+// what it was asked for. The rail's fault arm is bounded on it, so it claims
+// somebody must be TOLD.
+const activityStateDegraded = "degraded"
+
+// The build's own statuses in the projection's vocabulary.
+//
+// `succeeded` is this module's word for the projection's `done`; the other
+// three live states carry across unchanged.
+//
+// deferred settles rather than staying live, and reports `degraded`. The build
+// is not being worked — the workspace ran out of AI credit and the window may
+// reopen hours later — and an orb lit that whole time would report work that is
+// not happening. The next claim reopens the occurrence under a new attempt,
+// which is exactly the reopening the projection's guard admits.
+func voiceBuildActivityState(status string) string {
+	switch status {
+	case voiceBuildStatusSucceeded:
+		return "done"
+	case voiceBuildStatusDeferred:
+		return activityStateDegraded
+	default:
+		return status
+	}
+}
+
+// emitVoiceBuildActivity publishes one build's current state against an
+// existing ledger row.
+//
+// Derived ENTIRELY from the row, so no call site can announce a state it did
+// not just commit — including the attempt, which is the row's own column rather
+// than anything this function counts.
+//
+// lease is how long a LIVE state stays believable and is ignored for a settled
+// one: a closed occurrence is not claiming to work, so it has nothing to go
+// stale. It travels from the caller because only the claim knows its own
+// reclaim window; a queued row takes voiceBuildQueuedLease.
+func emitVoiceBuildActivity(
+	ctx context.Context, tx pgx.Tx, ledgerID ids.UUID, build VoiceBuild, lease time.Duration,
+) error {
+	task := VoiceBuildAITask
+	payload := crmcontracts.InternalEventAiTaskStateChanged{
+		Source: VoiceBuildActivitySource,
+		// The build's own row id. A voice is learned many times over its life
+		// and each build is its own occurrence, so the key is the build —
+		// never the profile.
+		OccurrenceKey: build.ID.String(),
+		Kind:          VoiceBuildAITask,
+		AiTask:        &task,
+		Attempt:       build.Attempt,
+		State:         voiceBuildActivityState(build.Status),
+		// The instant THIS attempt became current, not the build's creation: a
+		// live row ages from here, and a build deferred for a budget window
+		// would otherwise be past its lease the moment it resumed.
+		QueuedAt:   build.AttemptAt,
+		StartedAt:  build.StartedAt,
+		FinishedAt: voiceBuildSettledAt(build),
+	}
+	if lease > 0 && payload.FinishedAt == nil {
+		seconds := int(lease.Seconds())
+		payload.LeaseSeconds = &seconds
+	}
+	// status_detail is this module's own sentence on the failure and deferral
+	// paths — never a provider's message, which FailBuild's contract already
+	// requires — so it is safe to show a rep.
+	if reason := voiceBuildDegradeReason(build); reason != nil {
+		payload.DegradeReason = reason
+	}
+	// NO SUBJECT, deliberately. A build is about the reader's OWN writing
+	// voice: naming a subject would put the requester's own profile on their
+	// rail as though it were a record they had been working on, and there is
+	// no other party to name.
+	if err := storekit.EmitPipelinePayload(ctx, tx, ledgerID, payload); err != nil {
+		return fmt.Errorf("publish voice build activity: %w", err)
+	}
+	return nil
+}
+
+// voiceBuildSettledAt is when this attempt stopped being live.
+//
+// completed_at is stamped by the terminal writes only; a deferral leaves it
+// NULL because the build is not over, yet the ATTEMPT is — and the projection
+// requires a settled state to say when — so the deferral's own write instant
+// stands in.
+func voiceBuildSettledAt(build VoiceBuild) *time.Time {
+	if build.CompletedAt != nil {
+		return build.CompletedAt
+	}
+	if build.Status != voiceBuildStatusDeferred {
+		return nil
+	}
+	return build.UpdatedAt
+}
+
+// voiceBuildDegradeReason is the one sentence a settled-short build carries,
+// or nil when it went through.
+func voiceBuildDegradeReason(build VoiceBuild) *string {
+	switch build.Status {
+	case voiceBuildStatusFailed, voiceBuildStatusDeferred:
+		return build.StatusDetail
+	default:
+		return nil
+	}
+}

--- a/backend/migrations/core/1789111096_a_voice_build_says_which_attempt_is_current.down.sql
+++ b/backend/migrations/core/1789111096_a_voice_build_says_which_attempt_is_current.down.sql
@@ -1,0 +1,7 @@
+-- Same bound as the up: dropping a column takes ACCESS EXCLUSIVE too, and an
+-- unbounded wait behind one open reader stalls every write to the table.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE voice_build
+  DROP COLUMN attempt,
+  DROP COLUMN attempt_at;

--- a/backend/migrations/core/1789111096_a_voice_build_says_which_attempt_is_current.up.sql
+++ b/backend/migrations/core/1789111096_a_voice_build_says_which_attempt_is_current.up.sql
@@ -1,0 +1,31 @@
+-- Which claim of this build is current, and when it became current.
+--
+-- ACCESS EXCLUSIVE on a table this migration did not create. The change itself
+-- is instant — no row is rewritten — but the lock still queues behind every
+-- open transaction on the table, and an unbounded wait turns one long-running
+-- reader into a total write stall. Three seconds, so a migration that cannot
+-- get in fails the deploy loudly instead of holding the door.
+SET LOCAL lock_timeout = '3s';
+
+-- A build's lifecycle is not monotonic. A claimed row is deferred when the
+-- workspace runs out of AI credit and re-claimed when the window reopens, and
+-- one whose worker died is RECLAIMED in place once its lease expires. Every one
+-- of those begins a new attempt at the same build. Nothing needed to count them
+-- while the row was read only as "what is it doing now" — the status answered
+-- that alone.
+--
+-- The AI-activity projection needs the count, because it orders two events for
+-- one occurrence and status cannot: a 'queued' that supersedes a 'running' and
+-- a 'queued' that is a stale redelivery of an earlier one look identical
+-- without it. It lives HERE rather than as a counter the projection keeps,
+-- because a claim's identity is the source's fact.
+--
+-- attempt_at is the other half and is not decoration: the projection ages a
+-- LIVE occurrence from the instant its current attempt began, and created_at is
+-- that instant for the first attempt only. A build deferred for six hours and
+-- re-claimed would otherwise be past its lease the moment it resumed — it would
+-- render as stalled from the instant it started working, which is the display
+-- this projection exists to prevent.
+ALTER TABLE voice_build
+  ADD COLUMN attempt    integer     NOT NULL DEFAULT 1 CHECK (attempt >= 1),
+  ADD COLUMN attempt_at timestamptz NOT NULL DEFAULT now();

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -5941,6 +5941,8 @@ public.vault_secret.vault_secret_pkey PRIMARY KEY (ref)
 public.vault_secret_pkey CREATE UNIQUE INDEX vault_secret_pkey ON public.vault_secret USING btree (ref)
 public.voice_build acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.voice_build.archived_at timestamp with time zone gen=- def=-
+public.voice_build.attempt integer NOT NULL gen=- def=1
+public.voice_build.attempt_at timestamp with time zone NOT NULL gen=- def=now()
 public.voice_build.candidate_action text NOT NULL gen=- def='none'::text
 public.voice_build.completed_at timestamp with time zone gen=- def=-
 public.voice_build.created_at timestamp with time zone NOT NULL gen=- def=now()
@@ -5958,6 +5960,7 @@ public.voice_build.status_code text gen=- def=-
 public.voice_build.status_detail text gen=- def=-
 public.voice_build.updated_at timestamp with time zone gen=- def=-
 public.voice_build.version bigint NOT NULL gen=- def=1
+public.voice_build.voice_build_attempt_check CHECK ((attempt >= 1))
 public.voice_build.voice_build_candidate_action_check CHECK ((candidate_action = ANY (ARRAY['none'::text, 'auto_activated'::text, 'review_required'::text])))
 public.voice_build.voice_build_deferral_check CHECK ((((status = 'deferred'::text) AND (status_code = 'budget_deferred'::text) AND (next_attempt_at IS NOT NULL)) OR ((status <> 'deferred'::text) AND (status_code IS DISTINCT FROM 'budget_deferred'::text) AND (next_attempt_at IS NULL))))
 public.voice_build.voice_build_pkey PRIMARY KEY (id)

--- a/frontend/src/app/agentrail-line.tsx
+++ b/frontend/src/app/agentrail-line.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import type { SpokenLine } from "./ai-activity-lines";
+import type { SpokenLine } from "./ai-activity-speak";
 import { routeHash } from "./router";
 
 /**

--- a/frontend/src/app/agentrail.crossfade.test.tsx
+++ b/frontend/src/app/agentrail.crossfade.test.tsx
@@ -3,7 +3,7 @@
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RailSaying } from "./agentrail";
-import { plain, type SpokenLine } from "./ai-activity-lines";
+import { plain, type SpokenLine } from "./ai-activity-speak";
 
 // The rail's own line, split out of agentrail.test.tsx because that file is over
 // the 1000-line ceiling this tree holds test files to.

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -43,14 +43,9 @@ import { EdgeLightSetting } from "./agentrail-edgelight";
 import { RailLine } from "./agentrail-line";
 import { useAgentTicker } from "./agentrail-ticker";
 import { type AiActivity, useAiActivity } from "./ai-activity";
-import {
-  PANEL_HEADING,
-  plain,
-  type SpokenLine,
-  speak,
-  spokenText,
-} from "./ai-activity-lines";
+import { PANEL_HEADING } from "./ai-activity-lines";
 import { laneFor } from "./ai-activity-orb";
+import { plain, type SpokenLine, speak, spokenText } from "./ai-activity-speak";
 import { useAgentTierMap } from "./autonomy";
 import { useCan, useHoldsAdminRole } from "./capability";
 import { type CaptureProgress, liveCapture } from "./capture-progress";

--- a/frontend/src/app/ai-activity-lines.test.ts
+++ b/frontend/src/app/ai-activity-lines.test.ts
@@ -6,14 +6,13 @@ import { de } from "../i18n/de";
 import { en } from "../i18n/en";
 import { vi } from "../i18n/vi";
 import { NAMED, SAID, WROTE } from "./agentrail-copy";
+import { ACTIVITY_LINE, NAMED_LINE } from "./ai-activity-lines";
 import {
-  ACTIVITY_LINE,
   displayedKinds,
   displayedLines,
-  NAMED_LINE,
   speak,
   spokenText,
-} from "./ai-activity-lines";
+} from "./ai-activity-speak";
 
 /** The line as one string, which is what the unnamed cases are about. */
 function lineFor(
@@ -374,6 +373,14 @@ describe("the kinds the rail asks for", () => {
       // week, and uq_transcript_read_inflight allows one in flight per
       // transcript however often the button is pressed.
       "transcript_propose",
+      // Learning the reader's own writing voice. It reaches one person's feed:
+      // the build names the requester and visibleProfile admits only the
+      // profile's owner, so the occurrence can belong to nobody else. And it
+      // fits: a voice is learned when a rep asks for it or when their corpus
+      // has drifted, which is a handful of builds in a profile's life, and
+      // activeVoiceBuild refuses a second build over the same corpus while one
+      // is in flight.
+      "voice_build",
       // What the week TAUGHT, on the same terms as the sentence above it: one
       // occurrence per rep per week, scoped to that rep by ResolveActor. It
       // earns real copy rather than the system-sweep line for the same reason —

--- a/frontend/src/app/ai-activity-lines.ts
+++ b/frontend/src/app/ai-activity-lines.ts
@@ -3,8 +3,6 @@
 
 import type { components } from "../api/schema";
 import type { MessageKey } from "../i18n/en";
-import { ENTITY, isEntityKind } from "./entity";
-import type { Route } from "./router";
 
 type ActivityKind = components["schemas"]["AiActivityItem"]["kind"];
 type ActivityState = components["schemas"]["AiActivityItem"]["state"];
@@ -20,7 +18,7 @@ type ActivityState = components["schemas"]["AiActivityItem"]["state"];
 type NotDisplayed = Readonly<{ notDisplayed: string }>;
 
 /** The (state -> message key) table of a kind the rail narrates. */
-type LineSet = Readonly<Record<ActivityState, MessageKey>>;
+export type LineSet = Readonly<Record<ActivityState, MessageKey>>;
 
 const notDisplayed = (reason: string): NotDisplayed => ({
   notDisplayed: reason,
@@ -220,7 +218,20 @@ export const ACTIVITY_LINE: Readonly<
     degraded: "agent.activity.transcriptRead.degraded",
     failed: "agent.activity.transcriptRead.failed",
   },
-  voice_build: SYSTEM_SWEEP,
+  // Learning the reader's OWN writing voice, which they press a button and
+  // wait for. Narrated rather than swept: the build row records who asked, and
+  // it can say queued and running now that it carries its own occurrence.
+  //
+  // No named line, and nothing to name: a build is about the reader's own
+  // voice, so the sentence has no second party in it.
+  voice_build: {
+    queued: "agent.activity.voiceBuild.queued",
+    running: "agent.activity.voiceBuild.running",
+    stalled: "agent.activity.voiceBuild.stalled",
+    done: "agent.activity.voiceBuild.done",
+    degraded: "agent.activity.voiceBuild.degraded",
+    failed: "agent.activity.voiceBuild.failed",
+  },
 
   cert_judge: notDisplayed(
     "the certification lane grading this build's own answers — an operator's measurement, not a rep's work",
@@ -306,192 +317,3 @@ export const NAMED_LINE: Readonly<Partial<Record<ActivityKind, LineSet>>> = {
     failed: "agent.activity.siteReadNamed.failed",
   },
 };
-
-/**
- * One line as the rail says it: the words, and where the record's name sits in
- * them.
- *
- * Three pieces rather than one string because the name is not only a word in
- * the sentence — it is the way to the record, and a link can only be drawn
- * around a part the caller can still tell from the rest. `before` alone is
- * the whole line when it names no record.
- */
-export type SpokenLine = Readonly<{
-  before: string;
-  /**
-   * The record the line is about, with its page when this build has one for
-   * that kind of record. A name with no route is drawn as text: a document or
-   * a meeting has no page of its own, and so does a kind a newer server named
-   * that this tab has never heard of.
-   */
-  subject: Readonly<{ name: string; route: Route | null }> | null;
-  after: string;
-}>;
-
-/** A line that names no record: words and nothing else. */
-export function plain(words: string): SpokenLine {
-  return { before: words, subject: null, after: "" };
-}
-
-/** The line as one string, for a surface that draws no link. */
-export function spokenText(line: SpokenLine): string {
-  return `${line.before}${line.subject?.name ?? ""}${line.after}`;
-}
-
-/**
- * What to say about one item, or nothing at all.
- *
- * The existence check is not optional and `t()` cannot do it: translate() falls
- * back to THE KEY STRING, so a missing entry would put
- * `agent.activity.foo.running` in front of a reader.
- *
- * There are three ways to draw nothing, and they are different facts: the kind
- * is one this build has never heard of, the kind is one it deliberately does
- * not narrate, or the state has no line under a kind it does narrate. All three
- * answer null, because the reader's screen is the same either way — but they
- * are distinguished HERE rather than collapsed into a lookup miss, so a kind
- * that silently lost its copy cannot hide among the ones that never had any.
- *
- * It takes RAW strings rather than the contract's unions, and that widening is
- * the point: the map is total over the contract, so the only way to reach the
- * first case is a value the contract does not carry — which is exactly what an
- * older tab gets from a newer server that has added a kind or a state. Typed
- * narrowly, that case could only be written with a cast, and a test that casts
- * is asserting against its own escape hatch instead of against the function.
- */
-export function speak(
-  item: Readonly<{
-    kind: string;
-    state: string;
-    subject_label?: string | null;
-    subject_type?: string | null;
-    subject_id?: string | null;
-  }>,
-  t: (key: MessageKey, params?: Record<string, string>) => string,
-): SpokenLine | null {
-  if (!isActivityKind(item.kind)) {
-    return null;
-  }
-  const entry = ACTIVITY_LINE[item.kind];
-  if ("notDisplayed" in entry) {
-    return null;
-  }
-  // The named line first, and ONLY when both halves are present: a kind that
-  // has named copy and an occurrence that carried a name. Either missing falls
-  // through to the unnamed sentence, which is why an absent label is an
-  // ordinary case here rather than a gap to report.
-  const name = item.subject_label ?? "";
-  if (name !== "") {
-    const named: Readonly<Partial<Record<string, MessageKey>>> =
-      NAMED_LINE[item.kind] ?? {};
-    const namedKey = named[item.state];
-    if (namedKey !== undefined) {
-      return aroundTheName(t(namedKey), name, subjectRoute(item));
-    }
-  }
-  const byState: Readonly<Partial<Record<string, MessageKey>>> = entry;
-  const key = byState[item.state];
-  return key === undefined ? null : plain(t(key));
-}
-
-/**
- * The placeholder a named line is written around, in every locale.
- *
- * Held to exactly this spelling by ai-activity-lines.test.ts, which is what
- * lets the sentence be split here rather than interpolated: translate() would
- * put the name IN the words, and a name already in the words cannot be told
- * from them again — a company called "I" would link the wrong word.
- */
-const NAME_PLACEHOLDER = "{name}";
-
-/**
- * The translated template with the name set in its own slot.
- *
- * A template without the slot is one the copy gate does not admit, so the
- * branch is a guard against a fake translator rather than a case the catalog
- * can reach; it keeps the words and drops nothing.
- */
-function aroundTheName(
-  template: string,
-  name: string,
-  route: Route | null,
-): SpokenLine {
-  const at = template.indexOf(NAME_PLACEHOLDER);
-  if (at < 0) {
-    return plain(template);
-  }
-  return {
-    before: template.slice(0, at),
-    subject: { name, route },
-    after: template.slice(at + NAME_PLACEHOLDER.length),
-  };
-}
-
-/**
- * The page the occurrence's record has, or null when it has none.
- *
- * `isEntityKind` is the same question every other link in the app asks before
- * it links: the wire's type is free text — a document is `attachment`, a
- * meeting is `activity`, a newer server may say something this build has never
- * seen — and only the kinds with a record page become a route. Both halves have
- * to be present; a type with no id is nowhere to go.
- */
-function subjectRoute(
-  item: Readonly<{ subject_type?: string | null; subject_id?: string | null }>,
-): Route | null {
-  const type = item.subject_type ?? "";
-  const id = item.subject_id ?? "";
-  if (id === "" || !isEntityKind(type)) {
-    return null;
-  }
-  return ENTITY[type].route(id);
-}
-
-/**
- * Whether a raw string is a kind this build knows.
- *
- * An own-key check rather than a cast, so the narrowing is something the
- * runtime actually did: a newer server's kind is not in the map, and saying so
- * is the whole answer speak gives for it.
- */
-function isActivityKind(kind: string): kind is ActivityKind {
-  return Object.hasOwn(ACTIVITY_LINE, kind);
-}
-
-/**
- * The kinds this rail draws, as the server's `kinds` filter takes them.
- *
- * DERIVED from ACTIVITY_LINE rather than listed, and that is the whole point:
- * the server reports every AI task, and `recent` is bounded at ten. A client
- * that asked for everything and drew three kinds would be handed the newest ten
- * of twenty-three — ten it renders nothing for — and the rail would go blank on
- * the day a rep used the composer a lot, while the projection was right the
- * whole time. Naming the kinds moves the bound inside this list; deriving it
- * means the list cannot fall out of step with the copy that decides it.
- */
-export function displayedKinds(): ActivityKind[] {
-  return displayedLines().map(([kind]) => kind);
-}
-
-/**
- * The narrated kinds paired with their line tables.
- *
- * The narrowing happens HERE, once, where `"notDisplayed" in entry` is a check
- * the compiler performs rather than an assertion somebody makes: a caller that
- * looked the entry up again would be holding `LineSet | NotDisplayed` and would
- * need a cast to say what it already knows. Returning the pair means nobody
- * downstream has to.
- *
- * `Object.entries` widens the key to `string`, so the entry list is rebuilt from
- * the map's own keys rather than trusting that widening back — `ACTIVITY_LINE`
- * is a total `Record<ActivityKind, …>`, so its keys ARE the kinds.
- */
-export function displayedLines(): [ActivityKind, LineSet][] {
-  const kinds = Object.keys(ACTIVITY_LINE) as ActivityKind[];
-  return kinds.flatMap((kind) => {
-    const entry = ACTIVITY_LINE[kind];
-    return "notDisplayed" in entry
-      ? []
-      : [[kind, entry] as [ActivityKind, LineSet]];
-  });
-}

--- a/frontend/src/app/ai-activity-speak.ts
+++ b/frontend/src/app/ai-activity-speak.ts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Turning one occurrence into the sentence the rail says, and the two questions
+// that decide whether it says anything at all: is this a kind this build knows,
+// and does the copy table have words for the state it is in.
+//
+// The words themselves live in ai-activity-lines.ts. This file is what reads
+// them — kept apart because the copy table is the half that grows with every
+// kind, and the reading of it has not changed since the rail shipped.
+
+import type { components } from "../api/schema";
+import type { MessageKey } from "../i18n/en";
+import { ACTIVITY_LINE, type LineSet, NAMED_LINE } from "./ai-activity-lines";
+import { ENTITY, isEntityKind } from "./entity";
+import type { Route } from "./router";
+
+type ActivityKind = components["schemas"]["AiActivityItem"]["kind"];
+
+/**
+ * One line as the rail says it: the words, and where the record's name sits in
+ * them.
+ *
+ * Three pieces rather than one string because the name is not only a word in
+ * the sentence — it is the way to the record, and a link can only be drawn
+ * around a part the caller can still tell from the rest. `before` alone is
+ * the whole line when it names no record.
+ */
+export type SpokenLine = Readonly<{
+  before: string;
+  /**
+   * The record the line is about, with its page when this build has one for
+   * that kind of record. A name with no route is drawn as text: a document or
+   * a meeting has no page of its own, and so does a kind a newer server named
+   * that this tab has never heard of.
+   */
+  subject: Readonly<{ name: string; route: Route | null }> | null;
+  after: string;
+}>;
+
+/** A line that names no record: words and nothing else. */
+export function plain(words: string): SpokenLine {
+  return { before: words, subject: null, after: "" };
+}
+
+/** The line as one string, for a surface that draws no link. */
+export function spokenText(line: SpokenLine): string {
+  return `${line.before}${line.subject?.name ?? ""}${line.after}`;
+}
+
+/**
+ * What to say about one item, or nothing at all.
+ *
+ * The existence check is not optional and `t()` cannot do it: translate() falls
+ * back to THE KEY STRING, so a missing entry would put
+ * `agent.activity.foo.running` in front of a reader.
+ *
+ * There are three ways to draw nothing, and they are different facts: the kind
+ * is one this build has never heard of, the kind is one it deliberately does
+ * not narrate, or the state has no line under a kind it does narrate. All three
+ * answer null, because the reader's screen is the same either way — but they
+ * are distinguished HERE rather than collapsed into a lookup miss, so a kind
+ * that silently lost its copy cannot hide among the ones that never had any.
+ *
+ * It takes RAW strings rather than the contract's unions, and that widening is
+ * the point: the map is total over the contract, so the only way to reach the
+ * first case is a value the contract does not carry — which is exactly what an
+ * older tab gets from a newer server that has added a kind or a state. Typed
+ * narrowly, that case could only be written with a cast, and a test that casts
+ * is asserting against its own escape hatch instead of against the function.
+ */
+export function speak(
+  item: Readonly<{
+    kind: string;
+    state: string;
+    subject_label?: string | null;
+    subject_type?: string | null;
+    subject_id?: string | null;
+  }>,
+  t: (key: MessageKey, params?: Record<string, string>) => string,
+): SpokenLine | null {
+  if (!isActivityKind(item.kind)) {
+    return null;
+  }
+  const entry = ACTIVITY_LINE[item.kind];
+  if ("notDisplayed" in entry) {
+    return null;
+  }
+  // The named line first, and ONLY when both halves are present: a kind that
+  // has named copy and an occurrence that carried a name. Either missing falls
+  // through to the unnamed sentence, which is why an absent label is an
+  // ordinary case here rather than a gap to report.
+  const name = item.subject_label ?? "";
+  if (name !== "") {
+    const named: Readonly<Partial<Record<string, MessageKey>>> =
+      NAMED_LINE[item.kind] ?? {};
+    const namedKey = named[item.state];
+    if (namedKey !== undefined) {
+      return aroundTheName(t(namedKey), name, subjectRoute(item));
+    }
+  }
+  const byState: Readonly<Partial<Record<string, MessageKey>>> = entry;
+  const key = byState[item.state];
+  return key === undefined ? null : plain(t(key));
+}
+
+/**
+ * The placeholder a named line is written around, in every locale.
+ *
+ * Held to exactly this spelling by ai-activity-lines.test.ts, which is what
+ * lets the sentence be split here rather than interpolated: translate() would
+ * put the name IN the words, and a name already in the words cannot be told
+ * from them again — a company called "I" would link the wrong word.
+ */
+const NAME_PLACEHOLDER = "{name}";
+
+/**
+ * The translated template with the name set in its own slot.
+ *
+ * A template without the slot is one the copy gate does not admit, so the
+ * branch is a guard against a fake translator rather than a case the catalog
+ * can reach; it keeps the words and drops nothing.
+ */
+function aroundTheName(
+  template: string,
+  name: string,
+  route: Route | null,
+): SpokenLine {
+  const at = template.indexOf(NAME_PLACEHOLDER);
+  if (at < 0) {
+    return plain(template);
+  }
+  return {
+    before: template.slice(0, at),
+    subject: { name, route },
+    after: template.slice(at + NAME_PLACEHOLDER.length),
+  };
+}
+
+/**
+ * The page the occurrence's record has, or null when it has none.
+ *
+ * `isEntityKind` is the same question every other link in the app asks before
+ * it links: the wire's type is free text — a document is `attachment`, a
+ * meeting is `activity`, a newer server may say something this build has never
+ * seen — and only the kinds with a record page become a route. Both halves have
+ * to be present; a type with no id is nowhere to go.
+ */
+function subjectRoute(
+  item: Readonly<{ subject_type?: string | null; subject_id?: string | null }>,
+): Route | null {
+  const type = item.subject_type ?? "";
+  const id = item.subject_id ?? "";
+  if (id === "" || !isEntityKind(type)) {
+    return null;
+  }
+  return ENTITY[type].route(id);
+}
+
+/**
+ * Whether a raw string is a kind this build knows.
+ *
+ * An own-key check rather than a cast, so the narrowing is something the
+ * runtime actually did: a newer server's kind is not in the map, and saying so
+ * is the whole answer speak gives for it.
+ */
+function isActivityKind(kind: string): kind is ActivityKind {
+  return Object.hasOwn(ACTIVITY_LINE, kind);
+}
+
+/**
+ * The kinds this rail draws, as the server's `kinds` filter takes them.
+ *
+ * DERIVED from ACTIVITY_LINE rather than listed, and that is the whole point:
+ * the server reports every AI task, and `recent` is bounded at ten. A client
+ * that asked for everything and drew three kinds would be handed the newest ten
+ * of twenty-three — ten it renders nothing for — and the rail would go blank on
+ * the day a rep used the composer a lot, while the projection was right the
+ * whole time. Naming the kinds moves the bound inside this list; deriving it
+ * means the list cannot fall out of step with the copy that decides it.
+ */
+export function displayedKinds(): ActivityKind[] {
+  return displayedLines().map(([kind]) => kind);
+}
+
+/**
+ * The narrated kinds paired with their line tables.
+ *
+ * The narrowing happens HERE, once, where `"notDisplayed" in entry` is a check
+ * the compiler performs rather than an assertion somebody makes: a caller that
+ * looked the entry up again would be holding `LineSet | NotDisplayed` and would
+ * need a cast to say what it already knows. Returning the pair means nobody
+ * downstream has to.
+ *
+ * `Object.entries` widens the key to `string`, so the entry list is rebuilt from
+ * the map's own keys rather than trusting that widening back — `ACTIVITY_LINE`
+ * is a total `Record<ActivityKind, …>`, so its keys ARE the kinds.
+ */
+export function displayedLines(): [ActivityKind, LineSet][] {
+  const kinds = Object.keys(ACTIVITY_LINE) as ActivityKind[];
+  return kinds.flatMap((kind) => {
+    const entry = ACTIVITY_LINE[kind];
+    return "notDisplayed" in entry
+      ? []
+      : [[kind, entry] as [ActivityKind, LineSet]];
+  });
+}

--- a/frontend/src/app/ai-activity.test.tsx
+++ b/frontend/src/app/ai-activity.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "../api/model-inflight";
 import type { components } from "../api/schema";
 import { useAiActivity, watchStartedAiRun } from "./ai-activity";
-import { displayedKinds, speak } from "./ai-activity-lines";
+import { displayedKinds, speak } from "./ai-activity-speak";
 
 // What the rail asks the runner, and how often. Three things here can only be
 // wrong invisibly, which is why each has its own case: a poll left running for

--- a/frontend/src/app/ai-activity.ts
+++ b/frontend/src/app/ai-activity.ts
@@ -8,7 +8,7 @@ import { api } from "../api/client";
 import { useModelCallsInFlight } from "../api/model-inflight";
 import type { components } from "../api/schema";
 import { throwProblem } from "../screens/common";
-import { displayedKinds } from "./ai-activity-lines";
+import { displayedKinds } from "./ai-activity-speak";
 
 type AiActivityItem = components["schemas"]["AiActivityItem"];
 

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3983,6 +3983,16 @@ export const de = {
     "Ich habe das Transkript nicht zu Ende gelesen.",
   "agent.activity.transcriptRead.failed":
     "Ich konnte das Transkript nicht lesen.",
+  "agent.activity.voiceBuild.queued":
+    "Das Erlernen Ihres Schreibstils steht an.",
+  "agent.activity.voiceBuild.running": "Ich lerne Ihren Schreibstil.",
+  "agent.activity.voiceBuild.stalled":
+    "Das Erlernen Ihres Schreibstils dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen.",
+  "agent.activity.voiceBuild.done": "Ich habe Ihren Schreibstil gelernt.",
+  "agent.activity.voiceBuild.degraded":
+    "Ich habe aufgehört, bevor ich Ihren Schreibstil gelernt hatte.",
+  "agent.activity.voiceBuild.failed":
+    "Ich konnte Ihren Schreibstil nicht lernen.",
   "agent.activity.siteRead.queued":
     "Die Firmenwebsite steht zum Lesen in der Warteschlange.",
   "agent.activity.siteRead.running": "Ich lese die Firmenwebsite.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4052,6 +4052,14 @@ export const en = {
   "agent.activity.transcriptRead.degraded":
     "I stopped before finishing the transcript.",
   "agent.activity.transcriptRead.failed": "I couldn't read the transcript.",
+  "agent.activity.voiceBuild.queued": "Learning your writing voice is queued.",
+  "agent.activity.voiceBuild.running": "I'm learning your writing voice.",
+  "agent.activity.voiceBuild.stalled":
+    "Learning your writing voice has taken unusually long. It may have stopped.",
+  "agent.activity.voiceBuild.done": "I've learned your writing voice.",
+  "agent.activity.voiceBuild.degraded":
+    "I stopped before learning your writing voice.",
+  "agent.activity.voiceBuild.failed": "I couldn't learn your writing voice.",
   "agent.activity.siteRead.queued": "The company website is queued to be read.",
   "agent.activity.siteRead.running": "I'm reading the company website.",
   "agent.activity.siteRead.stalled":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3927,6 +3927,14 @@ export const vi = {
   "agent.activity.transcriptRead.degraded":
     "Tôi đã dừng trước khi đọc hết bản chép lời.",
   "agent.activity.transcriptRead.failed": "Tôi không đọc được bản chép lời.",
+  "agent.activity.voiceBuild.queued": "Việc học giọng văn của bạn đang chờ.",
+  "agent.activity.voiceBuild.running": "Tôi đang học giọng văn của bạn.",
+  "agent.activity.voiceBuild.stalled":
+    "Việc học giọng văn của bạn mất nhiều thời gian bất thường. Có thể nó đã dừng.",
+  "agent.activity.voiceBuild.done": "Tôi đã học được giọng văn của bạn.",
+  "agent.activity.voiceBuild.degraded":
+    "Tôi đã dừng giữa chừng khi đang học giọng văn của bạn.",
+  "agent.activity.voiceBuild.failed": "Tôi không thể học giọng văn của bạn.",
   "agent.activity.siteRead.queued": "Trang web của công ty đang chờ được đọc.",
   "agent.activity.siteRead.running": "Tôi đang đọc trang web của công ty.",
   "agent.activity.siteRead.stalled":


### PR DESCRIPTION
Step 2 of #2272, and the last of the three the issue names. Step 3 landed in #5161, step 1 in #5301.

## The defect

A rep asks the product to learn their writing voice and waits. The router learns of a call only once the call is over, so the occurrence was settled the moment it appeared — nothing, nothing, nothing, done. **For work a person waits on, settled-only is worse than silence.**

## What the row already had, and the one thing it did not

`voice_build` is queued before any worker sees it, records who asked, and `ClaimBuild` already takes a reclaim window — so the issue's "❌ lease" is stale, as `site_read`'s "❌ attempt" turned out to be.

What it could not say is **which claim is current**. A build deferred for a budget window and taken back hours later is the same build on a new attempt, and the projection orders two events for one occurrence by exactly that: a `running` that supersedes a settled deferral is indistinguishable from a stale redelivery without it. Hence one additive migration — `attempt` and `attempt_at`, the same pair `site_read` and `attachment_extraction` carry, for the same reason.

`attempt_at` is not decoration: the projection ages a LIVE occurrence from the instant its current attempt began. A build deferred for six hours and re-claimed, dated by `created_at`, would render as stalled from the instant it resumed working.

## The `deferred` ruling

A deferral **settles** and reports `degraded` — the same answer site read gives, for the same reason. The build is not being worked, the window may reopen hours later, and an orb lit that whole time would report work that is not happening. The next claim reopens the occurrence under a new attempt, which is exactly the reopening the projection's guard admits.

## Two details worth the review

**The claim announces from inside the claiming transaction.** A worker that takes the row and dies before announcing would leave a build the rail still calls queued until its lease ran out.

**No subject.** A build is about the reader's own writing voice: naming one would put the requester's own profile on their rail as a record they had been working on, and there is no other party to name.

## Proof

Three integration cases over a real Postgres, every transition driven through the real store:

- a queued build is the rep's own live work, personal-scoped, with a lease, and names no subject.
- the claim moves it to running carrying the reclaim window; the outcome settles it and drops the lease.
- a deferral settles as `degraded` with no lease, and the next claim reopens it as `running` on **attempt 2**.

Mutation-verified: dropping the attempt increment leaves the projection stuck on `degraded/1` — the re-claim cannot supersede the settled deferral, which is precisely what the migration buys. Dropping the `deferred → degraded` mapping is refused by the projection's own `ai_task_run_settled_has_finish` check.

## One file split

`ai-activity-lines.ts` crossed its 500-line ceiling with the new copy, so the SPEAKING of a line moves to `ai-activity-speak.ts`. The copy table is the half that grows with every kind; reading it has not changed since the rail shipped.

`make check` green, `make craft-static` clean whole-tree, the compose integration lane, the ai module lane and the migrations lane green.

## #2272 is finished with this

All five tasks the issue opened with now report something a rep can watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC