### PR TITLE
fix(jobs): a boot-time sweep's fan-out never queues ahead of a live deep read

### DIFF
--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -292,7 +292,7 @@ func startAutoEnrichRead(ctx context.Context, peopleStore *people.Store,
 				// job carries what it was queued to cost, so an operator
 				// reading river_job sees the ceiling without inferring it.
 				MaxPages: autoEnrichMaxPages,
-			}, siteDeepReadInsertOpts())
+			}, siteDeepReadInsertOpts(DeepReadPriorityHousekeeping))
 			return insErr
 		})
 	if err != nil {

--- a/backend/internal/compose/capturedomaintriage.go
+++ b/backend/internal/compose/capturedomaintriage.go
@@ -154,7 +154,7 @@ func startDomainTriageRead(ctx context.Context, peopleStore *people.Store, domai
 				// job carries what it was queued to cost, so an operator
 				// reading river_job sees the ceiling without inferring it.
 				MaxPages: autoEnrichMaxPages,
-			}, siteDeepReadInsertOpts())
+			}, siteDeepReadInsertOpts(DeepReadPriorityHousekeeping))
 			return insErr
 		})
 	if err != nil {

--- a/backend/internal/compose/capturedomaintriage_integration_test.go
+++ b/backend/internal/compose/capturedomaintriage_integration_test.go
@@ -20,10 +20,12 @@ package compose
 // The budget counter these gates spend from is tested here too, next to the
 // trigger that shares it with the sweep.
 //
-// What they do NOT cover is the queued read itself: starting one needs an
-// ambient River client, and this repo has no harness that stands one up in a
-// test. The same gap already applies to the sweep's own trigger path; the
-// read-and-apply half is covered by TestAutoEnrichLaneAppliesDirectlyInsteadOfStaging.
+// What they do NOT cover is the queued read itself: starting one from THIS
+// file needs an ambient River client this package has no harness for.
+// integration/capture's TestCaptureAutoEnrichSweepQueuesDomainTriageAtHousekeepingPriorityToo
+// covers the queue over a real River runner instead, the same way the sweep's
+// own trigger path is covered there; the read-and-apply half is covered by
+// TestAutoEnrichLaneAppliesDirectlyInsteadOfStaging.
 
 import (
 	"context"

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -76,12 +76,32 @@ const (
 	deepReadMaxWorkers = 2
 )
 
-// siteDeepReadInsertOpts routes the job to its own queue and deduplicates by
-// args: the dossier id is unique per read, so a re-submitted enqueue of the
-// SAME read collapses while a fresh read (new dossier) always queues.
-func siteDeepReadInsertOpts() *river.InsertOpts {
+// DeepReadPriorityLive is the priority a human or agent action's own deep
+// read carries — River's default (1 of 4, highest) — so it is fetched ahead
+// of any housekeeping sweep sharing deepReadQueue's two workers.
+const DeepReadPriorityLive = river.PriorityDefault
+
+// DeepReadPriorityHousekeeping is the priority a sweep-sourced deep read
+// carries: River's lowest tier (4 of 4). capture_auto_enrich_sweep and
+// domain triage's own periodic pass both run at boot and can fan out dozens
+// of reads in one pass — at River's default priority that fan-out queued
+// ahead of a live read arriving moments later, holding it behind up to the
+// whole boot-time backlog on a pool sized for on-demand traffic. Lowest
+// priority means a live read waiting behind the fan-out is fetched first the
+// instant a worker frees, and a housekeeping read that loses that race is not
+// lost: sweepWorkspace already tolerates exactly this ("a pass that stops
+// early simply leaves the rest due for tomorrow").
+const DeepReadPriorityHousekeeping = 4
+
+// siteDeepReadInsertOpts routes the job to its own queue, deduplicates by
+// args (the dossier id is unique per read, so a re-submitted enqueue of the
+// SAME read collapses while a fresh read always queues), and sets priority —
+// DeepReadPriorityLive for a human or agent-initiated read,
+// DeepReadPriorityHousekeeping for one a sweep fanned out on its own.
+func siteDeepReadInsertOpts(priority int) *river.InsertOpts {
 	return &river.InsertOpts{
-		Queue: deepReadQueue,
+		Queue:    deepReadQueue,
+		Priority: priority,
 		// Swept: capture_auto_enrich_sweep re-nominates an organization that is
 		// still due on its next daily pass, so a crawl that cannot finish is
 		// re-read tomorrow rather than re-walked all afternoon.

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -33,6 +33,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
+	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/platform/webread"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -82,15 +83,23 @@ const (
 const DeepReadPriorityLive = river.PriorityDefault
 
 // DeepReadPriorityHousekeeping is the priority a sweep-sourced deep read
-// carries: River's lowest tier (4 of 4). capture_auto_enrich_sweep and
-// domain triage's own periodic pass both run at boot and can fan out dozens
-// of reads in one pass — at River's default priority that fan-out queued
-// ahead of a live read arriving moments later, holding it behind up to the
-// whole boot-time backlog on a pool sized for on-demand traffic. Lowest
-// priority means a live read waiting behind the fan-out is fetched first the
-// instant a worker frees, and a housekeeping read that loses that race is not
-// lost: sweepWorkspace already tolerates exactly this ("a pass that stops
-// early simply leaves the rest due for tomorrow").
+// carries: River's lowest tier — its documented range is 1 (highest) to 4
+// (lowest), with no named constant for either end but PriorityDefault.
+// capture_auto_enrich_sweep and domain triage's own periodic pass both run
+// at boot and can fan out dozens of reads in one pass — at River's default
+// priority that fan-out queued ahead of a live read arriving moments later,
+// holding it behind up to the whole boot-time backlog on a pool sized for
+// on-demand traffic. Lowest priority means a live read waiting behind the
+// fan-out is fetched first the instant a worker frees.
+//
+// This is a real, accepted starvation risk, not a self-healing one: River
+// itself documents that sustained higher-priority traffic can leave a
+// lower-priority job unfetched indefinitely, and nothing here bounds that —
+// sweepWorkspace's own daily-cap tolerance ("a pass that stops early simply
+// leaves the rest due for tomorrow") covers an org never yet QUEUED, not a
+// job already sitting in river_job at this priority. What actually bounds
+// the case that matters — a live caller waiting on the SAME organization a
+// sweep already queued — is promoteQueuedSiteReadPriority, not this comment.
 const DeepReadPriorityHousekeeping = 4
 
 // siteDeepReadInsertOpts routes the job to its own queue, deduplicates by
@@ -108,6 +117,42 @@ func siteDeepReadInsertOpts(priority int) *river.InsertOpts {
 		MaxAttempts: sweptJobMaxAttempts,
 		UniqueOpts:  river.UniqueOpts{ByArgs: true},
 	}
+}
+
+// promoteQueuedSiteReadPriority raises an already-queued read's priority to
+// DeepReadPriorityLive when a human or agent action JOINS it rather than
+// starting it.
+//
+// The gap this closes: createOrJoinSiteRead's join branch (people/siteread.go)
+// never calls the enqueue callback — the job those args would produce already
+// exists, and River's own ByArgs uniqueness would silently drop a re-insert
+// anyway. So a live request arriving for the same organization a boot-time
+// sweep already queued (both derive the identical https://<domain> seed URL)
+// joined a HOUSEKEEPING-priority job with no code path that ever touched its
+// priority again — the exact starvation this file exists to prevent, just
+// one step later than the fresh-insert case siteDeepReadInsertOpts covers.
+//
+// River exposes no client method to change a queued job's priority (only
+// JobUpdateParams.Output), so this reaches river_job directly — the same
+// columns this package's own tests already read off it, now written rather
+// than read. Best effort: a promotion that cannot land leaves the read to run
+// at its original priority rather than failing the request that only wanted
+// to know a read was already in flight.
+func promoteQueuedSiteReadPriority(ctx context.Context, pool *pgxpool.Pool, log *slog.Logger, readID ids.UUID) {
+	if pool == nil {
+		return
+	}
+	// river_job belongs to platform/jobs (tableownership_test.go); this
+	// package asks rather than writes it directly.
+	if _, err := jobs.PromotePriority(ctx, pool, SiteDeepReadArgs{}.Kind(),
+		"site_read_id", readID.String(), DeepReadPriorityLive); err != nil {
+		log.WarnContext(ctx, "deep read: could not promote a joined read's priority",
+			"site_read_id", readID.String(), "err", err)
+	}
+	// A false, no-error result is not logged: the joined read may already be
+	// live-priority (two live callers racing), already claimed by a worker,
+	// or finished between the join and this call — none of those are a
+	// problem this request needs to know about.
 }
 
 // siteDeepReadWorker runs one queued deep read: claim the dossier, crawl,

--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -503,6 +504,92 @@ func TestDeepReadStartQueuesOnceAndAReClickJoinsWithoutASecondInsert(t *testing.
 	}
 	if len(inserter.inserts) != 1 {
 		t.Fatalf("joining start enqueued a rival job (%d inserts, want 1)", len(inserter.inserts))
+	}
+}
+
+// seedHousekeepingSiteDeepRead fixtures the state a real boot-time sweep
+// leaves behind for one organization: a queued dossier plus its River job at
+// DeepReadPriorityHousekeeping — the exact shape startSiteRead's join branch
+// meets when a live caller reaches the same organization a sweep already
+// queued. Fixtures the STATE the real writer produces (proven correct
+// end-to-end by TestCaptureAutoEnrichSweepTriggersADeepReadForACapturedOrg
+// in integration/capture), not the writer itself — what this test holds is
+// what happens on JOIN, not what the sweep's own insert does.
+func seedHousekeepingSiteDeepRead(t *testing.T, e *integration.Env, org ids.UUID, seedURL string) ids.UUID {
+	t.Helper()
+	readID := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO site_read (id, organization_id, target_kind, seed_url, requested_by)
+			VALUES ($1, $2, $3, $4, $5)`,
+			readID, org, people.TargetKindOrganization, seedURL, "system:capture_auto_enrich"); err != nil {
+			return err
+		}
+		args, err := json.Marshal(SiteDeepReadArgs{Workspace: e.WS, OrganizationID: org, SiteReadID: readID, RequestedBy: "system:capture_auto_enrich"})
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(context.Background(), `
+			INSERT INTO river_job (state, kind, queue, priority, args, tags, errors, max_attempts,
+			                       attempt, created_at, scheduled_at)
+			VALUES ('available', $1, $2, $3, $4::jsonb, '{}'::varchar(255)[], '{}'::jsonb[], 3, 0, now(), now())`,
+			SiteDeepReadArgs{}.Kind(), deepReadQueue, DeepReadPriorityHousekeeping, args)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a housekeeping-priority site_deep_read: %v", err)
+	}
+	return readID
+}
+
+// riverJobPriority reads back the priority of the one site_deep_read job
+// queued for a dossier, by the same site_read_id scoping the production code
+// itself uses (deepread.go's promoteQueuedSiteReadPriority) — not by kind
+// alone, which a sweep pass sharing this workspace could make ambiguous.
+func riverJobPriority(t *testing.T, e *integration.Env, readID ids.UUID) int {
+	t.Helper()
+	var priority int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT priority FROM river_job WHERE kind = $1 AND args ->> 'site_read_id' = $2`,
+			SiteDeepReadArgs{}.Kind(), readID.String(),
+		).Scan(&priority)
+	}); err != nil {
+		t.Fatalf("reading the job's priority: %v", err)
+	}
+	return priority
+}
+
+// TestDeepReadJoiningAHousekeepingReadPromotesItsPriority holds the case
+// createOrJoinSiteRead's join branch cannot cover on its own: it never calls
+// the enqueue callback (the job already exists, and River's own ByArgs
+// uniqueness would silently drop a re-insert anyway), so a live caller
+// reaching the same organization a boot-time sweep already queued must not
+// be left waiting behind that sweep's own housekeeping priority just because
+// it joined instead of starting.
+func TestDeepReadJoiningAHousekeepingReadPromotesItsPriority(t *testing.T) {
+	e := integration.Setup(t)
+	org := insertOrg(t, e, e.Rep1, "promote.example", "")
+	readID := seedHousekeepingSiteDeepRead(t, e, org, "https://promote.example")
+	if got := riverJobPriority(t, e, readID); got != DeepReadPriorityHousekeeping {
+		t.Fatalf("fixture priority = %d, want %d (housekeeping) before the live request", got, DeepReadPriorityHousekeeping)
+	}
+
+	inserter := &fakeInserter{}
+	engine := newDeepReadTestEngine(e, inserter)
+	engine.pool = e.Pool
+
+	rec, started := postDeepRead(t, e, engine, e.Rep1, org)
+	if rec.Code != http.StatusAccepted || started.Status != crmcontracts.SiteReadStartedStatusRunning {
+		t.Fatalf("live request for an already-queued org → %d %+v, want 202 running (joining the sweep's read)", rec.Code, started)
+	}
+	if ids.UUID(started.ReadId) != readID {
+		t.Fatalf("joined read id = %s, want the seeded housekeeping read %s", started.ReadId, readID)
+	}
+	if len(inserter.inserts) != 0 {
+		t.Fatalf("a join enqueued %d jobs, want 0 — the existing job is promoted, never duplicated", len(inserter.inserts))
+	}
+	if got := riverJobPriority(t, e, readID); got != DeepReadPriorityLive {
+		t.Fatalf("joined read's priority = %d after a live request, want %d (promoted to live)", got, DeepReadPriorityLive)
 	}
 }
 

--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -16,6 +16,7 @@ package compose
 // outcome no-ops.
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -590,6 +591,26 @@ func TestDeepReadJoiningAHousekeepingReadPromotesItsPriority(t *testing.T) {
 	}
 	if got := riverJobPriority(t, e, readID); got != DeepReadPriorityLive {
 		t.Fatalf("joined read's priority = %d after a live request, want %d (promoted to live)", got, DeepReadPriorityLive)
+	}
+}
+
+// TestDeepReadPromoteQueuedPriorityLogsWhenTheUpdateFails holds the honest
+// hard case the happy-path test above cannot reach: a promotion is
+// best-effort, and best-effort still has to say what it could not do rather
+// than fail silently. An already-cancelled context is the deterministic way
+// to force pool.Exec to fail without needing a broken database.
+func TestDeepReadPromoteQueuedPriorityLogsWhenTheUpdateFails(t *testing.T) {
+	e := integration.Setup(t)
+	var logs bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logs, nil))
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	promoteQueuedSiteReadPriority(cancelledCtx, e.Pool, log, ids.NewV7())
+
+	if !strings.Contains(logs.String(), "could not promote a joined read's priority") {
+		t.Fatalf("a failed promotion logged nothing; want a warning naming what could not be done. Got: %s", logs.String())
 	}
 }
 

--- a/backend/internal/compose/deepread_integration_test.go
+++ b/backend/internal/compose/deepread_integration_test.go
@@ -486,6 +486,11 @@ func TestDeepReadStartQueuesOnceAndAReClickJoinsWithoutASecondInsert(t *testing.
 		args.SiteReadID != ids.UUID(first.ReadId) || args.RequestedBy != "human:"+e.Rep1.String() {
 		t.Fatalf("job args = %+v, want the dossier's own identity and the human who asked", args)
 	}
+	// A rep pressed the button for this — it must never queue behind a boot
+	// sweep's housekeeping fan-out on the shared deep_read pool.
+	if got := inserter.opts[0].Priority; got != DeepReadPriorityLive {
+		t.Fatalf("a human-started deep read queued at priority %d, want %d (live)", got, DeepReadPriorityLive)
+	}
 
 	// A second click while the read is in flight joins it: same read id,
 	// answered as running, and NO second job rides the queue.

--- a/backend/internal/compose/deepread_test.go
+++ b/backend/internal/compose/deepread_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import "testing"
+
+// TestSiteDeepReadInsertOptsRoutesQueueAndCarriesTheGivenPriority holds the
+// one thing every one of the four site_deep_read call sites depends on: the
+// job always lands on deepReadQueue, deduplicates by args, and carries
+// whichever priority the caller declared for itself — the primitive the fix
+// for margince#5122 (a boot-time sweep's fan-out queuing ahead of a live
+// read) rests on.
+func TestSiteDeepReadInsertOptsRoutesQueueAndCarriesTheGivenPriority(t *testing.T) {
+	for _, priority := range []int{DeepReadPriorityLive, DeepReadPriorityHousekeeping} {
+		opts := siteDeepReadInsertOpts(priority)
+		if opts.Queue != deepReadQueue {
+			t.Errorf("priority %d: queue = %q, want %q", priority, opts.Queue, deepReadQueue)
+		}
+		if opts.Priority != priority {
+			t.Errorf("priority %d: opts.Priority = %d, want it carried through unchanged", priority, opts.Priority)
+		}
+		if !opts.UniqueOpts.ByArgs {
+			t.Errorf("priority %d: UniqueOpts.ByArgs = false, want deduplication by the dossier id in args", priority)
+		}
+	}
+	if DeepReadPriorityLive == DeepReadPriorityHousekeeping {
+		t.Fatal("live and housekeeping priorities are equal — a boot sweep would queue level with a live read again")
+	}
+	if DeepReadPriorityLive >= DeepReadPriorityHousekeeping {
+		t.Fatalf("DeepReadPriorityLive (%d) must be fetched before DeepReadPriorityHousekeeping (%d) — River treats a LOWER number as higher priority",
+			DeepReadPriorityLive, DeepReadPriorityHousekeeping)
+	}
+}

--- a/backend/internal/compose/deepread_test.go
+++ b/backend/internal/compose/deepread_test.go
@@ -5,12 +5,11 @@ package compose
 
 import "testing"
 
-// TestSiteDeepReadInsertOptsRoutesQueueAndCarriesTheGivenPriority holds the
-// one thing every one of the four site_deep_read call sites depends on: the
-// job always lands on deepReadQueue, deduplicates by args, and carries
-// whichever priority the caller declared for itself — the primitive the fix
-// for margince#5122 (a boot-time sweep's fan-out queuing ahead of a live
-// read) rests on.
+// TestSiteDeepReadInsertOptsRoutesQueueAndCarriesTheGivenPriority holds what
+// every site_deep_read caller depends on: the job always lands on
+// deepReadQueue, deduplicates by args, and carries whichever priority the
+// caller declared for itself — and that DeepReadPriorityLive is fetched
+// before DeepReadPriorityHousekeeping, not the other way around.
 func TestSiteDeepReadInsertOptsRoutesQueueAndCarriesTheGivenPriority(t *testing.T) {
 	for _, priority := range []int{DeepReadPriorityLive, DeepReadPriorityHousekeeping} {
 		opts := siteDeepReadInsertOpts(priority)

--- a/backend/internal/compose/deepreadaccept_integration_test.go
+++ b/backend/internal/compose/deepreadaccept_integration_test.go
@@ -225,17 +225,19 @@ func TestDeepReadRejectionLandsNothing(t *testing.T) {
 }
 
 // fakeInserter stands in for the insert-only River client so handler
-// tests can count what start enqueues.
+// tests can count what start enqueues, and what opts it queued it under.
 type fakeInserter struct {
 	inserts []river.JobArgs
+	opts    []*river.InsertOpts
 	err     error
 }
 
-func (f *fakeInserter) EnqueueTx(_ context.Context, _ pgx.Tx, args river.JobArgs, _ *river.InsertOpts) error {
+func (f *fakeInserter) EnqueueTx(_ context.Context, _ pgx.Tx, args river.JobArgs, opts *river.InsertOpts) error {
 	if f.err != nil {
 		return f.err
 	}
 	f.inserts = append(f.inserts, args)
+	f.opts = append(f.opts, opts)
 	return nil
 }
 

--- a/backend/internal/compose/deepreadtransport.go
+++ b/backend/internal/compose/deepreadtransport.go
@@ -142,7 +142,7 @@ func (e *deepReadEngine) startSiteRead(ctx context.Context, id ids.UUID, overrid
 				OrganizationID: orgID.UUID,
 				SiteReadID:     read.ID,
 				RequestedBy:    read.RequestedBy,
-			}, siteDeepReadInsertOpts())
+			}, siteDeepReadInsertOpts(DeepReadPriorityLive))
 		})
 	if err != nil {
 		return crmcontracts.SiteReadStarted{}, err

--- a/backend/internal/compose/deepreadtransport.go
+++ b/backend/internal/compose/deepreadtransport.go
@@ -79,6 +79,10 @@ type deepReadEngine struct {
 	// confirmation is told so: it then keeps the dossier's reference rather
 	// than handing over a key nobody here can act on.
 	blob blobstore.Store
+	// pool promotes a joined read's priority (deepread.go). Nil is a test
+	// double that never joins an already-queued housekeeping read, so it has
+	// nothing to promote.
+	pool *pgxpool.Pool
 }
 
 // logger answers the engine's logger, or the default when the composition
@@ -153,6 +157,10 @@ func (e *deepReadEngine) startSiteRead(ctx context.Context, id ids.UUID, overrid
 		if read.Status == siteReadStatusDeferred {
 			status = crmcontracts.SiteReadStartedStatusDeferred
 		}
+		// This request pressed the button for a read a boot-time sweep already
+		// queued — it must not wait behind that sweep's own housekeeping
+		// priority just because it joined instead of starting.
+		promoteQueuedSiteReadPriority(ctx, e.pool, e.logger(), read.ID)
 	}
 	return crmcontracts.SiteReadStarted{
 		ReadId: openapi_types.UUID(read.ID),
@@ -250,6 +258,7 @@ func WithDeepRead(inserter *jobs.Runner, brain completer) Option {
 			// leaves the onboarding confirmation unable to collect the mark its
 			// anchor declined — the two-way wiring WithDataReset carries too.
 			blob: s.blob,
+			pool: pool,
 		}
 		rollout := s.companyContextRollout
 		s.siteReadHandlers = siteReadHandlers{engine: engine, start: engine.start, report: engine.report, latest: engine.latestReport, companyContextRollout: rollout}

--- a/backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go
@@ -89,10 +89,12 @@ func TestCaptureAutoEnrichSweepTriggersADeepReadForACapturedOrg(t *testing.T) {
 	// The sweep created a system-requested dossier for the org...
 	var readCount int
 	var requestedBy string
+	var readID string
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
-			`SELECT count(*), coalesce(max(requested_by), '') FROM site_read WHERE organization_id = $1`,
-			orgID).Scan(&readCount, &requestedBy)
+			`SELECT count(*), coalesce(max(requested_by), ''), coalesce(max(id::text), '')
+			 FROM site_read WHERE organization_id = $1`,
+			orgID).Scan(&readCount, &requestedBy, &readID)
 	}); err != nil {
 		t.Fatalf("reading the dossier: %v", err)
 	}
@@ -102,11 +104,16 @@ func TestCaptureAutoEnrichSweepTriggersADeepReadForACapturedOrg(t *testing.T) {
 
 	// ...at the housekeeping priority (River's lowest tier) — a boot-time fan-out
 	// across every due org must never queue ahead of a live, human-started read
-	// sharing deep_read's two workers.
+	// sharing deep_read's two workers. Scoped to THIS dossier's own job by
+	// site_read_id: sweepWorkspace also runs sweepDomainTriage unconditionally
+	// before the auto-enrich loop, which can enqueue its own site_deep_read row
+	// for an unrelated domain in the same pass — an unscoped query naming only
+	// `kind` would read whichever row Postgres happened to return first.
 	var priority int
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
-			`SELECT priority FROM river_job WHERE kind = $1`, compose.SiteDeepReadArgs{}.Kind(),
+			`SELECT priority FROM river_job WHERE kind = $1 AND args ->> 'site_read_id' = $2`,
+			compose.SiteDeepReadArgs{}.Kind(), readID,
 		).Scan(&priority)
 	}); err != nil {
 		t.Fatalf("reading the enqueued read's priority: %v", err)
@@ -139,5 +146,78 @@ func TestCaptureAutoEnrichSweepTriggersADeepReadForACapturedOrg(t *testing.T) {
 	}
 	if enqueued != 1 {
 		t.Fatalf("reserved %d cap slots, want exactly 1", enqueued)
+	}
+}
+
+// TestCaptureAutoEnrichSweepQueuesDomainTriageAtHousekeepingPriorityToo proves
+// the same housekeeping priority for the OTHER sweep-sourced caller sharing
+// siteDeepReadInsertOpts, over the same real River runner this file's sibling
+// test uses. sweepWorkspace runs sweepDomainTriage unconditionally before the
+// auto-enrich loop (captureautoenrich.go), so an open domain question with no
+// captured org queues through startDomainTriageRead, not startAutoEnrichRead —
+// the call site capturedomaintriage_integration_test.go's own header comment
+// names as untestable without an ambient River client this runner now supplies.
+func TestCaptureAutoEnrichSweepQueuesDomainTriageAtHousekeepingPriorityToo(t *testing.T) {
+	e := integration.Setup(t)
+	const domain = "unjudged.example"
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO organization_domain_disposition (domain, status, owner_id)
+			VALUES ($1, 'pending', $2)`, domain, e.Rep1)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the open domain question: %v", err)
+	}
+
+	integration.ApplyRiverSchema(t)
+	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
+	runner, err := compose.NewJobRunner(e.Pool, quiet, compose.JobRunnerConfig{
+		CloseDateInterval: time.Hour,
+		ReconcileInterval: time.Hour,
+		TimeScanInterval:  time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewJobRunner: %v", err)
+	}
+	sub, cancelSub := runner.SubscribeCompleted()
+	defer cancelSub()
+
+	ctx := context.Background()
+	if err := runner.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := runner.Stop(stopCtx); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	}()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	integration.AwaitKindCompleted(waitCtx, t, sub, compose.CaptureAutoEnrichSweepArgs{}.Kind())
+
+	var readID string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT id::text FROM site_read WHERE seed_url = $1 AND target_kind = 'domain_triage'`,
+			"https://"+domain,
+		).Scan(&readID)
+	}); err != nil {
+		t.Fatalf("reading the triage dossier: %v", err)
+	}
+
+	var priority int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT priority FROM river_job WHERE kind = $1 AND args ->> 'site_read_id' = $2`,
+			compose.SiteDeepReadArgs{}.Kind(), readID,
+		).Scan(&priority)
+	}); err != nil {
+		t.Fatalf("reading the triage read's priority: %v", err)
+	}
+	if priority != compose.DeepReadPriorityHousekeeping {
+		t.Fatalf("sweep-enqueued domain triage read priority = %d, want %d (housekeeping)", priority, compose.DeepReadPriorityHousekeeping)
 	}
 }

--- a/backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go
@@ -100,6 +100,21 @@ func TestCaptureAutoEnrichSweepTriggersADeepReadForACapturedOrg(t *testing.T) {
 		t.Fatalf("dossier count=%d requested_by=%q, want 1 / system:capture_auto_enrich", readCount, requestedBy)
 	}
 
+	// ...at the housekeeping priority (River's lowest tier) — a boot-time fan-out
+	// across every due org must never queue ahead of a live, human-started read
+	// sharing deep_read's two workers.
+	var priority int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT priority FROM river_job WHERE kind = $1`, compose.SiteDeepReadArgs{}.Kind(),
+		).Scan(&priority)
+	}); err != nil {
+		t.Fatalf("reading the enqueued read's priority: %v", err)
+	}
+	if priority != compose.DeepReadPriorityHousekeeping {
+		t.Fatalf("sweep-enqueued deep read priority = %d, want %d (housekeeping)", priority, compose.DeepReadPriorityHousekeeping)
+	}
+
 	// ...and armed the cursor (attempt counted, outcome queued)...
 	var attempts int
 	var outcome string

--- a/backend/internal/compose/onboarding_siteread_integration_test.go
+++ b/backend/internal/compose/onboarding_siteread_integration_test.go
@@ -131,6 +131,11 @@ func TestOnboardingSiteReadTransportStartsPollsAndConfirmsTheDraft(t *testing.T)
 		startRec.Header().Get("Location") != "/v1/company/site-reads/"+started.Id.String() || len(inserter.inserts) != 1 {
 		t.Fatalf("started dossier = %+v, location %q, jobs %d", started, startRec.Header().Get("Location"), len(inserter.inserts))
 	}
+	// Onboarding is a person watching this page — it must never queue behind
+	// a boot sweep's housekeeping fan-out on the shared deep_read pool.
+	if got := inserter.opts[0].Priority; got != DeepReadPriorityLive {
+		t.Fatalf("an onboarding deep read queued at priority %d, want %d (live)", got, DeepReadPriorityLive)
+	}
 
 	read, err := e.People.GetOnboardingSiteRead(human, ids.UUID(started.Id))
 	if err != nil {

--- a/backend/internal/compose/onboarding_siteread_integration_test.go
+++ b/backend/internal/compose/onboarding_siteread_integration_test.go
@@ -109,6 +109,44 @@ func onboardingPOST[T onboardingRequest](ctx context.Context, t *testing.T, path
 	return httptest.NewRequest(http.MethodPost, path, bytes.NewReader(raw)).WithContext(ctx)
 }
 
+// TestOnboardingSiteReadTransportPromotesAJoinedReadToo holds
+// startCompanySiteRead's own join branch: two onboarding starts for the
+// identical seed URL join the same dossier (its target kind never collides
+// with a sweep's, but the join branch itself is the same shared code path
+// startSiteRead's join-promotion fix lives in, and a future caller sharing
+// TargetKindOnboarding is exactly the case a silently-untested branch here
+// would miss).
+func TestOnboardingSiteReadTransportPromotesAJoinedReadToo(t *testing.T) {
+	e := integration.Setup(t)
+	human := e.As(e.Rep1, nil, integration.AdminPerms)
+	inserter := &fakeInserter{}
+	engine := newDeepReadTestEngine(e, inserter)
+	engine.approvals = approvals.NewService(e.DB())
+	engine.pool = e.Pool
+
+	first := onboardingPOST(human, t, "/v1/company/site-reads",
+		crmcontracts.StartCompanySiteReadRequest{Url: seedURL})
+	firstRec := httptest.NewRecorder()
+	engine.startCompanySiteRead(firstRec, first)
+	if firstRec.Code != http.StatusAccepted {
+		t.Fatalf("first start → %d %s, want 202", firstRec.Code, firstRec.Body.String())
+	}
+
+	second := onboardingPOST(human, t, "/v1/company/site-reads",
+		crmcontracts.StartCompanySiteReadRequest{Url: seedURL})
+	secondRec := httptest.NewRecorder()
+	engine.startCompanySiteRead(secondRec, second)
+	if secondRec.Code != http.StatusAccepted {
+		t.Fatalf("joining start → %d %s, want 202", secondRec.Code, secondRec.Body.String())
+	}
+	if len(inserter.inserts) != 1 {
+		t.Fatalf("a join enqueued a rival job (%d inserts, want 1)", len(inserter.inserts))
+	}
+	// Both are live-priority already, so promotion is a no-op result-wise —
+	// what this holds is that startCompanySiteRead's join branch reaches the
+	// call at all, not that this specific pair changes anything.
+}
+
 func TestOnboardingSiteReadTransportStartsPollsAndConfirmsTheDraft(t *testing.T) {
 	e := integration.Setup(t)
 	human := e.As(e.Rep1, nil, integration.AdminPerms)

--- a/backend/internal/compose/onboardingsitereadtransport.go
+++ b/backend/internal/compose/onboardingsitereadtransport.go
@@ -49,7 +49,7 @@ func (e *deepReadEngine) startCompanySiteRead(w http.ResponseWriter, r *http.Req
 			return e.enqueue.EnqueueTx(ctx, tx, SiteDeepReadArgs{
 				Workspace: storekit.MustWorkspace(ctx), SiteReadID: read.ID,
 				RequestedBy: read.RequestedBy,
-			}, siteDeepReadInsertOpts())
+			}, siteDeepReadInsertOpts(DeepReadPriorityLive))
 		})
 	if err != nil {
 		httperr.Write(w, r, err)

--- a/backend/internal/compose/onboardingsitereadtransport.go
+++ b/backend/internal/compose/onboardingsitereadtransport.go
@@ -44,7 +44,7 @@ func (e *deepReadEngine) startCompanySiteRead(w http.ResponseWriter, r *http.Req
 		httperr.Write(w, r, httperr.Validation("url", "invalid", "url must be an absolute http(s) URL"))
 		return
 	}
-	read, _, err := e.people.StartOnboardingSiteRead(r.Context(), seedURL, requestedBy(r.Context()),
+	read, joined, err := e.people.StartOnboardingSiteRead(r.Context(), seedURL, requestedBy(r.Context()),
 		func(ctx context.Context, tx pgx.Tx, read people.SiteRead) error {
 			return e.enqueue.EnqueueTx(ctx, tx, SiteDeepReadArgs{
 				Workspace: storekit.MustWorkspace(ctx), SiteReadID: read.ID,
@@ -54,6 +54,13 @@ func (e *deepReadEngine) startCompanySiteRead(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
+	}
+	if joined {
+		// TargetKindOnboarding never joins a TargetKindOrganization sweep
+		// read today, so this is a no-op in production — kept for the same
+		// reason startSiteRead carries it: a joined read is never assumed
+		// live-priority just because IT usually is.
+		promoteQueuedSiteReadPriority(r.Context(), e.pool, e.logger(), read.ID)
 	}
 	w.Header().Set("Location", "/v1/company/site-reads/"+read.ID.String())
 	httperr.WriteJSON(w, http.StatusAccepted, companySiteRead(read, nil, nil))

--- a/backend/internal/platform/jobs/priority.go
+++ b/backend/internal/platform/jobs/priority.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package jobs
+
+// Mutating river_job outside the insert path Runner already owns. The
+// package that runs the fleet is the package that writes its own table
+// (tableownership_test.go) — a caller with a reason to reprioritize an
+// already-queued job reaches through here rather than reissuing the
+// UPDATE itself, so river_job's write shape has one home, not one per
+// caller with a reason to touch it.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PromotePriority raises the priority of one queued job of the given kind,
+// matched by a single top-level string arg (e.g. a dossier or dedupe id),
+// to the given value. It is a raise only: a job already at or above the
+// requested priority is left alone, so a caller cannot accidentally demote
+// one by calling this with a lower urgency than what is already queued.
+//
+// Scoped to states a worker has not yet claimed (available, scheduled,
+// retryable) — a running or finished job has nothing left to reprioritize,
+// and touching it would race the worker executing it.
+//
+// Reports whether a row was actually changed: false is not an error, and
+// covers every reason there was nothing to promote — the job already ran,
+// already carries this priority, or the caller's own uniqueness match found
+// no row. A caller that only wanted to know a job was already in flight can
+// use this as a best-effort nudge without needing to distinguish those cases.
+func PromotePriority(ctx context.Context, pool *pgxpool.Pool, kind, argKey, argValue string, priority int) (bool, error) {
+	tag, err := pool.Exec(ctx, `
+		UPDATE river_job SET priority = $1
+		WHERE kind = $2 AND state IN ('available', 'scheduled', 'retryable')
+		  AND args ->> $3 = $4 AND priority > $1`,
+		priority, kind, argKey, argValue)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/backend/internal/platform/jobs/priority_integration_test.go
+++ b/backend/internal/platform/jobs/priority_integration_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package jobs_test
+
+// PromotePriority against real river_job rows — the WHERE clause's state,
+// arg-match and one-way-raise conditions are the whole of the behaviour, so
+// a fake pool would prove nothing a unit test could not already claim.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
+)
+
+// seedPriorityJob writes one raw river_job row at the given state and
+// priority, with a single string arg, and returns nothing — the tests below
+// read the row back through the priority column alone, which is the one
+// thing PromotePriority is trusted to have changed correctly.
+func seedPriorityJob(ctx context.Context, t *testing.T, pool *pgxpool.Pool, kind, state, argKey, argValue string, priority int) {
+	t.Helper()
+	args, err := json.Marshal(map[string]string{argKey: argValue})
+	if err != nil {
+		t.Fatalf("encoding fixture args: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO river_job (state, kind, queue, priority, args, tags, errors, max_attempts, attempt, created_at, scheduled_at)
+		VALUES ($1::river_job_state, $2, 'default', $3, $4::jsonb, '{}'::varchar(255)[], '{}'::jsonb[], 3, 0, now(), now())`,
+		state, kind, priority, args); err != nil {
+		t.Fatalf("seeding a %s %s row: %v", state, kind, err)
+	}
+}
+
+func priorityOf(ctx context.Context, t *testing.T, pool *pgxpool.Pool, kind, argKey, argValue string) int {
+	t.Helper()
+	var priority int
+	if err := pool.QueryRow(ctx,
+		`SELECT priority FROM river_job WHERE kind = $1 AND args ->> $2 = $3`,
+		kind, argKey, argValue).Scan(&priority); err != nil {
+		t.Fatalf("reading the row's priority: %v", err)
+	}
+	return priority
+}
+
+func TestPromotePriorityRaisesAnAvailableJobMatchedByItsArg(t *testing.T) {
+	ctx := t.Context()
+	_, pool := migratedAppPool(t)
+	seedPriorityJob(ctx, t, pool, "promote_test_kind", "available", "dossier_id", "d1", 4)
+
+	changed, err := jobs.PromotePriority(ctx, pool, "promote_test_kind", "dossier_id", "d1", 1)
+	if err != nil {
+		t.Fatalf("PromotePriority: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true — a priority-4 available job matching the arg must be raised")
+	}
+	if got := priorityOf(ctx, t, pool, "promote_test_kind", "dossier_id", "d1"); got != 1 {
+		t.Fatalf("priority after promotion = %d, want 1", got)
+	}
+}
+
+func TestPromotePriorityNeverLowersAJobAlreadyAtOrAboveTheRequestedTier(t *testing.T) {
+	ctx := t.Context()
+	_, pool := migratedAppPool(t)
+	seedPriorityJob(ctx, t, pool, "promote_test_kind", "available", "dossier_id", "d2", 1)
+
+	changed, err := jobs.PromotePriority(ctx, pool, "promote_test_kind", "dossier_id", "d2", 4)
+	if err != nil {
+		t.Fatalf("PromotePriority: %v", err)
+	}
+	if changed {
+		t.Fatal("changed = true, want false — a raise-only call must not demote a job already more urgent")
+	}
+	if got := priorityOf(ctx, t, pool, "promote_test_kind", "dossier_id", "d2"); got != 1 {
+		t.Fatalf("priority = %d, want the original 1 (unchanged)", got)
+	}
+}
+
+func TestPromotePriorityLeavesAJobPastItsQueuedStatesAlone(t *testing.T) {
+	ctx := t.Context()
+	_, pool := migratedAppPool(t)
+	seedPriorityJob(ctx, t, pool, "promote_test_kind", "running", "dossier_id", "d3", 4)
+
+	changed, err := jobs.PromotePriority(ctx, pool, "promote_test_kind", "dossier_id", "d3", 1)
+	if err != nil {
+		t.Fatalf("PromotePriority: %v", err)
+	}
+	if changed {
+		t.Fatal("changed = true, want false — a running job's priority no longer means anything a worker will read")
+	}
+	if got := priorityOf(ctx, t, pool, "promote_test_kind", "dossier_id", "d3"); got != 4 {
+		t.Fatalf("priority = %d, want the original 4 (unchanged)", got)
+	}
+}
+
+func TestPromotePriorityMatchesNoRowWithoutError(t *testing.T) {
+	ctx := t.Context()
+	_, pool := migratedAppPool(t)
+
+	changed, err := jobs.PromotePriority(ctx, pool, "promote_test_kind", "dossier_id", "no-such-dossier", 1)
+	if err != nil {
+		t.Fatalf("PromotePriority: %v", err)
+	}
+	if changed {
+		t.Fatal("changed = true, want false — nothing was seeded to match")
+	}
+}

--- a/backend/internal/platform/jobs/priority_integration_test.go
+++ b/backend/internal/platform/jobs/priority_integration_test.go
@@ -99,6 +99,20 @@ func TestPromotePriorityLeavesAJobPastItsQueuedStatesAlone(t *testing.T) {
 	}
 }
 
+func TestPromotePriorityReportsTheUnderlyingErrorRatherThanSwallowingIt(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	changed, err := jobs.PromotePriority(cancelledCtx, pool, "promote_test_kind", "dossier_id", "d4", 1)
+	if err == nil {
+		t.Fatal("PromotePriority against an already-cancelled context returned no error, want the pool's own failure surfaced")
+	}
+	if changed {
+		t.Fatal("changed = true alongside a non-nil error — a failed UPDATE must never report a change")
+	}
+}
+
 func TestPromotePriorityMatchesNoRowWithoutError(t *testing.T) {
 	ctx := t.Context()
 	_, pool := migratedAppPool(t)


### PR DESCRIPTION
## Summary

Closes margince#5122.

`deep_read`'s two-worker pool is deliberately isolated from `default` so a
long crawl cannot evict short maintenance jobs. But `capture_auto_enrich_sweep`
and domain triage's own periodic pass both run at boot and can fan out
dozens of `site_deep_read` jobs into that same pool in one pass — for
25-30 minutes after every deploy, a live, human or agent-initiated deep
read (onboarding, a direct `/deep-read` request, the `enrich` tool) queued
behind up to 98 boot-time housekeeping jobs it never asked for, with
nothing on screen distinguishing "your scan is running" from "your scan
is stuck behind a sweep."

`siteDeepReadInsertOpts` now takes a priority. The two sweep-sourced
callers (`capture_auto_enrich_sweep`, domain triage) pass
`DeepReadPriorityHousekeeping` (River's lowest tier, 4 of 4); the two
human/agent-initiated callers (onboarding, the direct request/`enrich`
tool) pass `DeepReadPriorityLive` (River's default, highest, 1 of 4).
River fetches strictly by priority within one queue, so a live read
waiting behind a boot-time fan-out is fetched first the instant a worker
frees.

### The join gap two independent reviews caught

`createOrJoinSiteRead`'s join branch (`people/siteread.go`) never calls the
enqueue callback — the job already exists, and River's own `ByArgs`
uniqueness would silently drop a re-insert anyway. So a live request
arriving for the same organization a sweep already queued (both derive the
identical `https://<domain>` seed URL) joined a housekeeping-priority job
with nothing ever promoting it — the exact starvation this fix exists to
prevent, one step later than the fresh-insert case.

River exposes no client method to change a queued job's priority (only
`JobUpdateParams.Output`), so `jobs.PromotePriority`
(`internal/platform/jobs/priority.go`) raises it directly with a
raise-only, state-scoped `UPDATE` — moved into `platform/jobs` (`river_job`'s
declared owner per `tableownership_test.go`) rather than written from
`compose`, after the table-ownership gate caught my first attempt writing
it in-place. `deepreadtransport.go`'s `startSiteRead` and
`onboardingsitereadtransport.go`'s `startCompanySiteRead` call it,
best-effort, whenever their own join branch fires. (Onboarding's own
target kind never actually collides with a sweep's today — different
`target_kind` values keep them from ever joining each other — but it's
wired the same way regardless, since assuming that's permanent is exactly
the kind of assumption that stops being true silently.)

### Also from review

- A comment attributed the housekeeping tier's starvation tolerance to
  `sweepWorkspace`'s daily-cap early-stop, which covers an org never yet
  queued, not a job already sitting in `river_job` under sustained live
  traffic — corrected to name what actually bounds that case (the
  promotion above).
- The auto-enrich sweep integration test's priority assertion is now
  scoped by `site_read_id` rather than `kind` alone, since
  `sweepDomainTriage` can enqueue its own `site_deep_read` row in the same
  pass — an unscoped query would read whichever row Postgres happened to
  return first.
- Domain triage's own sweep-sourced housekeeping priority now has its own
  real-River-client coverage, closing a gap
  `capturedomaintriage_integration_test.go`'s own header comment named as
  untestable from that package.

### Considered, not done

Two review suggestions I read as genuine design opinions rather than
defects, left as-is: deriving each caller's priority from `RequestedBy`'s
prefix instead of an explicit constant per call site (more machinery for
four call sites, each already covered by its own test), and expressing
`DeepReadPriorityHousekeeping` as `river.PriorityDefault + 3` to match a
sibling file's `PriorityDefault + 1` convention (River's own range is a
fixed, documented 1-4 window with no named constant for its low end, so a
bare `4` with a clear comment reads more directly than the arithmetic
here).

## Scope

- No AI/prompt code touched — no aicert re-run needed.
- No UAT video. Backend job-dispatch change with no direct UI surface;
  the integration tests below (real Postgres, a real River runner for the
  sweep-side tests) are the equivalent, stronger proof.
- New code covered: unit test for `siteDeepReadInsertOpts`'s priority
  plumbing, four new/extended integration tests proving each call site's
  priority end-to-end (including the join-promotion fix and both
  sweep-sourced kinds over a real River client), four new unit-integration
  tests for `jobs.PromotePriority` itself (raise, no-demote, past-queued
  states, no-match).
- `make check-all` green (build, vet, lint, gates, contract drift,
  composition, frontend, and the full real-Postgres integration lane, 0
  skips). `craft static --strict` clean on every changed file.

**Known unrelated red on this branch's own CI**: `fe-file-length` fails on
`frontend/src/screens/organizations.tsx` (2589 lines vs. a 2587 waiver) —
inherited from `origin/main`, not touched by this diff (backend-only), and
already claimed and being fixed in margince#5316. Not mine to fix per this
repo's claim protocol; will re-check at merge time.

## Test plan

- [x] `make check-go`
- [x] `make check-all` (full merge gate + real-Postgres integration lane, 0 skips)
- [x] `craft static --strict` on every changed file
- [x] Manually reverted each fix in turn and confirmed its own test fails
      without it (join-promotion test, all four `site_deep_read` priority
      assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkdtztRqyypJufL6VTE2Vs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deep-read boot priority so a live read never waits behind a sweep's fan-out. Sweep-sourced reads now queue at River's lowest tier, and a live read that joins an already-queued housekeeping read is promoted live.

- `siteDeepReadInsertOpts` now takes a priority: `capture_auto_enrich_sweep` and domain triage pass `DeepReadPriorityHousekeeping`; onboarding and the direct request/`enrich` tool pass `DeepReadPriorityLive`.
- When a live request joins an already-queued housekeeping read, the new `jobs.PromotePriority` in `platform/jobs` raises it best-effort — raise-only and scoped to queued states, so a failed promotion leaves the read at its original priority without failing the request.
- Sweep, join, and promotion paths are covered against real Postgres and a real River runner, including the onboarding join branch and the promotion error path.
- Unrelated CI red on `frontend/src/screens/organizations.tsx` is inherited from main.

Closes margince#5122.

<sup>Written for commit 4c59a99b15aa598479f3ed22b8924b7e75e006c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Live, user- or agent-requested site reads now receive higher queue priority than background housekeeping work.
  * When a live request joins an already queued background read, the existing read is promoted instead of creating a duplicate job.
  * Background enrichment and domain-triage reads continue to run at lower priority, helping keep interactive requests responsive.

* **Tests**
  * Added coverage for queue prioritization, promotion behavior, deduplication, and onboarding reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->