### PR TITLE
docs(agents): add task-sizing rule to How you work here

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,11 @@ issue only when the fix lives in another module, needs a product or architecture
 decision, or would double the diff. Say in the PR body what you fixed along the
 way.
 
+**Size the task before you start.** A change that keeps pulling in new files
+and modules mid-session was never scoped, not merely large. Cut it at what you
+can finish, test and PR in one sitting; a genuinely bigger change is several of
+those in sequence, not one unbounded session.
+
 **One PR per piece of work.** Do not split related work across several small PRs
 — each one costs a full CI run. One branch, one PR.
 


### PR DESCRIPTION
## Summary
Prompted by kiro.dev's "frontier engineering" piece on agentic engineering workflows (https://kiro.dev/topics/frontier-engineering/). Most of its recommendations — steering files, matching quality gates to human standards, trust boundaries over blind delegation, fast feedback loops, agents used beyond codegen — are already how this repo works, more rigorously than the article describes (RBAC + `apperrors` sentinels, `craft static` + narrow `make check-go` lanes, `gen-composition`/`gen-perfdoc`).

The one real gap: `AGENTS.md` has "One PR per piece of work" for how a task ships, but nothing about scoping it *before* work starts. Adds one rule to "How you work here" addressing that.

## Test plan
- [x] `TestEverySourcePathNamedInProseExists` and `TestTheReviewerIsToldWhichPathsAreReallyOffLimits` (the two gates that read `AGENTS.md` content) still pass
- [x] `craft static`: no changed Go files, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a task-sizing rule to `AGENTS.md` so work is scoped before it starts, not just shipped one PR at a time.

The file already told agents how to ship work ("One PR per piece of work") but gave no guidance on sizing it up front. The new rule instructs agents to cut a task at what can be finished, tested, and PR'd in one sitting, and to treat larger changes as a sequence of those. No behavioral or code changes; the two tests that validate `AGENTS.md` content still pass.

<sup>Written for commit 43a27a3e9f583aa2e23a019c6c26a256f9f6ff2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to estimate task scope before starting work.
  * Clarified that larger changes should be completed as a sequence of focused, testable sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->