### PR TITLE
feat(ci): a pull request declares what it closes, and the report warns when it does not

### DIFF
--- a/.github/workflows/closing-declaration.yml
+++ b/.github/workflows/closing-declaration.yml
@@ -57,6 +57,13 @@ jobs:
           # The METADATA, not the body. This is the same list that closes an
           # issue on merge, so a pull request this reads as declaring is one
           # GitHub will actually act on.
+          #
+          # A FAILED QUERY IS NOT AN EMPTY ONE. Suppressing the failure would
+          # hand the check an empty list, and a pull request carrying perfectly
+          # good closing metadata would be warned for a transient API blip —
+          # the check would be loudest exactly when it knows least. The job
+          # still succeeds; it just says nothing rather than something false.
+          asked=0
           refs="$(gh api graphql -f query='
             query($owner:String!, $repo:String!, $pr:Int!) {
               repository(owner:$owner, name:$repo) {
@@ -67,7 +74,11 @@ jobs:
             }' -F owner="${{ github.repository_owner }}" \
                -F repo="${{ github.event.repository.name }}" \
                -F pr="$PR" \
-            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number' || true)"
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number')" || asked=$?
+          if [ "$asked" -ne 0 ]; then
+            echo "could not read this pull request's closing references; saying nothing rather than guessing" >&2
+            exit 0
+          fi
 
           status=0
           out="$(CLOSING_DECL_REFS="$refs" CLOSING_DECL_BODY="$BODY" \
@@ -85,21 +96,30 @@ jobs:
           # moment the author adds the declaration, which is the whole reason
           # `edited` is one of the triggers.
           marker='<!-- closing-declaration -->'
-          if [ "$status" -eq 0 ]; then
-            body="$(printf '%s\n%s' "$marker" 'This pull request declares what it closes.')"
-          else
-            body="$(printf '%s\n%s\n\n```\n%s\n```' "$marker" \
-              '**This pull request declares neither an issue it closes nor that it closes none.**' \
-              "$out")"
-          fi
+          existing="$(gh api --paginate "repos/${{ github.repository }}/issues/${PR}/comments" \
+            --jq "[.[] | select(.body != null and (.body | contains(\"$marker\"))) | .id] | first // empty" || true)"
 
+          # WITHDRAWN, not answered. A finding that resolves itself should leave
+          # nothing behind: rewriting it into "this pull request declares what it
+          # closes" would put a permanent line on every pull request that ever
+          # forgot one, which is a worse record than the omission was. So the
+          # comment is DELETED once the declaration is there.
+          #
           # Never fails the job, including when it cannot comment at all: a job
           # that went red because commenting failed would be the gate this is
           # not.
-          existing="$(gh api --paginate "repos/${{ github.repository }}/issues/${PR}/comments" \
-            --jq "[.[] | select(.body != null and (.body | contains(\"$marker\"))) | .id] | first // empty" || true)"
+          if [ "$status" -eq 0 ]; then
+            if [ -n "$existing" ]; then
+              gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${existing}" >/dev/null || true
+            fi
+            exit 0
+          fi
+
+          body="$(printf '%s\n%s\n\n```\n%s\n```' "$marker" \
+            '**This pull request declares neither an issue it closes nor that it closes none.**' \
+            "$out")"
           if [ -n "$existing" ]; then
             gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${existing}" -f body="$body" >/dev/null || true
-          elif [ "$status" -ne 0 ]; then
+          else
             gh api -X POST "repos/${{ github.repository }}/issues/${PR}/comments" -f body="$body" >/dev/null || true
           fi

--- a/.github/workflows/closing-declaration.yml
+++ b/.github/workflows/closing-declaration.yml
@@ -1,0 +1,105 @@
+# Does this pull request say which issue it closes, or that it closes none?
+#
+# The defect is not a missing reference, it is a reference nothing reads. A pull
+# request body said in as many words "Closes the residual half of #548" and its
+# metadata referenced nothing, because GitHub parses a closing keyword only when
+# the issue number follows it directly. The issue stayed open six days after its
+# fix merged and was then re-queued as new work. The author did write it down;
+# they wrote it somewhere nothing reads.
+#
+# So this reads `closingIssuesReferences` — the list that actually closes an
+# issue on merge — and never the prose.
+#
+# IT WARNS AND NEVER BLOCKS, and the job therefore succeeds whatever it finds.
+# That is load-bearing rather than lenient, for the reason review-coverage.yml
+# gives at length: `ci` is the one required check, but a red check of any kind
+# leaves the pull request blocked with administrator override as the only way
+# past, so a job that failed on a finding would be a gate no matter what its name
+# said. The mechanism here is not broken — the habit is patchy — and a hard block
+# on a mechanism that mostly works buys friction on every pull request to fix a
+# habit. Promote it if the warning is measurably ignored.
+name: closing-declaration
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+# Per pull request, cancelling in flight: only the tip's answer is worth having,
+# and `edited` fires on every body keystroke a client saves.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  declaration:
+    name: closing declaration (reports, never blocks)
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # write, for the sticky comment the finding lives in.
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: What this pull request says it closes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # The METADATA, not the body. This is the same list that closes an
+          # issue on merge, so a pull request this reads as declaring is one
+          # GitHub will actually act on.
+          refs="$(gh api graphql -f query='
+            query($owner:String!, $repo:String!, $pr:Int!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequest(number:$pr) {
+                  closingIssuesReferences(first: 20) { nodes { number } }
+                }
+              }
+            }' -F owner="${{ github.repository_owner }}" \
+               -F repo="${{ github.event.repository.name }}" \
+               -F pr="$PR" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number' || true)"
+
+          status=0
+          out="$(CLOSING_DECL_REFS="$refs" CLOSING_DECL_BODY="$BODY" \
+                 ./scripts/check-closing-declaration.sh 2>&1)" || status=$?
+          printf '%s\n' "$out"
+          {
+            echo '```'
+            printf '%s\n' "$out"
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          # The sticky comment, found by its marker rather than by author or
+          # position, so a run edits the one it left last time instead of
+          # stacking a finding on every push — and so it WITHDRAWS itself the
+          # moment the author adds the declaration, which is the whole reason
+          # `edited` is one of the triggers.
+          marker='<!-- closing-declaration -->'
+          if [ "$status" -eq 0 ]; then
+            body="$(printf '%s\n%s' "$marker" 'This pull request declares what it closes.')"
+          else
+            body="$(printf '%s\n%s\n\n```\n%s\n```' "$marker" \
+              '**This pull request declares neither an issue it closes nor that it closes none.**' \
+              "$out")"
+          fi
+
+          # Never fails the job, including when it cannot comment at all: a job
+          # that went red because commenting failed would be the gate this is
+          # not.
+          existing="$(gh api --paginate "repos/${{ github.repository }}/issues/${PR}/comments" \
+            --jq "[.[] | select(.body != null and (.body | contains(\"$marker\"))) | .id] | first // empty" || true)"
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${existing}" -f body="$body" >/dev/null || true
+          elif [ "$status" -ne 0 ]; then
+            gh api -X POST "repos/${{ github.repository }}/issues/${PR}/comments" -f body="$body" >/dev/null || true
+          fi

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ROOT_SCRIPT_GATES := check-craft-doc test-dev-isolation \
   no-jurisdiction test-no-jurisdiction \
   pkg-freeze test-desktop-launcher changelog-sections \
   test-changelog-sections test-dev-postgres-container test-e2e-llm-check \
-  test-release-version-stamped \
+  test-release-version-stamped test-closing-declaration \
   test-craft-review test-release-tag-version
 
 # How wide the gate fan-out runs: the machine's online core count, so a 4-core
@@ -64,7 +64,7 @@ MINIO_PORT ?= 29000
 # answer lands in its own assignment so `set -e` sees the refusal — a helper
 # called inside another command's argument would fail unnoticed.
 
-.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture bench-dispatch perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-snapshot dev-restore dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm e2e-llm-guards fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-edge-padding fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-review test-craft-review craft-residue craft-prose check-craft-doc test-craft-pin test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-review-coverage test-laneorder secret-scan test-secret-scan test-sbom-sign test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length fe-file-length rls-store-path no-jurisdiction test-no-jurisdiction pkg-freeze changelog-sections test-changelog-sections test-release-tag-version test-release-version-stamped test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
+.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture bench-dispatch perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-snapshot dev-restore dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm e2e-llm-guards fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-edge-padding fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-review test-craft-review craft-residue craft-prose check-craft-doc test-craft-pin test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-review-coverage test-laneorder secret-scan test-secret-scan test-sbom-sign test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length fe-file-length rls-store-path no-jurisdiction test-no-jurisdiction pkg-freeze changelog-sections test-changelog-sections test-release-tag-version test-release-version-stamped test-closing-declaration test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -1170,6 +1170,15 @@ test-changelog-sections:
 ## always stamp proves it, and this proves the proof still refuses.
 test-release-version-stamped:
 	@./scripts/release-version-stamped.test.sh
+
+## test-closing-declaration — prove the closing-declaration report still refuses
+## a pull request that declares nothing, and still accepts one that declares
+## either way. The case that matters is the prose one: the check exists because
+## "Closes the residual half of #548" reads as a declaration and closes nothing,
+## so a version reading the BODY would pass the exact pull request it was written
+## for and report the defect as absent.
+test-closing-declaration:
+	@./scripts/check-closing-declaration.test.sh
 
 ## test-release-tag-version — the release tag reader's own test: what the
 ## grammar accepts, and what shelf each accepted tag lands on. The reader has

--- a/docs/reference/ci-workflows.md
+++ b/docs/reference/ci-workflows.md
@@ -90,8 +90,16 @@ Nine workflows sit beside the gate, deliberately outside it:
   **Gates nothing**, for the reason `review-coverage.yml` gives: a job that
   failed on a finding would be a gate whatever its name said. The mechanism is
   not broken — the habit is patchy — so it warns where the omission happens, and
-  `edited` is a trigger so the comment withdraws itself the moment the author
-  adds the line. Promote it to blocking only if the warning is measurably
+  `edited` is a trigger so the comment is **deleted** the moment the author adds
+  the line. Deleted rather than rewritten into a success note: a finding that
+  resolves itself should leave nothing behind, and a permanent "this one
+  declares" line on every pull request that ever forgot one is a worse record
+  than the omission was.
+
+  **A failed metadata query is not an empty one.** Suppressing it would hand the
+  check an empty list and warn a pull request carrying perfectly good closing
+  metadata, which would make the check loudest exactly when it knows least — so
+  it says nothing and exits. Promote it to blocking only if the warning is measurably
   ignored. Reported by
   [`scripts/check-closing-declaration.sh`](../../scripts/check-closing-declaration.sh),
   which reads its evidence from the environment so every arm is drivable from a

--- a/docs/reference/ci-workflows.md
+++ b/docs/reference/ci-workflows.md
@@ -67,6 +67,36 @@ Nine workflows sit beside the gate, deliberately outside it:
   which reads its evidence from the environment so every arm is drivable from a
   fixture (`make test-review-coverage`).
 
+- **`closing-declaration.yml`** — on `opened`, `reopened`, `edited`,
+  `synchronize` and `ready_for_review`. A pull request declares either an issue
+  it closes or that it closes none.
+
+  **The defect is not a missing reference, it is a reference nothing reads.** A
+  body said in as many words *"Closes the residual half of #548"* and its
+  metadata referenced nothing — GitHub parses a closing keyword only when the
+  issue number follows it directly — so the issue stayed open six days after its
+  fix merged and was re-queued as new work. The author did write it down; they
+  wrote it somewhere nothing reads.
+
+  So it reads `closingIssuesReferences`, the list that actually closes an issue
+  on merge, and never the prose. The `Closes: none` half is what makes it
+  enforceable: most pull requests close no issue and are right not to, and
+  without a way to say so this would either nag them for ever or guess.
+
+  It does **not** try to decide whether a pull request fixes an issue it did not
+  mention. That is the real defect and it is not machine-decidable; the
+  declaration is the affordance that makes a human answer it.
+
+  **Gates nothing**, for the reason `review-coverage.yml` gives: a job that
+  failed on a finding would be a gate whatever its name said. The mechanism is
+  not broken — the habit is patchy — so it warns where the omission happens, and
+  `edited` is a trigger so the comment withdraws itself the moment the author
+  adds the line. Promote it to blocking only if the warning is measurably
+  ignored. Reported by
+  [`scripts/check-closing-declaration.sh`](../../scripts/check-closing-declaration.sh),
+  which reads its evidence from the environment so every arm is drivable from a
+  fixture (`make test-closing-declaration`).
+
 - **`main-health.yml`** — every two hours on `main`: the backend gate, the
   real-Postgres lane, the SPA lane (those two called, not copied — it `uses:`
   `_lane-integration.yml` and `_lane-frontend.yml`), the screen-acceptance UAT,

--- a/scripts/check-closing-declaration.sh
+++ b/scripts/check-closing-declaration.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Does this pull request say which issue it closes, or that it closes none?
+#
+# THE DEFECT IS NOT A MISSING REFERENCE, it is a reference nothing reads. A pull
+# request body said in as many words "Closes the residual half of #548" and its
+# metadata referenced nothing — GitHub parses a closing keyword only when the
+# issue number follows it directly, so the prose closed nothing. The issue stayed
+# open six days after its fix merged and was then re-queued as new work. The
+# author did write it down; they wrote it somewhere nothing reads.
+#
+# So this reads the METADATA — GitHub's own closingIssuesReferences, the same
+# list that actually closes an issue on merge — and never the prose. A check that
+# grepped the body would have passed that pull request and reported the defect as
+# absent.
+#
+# THE "CLOSES NONE" HALF IS WHAT MAKES IT ENFORCEABLE. Most pull requests close no
+# issue and are right not to; without a way to say so, this would either nag them
+# for ever or have to guess which ones meant it.
+#
+# IT IS NOT A GATE and will never be one on its own evidence. The mechanism works
+# — the finding that seemed to show four pull requests ignoring it turned out to
+# be false when its author checked, and the trailer had done exactly its job. What
+# is patchy is the habit, and a hard block on a mechanism that mostly works buys
+# friction on every pull request to fix one. Promote it if the warning is
+# measurably ignored; that is a decision with evidence behind it rather than
+# ahead of it.
+#
+# WHAT IT DELIBERATELY DOES NOT DO: decide whether a pull request fixes an issue
+# it did not mention. That is the actual defect and it is not machine-decidable.
+# The declaration is the affordance that makes a human answer it.
+#
+# Reads its evidence from the environment rather than fetching it, so every arm
+# is drivable from a fixture — the same shape check-review-coverage.sh uses.
+#
+#   CLOSING_DECL_REFS  newline-separated issue numbers GitHub records this pull
+#                      request as closing; empty when it records none
+#   CLOSING_DECL_BODY  the pull request body, for the closes-none declaration
+#
+# Exit 0 when the pull request has declared one way or the other, 1 when it has
+# not. The caller decides what a 1 costs; in this repository it costs a comment.
+set -euo pipefail
+
+# The token, matched at the start of a line so a sentence mentioning it in
+# passing does not count as a declaration. Case-insensitive, because an author
+# typing it from memory should not be refused over a capital.
+readonly NONE_PATTERN='^[[:space:]]*closes:[[:space:]]*none[[:space:]]*$'
+
+refs="${CLOSING_DECL_REFS-}"
+body="${CLOSING_DECL_BODY-}"
+
+if [ -n "${refs//[[:space:]]/}" ]; then
+	echo "declared: closes $(printf '%s' "$refs" | tr '\n' ' ' | sed 's/ *$//')"
+	exit 0
+fi
+
+# A here-string rather than a pipe: `grep -q` exits on its first match and the
+# producer then fails with EPIPE, which pipefail reports as a failed pipeline —
+# so a match would read as no-match, on some machines and not others.
+if grep -qiE "$NONE_PATTERN" <<<"$body"; then
+	echo "declared: closes no issue"
+	exit 0
+fi
+
+cat >&2 <<'MSG'
+This pull request declares neither an issue it closes nor that it closes none.
+
+Add ONE of these to the body:
+
+    Closes #1234
+    Closes: none
+
+The first must be exactly that shape. "Closes the residual half of #548" reads
+fine and closes nothing: GitHub parses a closing keyword only when the issue
+number follows it directly, so a sentence like that leaves the issue open after
+the fix merges — which happened, and the issue was re-queued as new work six days
+later.
+
+This is a warning. Nothing is blocked.
+MSG
+exit 1

--- a/scripts/check-closing-declaration.test.sh
+++ b/scripts/check-closing-declaration.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# The declaration check's own test — what it accepts, and what it must not.
+#
+# The second half carries the finding. This check exists because a pull request
+# body said "Closes the residual half of #548" and closed nothing, so a version
+# of it that read the PROSE would pass that exact pull request and report the
+# defect as absent — a green check over the one case it was written for. That
+# case is here by name.
+#
+# Usage: bash scripts/check-closing-declaration.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$SCRIPT_DIR/check-closing-declaration.sh"
+
+FAILURES=0
+
+# declared <refs> <body> <reason>
+declared() {
+	local refs="$1" body="$2" reason="$3" out
+	if ! out="$(CLOSING_DECL_REFS="$refs" CLOSING_DECL_BODY="$body" bash "$CHECK" 2>&1)"; then
+		printf 'FAIL: asked for a declaration when %s\n  refs=%q body=%q\n  %s\n' "$reason" "$refs" "$body" "$out"
+		FAILURES=$((FAILURES + 1))
+	fi
+}
+
+# undeclared <refs> <body> <reason>
+undeclared() {
+	local refs="$1" body="$2" reason="$3" out
+	if out="$(CLOSING_DECL_REFS="$refs" CLOSING_DECL_BODY="$body" bash "$CHECK" 2>&1)"; then
+		printf 'FAIL: accepted a pull request that %s\n  refs=%q body=%q\n' "$reason" "$refs" "$body"
+		FAILURES=$((FAILURES + 1))
+		return
+	fi
+	# The message has to carry the fix. A warning nobody can act on is noise,
+	# and this one fires on a habit rather than on a fault.
+	if [[ "$out" != *"Closes: none"* || "$out" != *"Closes #"* ]]; then
+		printf 'FAIL: the warning does not show both declarations:\n%s\n' "$out"
+		FAILURES=$((FAILURES + 1))
+	fi
+}
+
+declared "1234" "" "GitHub records a closing reference"
+declared "1234
+5678" "" "a pull request closing two issues is still declaring"
+declared "" "Closes: none" "the author said it closes nothing"
+declared "" "Some prose.
+
+closes: NONE
+
+More prose." "the declaration is a line of its own, whatever its case"
+
+# THE WORKED EXAMPLE. GitHub parses a closing keyword only when the number
+# follows it directly, so this body closed nothing while reading as if it did.
+undeclared "" "Closes the residual half of #548" \
+	"names an issue in prose GitHub does not parse, which is the whole finding"
+undeclared "" "" "says nothing at all"
+undeclared "" "Refs #548" "references an issue without closing it and without saying so"
+# Mentioned in passing is not a declaration: the token has to be the line.
+undeclared "" "I considered writing Closes: none here but this one does close something." \
+	"only mentions the token inside a sentence"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+	echo "check-closing-declaration: $FAILURES failure(s)" >&2
+	exit 1
+fi
+echo "OK: check-closing-declaration — 8 case(s), including the prose that closed nothing"


### PR DESCRIPTION
Refs #1737. Builds the ruling: require a declaration, warn rather than block.

**Closes: none** — the issue stays open for the promote-to-blocking decision,
which wants evidence this has not gathered yet. (That line is also this change
declaring itself.)

## The defect is a reference nothing reads

A pull request body said in as many words *"Closes the residual half of #548"*
and its metadata referenced nothing: GitHub parses a closing keyword only when
the issue number follows it **directly**. So the prose closed nothing, the issue
stayed open six days after its fix merged, and it was re-queued as new work. The
author did write it down; they wrote it somewhere nothing reads.

So the check reads `closingIssuesReferences` — the list that actually closes an
issue on merge — and never the body's prose. **A version that grepped the body
would pass that exact pull request** and report the defect as absent, which is why
that case is in the test by name and why the mutation that reads the prose fails
it.

## The "closes none" half

`Closes: none`, on a line of its own. Most pull requests close no issue and are
right not to; without a way to say so this would either nag them for ever or have
to guess which ones meant it. Matched at the start of a line, so a sentence
mentioning the token in passing is not a declaration — also mutation-checked.

## It warns and never blocks

`ci` is the one required check, but a red check of any kind leaves a pull request
blocked with administrator override as the only way past — so a job that failed on
a finding would be a gate whatever its name said. `review-coverage.yml` learned
that the hard way and this follows it.

And the evidence says the mechanism is fine. The second dataset on the issue
appeared to show four pull requests ignoring the trailer; its author checked,
found it false, and said so after having posted the wrong reading in three places.
The verified timeline shows `Closes #2133` opened 112 seconds after the issue was
filed and GitHub closing it on merge. **Usage is patchy, not the machinery**, and a
hard block on a mechanism that mostly works buys friction on every pull request to
fix a habit.

`edited` is a trigger so the sticky comment **withdraws itself** the moment the
author adds the line.

## What it deliberately does not do

Decide whether a pull request fixes an issue it did not mention. That is the real
defect and it is not machine-decidable; the declaration is the affordance that
makes a human answer it.

## Two gates caught real things while writing this

- `TestNoShellGateReadsAVerdictThroughAPipeThatCanBreak` — my first draft piped
  the body into `grep -q`, which exits on its first match and leaves the producer
  with EPIPE, so under `pipefail` **a match would have read as no-match**, on some
  machines and not others. Now a here-string.
- `TestEverySourcePathNamedInProseExists` — the doc named the script before it
  was tracked.

## Checks

`make check-backend`, `make-target-parity`, `ci-doc-parity`, and the new
`test-closing-declaration` (8 cases, mutation-checked both ways).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request feedback for missing closing declarations.
  * Recognizes issues GitHub will close and explicit “closes none” declarations.
  * Posts or updates a non-blocking status comment with the results.

* **Documentation**
  * Documented the new workflow, triggers, and declaration behavior.

* **Tests**
  * Added fixture-based coverage for declared and undeclared pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->