### PR TITLE
fix(consent): a claim its purpose contradicts is refused, not reconciled (#5148)

### DIFF
--- a/backend/internal/modules/consent/authorizecontradiction_integration_test.go
+++ b/backend/internal/modules/consent/authorizecontradiction_integration_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// A caller who says what a message IS and names a purpose meaning something
+// else is refused, rather than quietly sent under the purpose's reading.
+//
+// The reading was the escape path. A send claiming `marketing` under the
+// `business_correspondence` key resolved to reply_to_inbound, which the
+// correspondence arm authorizes on any recent exchange with that contact — not
+// evidence that THIS message is a reply to anything. So promotional content
+// went out as correspondence.
+//
+// And it went out past the subject. An Art. 21 objection binds
+// CategoryMarketing and is tested against the RESOLVED category, so a message
+// remapped to reply_to_inbound was never put to it: the stop was recorded,
+// appeared in the subject's own export, and did not stop the mail.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// claimingMarketingUnder is the request at the heart of this: the caller names
+// the category and a purpose key from another class.
+func claimingMarketingUnder(purposeKey string) commsauthz.Request {
+	return commsauthz.Request{
+		Context:          commsauthz.CategoryMarketing,
+		LegacyPurposeKey: purposeKey,
+	}
+}
+
+// The escape path itself, refused.
+func TestAClaimContradictedByItsPurposeIsRefused(t *testing.T) {
+	e := setupResolve(t)
+	e.seedPurpose(t, "business_correspondence", "business_correspondence")
+
+	d := e.decide(t, claimingMarketingUnder("business_correspondence"))
+
+	if d.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("verdict = %q, want deny — a request that claims one category and names a "+
+			"purpose meaning another asks two things at once", d.Verdict)
+	}
+	if d.ReasonCode != commsauthz.ReasonPurposeContradictsClaim {
+		t.Errorf("reason = %q, want %q", d.ReasonCode, commsauthz.ReasonPurposeContradictsClaim)
+	}
+	// The row says BOTH things. Requested is what the caller asked for, so an
+	// auditor can see that promotional content was claimed; Resolved stays the
+	// engine's own reading, because an unproven claim must never reach the
+	// column that selects the rollout mode and counts the advertising ceiling.
+	if d.Requested != commsauthz.CategoryMarketing {
+		t.Errorf("requested = %q, want %q — the claim has to survive into the row",
+			d.Requested, commsauthz.CategoryMarketing)
+	}
+	if d.Resolved != commsauthz.CategoryReplyToInbound {
+		t.Errorf("resolved = %q, want %q — the engine's own reading, never the claim",
+			d.Resolved, commsauthz.CategoryReplyToInbound)
+	}
+}
+
+// The half that makes it a privacy defect rather than a tidiness one: with the
+// remap in place the objection was never reached.
+func TestAMarketingObjectionIsNotWalkedPastByACorrespondencePurpose(t *testing.T) {
+	e := setupResolve(t)
+	e.seedPurpose(t, "business_correspondence", "business_correspondence")
+	e.suppress(t, "marketing_objection")
+	// A qualifying event on ANOTHER conversation, which is exactly what the
+	// correspondence arm authorizes on: any recent inbound from this contact,
+	// not evidence that the message being sent is a reply to anything. On a
+	// thread of its own so the request's own resolution cannot find it — this
+	// send has no anchor, so nothing resolves it before the purpose does.
+	e.inboundFrom(t, "an-unrelated-thread", e.address, time.Now().Add(-time.Hour))
+
+	d := e.decide(t, claimingMarketingUnder("business_correspondence"))
+
+	if d.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("verdict = %q, want deny — this contact objected to direct marketing and the "+
+			"caller said this message is direct marketing", d.Verdict)
+	}
+	// Refused before the suppression is even reached, which is the stronger
+	// answer: the request never becomes a message to test an objection
+	// against. What matters is that it does not SEND.
+	if d.ReasonCode == commsauthz.ReasonAllowed {
+		t.Errorf("reason = %q, and this message went out past an Art. 21 objection", d.ReasonCode)
+	}
+}
+
+// A claim the purpose AGREES with still goes through the legacy lane it always
+// did. The refusal is about disagreement, not about naming both.
+func TestAClaimItsPurposeAgreesWithIsStillDecidedByTheLegacyLane(t *testing.T) {
+	e := setupResolve(t)
+	e.seedPurpose(t, "newsletter", "marketing")
+
+	d := e.decide(t, commsauthz.Request{
+		Context:          commsauthz.CategoryMarketing,
+		LegacyPurposeKey: "newsletter",
+	})
+
+	if d.ReasonCode == commsauthz.ReasonPurposeContradictsClaim {
+		t.Fatalf("a marketing claim under a marketing purpose was called a contradiction")
+	}
+	if d.Resolved != commsauthz.CategoryMarketing {
+		t.Errorf("resolved = %q, want %q", d.Resolved, commsauthz.CategoryMarketing)
+	}
+}
+
+// A caller who claims NOTHING is the legacy path, and it is untouched: the
+// purpose alone says what the message is, and there is nothing to contradict.
+func TestAPurposeWithNoClaimStillSpeaksForTheMessage(t *testing.T) {
+	e := setupResolve(t)
+	e.seedPurpose(t, "business_correspondence", "business_correspondence")
+
+	d := e.decide(t, commsauthz.Request{LegacyPurposeKey: "business_correspondence"})
+
+	if d.ReasonCode == commsauthz.ReasonPurposeContradictsClaim {
+		t.Fatalf("a request that claimed nothing was called a contradiction — the legacy path " +
+			"names only a purpose, and refusing it would refuse every message that has not " +
+			"moved to the category vocabulary")
+	}
+	if d.Resolved != commsauthz.CategoryReplyToInbound {
+		t.Errorf("resolved = %q, want %q — the purpose's own class speaks when nobody else does",
+			d.Resolved, commsauthz.CategoryReplyToInbound)
+	}
+}

--- a/backend/internal/modules/consent/authorizecontradiction_integration_test.go
+++ b/backend/internal/modules/consent/authorizecontradiction_integration_test.go
@@ -46,8 +46,8 @@ func TestAClaimContradictedByItsPurposeIsRefused(t *testing.T) {
 		t.Fatalf("verdict = %q, want deny — a request that claims one category and names a "+
 			"purpose meaning another asks two things at once", d.Verdict)
 	}
-	if d.ReasonCode != commsauthz.ReasonPurposeContradictsClaim {
-		t.Errorf("reason = %q, want %q", d.ReasonCode, commsauthz.ReasonPurposeContradictsClaim)
+	if d.ReasonCode != commsauthz.ReasonClaimContradictsResolution {
+		t.Errorf("reason = %q, want %q", d.ReasonCode, commsauthz.ReasonClaimContradictsResolution)
 	}
 	// The row says BOTH things. Requested is what the caller asked for, so an
 	// auditor can see that promotional content was claimed; Resolved stays the
@@ -101,7 +101,7 @@ func TestAClaimItsPurposeAgreesWithIsStillDecidedByTheLegacyLane(t *testing.T) {
 		LegacyPurposeKey: "newsletter",
 	})
 
-	if d.ReasonCode == commsauthz.ReasonPurposeContradictsClaim {
+	if d.ReasonCode == commsauthz.ReasonClaimContradictsResolution {
 		t.Fatalf("a marketing claim under a marketing purpose was called a contradiction")
 	}
 	if d.Resolved != commsauthz.CategoryMarketing {
@@ -117,7 +117,7 @@ func TestAPurposeWithNoClaimStillSpeaksForTheMessage(t *testing.T) {
 
 	d := e.decide(t, commsauthz.Request{LegacyPurposeKey: "business_correspondence"})
 
-	if d.ReasonCode == commsauthz.ReasonPurposeContradictsClaim {
+	if d.ReasonCode == commsauthz.ReasonClaimContradictsResolution {
 		t.Fatalf("a request that claimed nothing was called a contradiction — the legacy path " +
 			"names only a purpose, and refusing it would refuse every message that has not " +
 			"moved to the category vocabulary")
@@ -125,5 +125,76 @@ func TestAPurposeWithNoClaimStillSpeaksForTheMessage(t *testing.T) {
 	if d.Resolved != commsauthz.CategoryReplyToInbound {
 		t.Errorf("resolved = %q, want %q — the purpose's own class speaks when nobody else does",
 			d.Resolved, commsauthz.CategoryReplyToInbound)
+	}
+}
+
+// The path the first fix here missed, and the one an evidence-supported record
+// makes easiest to reach.
+//
+// The guard lived on the legacy purpose path alone. A reply in the thread and a
+// live deal on the links each resolve a category from EVIDENCE and return
+// before that path is entered, so a caller claiming marketing about a
+// conversation the subject started was allowed — resolved as reply_to_inbound,
+// with the subject's objection to direct marketing asked about a category it
+// does not bind. The claim was never put to anything at all.
+func TestAClaimContradictedByTheThreadIsRefused(t *testing.T) {
+	e := setupResolve(t)
+	// A reply from the subject: the arm that answers before the purpose is
+	// ever consulted.
+	e.inboundFrom(t, "thread-contradiction", e.address, time.Now().Add(-time.Hour))
+
+	d := e.decide(t, commsauthz.Request{
+		Context:   commsauthz.CategoryMarketing,
+		ThreadKey: "thread-contradiction",
+	})
+
+	if d.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("verdict = %q, want deny — a sender calling their own message marketing has "+
+			"named a category the thread does not bear out, and the thread answering first is "+
+			"not a reason to stop asking", d.Verdict)
+	}
+	if d.ReasonCode != commsauthz.ReasonClaimContradictsResolution {
+		t.Errorf("reason = %q, want %q", d.ReasonCode, commsauthz.ReasonClaimContradictsResolution)
+	}
+	if d.Resolved != commsauthz.CategoryReplyToInbound {
+		t.Errorf("resolved = %q, want %q — the record's own reading, never the claim",
+			d.Resolved, commsauthz.CategoryReplyToInbound)
+	}
+	if d.Requested != commsauthz.CategoryMarketing {
+		t.Errorf("requested = %q, want %q — the claim has to survive into the row",
+			d.Requested, commsauthz.CategoryMarketing)
+	}
+}
+
+// And the half that makes the above a privacy defect: with the claim ignored,
+// the objection was asked about the wrong category and the mail went out.
+func TestAMarketingObjectionIsNotWalkedPastByAThread(t *testing.T) {
+	e := setupResolve(t)
+	e.inboundFrom(t, "thread-objection", e.address, time.Now().Add(-time.Hour))
+	e.suppress(t, commsauthz.ReasonObjection)
+
+	d := e.decide(t, commsauthz.Request{
+		Context:   commsauthz.CategoryMarketing,
+		ThreadKey: "thread-objection",
+	})
+
+	if d.Verdict == commsauthz.VerdictAllow {
+		t.Fatalf("a message its own sender called marketing reached a subject who objected to "+
+			"direct marketing, because the thread resolved it as correspondence: %+v", d)
+	}
+}
+
+// A caller naming nothing is not contradicting anything. Without this the guard
+// reads as "any evidence-resolved send is refused", which would stop every
+// ordinary reply in the product.
+func TestAnUnclaimedThreadReplyIsStillAllowed(t *testing.T) {
+	e := setupResolve(t)
+	e.inboundFrom(t, "thread-unclaimed", e.address, time.Now().Add(-time.Hour))
+
+	d := e.decide(t, commsauthz.Request{ThreadKey: "thread-unclaimed"})
+
+	if d.Verdict != commsauthz.VerdictAllow {
+		t.Fatalf("verdict = %q, want allow — naming no category is how a caller says the record "+
+			"should decide, and the record said reply_to_inbound", d.Verdict)
 	}
 }

--- a/backend/internal/modules/consent/authorizedecide.go
+++ b/backend/internal/modules/consent/authorizedecide.go
@@ -83,6 +83,33 @@ func allowOn(d commsauthz.Decision, res resolution) commsauthz.Decision {
 	return d
 }
 
+// contradictsClaim answers whether the caller named a category the record does
+// not bear out.
+//
+// ONE spelling, because the two paths that ask it would otherwise be two
+// answers to one question — and the first fix here proved that: the guard lived
+// on the legacy path alone, so a message whose thread or live deal resolved a
+// category the caller had not claimed went through with the claim never put to
+// anything. An empty claim is not a contradiction: naming nothing is how a
+// caller says the record should decide.
+func contradictsClaim(claimed, resolved commsauthz.Category) bool {
+	return claimed != "" && claimed != resolved
+}
+
+// denyContradiction is the refusal both paths give, with Resolved carrying the
+// RECORD's reading rather than the claim. An unproven claim must never reach
+// that column: it selects the rollout mode and decides whether the advertising
+// ceiling is counted, so a caller who set it would hold both
+// (TestAnUnsupportedClaimIsRecordedButNeverResolvedTo). The claim is already in
+// Requested, so the row still says what was asked for, what the record read,
+// and that the two disagree.
+func denyContradiction(d commsauthz.Decision, resolved commsauthz.Category) commsauthz.Decision {
+	d.Resolved = resolved
+	d.Verdict = commsauthz.VerdictDeny
+	d.ReasonCode = commsauthz.ReasonClaimContradictsResolution
+	return d
+}
+
 // decideResolved answers about a contact once nothing suppresses them: what the
 // record says this message is, and whether that is supported.
 //
@@ -115,6 +142,16 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 		d.Evidence = req.Evidence
 	}
 	if res.Supported {
+		// The claim first, because the record bearing out a category is not the
+		// same as the caller having named it. A sender who says "this is
+		// marketing" about a thread the subject replied into is asking for two
+		// things at once, and the withdrawal read below would be asked about
+		// reply_to_inbound — so a live objection to direct marketing would
+		// never be put to a message its own sender called marketing.
+		if contradictsClaim(req.Context, res.Category) {
+			d.Requested = req.Context
+			return denyContradiction(d, res.Category), nil
+		}
 		// The record bears the category out — and the subject may still have
 		// said stop. The evidence arms never read contact_consent, so this is
 		// the only place a withdrawal is put to them.
@@ -208,10 +245,8 @@ func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, contactID, purpo
 	// it, so the row still says both things: what was asked for, what it would
 	// have been read as, and that the two disagree.
 	d.Resolved = fromPurpose
-	if claimed != "" && claimed != fromPurpose {
-		d.Verdict = commsauthz.VerdictDeny
-		d.ReasonCode = commsauthz.ReasonPurposeContradictsClaim
-		return d, nil
+	if contradictsClaim(claimed, fromPurpose) {
+		return denyContradiction(d, fromPurpose), nil
 	}
 
 	w, err := g.store.packRulesFor(ctx, tx)

--- a/backend/internal/modules/consent/authorizedecide.go
+++ b/backend/internal/modules/consent/authorizedecide.go
@@ -153,7 +153,7 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 	// TestAnUnsupportedClaimIsRecordedButNeverResolvedTo, which is what that
 	// test's own comment records.
 	d.Requested = res.Category
-	return g.legacyVerdictFor(ctx, tx, subject.ID, req.LegacyPurposeKey, res, d, suppressed)
+	return g.legacyVerdictFor(ctx, tx, subject.ID, req.LegacyPurposeKey, req.Context, res, d, suppressed)
 }
 
 // legacyVerdictFor answers on the old purpose model when the record supports no
@@ -164,7 +164,7 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 // answering with one body of code about one contact. A second implementation
 // here would be a second answer, and the one that stopped matching would look
 // exactly like the one that still did.
-func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, contactID, purposeKey string, res resolution, d commsauthz.Decision, suppressed bool) (commsauthz.Decision, error) {
+func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, contactID, purposeKey string, claimed commsauthz.Category, res resolution, d commsauthz.Decision, suppressed bool) (commsauthz.Decision, error) {
 	purpose, defined, err := purposeRowFor(ctx, tx, purposeKey)
 	if err != nil {
 		return commsauthz.Decision{}, err
@@ -182,7 +182,37 @@ func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, contactID, purpo
 	// there alone would keep it out. Neither is redundant — they fail in
 	// different directions, and a decision that never reaches this function
 	// (the supported arm) is covered only by the first.
-	d.Resolved = resolutionForClass(purpose.Class).Category
+	fromPurpose := resolutionForClass(purpose.Class).Category
+
+	// A CLAIM AND A PURPOSE THAT DISAGREE ARE REFUSED, never reconciled.
+	//
+	// The caller said what this message IS and named a purpose key meaning
+	// something else. Taking the purpose's reading is not a conservative
+	// fallback, it is a downgrade the caller did not ask for and cannot see: a
+	// send claiming `marketing` under the `business_correspondence` key
+	// resolved to reply_to_inbound, which the correspondence arm authorizes on
+	// any recent exchange with that contact — not evidence that THIS message is
+	// a reply to anything. The message then went out as correspondence
+	// carrying promotional content.
+	//
+	// And it went out past the subject. An Art. 21 objection binds
+	// CategoryMarketing and is tested against Resolved, so a message remapped
+	// to reply_to_inbound was never put to it: the stop was recorded, appeared
+	// in the subject's own export, and did not stop the mail.
+	//
+	// Resolved still takes the PURPOSE'S reading, not the claim. An unproven
+	// claim must never reach that column — it selects the rollout mode and
+	// decides whether the advertising ceiling is counted, so a caller who set
+	// it would hold both (TestAnUnsupportedClaimIsRecordedButNeverResolvedTo).
+	// The claim is already in Requested, which is the column that exists for
+	// it, so the row still says both things: what was asked for, what it would
+	// have been read as, and that the two disagree.
+	d.Resolved = fromPurpose
+	if claimed != "" && claimed != fromPurpose {
+		d.Verdict = commsauthz.VerdictDeny
+		d.ReasonCode = commsauthz.ReasonPurposeContradictsClaim
+		return d, nil
+	}
 
 	w, err := g.store.packRulesFor(ctx, tx)
 	if err != nil {

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -31,6 +31,16 @@ const (
 	ReasonLegacyTransactionalUnevidenced = "legacy_transactional_unevidenced"
 	// ReasonUnknownPurpose is a purpose key nothing defines.
 	ReasonUnknownPurpose = "unknown_purpose"
+	// ReasonPurposeContradictsClaim is a caller naming what a message IS and a
+	// legacy purpose key that says it is something else.
+	//
+	// Not a verdict about the recipient: it is the engine declining to answer a
+	// request that asks two things at once. Reconciling the two is what let
+	// promotional mail ride the correspondence lane — the claim went in the
+	// column that records what somebody asked for, the purpose's class took
+	// the column that decides what a suppression binds, and an objection to
+	// direct marketing was never put to the message at all.
+	ReasonPurposeContradictsClaim = "purpose_contradicts_claim"
 	// ReasonNoSubject is a recipient that resolves to nobody, or to two contacts.
 	ReasonNoSubject = "recipient_resolves_to_no_single_subject"
 	// ReasonNoMarketingConsent is marketing without a grant or an exception.
@@ -86,6 +96,14 @@ var absoluteDenials = map[string]bool{
 	// the same message becomes lawful — so refusing costs a delay rather than
 	// the message.
 	ReasonFrequencyCapReached: true,
+	// A request that claims one category and names a purpose meaning another
+	// is here for the reason ReasonNoSubject is: it is not a refusal ABOUT
+	// somebody, it is the engine saying it cannot answer. Softening it does not
+	// fall back to a weaker reading of the same message — it falls back to the
+	// old gate, which answers on the PURPOSE KEY alone and so authorizes
+	// exactly the message this refusal exists to stop, past an objection that
+	// binds the category the caller themselves claimed.
+	ReasonPurposeContradictsClaim: true,
 }
 
 // Absolute reports whether this reason denies regardless of Mode.

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -31,16 +31,23 @@ const (
 	ReasonLegacyTransactionalUnevidenced = "legacy_transactional_unevidenced"
 	// ReasonUnknownPurpose is a purpose key nothing defines.
 	ReasonUnknownPurpose = "unknown_purpose"
-	// ReasonPurposeContradictsClaim is a caller naming what a message IS and a
-	// legacy purpose key that says it is something else.
+	// ReasonClaimContradictsResolution is a caller naming what a message IS
+	// against what the RECORD says it is.
 	//
 	// Not a verdict about the recipient: it is the engine declining to answer a
 	// request that asks two things at once. Reconciling the two is what let
 	// promotional mail ride the correspondence lane — the claim went in the
-	// column that records what somebody asked for, the purpose's class took
-	// the column that decides what a suppression binds, and an objection to
-	// direct marketing was never put to the message at all.
-	ReasonPurposeContradictsClaim = "purpose_contradicts_claim"
+	// column that records what somebody asked for, the record's own reading
+	// took the column that decides what a suppression binds, and an objection
+	// to direct marketing was never put to the message at all.
+	//
+	// The record reads the message two ways and the disagreement is the same
+	// either way: a legacy purpose key whose class says something else, or
+	// evidence — a reply in the thread, a live deal on the links — that bears
+	// out a category the caller did not name. Naming the SOURCE in this code
+	// would have made the second kind look like a different refusal, and the
+	// second kind is where the bypass actually survived a first fix.
+	ReasonClaimContradictsResolution = "claim_contradicts_resolution"
 	// ReasonNoSubject is a recipient that resolves to nobody, or to two contacts.
 	ReasonNoSubject = "recipient_resolves_to_no_single_subject"
 	// ReasonNoMarketingConsent is marketing without a grant or an exception.
@@ -103,7 +110,7 @@ var absoluteDenials = map[string]bool{
 	// old gate, which answers on the PURPOSE KEY alone and so authorizes
 	// exactly the message this refusal exists to stop, past an objection that
 	// binds the category the caller themselves claimed.
-	ReasonPurposeContradictsClaim: true,
+	ReasonClaimContradictsResolution: true,
 }
 
 // Absolute reports whether this reason denies regardless of Mode.

--- a/backend/internal/shared/ports/commsauthz/authority.go
+++ b/backend/internal/shared/ports/commsauthz/authority.go
@@ -122,7 +122,7 @@ func LevelForReason(reasonCode string) AuthorityLevel {
 		return LevelSubject
 
 	// EVERYTHING ELSE IS THE ENGINE READING AN INCOMPLETE RECORD, and a seat
-	// may know better. That includes four refusals that BIND ABSOLUTELY but are
+	// may know better. That includes five refusals that BIND ABSOLUTELY but are
 	// nobody's decision, so being overrulable is the right answer for each:
 	//
 	//   - a hard bounce is a mailbox fact, cleared by correcting the address;
@@ -133,7 +133,12 @@ func LevelForReason(reasonCode string) AuthorityLevel {
 	//     wishes;
 	//   - an unconfirmed double opt-in is the absence of the subject's act
 	//     rather than an act, and an installation holding a paper opt-in needs
-	//     a way to say so.
+	//     a way to say so;
+	//   - a purpose contradicting the claim is a malformed REQUEST, corrected
+	//     by sending it with a purpose that means what the caller said. Nothing
+	//     about the recipient refuses it, and an admin who knows which of the
+	//     two the message really is can say so — by sending it again, which is
+	//     the remedy, not by overruling the recipient's wishes.
 	//
 	// Absolute and overrulable are different axes, and Absolute() already
 	// carries the first. Collapsing them here would make an admin stare at a

--- a/backend/internal/shared/ports/commsauthz/authority_test.go
+++ b/backend/internal/shared/ports/commsauthz/authority_test.go
@@ -178,7 +178,7 @@ func TestEveryAbsoluteReasonIsClassifiedDeliberately(t *testing.T) {
 		// A request the engine cannot answer, corrected by asking again with a
 		// purpose that means what the caller claimed — nothing about the
 		// recipient refuses it.
-		ReasonPurposeContradictsClaim: LevelMachine,
+		ReasonClaimContradictsResolution: LevelMachine,
 	}
 
 	for reason := range absoluteDenials {

--- a/backend/internal/shared/ports/commsauthz/authority_test.go
+++ b/backend/internal/shared/ports/commsauthz/authority_test.go
@@ -175,6 +175,10 @@ func TestEveryAbsoluteReasonIsClassifiedDeliberately(t *testing.T) {
 		ReasonFrequencyCapReached: LevelMachine,
 		ReasonNoSubject:           LevelMachine,
 		ReasonUnconfirmedDOI:      LevelMachine,
+		// A request the engine cannot answer, corrected by asking again with a
+		// purpose that means what the caller claimed — nothing about the
+		// recipient refuses it.
+		ReasonPurposeContradictsClaim: LevelMachine,
 	}
 
 	for reason := range absoluteDenials {


### PR DESCRIPTION
Closes #5148.

## The escape path, reproduced

A send claims `communication_context=marketing` and names `consent_purpose=business_correspondence`. No thread and no live deal support it and the marketing claim has no evidence, so `legacyVerdictFor` overwrites the resolved category **from the purpose's class** — remapping the message to `reply_to_inbound`, which `correspondenceVerdict` authorizes on any recent inbound from that person. Not evidence that *this* message is a reply to anything.

**And it goes out past the subject.** An Art. 21 objection binds `CategoryMarketing` and is tested against the RESOLVED category, so a message remapped to `reply_to_inbound` was never put to it. The stop is recorded, it appears in the subject's own Art. 15 export, and it does not stop the mail.

The issue flagged this as read from the code. It reproduces: with this fix reverted, `TestAMarketingObjectionIsNotWalkedPastByACorrespondencePurpose` comes back **`allow`** for a message the caller labelled `marketing`, to a person carrying a live `marketing_objection`.

## The fix

The issue's stated direction, and the concept's: the conflict is refused rather than downgraded. A caller who says what a message is and names a purpose meaning something else has asked two things at once, and the engine declines rather than picking one.

**Absolute**, for the reason `ReasonNoSubject` is. Softening it does not fall back to a weaker reading of the same message — it falls back to the old gate, which answers on the purpose key alone and so authorizes exactly what the refusal exists to stop. It is classified `LevelMachine`: nothing about the recipient refuses it, and the remedy is to send it again with a purpose that means what was claimed.

## What it does NOT change

**`Resolved` still takes the purpose's reading, never the claim.** My first attempt set it to the claim so the objection would bind — and `TestAnUnsupportedClaimIsRecordedButNeverResolvedTo` caught it. That test is right: an unproven claim in that column selects the rollout mode and decides whether the advertising ceiling is counted, so a caller who set it would hold both. The claim is already in `Requested`, so the row says what was asked for, what it would have been read as, and that the two disagree — and the message does not send, which is what the objection needed.

**A claim its purpose agrees with** still goes down the legacy lane it always did, and **a caller who claims nothing** is untouched. Refusing either would refuse every message that has not moved to the category vocabulary.

## Proof

Four cases in `authorizecontradiction_integration_test.go`, over a real Postgres through `decideOne` — the whole per-recipient decision, not just the resolver:

- the contradictory pair is refused, with the claim preserved in `Requested` and the engine's own reading in `Resolved`;
- the objection is not walked past — seeded with a qualifying event **on an unrelated thread**, which is precisely what the correspondence arm authorizes on, so the old path had everything it needed;
- an agreeing claim is not called a contradiction;
- a purpose with no claim still speaks for the message.

Mutation-verified: removing the refusal turns the first into `review` and the second into `allow`.

`make check` green, `make craft-static` clean whole-tree, the consent module lane and the compose integration lane green.

## What this unblocks

The issue records that R3 ("an unsubscribe must not stop requested correspondence") is sequenced behind this, because narrowing the unsubscribe to marketing-class purposes while this lane was open would trade a known over-broad unsubscribe for a silent under-broad one. That ordering is now clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Requests are now refused when the stated category conflicts with the category implied by the selected purpose.
  - The refusal is enforced consistently across rollout modes and clearly identifies the category mismatch.
  - Marketing objections can no longer be bypassed by remapping a purpose to correspondence.
  - Requests without a stated category continue to be handled unchanged.
  - Compatible purposes continue through the existing authorization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->