### PR TITLE
feat(frontend): a contact's Deals tab can seat them on a deal

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -503,6 +503,7 @@ export const de = {
   "partner.stage.noFit": "Keine Passung",
 
   "rel.add": "Beziehung hinzufügen",
+  "rel.seatOnDeal": "Zu einem Deal hinzufügen",
   "rel.addStakeholder": "Beteiligten hinzufügen",
   "rel.dealStakeholders": "Beteiligte",
   "rel.dealStakeholdersEmpty": "Für diesen Deal ist niemand erfasst",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -528,6 +528,7 @@ export const en = {
   "partner.stage.noFit": "No fit",
 
   "rel.add": "Add relationship",
+  "rel.seatOnDeal": "Add to a deal",
   "rel.addStakeholder": "Add stakeholder",
   "rel.dealStakeholders": "Stakeholders",
   "rel.dealStakeholdersEmpty": "No stakeholder is recorded on this deal",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -506,6 +506,7 @@ export const vi = {
   "partner.stage.noFit": "Không phù hợp",
 
   "rel.add": "Thêm quan hệ",
+  "rel.seatOnDeal": "Thêm vào một thương vụ",
   "rel.addStakeholder": "Thêm bên liên quan",
   "rel.dealStakeholders": "Các bên liên quan",
   "rel.dealStakeholdersEmpty": "Chưa ghi nhận bên liên quan nào cho deal này",

--- a/frontend/src/screens/persontabs.test.tsx
+++ b/frontend/src/screens/persontabs.test.tsx
@@ -280,6 +280,78 @@ describe("the deals tab", () => {
     withProviders(<PersonDealsTab view={withheld} />);
     expect(screen.queryByText(/not recorded on any deal/)).toBeNull();
   });
+
+  // THE TAB'S OWN VERB. A reader asking which deals this contact is on is the
+  // reader who wants to put them on one, and before this the only path was the
+  // relationships tab — a different question, reached from a different place.
+  it("offers the verb that seats this contact on a deal", async () => {
+    const searched: string[] = [];
+    const page = (rows: { id: string; name: string }[]) =>
+      new Response(
+        JSON.stringify({
+          data: rows,
+          page: { has_more: false, next_cursor: null },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    stubWithSession(
+      {
+        "GET /deals": () => {
+          searched.push("deals");
+          // A name NOT already on the tab. "Fleet renewal 2026" is the row the
+          // page draws, so waiting for it would pass on the rendering the
+          // picker had nothing to do with.
+          return page([{ id: "d-9", name: "Depot expansion 2027" }]);
+        },
+        "GET /organizations": () => {
+          // The contract path is still /organizations; the record is called a
+          // company, which is the word this marker uses.
+          searched.push("companies");
+          return page([]);
+        },
+      },
+      { relationship: ["create"] },
+    );
+    withProviders(<PersonDealsTab view={view} />);
+
+    const add = await screen.findByRole("button", { name: "Add to a deal" });
+    await userEvent.click(add);
+
+    expect(screen.getByRole("heading", { name: "Add to a deal" })).toBeTruthy();
+
+    // NARROWED TO THE DEAL EDGE, asserted on what the picker SEARCHES.
+    //
+    // Two weaker assertions were tried and both passed with the narrowing
+    // removed: the kind selector is hidden either way, and no option label is
+    // rendered when it is hidden. What the narrowing actually decides is which
+    // endpoint the dialog picks first — unnarrowed, a person scope leads with
+    // `employment` and the picker searches COMPANIES, so a reader typing a deal
+    // name would find nothing and never learn why.
+    await userEvent.type(
+      screen.getByRole("searchbox", { name: /search/i }),
+      "Depot",
+    );
+    await waitFor(
+      () => {
+        expect(screen.getByText("Depot expansion 2027")).toBeTruthy();
+      },
+      { timeout: 2000 },
+    );
+    expect(searched).toContain("deals");
+    expect(searched).not.toContain("companies");
+  });
+
+  // Withheld rather than disabled: a grant the role does not hold is not a fact
+  // about this contact, so there is nothing for a disabled button to explain.
+  it("withholds the verb from a reader who may not write an edge", async () => {
+    stubWithSession({}, {});
+    withProviders(<PersonDealsTab view={view} />);
+
+    // Awaited through the rows, so the absence is read AFTER the grant probe
+    // has answered rather than before it has run.
+    await screen.findByText("Fleet renewal 2026");
+    expect(screen.queryByRole("button", { name: "Add to a deal" })).toBeNull();
+  });
 });
 
 describe("the meetings tab", () => {

--- a/frontend/src/screens/persontabs.test.tsx
+++ b/frontend/src/screens/persontabs.test.tsx
@@ -303,9 +303,7 @@ describe("the deals tab", () => {
           // picker had nothing to do with.
           return page([{ id: "d-9", name: "Depot expansion 2027" }]);
         },
-        "GET /organizations": () => {
-          // The contract path is still /organizations; the record is called a
-          // company, which is the word this marker uses.
+        "GET /companies": () => {
           searched.push("companies");
           return page([]);
         },

--- a/frontend/src/screens/persontabs.tsx
+++ b/frontend/src/screens/persontabs.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import type { components } from "../api/schema";
+import { useCanWrite } from "../app/capability";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { activityTimeline } from "../design-system/activitytimeline";
@@ -28,6 +29,7 @@ import {
   useRecordChronology,
 } from "./recordchronology";
 import { ConversationList, useChronologyCut } from "./recordconversations";
+import { AddRelationshipAction } from "./relationships";
 import { TimelineActions } from "./timelineactions";
 import { groupChronology } from "./timelinegroups";
 import "./person360.css";
@@ -226,6 +228,11 @@ export function PersonDealsTab({
   loading = false,
 }: Readonly<{ view?: Person360; loading?: boolean }>) {
   const t = useT();
+  // The object half of the gate, asked as the server asks it. The row half —
+  // whether this caller may write THIS contact — is the anchor's own, and the
+  // server applies it to the write; a tab that second-guessed it here would
+  // withhold the verb on a record the write would have accepted.
+  const canSeat = useCanWrite("relationship", "create");
   const roles = view?.deal_roles?.data ?? [];
   const state = sectionState(
     view,
@@ -236,7 +243,26 @@ export function PersonDealsTab({
   );
   return (
     <div className="record-stack">
-      <Panel title={t("tab.deals")}>
+      <Panel
+        title={t("tab.deals")}
+        // THE TAB'S OWN VERB, and the same one the relationships tab offers —
+        // reached from where a reader is already asking the question rather
+        // than spelled a second time. Narrowed to the deal edge: a kind
+        // selector offering "employment" on a Deals tab would ask the reader to
+        // answer what the tab already answered.
+        //
+        // Withheld outright without the grant, as the relationships tab does:
+        // there is no fact about this contact to report, so a disabled button
+        // would be an affordance that says nothing.
+        titleAction={
+          view?.person.id && canSeat ? (
+            <AddRelationshipAction
+              scope={{ person_id: view.person.id }}
+              only={{ kind: "deal_stakeholder", label: "rel.seatOnDeal" }}
+            />
+          ) : undefined
+        }
+      >
         <SurfaceState
           state={state}
           emptyLabel={t("person.deals.empty")}

--- a/frontend/src/screens/relationshipcandidates.ts
+++ b/frontend/src/screens/relationshipcandidates.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// WHO CAN BE THE OTHER SIDE OF AN EDGE, found by typing.
+//
+// One file because it is one question asked three ways: a company, a person or
+// a deal, each reached through its own list endpoint and each narrowed the way
+// that endpoint narrows. The dialog that uses them cares only which entity the
+// chosen edge points at.
+
+import { api } from "../api/client";
+import type { EntityKind } from "../app/entity";
+import { throwProblem } from "./common";
+
+export type Candidate = { id: string; name: string };
+
+// include_anchor: recording that a person works at the company running the CRM
+// is an ordinary, frequent fact. The list hides the own company by default
+// because it answers "which companies are we selling to"; this question is a
+// different one, so it opts back in (ADR-0082/A127).
+async function searchCompanyCandidates(q: string): Promise<Candidate[]> {
+  const { data, error } = await api.GET("/companies", {
+    params: { query: { q, limit: 10, include_anchor: true } },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data.data.map((company) => ({
+    id: company.id,
+    name: company.display_name,
+  }));
+}
+
+async function searchPersonCandidates(q: string): Promise<Candidate[]> {
+  const { data, error } = await api.GET("/people", {
+    params: { query: { q, limit: 10 } },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data.data.map((person) => ({ id: person.id, name: person.full_name }));
+}
+
+// /deals has no free-text `q` in the contract (only structured filters), so
+// the stakeholder picker fetches a recent page and matches the typed term
+// against the deal name client-side. Deals past that page aren't reached — an
+// accepted PoC limit, scoped to the manual deal_stakeholder edge.
+const DEAL_PICKER_PAGE = 50;
+
+async function searchDealCandidates(q: string): Promise<Candidate[]> {
+  const { data, error } = await api.GET("/deals", {
+    params: { query: { limit: DEAL_PICKER_PAGE } },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  const needle = q.toLowerCase();
+  return data.data
+    .filter((deal) => deal.name.toLowerCase().includes(needle))
+    .slice(0, 10)
+    .map((deal) => ({ id: deal.id, name: deal.name }));
+}
+
+// The entity kinds this tab can ever pick as a relationship's other side —
+// company/person/deal, per the rel_*_shape CHECKs (migration 0007). A
+// lead has no relationship edges (it is promoted into a person first) and a
+// project seats its stakeholders through its own endpoint, so
+// this narrows EntityKind rather than switching on a kind the module can
+// never produce.
+export type RelationshipEntity = Exclude<EntityKind, "lead" | "project">;
+
+export function searchByEntity(
+  entity: RelationshipEntity,
+  query: string,
+): Promise<Candidate[]> {
+  switch (entity) {
+    case "company":
+      return searchCompanyCandidates(query);
+    case "person":
+      return searchPersonCandidates(query);
+    case "deal":
+      return searchDealCandidates(query);
+    default:
+      // Relationship edges only ever anchor person/company/deal (see
+      // edgeOptions below) — `lead`/`user`/`team` are EntityRefKind additions
+      // for record refs elsewhere (EntityRef), not creatable relationship
+      // endpoints, so this branch is unreachable for any real EdgeOption but
+      // still needs to satisfy the now-widened union's exhaustiveness check.
+      return Promise.resolve([]);
+  }
+}

--- a/frontend/src/screens/relationshipcandidates.ts
+++ b/frontend/src/screens/relationshipcandidates.ts
@@ -17,7 +17,7 @@ export type Candidate = { id: string; name: string };
 // include_anchor: recording that a person works at the company running the CRM
 // is an ordinary, frequent fact. The list hides the own company by default
 // because it answers "which companies are we selling to"; this question is a
-// different one, so it opts back in (ADR-0082/A127).
+// different one, so it opts back in (ADR-0082).
 async function searchCompanyCandidates(q: string): Promise<Candidate[]> {
   const { data, error } = await api.GET("/companies", {
     params: { query: { q, limit: 10, include_anchor: true } },
@@ -62,9 +62,9 @@ async function searchDealCandidates(q: string): Promise<Candidate[]> {
 }
 
 // The entity kinds this tab can ever pick as a relationship's other side —
-// company/person/deal, per the rel_*_shape CHECKs (migration 0007). A
-// lead has no relationship edges (it is promoted into a person first) and a
-// project seats its stakeholders through its own endpoint, so
+// company/person/deal, which is what the rel_*_shape CHECKs admit. A lead has
+// no relationship edges (it is promoted into a person first) and a project
+// seats its stakeholders through its own endpoint, so
 // this narrows EntityKind rather than switching on a kind the module can
 // never produce.
 export type RelationshipEntity = Exclude<EntityKind, "lead" | "project">;

--- a/frontend/src/screens/relationships.tsx
+++ b/frontend/src/screens/relationships.tsx
@@ -28,6 +28,11 @@ import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import type { CreateField } from "./create";
 import { EditAction } from "./edit";
 import { EntityRef } from "./entityref";
+import {
+  type Candidate,
+  type RelationshipEntity,
+  searchByEntity,
+} from "./relationshipcandidates";
 import "./candidatepicker.css";
 
 // The Relationships tab (P-5): the one surface a person/company 360 renders
@@ -188,84 +193,6 @@ function dateRange(rel: Relationship, t: (key: MessageKey) => string): string {
   return rel.started_at ? `${rel.started_at} – ${end}` : end;
 }
 
-type Candidate = { id: string; name: string };
-
-// include_anchor: recording that a person works at the company running the CRM
-// is an ordinary, frequent fact. The list hides the own company by default
-// because it answers "which companies are we selling to"; this question is a
-// different one, so it opts back in (ADR-0082/A127).
-async function searchCompanyCandidates(q: string): Promise<Candidate[]> {
-  const { data, error } = await api.GET("/companies", {
-    params: { query: { q, limit: 10, include_anchor: true } },
-  });
-  if (error) {
-    throwProblem(error);
-  }
-  return data.data.map((company) => ({
-    id: company.id,
-    name: company.display_name,
-  }));
-}
-
-async function searchPersonCandidates(q: string): Promise<Candidate[]> {
-  const { data, error } = await api.GET("/people", {
-    params: { query: { q, limit: 10 } },
-  });
-  if (error) {
-    throwProblem(error);
-  }
-  return data.data.map((person) => ({ id: person.id, name: person.full_name }));
-}
-
-// /deals has no free-text `q` in the contract (only structured filters), so
-// the stakeholder picker fetches a recent page and matches the typed term
-// against the deal name client-side. Deals past that page aren't reached — an
-// accepted PoC limit, scoped to the manual deal_stakeholder edge.
-const DEAL_PICKER_PAGE = 50;
-
-async function searchDealCandidates(q: string): Promise<Candidate[]> {
-  const { data, error } = await api.GET("/deals", {
-    params: { query: { limit: DEAL_PICKER_PAGE } },
-  });
-  if (error) {
-    throwProblem(error);
-  }
-  const needle = q.toLowerCase();
-  return data.data
-    .filter((deal) => deal.name.toLowerCase().includes(needle))
-    .slice(0, 10)
-    .map((deal) => ({ id: deal.id, name: deal.name }));
-}
-
-// The entity kinds this tab can ever pick as a relationship's other side —
-// company/person/deal, per the rel_*_shape CHECKs (migration 0007). A
-// lead has no relationship edges (it is promoted into a person first) and a
-// project seats its stakeholders through its own endpoint, so
-// this narrows EntityKind rather than switching on a kind the module can
-// never produce.
-type RelationshipEntity = Exclude<EntityKind, "lead" | "project">;
-
-function searchByEntity(
-  entity: RelationshipEntity,
-  query: string,
-): Promise<Candidate[]> {
-  switch (entity) {
-    case "company":
-      return searchCompanyCandidates(query);
-    case "person":
-      return searchPersonCandidates(query);
-    case "deal":
-      return searchDealCandidates(query);
-    default:
-      // Relationship edges only ever anchor person/company/deal (see
-      // edgeOptions below) — `lead`/`user`/`team` are EntityRefKind additions
-      // for record refs elsewhere (EntityRef), not creatable relationship
-      // endpoints, so this branch is unreachable for any real EdgeOption but
-      // still needs to satisfy the now-widened union's exhaustiveness check.
-      return Promise.resolve([]);
-  }
-}
-
 // A creatable edge from this scope: the kind, which entity fills the picked
 // endpoint, and which request field carries its id — all fixed by (scope,
 // kind) per the rel_*_shape CHECKs (migration 0007). The anchor endpoint
@@ -358,21 +285,37 @@ function invalidateAfterEdge(
 // other-side target picker (mirrors merge.tsx's debounced search-and-pick —
 // the source of the edge is fixed by scope, so there is no "exclude self"
 // filtering here).
-function AddRelationshipAction({
+export function AddRelationshipAction({
   scope,
   refusedReasonId,
+  only,
 }: Readonly<{
   scope: RelationshipScope;
   // The id of the anchor page's sentence about why its record takes no
   // changes. An edge is written through the anchor's own write gate on the
   // server, so a deal this caller cannot write takes no stakeholder from them.
   refusedReasonId?: string;
+  // ONE edge and the word for it, when the surface offering this verb is about
+  // that edge alone. A contact's Deals tab is exactly that: the reader is there
+  // to seat this person on a deal, and a kind selector offering "employment"
+  // beside it would ask them to answer a question the tab already answered.
+  //
+  // The scope is unchanged — it is still this person — so the picker, the write
+  // and the invalidation are the ones the relationships tab already uses. What
+  // narrows is what this surface offers and what it calls it.
+  only?: { kind: CreatableRelationshipKind; label: MessageKey };
 }>) {
   const t = useT();
   const queryClient = useQueryClient();
   const headingId = useId();
-  const options = edgeOptions(scope);
-  const copy = scopeCopy(scope);
+  const all = edgeOptions(scope);
+  const options = only
+    ? all.filter((option) => option.kind === only.kind)
+    : all;
+  const scopeWords = scopeCopy(scope);
+  const copy = only
+    ? { ...scopeWords, add: only.label, singleKind: true }
+    : scopeWords;
   const [open, setOpen] = useState(false);
   const [kind, setKind] = useState<CreatableRelationshipKind>(options[0].kind);
   const [role, setRole] = useState("");

--- a/scripts/fe-file-length-waivers.txt
+++ b/scripts/fe-file-length-waivers.txt
@@ -129,7 +129,7 @@
 827 frontend/src/screens/voice-dna.tsx
 835 frontend/src/screens/record360/spine.tsx
 839 frontend/src/screens/buyerroom.tsx
-842 frontend/src/screens/relationships.tsx
+785 frontend/src/screens/relationships.tsx
 844 frontend/src/screens/filterbuilder.tsx
 856 frontend/src/screens/onboarding-gate.tsx
 857 frontend/src/screens/worklist.copy.ts


### PR DESCRIPTION
Refs #1694 — the **Deals** half. Documents already landed; Meetings stays open
for its product question (below).

## The gap

The tab listed the deals a contact is recorded on and offered no way to record
one. A reader asking *which deals is this contact on* is the reader who wants to
put them on one, and the only path was the relationships tab — a different
question, reached from a different place.

## The verb is the one that already exists

`AddRelationshipAction` with this person's scope already writes exactly this
edge, with a deal picker, a role and dates. What is new is **where it is
offered**, not a second dialog:

- narrowed to the deal edge, because a kind selector offering "employment" on a
  Deals tab asks the reader to answer what the tab already answered;
- its own wording (`rel.seatOnDeal`, en/de/vi), because "Add stakeholder" is the
  deal-side phrasing and this is the contact side;
- **withheld** without `relationship:create` rather than disabled — a grant the
  role does not hold is not a fact about this contact, so there is nothing for a
  disabled button to explain. The row half stays the server's: a tab
  second-guessing it would withhold the verb on a record the write would accept.

## The narrowing test took three attempts, and that is the interesting part

Two assertions were written and thrown away because they passed with the
narrowing removed:

1. `queryByLabelText("Kind")` — the selector is hidden either way, since `only`
   forces `singleKind`.
2. `queryByText("Employment")` — no option label renders when the selector is
   hidden.

What the narrowing actually decides is **which endpoint the picker searches**:
unnarrowed, a person scope leads with `employment` and searches companies, so a
reader typing a deal name finds nothing and never learns why. So the case types
into the picker and asserts the deals route was called and the companies route
was not — on a deal name the tab does not already draw, because waiting for one
it does draw passes on the row rather than on the search.

All three decisions mutation-checked: dropping the verb, dropping the grant
check, and dropping the narrowing each fail their own case.

## One file split

`relationships.tsx` is ratcheted and the added prop took it over. The three
candidate searches are one question asked three ways and come out whole into
`relationshipcandidates.ts`; the waiver moves **down**, 842 → 785.

## Meetings is still not buildable

Unchanged from the status pass on the issue: there is no internal book-a-meeting
flow to put in the actions band. `book.tsx` is the **public** booking screen a
counterparty lands on, so "add a Book button" is not moving an existing verb — it
is building the first internal booking flow, and what it should do (prefilled
public page? internal composer? calendar hand-off?) is a product question this
issue does not settle.

## Checks

`make check-fe` and `make check-backend` green; `persontabs` and `relationships`
suites green.