### PR TITLE
perf(ci): the uat lane stops paying for work another job already did

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -636,6 +636,16 @@ fe-typecheck-composed: composition
 ## frontend-e2e — the screen-acceptance harness (AC-<screen>-N + axe WCAG AA
 ## + PERF-1's held-read claim) against the built app over the seed mock.
 ## Set BASE_URL to point the same suite at a live backend.
+##
+## `pnpm e2e` builds the BUNDLE and not the typecheck in front of it. That
+## typecheck is `pnpm build`'s first half and it dominates the build — vite
+## emits in seconds and `tsc -b` takes over a minute of them. This
+## lane is about what the built app renders; whether the sources typecheck is
+## fe-bundle's question, it runs the same `tsc -b` on every change that reaches
+## here (both jobs sit behind the same frontend classifier and both are in the
+## `ci` aggregate), and a type error therefore still fails the merge. What the
+## two share is `build:bundle`, so the app this suite exercises cannot quietly
+## become a different artefact from the one that ships.
 frontend-e2e:
 	cd frontend && pnpm install --frozen-lockfile && pnpm e2e
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "dev": "vite",
     "dev:preview": "VITE_UI_PREVIEW_OIDC=1 VITE_UI_PREVIEW_RESET=1 vite",
-    "build": "tsc -b && vite build && node scripts/build-mcp-apps.mjs",
+    "build": "tsc -b && pnpm build:bundle",
+    "build:bundle": "vite build && node scripts/build-mcp-apps.mjs",
     "build:preview": "VITE_UI_PREVIEW_OIDC=1 VITE_UI_PREVIEW_RESET=1 pnpm build",
     "preview": "vite preview",
     "test": "vitest run",
@@ -24,8 +25,8 @@
     "gen:events": "openapi-typescript ../backend/api/public-events.yaml --enum-values -o src/api/public-events.ts",
     "gen:composed-types": "openapi-typescript ../build/composition/api/crm.yaml -o ../build/composition-frontend/schema.d.ts",
     "gen:events:composed": "openapi-typescript ../build/composition/api/public-events.yaml --enum-values -o src/api/public-events.ts",
-    "build:composed": "tsc -p tsconfig.composed.json && vite build && node scripts/build-mcp-apps.mjs",
-    "e2e": "pnpm build && playwright test",
+    "build:composed": "tsc -p tsconfig.composed.json && pnpm build:bundle",
+    "e2e": "pnpm build:bundle && playwright test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o storybook-static"
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -28,19 +28,6 @@ export default defineConfig({
   // reasons that are the point rather than a fault.
   timeout: benchMobile ? 300_000 : 30_000,
   fullyParallel: true,
-  // One worker per core, not Playwright's default half.
-  //
-  // The default is a machine-sharing rule: a developer running the suite wants
-  // the other half of their laptop back. A CI runner is not shared — it exists
-  // for this run and is discarded after it — so half its cores were being left
-  // idle for nine minutes on every frontend pull request, and this lane is the
-  // last check to report on all of them.
-  //
-  // Bounded by the CPU count rather than a constant, so it follows the runner
-  // instead of encoding today's four cores. These specs mock the API at the
-  // network edge and share no server state, which is what makes the extra
-  // parallelism safe: `fullyParallel` above already runs them in any order.
-  workers: process.env.CI ? "100%" : undefined,
   use: {
     baseURL: process.env.BASE_URL ?? "http://localhost:4317",
     // MOBILE-AC-2 measures the mobile viewport (§3.8's 390px), so the benchmark

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -28,6 +28,19 @@ export default defineConfig({
   // reasons that are the point rather than a fault.
   timeout: benchMobile ? 300_000 : 30_000,
   fullyParallel: true,
+  // One worker per core, not Playwright's default half.
+  //
+  // The default is a machine-sharing rule: a developer running the suite wants
+  // the other half of their laptop back. A CI runner is not shared — it exists
+  // for this run and is discarded after it — so half its cores were being left
+  // idle for nine minutes on every frontend pull request, and this lane is the
+  // last check to report on all of them.
+  //
+  // Bounded by the CPU count rather than a constant, so it follows the runner
+  // instead of encoding today's four cores. These specs mock the API at the
+  // network edge and share no server state, which is what makes the extra
+  // parallelism safe: `fullyParallel` above already runs them in any order.
+  workers: process.env.CI ? "100%" : undefined,
   use: {
     baseURL: process.env.BASE_URL ?? "http://localhost:4317",
     // MOBILE-AC-2 measures the mobile viewport (§3.8's 390px), so the benchmark


### PR DESCRIPTION
Closes #1707.

## What the measurement says, which is not what the issue says

The issue was filed against run `32118851984` and proposed three fixes. Measured on the `uat` job of run `34592408471` (main, today), two of them buy nothing and the one it ranked last is the whole cost.

| step | duration |
|---|---|
| checkout + pnpm + setup-node | 11s |
| install deps | **4s** |
| playwright install --with-deps chromium | **22s** |
| build → preview → AC + axe | **599s** |
| **job total** | **639s** |

Inside that last step:

| phase | duration |
|---|---|
| `tsc -b` | **70s** |
| `vite build` + the six mcp-app bundles | **4s** |
| `playwright test` — 436 tests, 2 workers | **523s** |

So:

- **"It starts last by construction" is already fixed on main**, and fixed better than proposed. `uat` declares `needs: [changes]` and runs beside the frontend lane rather than behind `fe-quality`.
- **"It redoes work three other jobs already did"** is 26 seconds, not minutes. Caching `~/.cache/ms-playwright` to save part of 22s, and shipping `dist/` between jobs to save 4s of `vite build`, are worth less than the plumbing they need — and the `dist/` half is now actively wrong: it would put `uat` behind `fe-bundle` (1m25s) to save four seconds, which is the sequencing the current `needs: [changes]` comment deliberately removed.
- **"The suite itself — not worth touching until 1 and 2 are done"** is 82% of the job, and 1 is done.

## What lands

**The build stops typechecking.** `pnpm e2e` was `pnpm build && playwright test`, and `pnpm build` is `tsc -b` and then the bundle. `fe-bundle` runs that same `tsc -b` on every change that reaches this lane — both jobs sit behind the same `frontend` classifier output and both report into `ci` — so a type error still fails the merge with nothing rescued by the second run. `e2e` now calls `build:bundle`, the emit half, which `build` and `build:composed` also call; sharing it is the point, so the app this suite exercises cannot quietly become a different artefact from the one that ships.

**Measured on this PR's own run (`34606521466`): the step went 599s → 524s.** That is the 70 seconds of `tsc -b`, and it is the whole of what this lane had to give without touching the suite.

## What was tried and reverted, because the measurement refused it

`workers: "100%"` under CI — one worker per core instead of Playwright's default half. The reasoning was that a CI runner is not shared with anybody, so half its cores were idle for nine minutes on every frontend PR.

They are not idle. Four workers ran the suite in **8.6 minutes against 8.8 at two** — two percent, which is noise — and failed two specs that pass at two workers (`ac.spec.ts` "offers the providers an installation does serve", a 30-second test timeout; `coldstart.spec.ts` desktop, a five-second visibility wait). Both are the shape contention produces. The runner is already saturated at half its cores, so the change bought nothing and cost stability. Reverted in its own commit, with the numbers, so the next person does not re-derive it.

**What that leaves**: the suite is now 87% of a lane that is the last check to report on every frontend PR, and it does not go faster by being given more of this runner. Anything further is a decision about what the suite covers — sharding it across jobs trades queue time for wall clock, and cutting specs trades coverage — neither of which is plumbing, and neither of which this issue asked for.

## Checks

`make check-fe` green locally. The suite itself is unchanged: no spec edited, no assertion touched.