### PR TITLE
fix(leads): a merged-away lead's page says it was merged, and where it went

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2194,6 +2194,9 @@ export const de = {
   "lead.boardTerminalOnly":
     "Keiner dieser Leads ist noch offen \u2014 sie z\u00e4hlen unter Qualifiziert und Disqualifiziert.",
   "person.fromLead": "Aus Lead übernommen",
+  "lead.mergedTitle": "Mit einem anderen Lead zusammengeführt",
+  "lead.mergedBody":
+    "Dieser Lead war derselbe Interessent wie ein anderer. Verlauf, Einwilligung und Score liegen jetzt dort; dieser Datensatz bleibt als Nachweis.",
   "lead.promotedTitle": "Als Kontakt übernommen",
   "lead.promotedMerged":
     "Dieser Lead wurde mit einem bereits bekannten Kontakt zusammengeführt — es entstand kein Duplikat.",
@@ -2232,6 +2235,7 @@ export const de = {
   "lead.statusPromoted": "Qualifiziert",
   "lead.statusDisqualified": "Disqualifiziert",
   "lead.disqualified": "Disqualifiziert",
+  "lead.merged": "Zusammengeführt",
   "lead.status.new": "Neu",
   "lead.status.contacted": "Kontaktiert",
   "lead.status.engaged": "Im Gespräch",
@@ -9419,6 +9423,9 @@ export const de = {
   "lead.standing.qualifiedOn":
     "Qualifiziert am {at}. Dieser Lead ist jetzt ein Kontakt.",
   "lead.standing.qualifiedUndated": "Dieser Lead ist jetzt ein Kontakt.",
+  "lead.standing.merged": "Zusammengeführt",
+  "lead.standing.mergedBecause":
+    "Derselbe Interessent wie ein anderer Lead. Lies dort weiter \u2014 dieser Datensatz bleibt als Nachweis.",
   "lead.standing.closed": "Geschlossen",
   "lead.standing.closedFor":
     "Geschlossen: {reason}. Der Datensatz bleibt als Spur.",
@@ -9433,6 +9440,7 @@ export const de = {
   "lead.standing.engagedBecause":
     "Der Lead hat geantwortet, oder ein Termin steht im Kalender.",
   "lead.standing.rests.promoted": "Zu einem Kontakt befördert.",
+  "lead.standing.rests.merged": "Mit einem anderen Lead zusammengeführt.",
   "lead.standing.rests.closed": "Disqualifiziert, kein Grund erfasst.",
   "lead.standing.rests.ladder": "Lead-Leiter",
   "lead.standing.rests.record": "Lead-Datensatz",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2274,6 +2274,9 @@ export const en = {
   "lead.boardTerminalOnly":
     "None of these leads are still open \u2014 they are counted under Qualified and Disqualified.",
   "person.fromLead": "From lead",
+  "lead.mergedTitle": "Merged into another lead",
+  "lead.mergedBody":
+    "This lead turned out to be the same prospect as another one. Its timeline, its consent and its score moved there; this record stays as the trail.",
   "lead.promotedTitle": "Promoted to a contact",
   "lead.promotedMerged":
     "This lead merged into a contact we already knew — no duplicate was created.",
@@ -2309,6 +2312,7 @@ export const en = {
   "lead.statusPromoted": "Qualified",
   "lead.statusDisqualified": "Disqualified",
   "lead.disqualified": "Disqualified",
+  "lead.merged": "Merged",
   "lead.status.new": "New",
   "lead.status.contacted": "Contacted",
   "lead.status.engaged": "Engaged",
@@ -9531,6 +9535,9 @@ export const en = {
   "lead.standing.qualified": "Qualified",
   "lead.standing.qualifiedOn": "Qualified on {at}. This lead is a contact now.",
   "lead.standing.qualifiedUndated": "This lead is a contact now.",
+  "lead.standing.merged": "Merged away",
+  "lead.standing.mergedBecause":
+    "The same prospect as another lead. Read that one instead \u2014 this record stays as the trail.",
   "lead.standing.closed": "Closed",
   "lead.standing.closedFor": "Closed: {reason}. The record stays as the trail.",
   "lead.standing.closedUnreasoned": "Closed. The record stays as the trail.",
@@ -9542,6 +9549,7 @@ export const en = {
   "lead.standing.engagedBecause":
     "They answered, or a meeting is on the calendar.",
   "lead.standing.rests.promoted": "Promoted to a contact.",
+  "lead.standing.rests.merged": "Merged into another lead.",
   "lead.standing.rests.closed": "Disqualified, no reason recorded.",
   "lead.standing.rests.ladder": "Lead ladder",
   "lead.standing.rests.record": "Lead record",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2177,6 +2177,9 @@ export const vi = {
   "lead.boardTerminalOnly":
     "Không còn mục nào đang mở — chúng được tính ở cột Đã chuyển đổi và Đã loại.",
   "person.fromLead": "Từ khách hàng tiềm năng",
+  "lead.mergedTitle": "Đã gộp vào một khách hàng tiềm năng khác",
+  "lead.mergedBody":
+    "Khách hàng tiềm năng này hoá ra trùng với một mục khác. Dòng thời gian, chấp thuận và điểm số đã chuyển sang đó; bản ghi này ở lại làm dấu vết.",
   "lead.promotedTitle": "Đã chuyển thành liên hệ",
   "lead.promotedMerged":
     "Khách hàng tiềm năng này đã được gộp vào một liên hệ đã biết — không tạo bản trùng.",
@@ -2214,6 +2217,7 @@ export const vi = {
   "lead.statusPromoted": "Đã đủ điều kiện",
   "lead.statusDisqualified": "Đã loại",
   "lead.disqualified": "Đã loại",
+  "lead.merged": "Đã gộp",
   "lead.status.new": "Mới",
   "lead.status.contacted": "Đã liên hệ",
   "lead.status.engaged": "Đang trao đổi",
@@ -9278,6 +9282,9 @@ export const vi = {
     "Đủ điều kiện ngày {at}. Khách hàng tiềm năng này giờ là liên hệ trong CRM.",
   "lead.standing.qualifiedUndated":
     "Khách hàng tiềm năng này giờ là liên hệ trong CRM.",
+  "lead.standing.merged": "Đã gộp",
+  "lead.standing.mergedBecause":
+    "Trùng với một khách hàng tiềm năng khác. Hãy đọc mục đó \u2014 bản ghi này ở lại làm dấu vết.",
   "lead.standing.closed": "Đã đóng",
   "lead.standing.closedFor":
     "Đã đóng: {reason}. Hồ sơ vẫn giữ lại làm dấu vết.",
@@ -9291,6 +9298,7 @@ export const vi = {
   "lead.standing.engagedBecause":
     "Họ đã trả lời, hoặc đã có cuộc họp trong lịch.",
   "lead.standing.rests.promoted": "Đã chuyển thành liên hệ.",
+  "lead.standing.rests.merged": "Đã gộp vào một khách hàng tiềm năng khác.",
   "lead.standing.rests.closed": "Đã loại, không ghi lý do.",
   "lead.standing.rests.ladder": "Bậc thang khách hàng tiềm năng",
   "lead.standing.rests.record": "Hồ sơ khách hàng tiềm năng",

--- a/frontend/src/screens/leadmerged.test.tsx
+++ b/frontend/src/screens/leadmerged.test.tsx
@@ -1,0 +1,111 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { en } from "../i18n/en";
+import { LeadScreen, terminalBadge } from "./leads";
+import { jsonResponse, StoryProviders, stubWithSession } from "./story-utils";
+
+// What a merged-away lead's page says it is.
+//
+// The merge archives the loser, points it at the survivor and leaves the
+// ladder status untouched — so the page has one fact and one fact only to
+// read this ending from, and reading it from anything else says a different
+// thing about a real prospect.
+
+beforeEach(() => {
+  globalThis.localStorage.setItem("margince.workspaceSlug", "acme");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  globalThis.localStorage.clear();
+  window.location.hash = "";
+});
+
+// Merged away MID CONVERSATION, which is the case the ladder cannot describe:
+// `contacted` with a first response already sent, archived, and pointed at the
+// lead it turned out to be.
+const mergedAway = {
+  id: "l-1",
+  full_name: "Jonas Petersen",
+  email: "jonas@nordwind.example",
+  company_name: "Nordwind Logistik",
+  status: "contacted" as const,
+  score: 72,
+  captured_by: "human:u-1",
+  source: "manual",
+  writable: false,
+  version: 2,
+  created_at: "2026-06-01T08:00:00Z",
+  updated_at: "2026-06-20T08:00:00Z",
+  first_response_at: "2026-06-02T09:00:00Z",
+  merged_into_id: "l-2",
+  archived_at: "2026-06-20T08:00:00Z",
+};
+
+const survivor = {
+  ...mergedAway,
+  id: "l-2",
+  full_name: "Jonas Pedersen",
+  version: 1,
+  first_response_at: null,
+  merged_into_id: null,
+  archived_at: null,
+  writable: true,
+};
+
+function stub(): void {
+  stubWithSession(
+    {
+      "GET /leads/l-1": () => jsonResponse(mergedAway),
+      "GET /leads/l-2": () => jsonResponse(survivor),
+    },
+    { lead: ["read", "update"], activity: ["read"] },
+  );
+}
+
+describe("a merged-away lead's page", () => {
+  it("says the lead was merged and names the lead it was merged into", async () => {
+    stub();
+    render(
+      <StoryProviders>
+        <LeadScreen id="l-1" />
+      </StoryProviders>,
+    );
+
+    expect(await screen.findByText(en["lead.mergedTitle"])).toBeTruthy();
+    // The pointer is the useful half: the survivor by NAME, as a link, because
+    // a reader who learns the lead was merged wants the one it went into.
+    const link = await screen.findByRole("link", { name: /Jonas Pedersen/ });
+    expect(link.getAttribute("href")).toContain("l-2");
+  });
+
+  it("does not read as open work, which its ladder status still says it is", async () => {
+    stub();
+    render(
+      <StoryProviders>
+        <LeadScreen id="l-1" />
+      </StoryProviders>,
+    );
+
+    expect(await screen.findByText(en["lead.standing.merged"])).toBeTruthy();
+    // `contacted` with a first response is "their move" on a live lead. Drawn
+    // here it would send a rep back to a prospect somebody else already owns.
+    expect(screen.queryByText(en["lead.standing.theirMove"])).toBeNull();
+  });
+});
+
+describe("the terminal badge a merged-away lead wears", () => {
+  // The badge is what every lead SURFACE reads — the list row, the readings
+  // card, the header — so the pointer has to decide it there too. Read from
+  // the ladder alone this lead is `contacted` and wears nothing at all.
+  it("says merged, on a lead whose ladder never left the conversation", () => {
+    expect(
+      terminalBadge({ status: "contacted", merged_into_id: "l-2" }),
+    ).toEqual({ label: "lead.merged", tone: "warn" });
+    expect(
+      terminalBadge({ status: "contacted", merged_into_id: null }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/screens/leadmerged.tsx
+++ b/frontend/src/screens/leadmerged.tsx
@@ -1,0 +1,38 @@
+import { Panel, PanelBody } from "../design-system/panel";
+import { useT } from "../i18n";
+import { EntityRef } from "./entityref";
+
+/**
+ * MergedLeadPanel is what a merged-away lead's page is FOR.
+ *
+ * The merge archives the loser and points it at the survivor, and it leaves
+ * the ladder status exactly where it stood — a lead merged away while it was
+ * being worked is still `contacted`. So without this the page draws an open
+ * lead nobody is working, or, once it reads as terminal at all, reads as
+ * *disqualified*: a human judged this prospect not worth pursuing. Merged says
+ * something else entirely — it was the same prospect as another one — and a
+ * rep who reads the wrong one draws the wrong conclusion about their own
+ * pipeline.
+ *
+ * The pointer is the useful half. A reader who learns the lead was merged
+ * wants the lead it was merged INTO, which is where its timeline, its consent
+ * and its score now live. Same shape as the promoted lead's link to its
+ * contact, for the same reason.
+ */
+export function MergedLeadPanel({
+  mergedIntoId,
+}: Readonly<{ mergedIntoId: string }>) {
+  const t = useT();
+  return (
+    <Panel title={t("lead.mergedTitle")}>
+      <PanelBody>
+        <div className="lead-stack">
+          <p className="t-body">{t("lead.mergedBody")}</p>
+          <p className="t-body">
+            <EntityRef kind="lead" id={mergedIntoId} />
+          </p>
+        </div>
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/frontend/src/screens/leadpresentation.tsx
+++ b/frontend/src/screens/leadpresentation.tsx
@@ -522,26 +522,6 @@ export function promoteEligible(lead: Lead): boolean {
   return isOpenStatus(lead.status) && Boolean(lead.email);
 }
 
-// The terminal badge a lead status earns (null = live/open, no badge). A lead
-// is archived iff it is promoted or disqualified; keying the label off the
-// status — not a bare archived_at — is what stops a promoted lead reading
-// "Disqualified". Exhaustive over the four statuses: a new value is a compile
-// error here, not a silently-unlabelled row.
-export function terminalBadge(
-  status: Lead["status"],
-): { label: MessageKey; tone: "warn" } | null {
-  switch (status) {
-    case "disqualified":
-      return { label: "lead.disqualified", tone: "warn" };
-    case "promoted":
-      return { label: "record.archived", tone: "warn" };
-    case "new":
-    case "contacted":
-    case "engaged":
-      return null;
-  }
-}
-
 // The open ladder, as the page's open-step predicate reads it.
 export const LEAD_OPEN_STATUSES = ["new", "contacted", "engaged"] as const;
 type LeadOpenStatus = (typeof LEAD_OPEN_STATUSES)[number];

--- a/frontend/src/screens/leadreadings.tsx
+++ b/frontend/src/screens/leadreadings.tsx
@@ -10,12 +10,8 @@ import { viewerZone } from "../format/timezone";
 import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import { throwProblem } from "./common";
 import { leadScoreKey } from "./leadkeys";
-import {
-  leadStatusLabel,
-  scoreFactorLabel,
-  terminalBadge,
-} from "./leadpresentation";
-import { firstResponseClock } from "./leadstanding";
+import { leadStatusLabel, scoreFactorLabel } from "./leadpresentation";
+import { firstResponseClock, terminalBadge } from "./leadstanding";
 
 // The lead's four readings, in the cards every record page draws them in: how
 // it scores and what made the score; whether anybody has answered, and how
@@ -57,7 +53,7 @@ export function LeadReadings({ lead }: Readonly<{ lead: Lead }>) {
 
 /** The status as the readings state it: the terminal wording when it has one. */
 export function statusReading(lead: Lead, t: Translator): string {
-  const terminal = terminalBadge(lead.status);
+  const terminal = terminalBadge(lead);
   const label = terminal?.label ?? leadStatusLabel(lead.status);
   return label ? t(label) : lead.status;
 }

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -33,7 +33,6 @@ import {
   StatusBadge,
   scoreFactorLabel,
   scoreTone,
-  terminalBadge,
 } from "./leadpresentation";
 import {
   sourceFilterOptions,
@@ -42,6 +41,7 @@ import {
   useLeadSettings,
   useLeadSources,
 } from "./leadsources";
+import { terminalBadge } from "./leadstanding";
 import {
   type ListPage,
   type ListQuery,
@@ -376,7 +376,7 @@ function LeadsWorkbench({
             key: "name",
             header: t("people.name"),
             cell: (lead: Lead) => {
-              const terminal = terminalBadge(lead.status);
+              const terminal = terminalBadge(lead);
               return (
                 <span>
                   <strong>{leadIdentityName(lead) || t("lead.unnamed")}</strong>

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -2357,17 +2357,17 @@ describe("LeadScreen — History tab", () => {
 
 describe("terminalBadge (archived/terminal labelling)", () => {
   it("labels disqualified and promoted distinctly and leaves open leads unbadged", () => {
-    expect(terminalBadge("disqualified")).toEqual({
+    expect(terminalBadge({ status: "disqualified" })).toEqual({
       label: "lead.disqualified",
       tone: "warn",
     });
     // A promoted lead IS archived, but reads "Archived" — never "Disqualified".
-    expect(terminalBadge("promoted")).toEqual({
+    expect(terminalBadge({ status: "promoted" })).toEqual({
       label: "record.archived",
       tone: "warn",
     });
-    expect(terminalBadge("new")).toBeNull();
-    expect(terminalBadge("contacted")).toBeNull();
+    expect(terminalBadge({ status: "new" })).toBeNull();
+    expect(terminalBadge({ status: "contacted" })).toBeNull();
   });
 });
 

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -81,6 +81,7 @@ import {
 } from "./entityref";
 import { RecordHistoryTab, useRecordHistory } from "./history";
 import { leadBand } from "./leadband";
+import { MergedLeadPanel } from "./leadmerged";
 import {
   promoteEligible,
   scoreFactorLabel,
@@ -127,11 +128,8 @@ import {
   useLeadSources,
 } from "./leadsources";
 
-export {
-  promoteEligible,
-  scoreTone,
-  terminalBadge,
-} from "./leadpresentation";
+export { promoteEligible, scoreTone } from "./leadpresentation";
+export { terminalBadge } from "./leadstanding";
 
 import { leadKey, leadScoreKey, leadWriteKeys } from "./leadkeys";
 import { invalidateRecord } from "./recordwritekeys";
@@ -1530,6 +1528,11 @@ function LeadOverviewPane({
     <div className="record-stack">
       {/* The readings open the overview, as they do on every record page. */}
       <LeadReadings lead={lead} />
+      {/* A merged-away lead's page leads with where it went, for the same
+          reason: the reader arrived asking what happened to this prospect. */}
+      {lead.merged_into_id && (
+        <MergedLeadPanel mergedIntoId={lead.merged_into_id} />
+      )}
       {/* A promoted lead's page leads with what the promotion did — the
           reader arrived asking whether this became a contact, and which one. */}
       {lead.promoted_person_id && (

--- a/frontend/src/screens/leadstanding.test.ts
+++ b/frontend/src/screens/leadstanding.test.ts
@@ -31,6 +31,30 @@ function lead(extra: Partial<Lead>): Lead {
 }
 
 describe("leadStanding", () => {
+  // The merge leaves the ladder alone, so the pointer is the only thing that
+  // says this lead ended. Read from `status` instead, a lead merged away mid
+  // conversation is open work forever — and the terminal reading it would
+  // eventually get is "disqualified", which says a human judged the prospect
+  // not worth pursuing rather than that two records were one prospect.
+  it("says a merged-away lead was merged, whatever its ladder still says", () => {
+    const merged = leadStanding(
+      lead({
+        status: "contacted",
+        first_response_at: "2026-08-19T09:00:00Z",
+        merged_into_id: "l2",
+        archived_at: "2026-08-20T10:00:00Z",
+      }),
+      t,
+      "en",
+      zone,
+    );
+    expect(merged.label).toBe("lead.standing.merged");
+    expect(merged.because).toBe("lead.standing.mergedBecause");
+    expect(merged.restsOn.map((r) => r.quote)).toContain(
+      "lead.standing.rests.merged",
+    );
+  });
+
   it("is our move on an unanswered lead, as loud as the first-response clock", () => {
     const breached = leadStanding(
       lead({ sla_state: "breached", sla_deadline_at: "2026-08-19T08:14:00Z" }),

--- a/frontend/src/screens/leadstanding.ts
+++ b/frontend/src/screens/leadstanding.ts
@@ -1,6 +1,7 @@
 import type { components } from "../api/schema";
 import { formatDateAbbrev, formatDateTime } from "../format/format";
 import type { Locale, Translator } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import type { Grounding, StandingTone } from "./record360";
 
 type Lead = components["schemas"]["Lead"];
@@ -37,6 +38,35 @@ export function firstResponseClock(
   return { deadline: lead.sla_deadline_at, state: lead.sla_state };
 }
 
+// The terminal badge a lead earns (null = live/open, no badge). Keying the
+// label off the ENDING rather than a bare archived_at is what stops a promoted
+// lead reading "Disqualified".
+//
+// The merge is read first because it is the ending the ladder does not record:
+// it archives the lead, points it at the survivor and leaves `status` exactly
+// where it stood. Read from the status alone, a lead merged away mid
+// conversation wears no badge at all and every surface draws it as open work.
+//
+// Exhaustive over the four statuses below: a new value is a compile error
+// here, not a silently-unlabelled row.
+export function terminalBadge(
+  lead: Pick<Lead, "status" | "merged_into_id">,
+): { label: MessageKey; tone: "warn" } | null {
+  if (lead.merged_into_id) {
+    return { label: "lead.merged", tone: "warn" };
+  }
+  switch (lead.status) {
+    case "disqualified":
+      return { label: "lead.disqualified", tone: "warn" };
+    case "promoted":
+      return { label: "record.archived", tone: "warn" };
+    case "new":
+    case "contacted":
+    case "engaged":
+      return null;
+  }
+}
+
 export function leadStanding(
   lead: Lead,
   t: Translator,
@@ -47,6 +77,27 @@ export function leadStanding(
   // The first-response target is set in hours, so its deadline is an instant
   // and prints with its time — the same precision the readings card gives it.
   const instant = (at: string) => formatDateTime(at, locale, zone);
+  // Merged away is read FIRST, because it is the one ending the ladder does
+  // not record: the merge archives the loser and points it at the survivor
+  // and leaves `status` exactly where it stood. A lead merged away while it
+  // was being worked therefore still says `contacted`, and every branch below
+  // would call it open work — or, once something did call it terminal, call
+  // it disqualified, which says a human judged the prospect not worth
+  // pursuing rather than that it was the same prospect as another one.
+  if (lead.merged_into_id) {
+    return {
+      label: t("lead.standing.merged"),
+      tone: "unknown",
+      because: t("lead.standing.mergedBecause"),
+      restsOn: [
+        {
+          key: "merged",
+          quote: t("lead.standing.rests.merged"),
+          from: t("lead.standing.rests.record"),
+        },
+      ],
+    };
+  }
   if (lead.status === "promoted") {
     return {
       label: t("lead.standing.qualified"),

--- a/scripts/fe-file-length-waivers.txt
+++ b/scripts/fe-file-length-waivers.txt
@@ -84,11 +84,11 @@
 531 frontend/src/screens/voice-versions.tsx
 533 frontend/src/screens/companywork.tsx
 535 frontend/src/screens/brief.plan.tsx
+542 frontend/src/screens/leadpresentation.tsx
 547 frontend/src/screens/connected-agents.tsx
 547 frontend/src/screens/scheduledsends.tsx
 560 frontend/src/screens/users-access.tsx
 561 frontend/src/screens/worklist.queries.ts
-562 frontend/src/screens/leadpresentation.tsx
 571 frontend/src/screens/capture-activity.tsx
 573 frontend/src/screens/project360.tsx
 583 frontend/src/screens/companycontracts.tsx


### PR DESCRIPTION
Closes #1663.

## What was wrong, restated against today's main

The ruling on this issue said the contract had to carry `Lead.merged_into_id` first. It does — the field is on the `Lead` schema with the disclosure the ruling asked for, `lead_read.go`'s column list scans it, and `leaddedupe_integration_test.go` already holds that a merged-away lead's read carries the pointer at the survivor. **Nothing on the client had ever read it**, which is the whole of what was left.

The issue describes the page saying *Disqualified*. It does not say that any more, and what it says instead is worse: the merge archives the loser, points it at the survivor and **leaves `status` exactly where it stood**. A lead merged away in the middle of a conversation is still `contacted` with a first response recorded, so —

- the call at the head of the page read **"Their move"**,
- `terminalBadge` returned `null`, so the readings card and the list row wore no badge at all,
- and the page offered no route to the lead this one turned out to be.

A rep following that lands on a prospect somebody else already owns, whose timeline, consent and score have all moved elsewhere.

## What changes

Three surfaces now read `merged_into_id`, each from one place:

- **`leadStanding`** gains its third terminal case, checked **first** — it is the one ending the ladder does not record, so every branch below it would call the lead open work.
- **`terminalBadge`** takes the lead rather than its status. Its doc claimed *"a lead is archived iff it is promoted or disqualified"*, which stopped being true when leads learned to merge; the claim is gone and the case is handled.
- **`MergedLeadPanel`** leads the page with where the lead went, in the shape `PromotedLeadPanel` already uses for its contact — an `EntityRef` to the survivor, by name.

`terminalBadge` moves in beside `leadStanding`. Both answer where a lead stands, one in a word and one in a sentence, and holding them in two files is how they came to disagree about the same ending. That also pays `leadpresentation.tsx` down from 562 to 542 lines, re-frozen in `scripts/fe-file-length-waivers.txt`.

## Tests

`leadmerged.test.tsx` renders the real `LeadScreen` over a stubbed wire, not the panel alone:

- the page names the survivor as a link to `l-2`;
- it does **not** draw `lead.standing.theirMove`, which is what its ladder still says it is;
- and `terminalBadge` says merged on a lead whose status never left the conversation.

Each half was mutation-checked separately — the standing branch, the page's render of the panel, and the badge all fail their own case when disabled. `leadstanding.test.ts` carries the unit case for the standing itself.

`make check-fe` green (3m01s).

## One thing found and left

`person` and `company` carry `merged_into_id` on the wire too, and their pages read it nowhere either — the same defect, two records over. It is not this diff: the lead page is what the issue is about, and the other two want their own look at what a merged-away record's page should lead with. Worth an issue; say the word and I will file it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying leads merged into another lead.
  - Merged leads now show an explanatory panel with a link to the surviving lead.
  - Added “Merged” status and standing details in English, German, and Vietnamese.
  - Merged leads display an appropriate warning badge and standing information.

- **Tests**
  - Added coverage for merged-lead panels, badges, links, and standing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->