### PR TITLE
fix(uploads): the grant is asked before the body is read, not after it

### DIFF
--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 50
+	wantFixtureAnnotations = 51
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/uploadauthorder_test.go
+++ b/backend/gates/uploadauthorder_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H1
+
+package gates
+
+// An upload route refuses an unauthorized caller BEFORE it reads the body.
+//
+// The gate is about ORDER, and order is the whole of it: every one of these
+// routes was already authorized, and every one of them authorized too late.
+// The store is where the grant decides, the store runs after the handler, and
+// the handler's first act was to parse a multipart body — so a session holding
+// no grant at all sent one request, made this server take a whole file apart
+// and spill it to disk, and got a 403. Repeatable, and free to the sender: the
+// attacker spends a request and the server spends a file.
+//
+// What the early check is NOT is the gate. It is deliberately allowed to be
+// coarser than the store's — the attachment upload cannot even know which
+// object type the body names until it has parsed it, so it asks whether the
+// caller may write ANYTHING — and the store still asks the exact question
+// afterwards, because the store is the gate every transport passes.
+//
+// Derived from the tree rather than from a list of routes: the subject is any
+// function that parses a multipart body, so a seventh upload route is in the
+// obligation set the moment it is written, which is the only way this stays
+// true. A parse whose caller authorizes instead is waived BY NAME below, with
+// the caller named, because that shape is correct and unprovable from inside
+// one function.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The two ways a handler takes a multipart body apart. Both are the cost this
+// gate is about: ParseMultipartForm reads the whole body, and MultipartReader
+// hands back a stream the caller then reads.
+var multipartParsers = []string{"ParseMultipartForm", "MultipartReader"}
+
+// gatekit:fixture the parses whose authorization is their CALLER's, not their
+// own — a waiver, and each entry names the caller that holds the grant so the
+// claim can be checked rather than taken.
+//
+// This is the one shape the rule cannot see: a helper that only decodes is
+// right to hold no grant, and whether its caller holds one is a fact about a
+// different function. An entry here is a claim about that caller, so it goes
+// stale the way any claim does — which is why an entry no parse reaches is
+// reported below rather than left to sit.
+var uploadParseAuthorizedByCaller = map[string]string{
+	"decodeCompanyLogoUpload": "its only caller, uploadCompanyMark, reads the anchor company " +
+		"first, and GetAnchorCompany requires company.read",
+	"readImportUpload": "its only caller, stageImportSource, requires import_run.create before it calls this",
+}
+
+func TestEveryMultipartParseRefusesBeforeItReads(t *testing.T) {
+	t.Parallel()
+	parses := 0
+	waived := map[string]bool{}
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// path != "." because the root's own name is dotted, and skipping
+			// it would take the whole tree — reporting nothing, for the most
+			// reassuring possible reason.
+			if path != "." && skipUploadAuthDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			t.Fatalf("parsing %s: %v", path, perr)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			parse := firstMultipartParse(fn.Body)
+			if parse == token.NoPos {
+				continue
+			}
+			parses++
+			if why, ok := uploadParseAuthorizedByCaller[fn.Name.Name]; ok {
+				waived[fn.Name.Name] = true
+				t.Logf("%s: %s takes its authorization from its caller — %s", path, fn.Name.Name, why)
+				continue
+			}
+			if authorizesBefore(fn.Body, parse) {
+				continue
+			}
+			t.Errorf("%s: %s parses a multipart body before it refuses anybody. "+
+				"A caller with no grant then spends one request and makes this server "+
+				"spend a whole file — parsed, spilled and thrown away — for a 403 it was "+
+				"always going to get. Ask the grant first: the exact one if the object is "+
+				"known here, auth.RequireAnyObject if the body is what names it. The "+
+				"store's own check stays either way. If the grant genuinely belongs to "+
+				"this function's caller, add it to uploadParseAuthorizedByCaller with the "+
+				"caller named.", path, fn.Name.Name)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the module: %v", err)
+	}
+	if parses == 0 {
+		t.Fatal("no multipart parse found anywhere, so this gate has stopped reading the code it derives from")
+	}
+	for name, why := range uploadParseAuthorizedByCaller {
+		if !waived[name] {
+			t.Errorf("uploadParseAuthorizedByCaller waives %s (%s) and no multipart parse is in it any more — "+
+				"a stale waiver is a hole nobody can see", name, why)
+		}
+	}
+}
+
+// firstMultipartParse is where in this function the body starts being read, or
+// NoPos if it never is.
+func firstMultipartParse(body *ast.BlockStmt) token.Pos {
+	at := token.NoPos
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		for _, name := range multipartParsers {
+			if selector.Sel.Name == name && (at == token.NoPos || call.Pos() < at) {
+				at = call.Pos()
+			}
+		}
+		return true
+	})
+	return at
+}
+
+// authorizesBefore reports whether this function calls into platform/auth
+// ahead of the parse. Any of that package's gates counts: which one is the
+// right question is the handler's judgement and the store's to re-ask, while
+// "asked nobody" is the failure with a shape.
+func authorizesBefore(body *ast.BlockStmt, parse token.Pos) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || found {
+			return !found
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := selector.X.(*ast.Ident)
+		if ok && pkg.Name == "auth" && call.Pos() < parse {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func skipUploadAuthDir(name string) bool {
+	return name == "node_modules" || name == "build" || name == "testdata" ||
+		strings.HasPrefix(name, ".")
+}

--- a/backend/internal/modules/activities/handlers_attachment.go
+++ b/backend/internal/modules/activities/handlers_attachment.go
@@ -10,8 +10,10 @@ import (
 	"net/http"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // multipartSpillBytes is how much of an upload is held in memory before the
@@ -46,8 +48,13 @@ func (h Handlers) WithUploadLimit(bytes int64) Handlers {
 }
 
 // UploadAttachment stores an uploaded file against an entity. Multipart is
-// parsed here (the JSON decoder cannot carry bytes); the store owns the
-// RBAC gate, provenance, and the write shape.
+// parsed here (the JSON decoder cannot carry bytes); the store owns provenance
+// and the write shape, and the RBAC gate that decides.
+//
+// The grant is asked TWICE, and the two are not the same question. Here it is
+// only "may this caller write anything at all", asked before the parse so a
+// refusal costs a header rather than a file; in the store it is "may this
+// caller write THIS object type", asked once the body has said which.
 func (h Handlers) UploadAttachment(w http.ResponseWriter, r *http.Request) {
 	if h.uploadLimit <= 0 {
 		// Answered as OUR fault, because it is: nobody wired the ceiling. The
@@ -55,6 +62,20 @@ func (h Handlers) UploadAttachment(w http.ResponseWriter, r *http.Request) {
 		// perfectly good file and tells them it exceeds a 0 MB limit, which
 		// sends them off to shrink a file that was never the problem.
 		httperr.Write(w, r, errUploadLimitUnset)
+		return
+	}
+	// THE GRANT, BEFORE THE BYTES. The exact question — may this caller write
+	// THIS object type — cannot be asked yet: the type arrives inside the body,
+	// and reading the body is the cost. So the coarse half is asked first, and
+	// a caller holding no write grant on anything is refused for the price of a
+	// header rather than the price of a file. Without it a session with no
+	// grants at all was a free amplifier: one request in, one whole upload
+	// parsed and spilled, a 403 out, repeatable.
+	//
+	// The store still asks the exact question once the body names its object,
+	// and keeps asking it — this is an early refusal, never the gate.
+	if err := auth.RequireAnyObject(r.Context(), principal.ActionUpdate); err != nil {
+		httperr.Write(w, r, err)
 		return
 	}
 	// The same ceiling the chassis already applied, and applied again anyway: it
@@ -73,7 +94,7 @@ func (h Handlers) UploadAttachment(w http.ResponseWriter, r *http.Request) {
 	entityType := r.FormValue("entity_type")
 	if !crmcontracts.AttachmentEntityType(entityType).Valid() {
 		httperr.Write(w, r, httperr.Validation("entity_type", "invalid_enum",
-			"entity_type must be one of person, company, deal, activity, lead"))
+			"entity_type must be one of person, company, deal, activity, lead, project"))
 		return
 	}
 	entityID, err := ids.Parse(r.FormValue("entity_id"))

--- a/backend/internal/modules/activities/uploadgrantorder_test.go
+++ b/backend/internal/modules/activities/uploadgrantorder_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// The refusal must cost the SERVER nothing, which is a claim about order and
+// not about the status code.
+//
+// The store's gate is the one that decides, and it decides after the multipart
+// parse: the object type arrives inside the body. So a session holding no write
+// grant anywhere used to spend one request and make this server parse and spill
+// a whole file before answering 403 — repeatable, and free to the caller. These
+// hold the early refusal in front of that, in BOTH directions: a caller it turns
+// away never had its body read, and a caller it admits is not turned away.
+
+// watchedBody reports whether anything read it. A bare flag is enough: the
+// question is whether the parse ran at all, not how much of it did.
+type watchedBody struct {
+	r    io.Reader
+	read bool
+}
+
+func (b *watchedBody) Read(p []byte) (int, error) {
+	b.read = true
+	return b.r.Read(p)
+}
+
+func uploadRequest(t *testing.T, p principal.Principal) (*httptest.ResponseRecorder, *watchedBody) {
+	t.Helper()
+	body := &watchedBody{r: strings.NewReader("--x\r\nnot a well-formed part\r\n--x--\r\n")}
+	req := httptest.NewRequest(http.MethodPost, "/v1/attachments", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=x")
+	req = req.WithContext(principal.WithActor(req.Context(), p))
+	rec := httptest.NewRecorder()
+	Handlers{}.WithUploadLimit(25<<20).UploadAttachment(rec, req)
+	return rec, body
+}
+
+func TestAnUploadFromAGrantlessSessionIsRefusedBeforeItsBodyIsRead(t *testing.T) {
+	rec, body := uploadRequest(t, principal.Principal{
+		Type: principal.PrincipalHuman,
+		// A reader: every grant this session holds is a read, so no object type
+		// the body could name would admit the write.
+		Permissions: principal.Permissions{Objects: map[string]principal.ObjectGrant{
+			"person":   {Read: true},
+			"activity": {Read: true},
+		}},
+	})
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("a session with no write grant anywhere got %d, want 403", rec.Code)
+	}
+	if body.read {
+		t.Error("the refusal read the body first, which is the whole cost it exists to avoid: " +
+			"the grant check has to run in front of the multipart parse, not behind it")
+	}
+}
+
+func TestAnUploadFromASessionThatMayWriteSomethingReachesTheParse(t *testing.T) {
+	// The early check is deliberately coarse — it cannot know which object the
+	// body names — so its one failure mode is refusing a caller the store would
+	// have admitted. This is that direction: a grant on ANY object type is
+	// enough to get past it, and the body is read.
+	rec, body := uploadRequest(t, principal.Principal{
+		Type: principal.PrincipalHuman,
+		Permissions: principal.Permissions{Objects: map[string]principal.ObjectGrant{
+			"person": {Read: true, Update: true},
+		}},
+	})
+
+	if !body.read {
+		t.Fatal("a session holding a write grant never reached the parse, so the early " +
+			"refusal is turning away callers the store would admit")
+	}
+	if rec.Code == http.StatusForbidden {
+		t.Errorf("the early check refused a session that may write: %s", rec.Body.String())
+	}
+}

--- a/backend/internal/modules/knowledge/handlers.go
+++ b/backend/internal/modules/knowledge/handlers.go
@@ -14,10 +14,12 @@ import (
 	"net/http"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // Handlers is the knowledge module's transport surface.
@@ -141,6 +143,15 @@ func (h Handlers) UploadCorpusDocument(w http.ResponseWriter, r *http.Request, i
 	}
 	if h.queue == nil {
 		httperr.Write(w, r, errIngestUnavailable)
+		return
+	}
+	// THE GRANT, BEFORE THE BYTES. The store asks this same question, and asks
+	// it again where it decides — but it asks after the parse, so without this
+	// a session that may not file a document still made the server take one
+	// apart and spill it to disk before being refused. The import lane
+	// (compose.stageImportSource) has always had it in this order.
+	if err := auth.Require(r.Context(), "knowledge_document", principal.ActionCreate); err != nil {
+		httperr.Write(w, r, err)
 		return
 	}
 	// The same ceiling the chassis already applied, applied again: it is what

--- a/backend/internal/modules/people/handlers_linkedin.go
+++ b/backend/internal/modules/people/handlers_linkedin.go
@@ -14,6 +14,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -67,6 +68,14 @@ func (h Handlers) ImportLinkedInConnections(w http.ResponseWriter, r *http.Reque
 		// Our fault, not the caller's: nobody wired the ceiling. Carrying on
 		// with a zero bound would refuse their export and blame its size.
 		httperr.Write(w, r, errUploadLimitUnset)
+		return
+	}
+	// THE GRANT, BEFORE THE BYTES. The store asks for exactly this and keeps
+	// asking — but it asks after the parse, so a session that may not create a
+	// person still made the server take a whole export apart and spill it
+	// before being refused, once per request and free to the sender.
+	if err := auth.Require(r.Context(), entityPerson, principal.ActionCreate); err != nil {
+		httperr.Write(w, r, err)
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, h.uploadLimit)

--- a/backend/internal/modules/people/handlers_person.go
+++ b/backend/internal/modules/people/handlers_person.go
@@ -11,9 +11,11 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // MergePerson: POST /people/{id}/merge — merge this person (A, the path id)
@@ -108,6 +110,19 @@ func (h Handlers) CreatePerson(w http.ResponseWriter, r *http.Request, _ crmcont
 // half of one endpoint where nobody looks for it. The ceiling the parse runs
 // under is granted to this route in compose.uploadCeilings.
 func (h Handlers) ImportVCards(w http.ResponseWriter, r *http.Request) {
+	// THE GRANTS, BEFORE THE BYTES, and both of them because the import needs
+	// both: it creates the people no card matches and updates the ones a card
+	// does. The store asks for the pair and keeps asking — but it asks after
+	// the parse, so a session holding neither still made the server take a
+	// whole address book apart before being refused.
+	if err := auth.Require(r.Context(), entityPerson, principal.ActionCreate); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	if err := auth.Require(r.Context(), entityPerson, principal.ActionUpdate); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
 	// upload:route /v1/people/vcard-import — the ceiling this parse runs under
 	// is granted to that path in compose.uploadCeilings, and
 	// TestEveryMultipartParseNamesItsRoute holds the two together. What is

--- a/backend/internal/platform/auth/rbac.go
+++ b/backend/internal/platform/auth/rbac.go
@@ -101,6 +101,42 @@ func RequireAny(ctx context.Context, object string, actions ...principal.Action)
 	return fmt.Errorf("%s.%s: %w", object, strings.Join(verbs, "|"), apperrors.ErrPermissionDenied)
 }
 
+// RequireAnyObject admits when the actor holds the action on AT LEAST ONE
+// object type. It is the upfront half of a pair, in RequireAny's sense and for
+// the mirror reason: RequireAny knows the object and not yet the action, this
+// knows the action and not yet the object.
+//
+// Where the object is unknowable is a multipart upload. The object type arrives
+// INSIDE the body, so the handler cannot ask the exact question until it has
+// parsed the bytes — and parsing them is the cost. That made a refusal the
+// expensive answer: a session holding no write grant anywhere could spend one
+// request and make the server spend a whole file, every time, and still be
+// refused. This is what the handler can ask BEFORE reading, and a caller it
+// turns away is one the exact check would have turned away too, whatever object
+// the body went on to name.
+//
+// Deliberately coarse, and never a substitute for the specific check. The store
+// still requires the action on the object the body actually named, because the
+// store is the gate every transport passes.
+func RequireAnyObject(ctx context.Context, action principal.Action) error {
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return err
+	}
+	if err := refuseBuyer(p, string(action)); err != nil {
+		return err
+	}
+	if p.Type == principal.PrincipalSystem {
+		return nil
+	}
+	for object := range p.Permissions.Objects {
+		if p.Permissions.Allows(object, action) {
+			return nil
+		}
+	}
+	return fmt.Errorf("*.%s: %w", action, apperrors.ErrPermissionDenied)
+}
+
 // UpsertAction names the grant an upsert actually demands once it knows
 // which half it is: create for a row it inserts, update for a row it
 // replaces. Keeping the mapping here means the two upsert sites that admit

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -331,7 +331,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 | `writeliveness_test.go` | H2 | The LIVENESS obligation as a fitness function: a write that targets one standing row of a table which can be archived either REFUSES an archived row, DECLARES that it deliberately reaches one, or is ratified with a reason. |
 
-## Prohibition (54)
+## Prohibition (55)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -387,6 +387,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `txseamacquire_test.go` | H2 | Code that runs on a caller's `pgx.Tx` acquires no connection of its own. |
 | `undoabledatecolumns_test.go` | H2 | A `date` column's audit image is written in Postgres's own spelling of a date. |
 | `unitegress_test.go` | H2 | A unit dials through the installation's egress policy, not through a copy of it. |
+| `uploadauthorder_test.go` | H1 | An upload route refuses an unauthorized caller BEFORE it reads the body. |
 | `waiveronoffender_test.go` | H2 | A waiver must be asked about an offender, never about a candidate. |
 | `workflowhandler_test.go` | H2 | The workflow.Handler read/write contract as a fitness function (ports/workflow.Handler): Match is a pure predicate and Plan computes the typed Effect WITHOUT applying it — "this is what makes dry-run and diff preview possible". |
 


### PR DESCRIPTION
Closes #1567 — item 1 of the ruling, widened to every route with the same defect. Items 2 and 3 are not in here; why is at the bottom.

## The defect, and that it was not one route

The ruling named the attachment upload: `auth.Require` sits in the store, the store runs after the handler, and the handler's first act is `ParseMultipartForm`. So a session holding **no grant on any object type** spends one request and makes the server parse and spill a whole file before answering 403 — a free amplifier, repeatable.

Checking the other multipart parses in the tree, three more had the same shape:

| route | authorized before the parse? |
|---|---|
| `POST /v1/imports/sources` | **yes** — `stageImportSource` requires `import_run.create` first |
| `POST /v1/company/logo{,/icon}` | **yes** — reads the anchor company first, which requires `company.read` |
| `POST /v1/attachments` | no |
| `POST /v1/knowledge/corpora/{id}/documents` | no |
| `POST /v1/me/linkedin-connections` | no |
| `POST /v1/people/vcard-import` | no |

The import lane is the exemplar; the other three are the same bug two modules over. Fixing only the one under review is the catch `AGENTS.md` names as the recurring reviewer finding, so all four go in one change.

## What each now asks

Three of them can ask **exactly** what their store asks, so the early check cannot refuse anybody the store would admit:

- vCard import — `person.create` **and** `person.update`, because `importCardsFrom` requires both: it creates the people no card matches and updates the ones a card does.
- LinkedIn import — `person.create`.
- Corpus document — `knowledge_document.create`.

The attachment upload cannot: **the object type arrives inside the body it has not parsed yet.** So it asks the coarse half — may this caller write anything at all — through a new `auth.RequireAnyObject`, the mirror of the existing `RequireAny` (which knows the object and not yet the action; this knows the action and not yet the object). A caller it turns away holds no write grant anywhere, so the store would have refused it whatever object the body went on to name.

**None of this moves the gate.** Every store keeps the check it had, because the store is the gate every transport passes. These are early refusals.

## Held by a fitness function, not by four call sites

`backend/gates/uploadauthorder_test.go` — `TestEveryMultipartParseRefusesBeforeItReads`. It derives its subject from the tree (any function containing `ParseMultipartForm` or `MultipartReader`), so a seventh upload route is in the obligation set the moment it is written rather than when someone remembers. It checks **order**, not presence: moving a check below the parse fails it, which is how it was mutation-checked.

The two parses whose authorization belongs to their caller are waived by name, each entry naming that caller so the claim can be checked; a waiver no parse reaches is reported stale rather than left to sit.

And the attachment handler's ordering is held as behaviour too, in both directions — the direction that matters for a coarse check is the second one:

- a grantless session gets 403 and its body is **never read**;
- a session that may write *something* still reaches the parse, so the coarse check is not turning away callers the store would admit.

## What is deliberately not here

**Item 2, the per-principal concurrency bound.** The ruling says to build it on the Redis limiter from #495 "rather than an in-process counter, or it will be the next thing to multiply by replica count". #495 is still open and `platform/ratelimit` is still the in-process fixed-window limiter — and it is a *rate* limiter, where item 2 wants a *concurrency* bound. Building it here means either building the thing #495 is about, or building exactly what that issue says not to. It waits on #495.

**Item 3, the per-workspace quota.** As ruled: it needs a number nobody has chosen, and it is a product decision.

**One thing fixed on the way**: the attachment handler's `entity_type` refusal listed five types and the enum has six — `project` was missing from the message, so a caller uploading against a project was told their valid value was invalid.

## Checks

`make check-backend` green, `make craft-static` 0/0/0. The gate inventory page and the fixture-annotation pin move with the new gate, as their own gates require.