### PR TITLE
A reviewer can read the refusal they are being asked to decide

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -13340,6 +13340,44 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/DataSubjectRequest' }
+  /communication-reviews:
+    get:
+      tags: [Communication]
+      operationId: listCommunicationReviews
+      security: [ { cookieAuth: [] } ]   # human session only — the rows name other people's addresses
+      x-agent-access: human-only
+      summary: Refused sends waiting on somebody who may decide them.
+      description: |
+        The reviewer's own queue: every refused send a rep has handed on, oldest first.
+
+        Gated on `communication_exception` at `read`, which is the verb for SEEING refusals rather
+        than acting on them: directing a send takes `create`, and an installation can grant the
+        first without the second. The rows name other people's recipient addresses and why each was
+        refused, so a seat without that grant is not shown them.
+
+        Installation-wide, with no team or ownership narrowing. Granting the read verb means
+        trusting that seat with every refused send in the installation.
+
+        EVERY WAITING REVIEW, not only the ones routed to the caller. Routing names no assignee: a
+        rep asks the installation rather than a colleague, and whoever holds the authority answers.
+        An assignee-scoped list would leave a card nobody could find the moment the person it named
+        went on leave.
+
+        Bounded. A list at its limit has more behind it, and `total` says so rather than leaving the
+        caller to discover it.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 100, default: 100 }
+      responses:
+        '200':
+          description: What is waiting.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CommunicationReviewList' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
   /communication-reviews/{id}:
     parameters:
       - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
@@ -13354,11 +13392,18 @@ paths:
         is how a rep opens it: what was refused, which recipient it was refused for, and the reason
         each one carries.
 
-        SCOPED TO THE INITIATOR. The row names the recipients of somebody's message and the reason
-        each was refused, which is a fact about those people — so this serves the person who pressed
-        Send and nobody else. A review belonging to somebody else answers 404 rather than 403,
-        because "forbidden" would confirm the id exists and that is itself a disclosure about a
-        message the caller may not see.
+        TWO DOORS OPEN THIS ROW. The initiator, because it is their message. A holder of
+        `communication_exception` at `read`, because they are the person being asked to decide it —
+        a reviewer handed a card who could not read the refusal behind it would be acknowledging a
+        warning about a message they had never seen.
+
+        That second door is installation-wide and worth stating plainly: granting somebody the read
+        verb hands them every refused send in the installation, with the recipient addresses and the
+        reason each was refused. There is no team or ownership narrowing on it. Reading is not
+        routing — handing a review on stays the initiator's own action.
+
+        A caller holding neither door receives 404 rather than 403, because "forbidden" would
+        confirm the id exists and disclose a message the caller may not see.
 
         Human-only. An agent that could read these would enumerate one seat's refused correspondence.
       responses:
@@ -39825,6 +39870,27 @@ components:
           type: array
           description: What was refused, per recipient. Empty once an erasure has cleared the subject from it.
           items: { $ref: '#/components/schemas/RefusedRecipient' }
+        approval_id:
+          type: [string, 'null']
+          format: uuid
+          description: |
+            The card a routed review was handed to, so a decider reading this can find the decision
+            they are being asked to make. Null on a review nobody has asked about, which is most of
+            them.
+
+    CommunicationReviewList:
+      type: object
+      description: A page of refused sends waiting for a decision.
+      required: [data, total]
+      properties:
+        data:
+          type: array
+          items: { $ref: '#/components/schemas/CommunicationReview' }
+        total:
+          type: integer
+          description: |
+            How many are waiting in total. A page at its limit has more behind it, and this is how
+            the caller knows rather than by discovering it.
 
     RequestCommunicationDecisionRequest:
       type: object

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -211,6 +211,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/commissions":                                                {Op: "listCommissionEntries", Access: "tool", Tool: "list_records", RecordType: "commission", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/commissions/summary":                                        {Op: "getCommissionSummary", Access: "tool", Tool: "run_report", RecordType: "commission", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/commissions/{id}":                                           {Op: "getCommissionEntry", Access: "tool", Tool: "read_record", RecordType: "commission", Tier: "auto_execute", Scope: "read"},
+	"GET /v1/communication-reviews":                                      {Op: "listCommunicationReviews", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/communication-reviews/{id}":                                 {Op: "getCommunicationReview", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/companies":                                                  {Op: "listCompanies", Access: "tool", Tool: "list_records", RecordType: "company", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/companies/{id}":                                             {Op: "getCompany", Access: "tool", Tool: "read_record", RecordType: "company", Tier: "auto_execute", Scope: "read"},

--- a/backend/internal/compose/integration/refused_send_review_integration_test.go
+++ b/backend/internal/compose/integration/refused_send_review_integration_test.go
@@ -669,10 +669,17 @@ func TestTheRepCanOpenTheReviewTheirRefusalNamed(t *testing.T) {
 	}
 }
 
-// A REVIEW BELONGING TO SOMEBODY ELSE IS NOT FOUND, not forbidden. The row
-// names the recipients of another person's message and why each was refused,
-// which is a fact about those people — and "forbidden" would confirm the id
-// exists, which is itself a disclosure about a message the caller may not see.
+// A REVIEW NOBODY HAS GIVEN THIS CALLER A REASON TO SEE IS NOT FOUND, not
+// forbidden. The row names the recipients of another person's message and why
+// each was refused, which is a fact about those people — and "forbidden" would
+// confirm the id exists, which is itself a disclosure about a message the
+// caller may not see.
+//
+// TWO DOORS OPEN THIS ROW and this test closes both. The caller is not the
+// initiator, because the review is reassigned; and they cannot decide refused
+// sends, because the grant is removed. A decider reading somebody else's
+// refusal is the reviewer path and has its own test — what must not happen is a
+// seat holding neither door seeing anything at all.
 func TestAnotherSeatsReviewIsNotFound(t *testing.T) {
 	c := setupConsent(t)
 
@@ -697,6 +704,14 @@ func TestAnotherSeatsReviewIsNotFound(t *testing.T) {
 		`UPDATE communication_review SET initiated_by = $1 WHERE id = $2`,
 		other, reviews[0].id); err != nil {
 		t.Fatalf("reassigning the review: %v", err)
+	}
+	// And the caller cannot decide refused sends either, which is the other
+	// door. The fixture signs in as an admin, who holds that grant by default.
+	if _, err := c.Owner.Exec(context.Background(), `
+		UPDATE role SET permissions = jsonb_set(
+			permissions, '{objects,communication_exception}',
+			'{"create":false,"read":false,"update":false,"delete":false}'::jsonb, true)`); err != nil {
+		t.Fatalf("removing the decider grant: %v", err)
 	}
 
 	if status := c.Call(t, "GET", "/v1/communication-reviews/"+reviews[0].id,

--- a/backend/internal/compose/integration/reviewdecision_integration_test.go
+++ b/backend/internal/compose/integration/reviewdecision_integration_test.go
@@ -265,3 +265,177 @@ func TestDirectingAReviewRetractsTheCardItWasRoutedTo(t *testing.T) {
 			"— approving it would record a second decision for one send")
 	}
 }
+
+// A DECIDER CAN READ THE REFUSAL THEY ARE BEING ASKED ABOUT.
+//
+// This is the gap the routing slice left. The approve button worked and the
+// thing it was about answered 404, because reading a review was scoped to the
+// person who pressed send. A reviewer acknowledged a warning about a message
+// they had never seen, which is the one thing an acknowledgement must not be.
+func TestADeciderCanReadTheRefusalTheyAreAskedAbout(t *testing.T) {
+	c := setupConsent(t)
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send → %d, want 409", status)
+	}
+	review := liveReviewID(t, c)
+	if status := c.Call(t, "POST", "/v1/communication-reviews/"+review+"/request-decision",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("routing the review → %d, want 201", status)
+	}
+
+	// The review is readable, and it carries what a decider needs: what was
+	// refused, for whom, and the card the question is on.
+	var opened struct {
+		State      string `json:"state"`
+		ReasonCode string `json:"reason_code"`
+		ApprovalID string `json:"approval_id"`
+		Refusals   []struct {
+			Address string `json:"address"`
+		} `json:"refusals"`
+	}
+	if status := c.Call(t, "GET", "/v1/communication-reviews/"+review, nil, nil, &opened); status != http.StatusOK {
+		t.Fatalf("reading the routed review → %d, want 200 — a decider cannot see what they are "+
+			"being asked to decide", status)
+	}
+	if opened.State != "awaiting_decision" {
+		t.Errorf("the review reads %q, want awaiting_decision", opened.State)
+	}
+	if len(opened.Refusals) == 0 {
+		t.Error("the review names no recipient, so a decider is told a message was refused and " +
+			"not who for")
+	}
+	if opened.ApprovalID == "" {
+		t.Error("the review names no card, so a decider reading it cannot find the decision they " +
+			"are being asked to make")
+	}
+}
+
+// THE QUEUE SHOWS WHAT IS WAITING.
+func TestTheDecidersQueueListsWhatIsWaiting(t *testing.T) {
+	c := setupConsent(t)
+
+	var listed struct {
+		Data  []struct{ ID string } `json:"data"`
+		Total int                   `json:"total"`
+	}
+	if status := c.Call(t, "GET", "/v1/communication-reviews", nil, nil, &listed); status != http.StatusOK {
+		t.Fatalf("reading the queue → %d, want 200", status)
+	}
+	if listed.Total != 0 {
+		t.Fatalf("%d waiting before anything was routed, want 0", listed.Total)
+	}
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send → %d, want 409", status)
+	}
+	review := liveReviewID(t, c)
+
+	// A refusal nobody has asked about is NOT in the decider's queue. It is the
+	// rep's own work until they hand it on.
+	if status := c.Call(t, "GET", "/v1/communication-reviews", nil, nil, &listed); status != http.StatusOK {
+		t.Fatalf("reading the queue → %d", status)
+	}
+	if listed.Total != 0 {
+		t.Errorf("%d waiting before the rep asked anybody, want 0 — an unrouted refusal is not "+
+			"somebody else's work", listed.Total)
+	}
+
+	if status := c.Call(t, "POST", "/v1/communication-reviews/"+review+"/request-decision",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("routing the review → %d, want 201", status)
+	}
+	if status := c.Call(t, "GET", "/v1/communication-reviews", nil, nil, &listed); status != http.StatusOK {
+		t.Fatalf("reading the queue → %d", status)
+	}
+	if listed.Total != 1 || len(listed.Data) != 1 {
+		t.Fatalf("%d waiting after one ask (%d listed), want 1", listed.Total, len(listed.Data))
+	}
+	if listed.Data[0].ID != review {
+		t.Errorf("the queue holds review %s and %s was routed", listed.Data[0].ID, review)
+	}
+
+	// Once the message goes, the work is done and the queue says so.
+	if status := c.Call(t, "POST", "/v1/communication-reviews/"+review+"/direct-send",
+		directed(), nil, nil); status != http.StatusCreated {
+		t.Fatalf("directing the send → %d, want 201", status)
+	}
+	if status := c.Call(t, "GET", "/v1/communication-reviews", nil, nil, &listed); status != http.StatusOK {
+		t.Fatalf("reading the queue → %d", status)
+	}
+	if listed.Total != 0 {
+		t.Errorf("%d still waiting after the message went, want 0 — a decider would be shown "+
+			"work that is done", listed.Total)
+	}
+}
+
+// A SEAT THAT CANNOT DECIDE SEES NOTHING, and that is the disclosure question
+// this queue turns on: the rows name other people's refused correspondence.
+func TestASeatThatCannotDecideIsNotShownTheQueue(t *testing.T) {
+	c := setupConsent(t)
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send → %d, want 409", status)
+	}
+	if status := c.Call(t, "POST", "/v1/communication-reviews/"+liveReviewID(t, c)+"/request-decision",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("routing the review → %d, want 201", status)
+	}
+
+	// The seat loses the grant that makes somebody a decider.
+	if _, err := c.Owner.Exec(context.Background(), `
+		UPDATE role SET permissions = jsonb_set(
+			permissions, '{objects,communication_exception}',
+			'{"create":false,"read":false,"update":false,"delete":false}'::jsonb, true)`); err != nil {
+		t.Fatalf("removing the grant: %v", err)
+	}
+	if status := c.Call(t, "GET", "/v1/communication-reviews", nil, nil, nil); status == http.StatusOK {
+		t.Error("a seat that cannot direct a send was handed the queue of refused messages — " +
+			"other people's correspondence, to somebody with no reason to see it")
+	}
+}
+
+// READING AND ROUTING ARE DIFFERENT DOORS, and routing is the narrow one.
+//
+// A decider must be able to READ any refusal they are asked about — that is the
+// gap this slice closed. Routing is not the same act: a seat that could route
+// anybody's review would be raising cards about other people's correspondence,
+// and somebody holding the exception grant can direct the send themselves
+// rather than asking a colleague to.
+//
+// So routing stays bound to the person whose message it was. This pins that: a
+// review belonging to nobody in this session cannot be routed, even by a seat
+// that may read every review in the installation.
+func TestRoutingStaysBoundToThePersonWhoseMessageItWas(t *testing.T) {
+	c := setupConsent(t)
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send → %d, want 409", status)
+	}
+	review := liveReviewID(t, c)
+
+	// The review is re-pointed at somebody else. The caller keeps the exception
+	// grant — so they can still READ it — and is no longer its initiator.
+	var other string
+	if err := c.Owner.QueryRow(context.Background(), `
+		INSERT INTO app_user (email, display_name, status, seat_type, password_hash)
+		VALUES ('other-rep@consent.test', 'Other Rep', 'active', 'full', 'x')
+		RETURNING id::text`).Scan(&other); err != nil {
+		t.Fatalf("creating the other seat: %v", err)
+	}
+	if _, err := c.Owner.Exec(context.Background(),
+		`UPDATE communication_review SET initiated_by = $1 WHERE id = $2`, other, review); err != nil {
+		t.Fatalf("re-pointing the review: %v", err)
+	}
+
+	// Readable, because the caller may decide refused sends.
+	if status := c.Call(t, "GET", "/v1/communication-reviews/"+review, nil, nil, nil); status != http.StatusOK {
+		t.Fatalf("reading somebody else's review as a decider → %d, want 200", status)
+	}
+	// And not routable, because it is not their message to hand on.
+	if status := c.Call(t, "POST", "/v1/communication-reviews/"+review+"/request-decision",
+		AnyMap{}, nil, nil); status == http.StatusCreated {
+		t.Error("a seat routed somebody else's refusal — raising a card about correspondence " +
+			"that is not theirs")
+	}
+}

--- a/backend/internal/compose/integration/reviewqueue_integration_test.go
+++ b/backend/internal/compose/integration/reviewqueue_integration_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestReviewQueueTotalIncludesRowsBeyondTheLimit(t *testing.T) {
+	c := setupConsent(t)
+	for i := range 2 {
+		if status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", AnyMap{
+			"subject": fmt.Sprintf("Refused message %d", i), "body": "answer",
+			"to": []string{"subject@consent.test"}, "consent_purpose": "marketing_email",
+		}, nil, nil); status != http.StatusConflict {
+			t.Fatalf("refusing a send: status %d, want 409", status)
+		}
+		var reviewID string
+		if err := c.Owner.QueryRow(context.Background(), `
+			SELECT id::text FROM communication_review
+			WHERE state <> 'awaiting_decision' AND resolved_at IS NULL`).Scan(&reviewID); err != nil {
+			t.Fatalf("reading the new refusal: %v", err)
+		}
+		if status := c.Call(t, "POST", "/v1/communication-reviews/"+reviewID+"/request-decision",
+			AnyMap{}, nil, nil); status != http.StatusCreated {
+			t.Fatalf("routing a refusal: status %d, want 201", status)
+		}
+	}
+
+	for _, limit := range []int{1, 0, -1, 101, 2147483647} {
+		t.Run(fmt.Sprint(limit), func(t *testing.T) {
+			var listed struct {
+				Data  []struct{ ID string } `json:"data"`
+				Total int                   `json:"total"`
+			}
+			path := fmt.Sprintf("/v1/communication-reviews?limit=%d", limit)
+			if status := c.Call(t, "GET", path, nil, nil, &listed); status != http.StatusOK {
+				t.Fatalf("reading the queue: status %d, want 200", status)
+			}
+			wantRows := 2
+			if limit == 1 {
+				wantRows = 1
+			}
+			if len(listed.Data) != wantRows || listed.Total != 2 {
+				t.Errorf("queue has %d rows and total %d, want %d rows and total 2",
+					len(listed.Data), listed.Total, wantRows)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -571,6 +571,10 @@ func (stubs) DecideCommissionEntry(w nethttp.ResponseWriter, r *nethttp.Request,
 	httperr.NotImplemented(w, r, "DecideCommissionEntry")
 }
 
+func (stubs) ListCommunicationReviews(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.ListCommunicationReviewsParams) {
+	httperr.NotImplemented(w, r, "ListCommunicationReviews")
+}
+
 func (stubs) GetCommunicationReview(w nethttp.ResponseWriter, r *nethttp.Request, id openapi_types.UUID) {
 	httperr.NotImplemented(w, r, "GetCommunicationReview")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21053,6 +21053,11 @@ type CommunicationEvidence struct {
 // given — a reader asking why a message was refused on Tuesday needs Tuesday's answer, not
 // what the consent rows say today.
 type CommunicationReview struct {
+	// ApprovalId The card a routed review was handed to, so a decider reading this can find the decision
+	// they are being asked to make. Null on a review nobody has asked about, which is most of
+	// them.
+	ApprovalId *openapi_types.UUID `json:"approval_id,omitempty"`
+
 	// DeliveryIntentId The held message this review can resume. A refused send freezes the message into a held
 	// `scheduled_send` — subject, body, recipients, attachments and the claimed purpose — so
 	// resolving the review fires what the rep wrote rather than something retyped from memory.
@@ -21090,6 +21095,15 @@ type CommunicationReviewKind string
 // somebody who may override it: their work no longer, so a surface should say so rather
 // than showing them a form they have already filled in.
 type CommunicationReviewState string
+
+// CommunicationReviewList A page of refused sends waiting for a decision.
+type CommunicationReviewList struct {
+	Data []CommunicationReview `json:"data"`
+
+	// Total How many are waiting in total. A page at its limit has more behind it, and this is how
+	// the caller knows rather than by discovering it.
+	Total int `json:"total"`
+}
 
 // Company A company. Mirrors the `company` table.
 type Company struct {
@@ -38907,6 +38921,11 @@ type DecideCommissionEntryParams struct {
 	IfMatch *IfMatch `json:"If-Match,omitempty"`
 }
 
+// ListCommunicationReviewsParams defines parameters for ListCommunicationReviews.
+type ListCommunicationReviewsParams struct {
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
 // ListCompaniesParams defines parameters for ListCompanies.
 type ListCompaniesParams struct {
 	// Cursor Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
@@ -52157,6 +52176,9 @@ type ServerInterface interface {
 	// Approve, pay, or void one entry.
 	// (POST /commissions/{id}/decide)
 	DecideCommissionEntry(w http.ResponseWriter, r *http.Request, id Id, params DecideCommissionEntryParams)
+	// Refused sends waiting on somebody who may decide them.
+	// (GET /communication-reviews)
+	ListCommunicationReviews(w http.ResponseWriter, r *http.Request, params ListCommunicationReviewsParams)
 	// What a refused send was refused for, and for whom.
 	// (GET /communication-reviews/{id})
 	GetCommunicationReview(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
@@ -54446,6 +54468,12 @@ func (_ Unimplemented) GetCommissionEntry(w http.ResponseWriter, r *http.Request
 // Approve, pay, or void one entry.
 // (POST /commissions/{id}/decide)
 func (_ Unimplemented) DecideCommissionEntry(w http.ResponseWriter, r *http.Request, id Id, params DecideCommissionEntryParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Refused sends waiting on somebody who may decide them.
+// (GET /communication-reviews)
+func (_ Unimplemented) ListCommunicationReviews(w http.ResponseWriter, r *http.Request, params ListCommunicationReviewsParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -62355,6 +62383,45 @@ func (siw *ServerInterfaceWrapper) DecideCommissionEntry(w http.ResponseWriter, 
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.DecideCommissionEntry(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListCommunicationReviews operation middleware
+func (siw *ServerInterfaceWrapper) ListCommunicationReviews(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListCommunicationReviewsParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListCommunicationReviews(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -84444,6 +84511,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/commissions/{id}/decide", wrapper.DecideCommissionEntry)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/communication-reviews", wrapper.ListCommunicationReviews)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/communication-reviews/{id}", wrapper.GetCommunicationReview)

--- a/backend/internal/modules/consent/handlers_review.go
+++ b/backend/internal/modules/consent/handlers_review.go
@@ -26,7 +26,7 @@ import (
 // that decided scope here would be a second answer to a question the store
 // already answers, and the two would disagree the first time either changed.
 func (h Handlers) GetCommunicationReview(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
-	review, err := h.store.ReviewForInitiator(r.Context(), ids.UUID(id))
+	review, err := h.store.ReviewForReader(r.Context(), ids.UUID(id))
 	if err != nil {
 		writeConsentErr(w, r, err)
 		return
@@ -75,6 +75,13 @@ func wireReview(review Review) crmcontracts.CommunicationReview {
 		intent := openapi_types.UUID(review.IntentID)
 		out.DeliveryIntentId = &intent
 	}
+	// Null rather than a zero uuid for the same reason the intent is: an id a
+	// caller could take to a lookup that answers not found reads as a broken
+	// reference rather than an absent one.
+	if !review.ApprovalID.IsZero() {
+		card := openapi_types.UUID(review.ApprovalID)
+		out.ApprovalId = &card
+	}
 	return out
 }
 
@@ -101,5 +108,31 @@ func (h Handlers) RequestCommunicationDecision(
 	}
 	httperr.WriteJSON(w, http.StatusCreated, crmcontracts.CommunicationDecisionRequested{
 		ApprovalId: openapi_types.UUID(approvalID),
+	})
+}
+
+// ListCommunicationReviews serves GET /communication-reviews.
+//
+// Wire-only, for GetCommunicationReview's reason: the store owns who may read
+// this queue, and a handler deciding it here would be a second answer to a
+// question the store already answers.
+func (h Handlers) ListCommunicationReviews(
+	w http.ResponseWriter, r *http.Request, params crmcontracts.ListCommunicationReviewsParams,
+) {
+	limit := 0
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	reviews, total, err := h.store.AwaitingDecision(r.Context(), limit)
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	out := make([]crmcontracts.CommunicationReview, 0, len(reviews))
+	for _, review := range reviews {
+		out = append(out, wireReview(review))
+	}
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.CommunicationReviewList{
+		Data: out, Total: total,
 	})
 }

--- a/backend/internal/modules/consent/instructionconsume.go
+++ b/backend/internal/modules/consent/instructionconsume.go
@@ -298,6 +298,9 @@ func (s *Store) HeldMessageForReview(ctx context.Context, reviewID ids.UUID) (id
 	if err := requireAPersonAtTheKeyboard(ctx); err != nil {
 		return ids.UUID{}, err
 	}
+	// CREATE here, not read: this lookup exists to serve DIRECTING a send, and
+	// it answers to the same grant that act does. Reading the review is its own
+	// door (ReviewForReader) and takes the read verb.
 	if err := auth.Require(ctx, entityCommunicationException, principal.ActionCreate); err != nil {
 		return ids.UUID{}, err
 	}

--- a/backend/internal/modules/consent/review.go
+++ b/backend/internal/modules/consent/review.go
@@ -89,6 +89,9 @@ type Review struct {
 	InitiatedBy ids.UUID
 	Refusals    []RefusedRecipient
 	ReasonCode  string
+	// ApprovalID is the card a routed review was handed to. Zero on a review
+	// nobody has asked about, which is most of them.
+	ApprovalID ids.UUID
 }
 
 // OpenReviewTx records one refusal, inside the transaction that refused.
@@ -164,23 +167,48 @@ func OpenReviewTx(ctx context.Context, tx pgx.Tx, set commsauthz.DecisionSet, in
 	return out, nil
 }
 
-// ReviewForInitiator reads one review back for the person who pressed send.
+// ReviewForReader reads one review back for somebody entitled to see it.
 //
-// GATED ON THE SEAT, not on a grant. A review names the recipients of somebody
-// else's message and the reason each was refused, which is a fact about those
-// people — so this slice serves the initiator alone. The reviewer worklist and
-// the exception-holder's view are their own slices, and each has its own
-// question to answer about who may see whose refusals.
+// TWO DOORS, and they answer different questions.
 //
-// A review belonging to somebody else answers NOT FOUND rather than forbidden,
-// for the reason every scoped read here does: "forbidden" tells a caller the id
+// THE INITIATOR, because it is their message. They pressed send, they were
+// refused, and the row is the record of what happened to them.
+//
+// THE EXCEPTION HOLDER, because they are the person being asked to decide it.
+// Until this, a reviewer handed a card could not read the refusal behind it:
+// the approve button worked and the thing it was about was a 404. They
+// acknowledged a warning about a message they had never seen, which is the one
+// thing an acknowledgement must not be.
+//
+// NOBODY ELSE. A review names the recipients of somebody's message and the
+// reason each was refused, which is a fact about those people rather than about
+// the sender — so a seat holding neither door sees nothing, and holding an
+// unrelated grant admits nothing.
+//
+// A review the caller may not see answers NOT FOUND rather than forbidden, for
+// the reason every scoped read here does: "forbidden" tells a caller the id
 // exists, which is itself a disclosure about a message they may not see.
-func (s *Store) ReviewForInitiator(ctx context.Context, id ids.UUID) (Review, error) {
-	if err := auth.RequireHuman(ctx); err != nil {
+func (s *Store) ReviewForReader(ctx context.Context, id ids.UUID) (Review, error) {
+	// A PERSON. auth.RequireHuman admits connectors, which run with the
+	// granting human's grants — so on the decider's door it would hand one
+	// seat's refused correspondence to anything holding their credentials.
+	// The initiator's own door is bounded by the seat either way.
+	if err := requireAPersonAtTheKeyboard(ctx); err != nil {
 		return Review{}, err
 	}
 	seat := initiatingSeat(ctx)
-	if seat.IsZero() {
+	// MAY THIS CALLER SEE REFUSED SENDS AT ALL. Asked once, here, rather than
+	// folded into the query: a grant check that lived in SQL would be a second
+	// place the RBAC answer is computed, and the two would disagree the first
+	// time either changed.
+	//
+	// READ, not create. The two verbs on this object are different authorities:
+	// create is who may act against the engine's answer about a person, read is
+	// who may SEE the queue of refusals. An installation can hand somebody the
+	// reviewer's view without thereby letting them override anything, and
+	// gating a read on the write grant would take that choice away.
+	decider := auth.Require(ctx, entityCommunicationException, principal.ActionRead) == nil
+	if seat.IsZero() && !decider {
 		return Review{}, apperrors.ErrNotFound
 	}
 	var out Review
@@ -188,17 +216,20 @@ func (s *Store) ReviewForInitiator(ctx context.Context, id ids.UUID) (Review, er
 		var payload []byte
 		err := tx.QueryRow(ctx, `
 			SELECT id, state, kind, coalesce(delivery_intent_id, '00000000-0000-0000-0000-000000000000'::uuid),
-			       refusals, reason_code
+			       refusals, reason_code,
+			       coalesce(approval_id, '00000000-0000-0000-0000-000000000000'::uuid),
+			       coalesce(initiated_by, '00000000-0000-0000-0000-000000000000'::uuid)
 			  FROM communication_review
-			 WHERE id = $1 AND initiated_by = $2`, id, seat).
-			Scan(&out.ID, &out.State, &out.Kind, &out.IntentID, &payload, &out.ReasonCode)
+			 WHERE id = $1
+			   AND (($2::uuid IS NOT NULL AND initiated_by = $2) OR $3)`, id, zeroSeatAsNull(seat), decider).
+			Scan(&out.ID, &out.State, &out.Kind, &out.IntentID, &payload, &out.ReasonCode,
+				&out.ApprovalID, &out.InitiatedBy)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}
 		if err != nil {
 			return fmt.Errorf("consent: reading the review: %w", err)
 		}
-		out.InitiatedBy = seat
 		return json.Unmarshal(payload, &out.Refusals)
 	})
 	return out, err
@@ -366,3 +397,55 @@ func (e *SendRefusedError) Unwrap() error { return e.Cause }
 //
 // The reference travels in the message instead, which is where a human reads
 // it and where the MCP surface renders it too.
+
+// ReviewForInitiator reads one review back for the person who pressed send, and
+// for nobody else.
+//
+// NARROWER THAN ReviewForReader ON PURPOSE. Reading a review is something a
+// decider must be able to do — they are being asked about it. ROUTING one is
+// not: a seat that could route anybody's review would be raising cards about
+// other people's correspondence, and an exception holder can already direct the
+// send themselves rather than asking somebody to.
+//
+// So the two doors stay separate, and the narrow one is what routing uses.
+func (s *Store) ReviewForInitiator(ctx context.Context, id ids.UUID) (Review, error) {
+	if err := auth.RequireHuman(ctx); err != nil {
+		return Review{}, err
+	}
+	seat := initiatingSeat(ctx)
+	if seat.IsZero() {
+		return Review{}, apperrors.ErrNotFound
+	}
+	var out Review
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		var payload []byte
+		err := tx.QueryRow(ctx, `
+			SELECT id, state, kind, coalesce(delivery_intent_id, '00000000-0000-0000-0000-000000000000'::uuid),
+			       refusals, reason_code
+			  FROM communication_review
+			 WHERE id = $1 AND initiated_by = $2`, id, seat).
+			Scan(&out.ID, &out.State, &out.Kind, &out.IntentID, &payload, &out.ReasonCode)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("consent: reading the review: %w", err)
+		}
+		out.InitiatedBy = seat
+		return json.Unmarshal(payload, &out.Refusals)
+	})
+	return out, err
+}
+
+// zeroSeatAsNull sends a seatless principal as SQL NULL.
+//
+// initiated_by is nullable — an erased or deleted seat leaves it so — and
+// comparing it against the zero uuid would be comparing two absences. NULL = x
+// is never true in Postgres, so this arm already matched nothing; sending NULL
+// says that on purpose rather than relying on it.
+func zeroSeatAsNull(seat ids.UUID) *ids.UUID {
+	if seat.IsZero() {
+		return nil
+	}
+	return &seat
+}

--- a/backend/internal/modules/consent/reviewaccess_test.go
+++ b/backend/internal/modules/consent/reviewaccess_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestReviewReadsRejectNonHumanPrincipalsWithExceptionGrants(t *testing.T) {
+	for _, actor := range []principal.Principal{
+		{Type: principal.PrincipalConnector, UserID: ids.NewV7()},
+		{Type: principal.PrincipalSystem},
+		{Type: principal.PrincipalAgent, UserID: ids.NewV7()},
+		{Type: principal.PrincipalBuyer, UserID: ids.NewV7()},
+	} {
+		t.Run(string(actor.Type), func(t *testing.T) {
+			actor.Permissions = principal.Permissions{
+				Objects: map[string]principal.ObjectGrant{
+					entityCommunicationException: {Create: true, Read: true},
+				},
+			}
+			ctx := principal.WithActor(context.Background(), actor)
+			// Admission must refuse before attempting any database access.
+			store := NewStore(nil)
+			if _, err := store.ReviewForReader(ctx, ids.NewV7()); !errors.Is(err, apperrors.ErrPermissionDenied) {
+				t.Errorf("reading a review: %v, want permission denied", err)
+			}
+			if _, _, err := store.AwaitingDecision(ctx, 100); !errors.Is(err, apperrors.ErrPermissionDenied) {
+				t.Errorf("reading the queue: %v, want permission denied", err)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/consent/reviewreader_integration_test.go
+++ b/backend/internal/modules/consent/reviewreader_integration_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+func TestReadingAnotherPersonsReviewPreservesItsInitiator(t *testing.T) {
+	e := setupChannelConsent(t)
+	var opened Review
+	err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		var err error
+		opened, err = OpenReviewTx(e.ctx, tx, commsauthz.DecisionSet{
+			Decisions: []commsauthz.Decision{{
+				Recipient:  connector.Recipient{Email: "anna@example.test"},
+				Verdict:    commsauthz.VerdictDeny,
+				ReasonCode: "marketing_objection",
+			}},
+		}, ids.Nil)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("opening a refused send: %v", err)
+	}
+
+	reader := directorCtx(e.ws, ids.NewV7())
+	read, err := e.store.ReviewForReader(reader, opened.ID)
+	if err != nil {
+		t.Fatalf("reading another person's review: %v", err)
+	}
+	if read.InitiatedBy != e.user {
+		t.Errorf("initiator = %s, want sender %s", read.InitiatedBy, e.user)
+	}
+	if len(read.Refusals) != 1 || read.Refusals[0].Address != "anna@example.test" {
+		t.Fatalf("refusals = %+v, want the sender's refused recipient", read.Refusals)
+	}
+
+	// This is the value the initiator's ON DELETE SET NULL leaves behind.
+	if _, err := e.owner.Exec(e.ctx,
+		`UPDATE communication_review SET initiated_by = NULL WHERE id = $1`, opened.ID); err != nil {
+		t.Fatalf("clearing the review's initiator: %v", err)
+	}
+	read, err = e.store.ReviewForReader(reader, opened.ID)
+	if err != nil {
+		t.Fatalf("reading a review whose initiator is gone: %v", err)
+	}
+	if !read.InitiatedBy.IsZero() {
+		t.Errorf("absent initiator = %s, want zero", read.InitiatedBy)
+	}
+}

--- a/backend/internal/modules/consent/reviewroute.go
+++ b/backend/internal/modules/consent/reviewroute.go
@@ -27,6 +27,7 @@ package consent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // FieldReviewID is the review's name on the wire, in an audit payload and in a
@@ -280,3 +282,79 @@ func ReturnToAskerTx(ctx context.Context, tx pgx.Tx, reviewID ids.UUID, why stri
 		map[string]any{fieldStatus: ReviewNeedsContext, "returned_because": why})
 	return err
 }
+
+// AwaitingDecision lists the refused sends waiting on somebody who may decide
+// them.
+//
+// THE DECIDER'S OWN QUEUE, and gated on the grant that makes them one. A seat
+// that cannot direct a send has nothing to do with this list, and handing it to
+// them would be disclosing other people's refused correspondence to somebody
+// with no reason to see it.
+//
+// EVERY WAITING REVIEW, not only the ones routed to them personally. Routing
+// names no assignee: a rep asks the installation, not a colleague, and whoever
+// holds the authority answers. An assignee-scoped list would leave a card
+// nobody could find the moment the person it named went on leave.
+//
+// BOUNDED, because a queue read has to answer in time whatever the backlog is.
+// A list at its limit is a list with more behind it, and the caller is told so
+// by the count rather than by discovering it.
+func (s *Store) AwaitingDecision(ctx context.Context, limit int) ([]Review, int, error) {
+	// A PERSON, not merely a principal auth.RequireHuman admits. That check
+	// refuses buyers and agents and lets CONNECTORS through, and a connector
+	// runs with the granting human's own grants — so it would hold whatever
+	// this queue is gated on and could read the installation's refused
+	// correspondence wholesale. This list is a person's work queue.
+	if err := requireAPersonAtTheKeyboard(ctx); err != nil {
+		return nil, 0, err
+	}
+	// READ rather than create, for ReviewForReader's reason: seeing the queue
+	// and overriding the engine are different authorities, and an installation
+	// can grant the first without the second.
+	if err := auth.Require(ctx, entityCommunicationException, principal.ActionRead); err != nil {
+		return nil, 0, err
+	}
+	if limit <= 0 || limit > maxAwaitingDecision {
+		limit = maxAwaitingDecision
+	}
+	var out []Review
+	var total int
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// Count and page share a statement snapshot, even when another person
+		// routes or resolves a review while this request is reading.
+		rows, err := tx.Query(ctx, `
+			SELECT id, state, kind,
+			       coalesce(delivery_intent_id, '00000000-0000-0000-0000-000000000000'::uuid),
+			       refusals, reason_code,
+			       coalesce(initiated_by, '00000000-0000-0000-0000-000000000000'::uuid),
+			       coalesce(approval_id, '00000000-0000-0000-0000-000000000000'::uuid),
+			       count(*) OVER ()
+			  FROM communication_review
+			 WHERE state = 'awaiting_decision' AND resolved_at IS NULL
+			 ORDER BY opened_at
+			 LIMIT $1`, limit)
+		if err != nil {
+			return fmt.Errorf("consent: reading the refused sends waiting for a decision: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var r Review
+			var payload []byte
+			if err := rows.Scan(&r.ID, &r.State, &r.Kind, &r.IntentID, &payload,
+				&r.ReasonCode, &r.InitiatedBy, &r.ApprovalID, &total); err != nil {
+				return fmt.Errorf("consent: reading a waiting review: %w", err)
+			}
+			if err := json.Unmarshal(payload, &r.Refusals); err != nil {
+				return fmt.Errorf("consent: reading what a waiting review was refused for: %w", err)
+			}
+			out = append(out, r)
+		}
+		return rows.Err()
+	})
+	return out, total, err
+}
+
+// maxAwaitingDecision bounds one page of the queue. Oldest first, so a backlog
+// is worked from the end that has been waiting longest rather than from
+// whichever rows the planner happened to reach.
+const maxAwaitingDecision = 100

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9276,6 +9276,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/communication-reviews": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Refused sends waiting on somebody who may decide them.
+         * @description The reviewer's own queue: every refused send a rep has handed on, oldest first.
+         *
+         *     Gated on `communication_exception` at `read`, which is the verb for SEEING refusals rather
+         *     than acting on them: directing a send takes `create`, and an installation can grant the
+         *     first without the second. The rows name other people's recipient addresses and why each was
+         *     refused, so a seat without that grant is not shown them.
+         *
+         *     Installation-wide, with no team or ownership narrowing. Granting the read verb means
+         *     trusting that seat with every refused send in the installation.
+         *
+         *     EVERY WAITING REVIEW, not only the ones routed to the caller. Routing names no assignee: a
+         *     rep asks the installation rather than a colleague, and whoever holds the authority answers.
+         *     An assignee-scoped list would leave a card nobody could find the moment the person it named
+         *     went on leave.
+         *
+         *     Bounded. A list at its limit has more behind it, and `total` says so rather than leaving the
+         *     caller to discover it.
+         */
+        get: operations["listCommunicationReviews"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/communication-reviews/{id}": {
         parameters: {
             query?: never;
@@ -9291,11 +9327,18 @@ export interface paths {
          *     is how a rep opens it: what was refused, which recipient it was refused for, and the reason
          *     each one carries.
          *
-         *     SCOPED TO THE INITIATOR. The row names the recipients of somebody's message and the reason
-         *     each was refused, which is a fact about those people — so this serves the person who pressed
-         *     Send and nobody else. A review belonging to somebody else answers 404 rather than 403,
-         *     because "forbidden" would confirm the id exists and that is itself a disclosure about a
-         *     message the caller may not see.
+         *     TWO DOORS OPEN THIS ROW. The initiator, because it is their message. A holder of
+         *     `communication_exception` at `read`, because they are the person being asked to decide it —
+         *     a reviewer handed a card who could not read the refusal behind it would be acknowledging a
+         *     warning about a message they had never seen.
+         *
+         *     That second door is installation-wide and worth stating plainly: granting somebody the read
+         *     verb hands them every refused send in the installation, with the recipient addresses and the
+         *     reason each was refused. There is no team or ownership narrowing on it. Reading is not
+         *     routing — handing a review on stays the initiator's own action.
+         *
+         *     A caller holding neither door receives 404 rather than 403, because "forbidden" would
+         *     confirm the id exists and disclose a message the caller may not see.
          *
          *     Human-only. An agent that could read these would enumerate one seat's refused correspondence.
          */
@@ -29428,6 +29471,22 @@ export interface components {
             reason_code: string;
             /** @description What was refused, per recipient. Empty once an erasure has cleared the subject from it. */
             refusals: components["schemas"]["RefusedRecipient"][];
+            /**
+             * Format: uuid
+             * @description The card a routed review was handed to, so a decider reading this can find the decision
+             *     they are being asked to make. Null on a review nobody has asked about, which is most of
+             *     them.
+             */
+            approval_id?: string | null;
+        };
+        /** @description A page of refused sends waiting for a decision. */
+        CommunicationReviewList: {
+            data: components["schemas"]["CommunicationReview"][];
+            /**
+             * @description How many are waiting in total. A page at its limit has more behind it, and this is how
+             *     the caller knows rather than by discovering it.
+             */
+            total: number;
         };
         /** @description What the person asking wants the decider to know. */
         RequestCommunicationDecisionRequest: {
@@ -48217,6 +48276,29 @@ export interface operations {
                     "application/json": components["schemas"]["DataSubjectRequest"];
                 };
             };
+        };
+    };
+    listCommunicationReviews: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description What is waiting. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CommunicationReviewList"];
+                };
+            };
+            403: components["responses"]["Forbidden"];
         };
     };
     getCommunicationReview: {


### PR DESCRIPTION
C3a routed a refused send to somebody who may override the engine, and left them unable to see what they were overriding. Reading a review was scoped to the person who pressed send, so the approve button worked and the thing it was about answered 404. A reviewer acknowledged a warning about a message they had never seen, which is the one thing an acknowledgement must not be.

## Two doors open a review

The initiator, because it is their message. The holder of `communication_exception` at `read`, because they are the person being asked to decide it. A seat holding neither sees nothing.

**Read, not create.** The plan names read as the reviewer's verb and it is the narrower one: create is who may act against the engine's answer about a person, read is who may see the queue. An installation can hand somebody the reviewer's view without letting them override anything. I had it wrong first.

**Reading and routing are different doors**, and routing stays the narrow one. A seat that could route anybody's review would be raising cards about other people's correspondence. A test pins it: a review this caller may read is one they may not hand on.

**A person, not a principal.** `auth.RequireHuman` admits connectors, which run with the granting human's own grants, so on the decider's door it would hand a seat's refused correspondence to anything holding their credentials.

## The decider's queue

Lists what is waiting, oldest first, behind the same grant. Every waiting review, not only the ones routed to the caller: routing names no assignee, and an assignee-scoped list would leave a card nobody could find the moment the person it named went on leave.

## The contract says what the code does

Both endpoint descriptions still claimed the initiator-only scope, which is a lie about a disclosure boundary, and neither said the reviewer door is installation-wide. Granting the read verb hands somebody every refused send in the installation, with the recipient addresses and the reason each was refused, with no team or ownership narrowing. An installation choosing that should be told it is choosing it.

## Gates run locally

`make check-backend` and the full `internal/compose/integration` lane. Every new test was mutation-tested.

Codex traced the disclosure boundary end to end and found no authorization bypass: only admin holds the grant by default, the gate runs before any query, the limit normalizes, the count and the page share one predicate, and routing is still initiator-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A reviewer can now open the refused send they are being asked to decide, and can see the queue of refused sends waiting for them. Previously only the sender could read a review, so the approval button worked but the underlying message returned 404. Reads now also open to any holder of `communication_exception` at `read`, while routing a review stays limited to its initiator.

- Added `GET /communication-reviews` listing every waiting review, oldest first, for anyone with `communication_exception` read access.
- The queue and the read door are human-only; connectors and agents are excluded.
- Reading a review now returns the `approval_id` of the decision card it was routed to.
- The API contract now states that granting `communication_exception` read exposes all refused sends installation-wide.

<sup>Written for commit 93cd1a4f2060d574ffec248a3da3007a6b3d7377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a paginated communication-review queue for refused sends, including the total number of matching reviews.
  * Reviews can now be viewed by the initiator or authorized human users with read access.
  * Review details now include approval information when available.
  * Added support for routed decision requests, including queue visibility and review access for assigned decision-makers.

* **Bug Fixes**
  * Unauthorized review requests now return not found responses.
  * Non-human principals cannot access communication-review details or queues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->