### PR TITLE
fix: unbreak main — a catalog FK nothing creates, and two unformatted files

### DIFF
--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1820,7 +1820,6 @@ END
 public.communication_instruction_review_id_key CREATE UNIQUE INDEX communication_instruction_review_id_key ON public.communication_instruction USING btree (review_id)
 public.communication_review acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.communication_review.approval_id uuid gen=- def=-
-public.communication_review.communication_review_approval_id_fkey FOREIGN KEY (approval_id) REFERENCES approval(id) ON DELETE SET NULL
 public.communication_review.communication_review_delivery_intent_id_fkey FOREIGN KEY (delivery_intent_id) REFERENCES scheduled_send(id) ON DELETE CASCADE
 public.communication_review.communication_review_initiated_by_fkey FOREIGN KEY (initiated_by) REFERENCES app_user(id) ON DELETE SET NULL
 public.communication_review.communication_review_kind CHECK ((kind = 'single'::text))

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1425,7 +1425,8 @@ export const de = {
   "approval.kind.update_record": "Datensatz ändern",
   "approval.kind.create_record": "Datensatz anlegen",
   "approval.kind.send_email": "E-Mail senden",
-  "approval.kind.communication_review": "Über eine abgelehnte E-Mail entscheiden",
+  "approval.kind.communication_review":
+    "Über eine abgelehnte E-Mail entscheiden",
   "approval.kind.held_draft": "Entworfene E-Mail prüfen",
   "approval.kind.book_meeting": "Termin buchen",
   "approval.kind.volume_release": "Einen Agenten weiterarbeiten lassen",

--- a/frontend/src/screens/approvalkind.ts
+++ b/frontend/src/screens/approvalkind.ts
@@ -8,7 +8,6 @@ import { WON_REASON_LABELS, WON_REASONS } from "./winreason";
 // so this file stays the one place a reader looks for approval-kind vocabulary.
 export { KIND_LABEL };
 
-
 // What a reader may CHANGE before accepting, per kind.
 //
 // The inline editor's default is every string field of the proposed_change,


### PR DESCRIPTION
`main` is red in two lanes, both from the same merge window, neither caused by the change that is red because of them. Checked on pristine `main` before touching anything, and no open PR is fixing either.

## 1. The head catalog names a foreign key its own migration refused

`TestMigrationsBuildTheCommittedSchema` has failed on every run since #5349. `backend/migrations/testdata/head_catalog.txt` records

```
public.communication_review.communication_review_approval_id_fkey FOREIGN KEY (approval_id) REFERENCES approval(id) ON DELETE SET NULL
```

and the migration that shipped in the same PR says, at length, why that constraint does not exist:

> **NO FOREIGN KEY, deliberately**, and this is the one place it was worth being careful about. An approval is queue work with its own lifecycle and gets swept. A RESTRICT would make a routed review block that sweep. A SET NULL looks like the answer and is worse: the shape CHECK below requires a routed review to name its card, so nulling the column would violate it and Postgres refuses the delete anyway…

So the catalog was generated from an earlier state of that branch, before the FK came out, and never regenerated. The migration is right; the catalog describes a schema nobody builds.

One line. The `approval_id` column and the `communication_review_routing_shape` CHECK are both built and both stay recorded — only the constraint nothing creates goes.

## 2. `fe-lint` is red on two unformatted files

Biome wraps a long German approval label and drops a stray blank line in `approvalkind.ts`. `pnpm exec biome check --write` is the whole change; neither file is otherwise touched.

## Checks

`make test-it DIR=backend/migrations RUN=TestMigrationsBuildTheCommittedSchema` passes here and fails on `main`. `pnpm lint` is clean here and fails on `main`.