### PR TITLE
fix(scheduled_send): an agent-scheduled message must name the agent

### DIFF
--- a/backend/internal/compose/commsscheduled.go
+++ b/backend/internal/compose/commsscheduled.go
@@ -324,11 +324,14 @@ func (w *scheduledSendWorker) fireAs(ctx context.Context, sched schedulerOf) (co
 			actor.OnBehalfOf = sched.AgentOnBehalfOf
 		}
 		if actor.ID == "" {
-			// Scheduled before 0260, so the row never recorded which agent it
-			// was and cannot be given one now. The derived id is what those
-			// rows have always fired under; keeping it confines the invented
-			// identity to them rather than putting a blank actor in the audit.
-			actor.ID = "agent:" + userID.String()
+			// scheduled_send_agent_provenance_shape requires an agent row to
+			// name its actor, so this is a row the database says cannot exist.
+			// It refuses rather than deriving `agent:<human-uuid>`, which is
+			// what stood here: that id names an actor that never existed and
+			// collapses every agent acting for one person into one identity,
+			// and a message firing under it is worse than a message held.
+			return nil, "", fmt.Errorf(
+				"comms_scheduled_send: an agent-kind scheduled send for %s names no agent", userID)
 		}
 	}
 	fireCtx := principal.WithActor(ctx, actor)

--- a/backend/migrations/agentprovenanceshape_integration_test.go
+++ b/backend/migrations/agentprovenanceshape_integration_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations_test
+
+// An agent-scheduled message says which agent scheduled it, and the DATABASE is
+// what says so.
+//
+// The point of asserting it here rather than in the store is what the assertion
+// survives. A store test proves today's writer fills the columns; it proves
+// nothing about tomorrow's, and a writer that forgot them used to degrade in
+// silence — the fire path read the absent actor as "cannot say which agent this
+// was" and derived `agent:<human-uuid>`, an identity that never existed and
+// that every agent acting for one person collapses into. Making omission a
+// REFUSAL is what stops that being reachable at all.
+//
+// Both directions, because a constraint that refused everything would pass the
+// refusal half on its own: the same row with an actor id is accepted, and a
+// human row with no provenance is accepted too.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// scheduleAs inserts one scheduled_send of the given principal kind, with the
+// agent columns exactly as given, and answers what the database said.
+//
+// The columns that are not the subject carry the cheapest values the table's
+// OTHER constraints admit — an account-kind origin with an empty link array,
+// which scheduled_send_origin_shape requires — so a refusal here can only be
+// the provenance shape.
+func scheduleAs(t *testing.T, owner *pgx.Conn, kind string, actorID *string) error {
+	t.Helper()
+	var scheduledBy string
+	if err := owner.QueryRow(context.Background(),
+		`INSERT INTO app_user (email, display_name, status)
+		 VALUES ($1, 'Provenance Scheduler', 'active') RETURNING id`,
+		"provenance-"+kind+"-"+boolWord(actorID != nil)+"@example.test").Scan(&scheduledBy); err != nil {
+		t.Fatalf("seeding the scheduling user: %v", err)
+	}
+	_, err := owner.Exec(context.Background(), `
+		INSERT INTO scheduled_send
+		    (id, scheduled_at, scheduled_tz, origin_kind, origin_links, payload,
+		     scheduled_by, principal_kind, agent_actor_id)
+		VALUES (gen_random_uuid(), now() + interval '1 hour', 'Europe/Berlin',
+		        'account', '[]'::jsonb, '{}'::jsonb, $1, $2, $3)`,
+		scheduledBy, kind, actorID)
+	return err
+}
+
+// boolWord keeps the seeded addresses distinct without a counter, which would
+// be state shared between the cases below.
+func boolWord(b bool) string {
+	if b {
+		return "named"
+	}
+	return "anonymous"
+}
+
+func TestAnAgentScheduledSendMustNameTheAgent(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	owner := connect(t, ownerDSN)
+	headSchema(t, owner)
+
+	// THE REFUSAL. This row is what a writer that forgot the provenance columns
+	// produces, and before the narrowed constraint the table took it.
+	err := scheduleAs(t, owner, "agent", nil)
+	if err == nil {
+		t.Fatal("an agent-kind scheduled send with no agent_actor_id was accepted — " +
+			"the row is indistinguishable from one whose writer forgot, and the fire " +
+			"path has no way to tell which agent asked for it")
+	}
+	if !strings.Contains(err.Error(), "scheduled_send_agent_provenance_shape") {
+		t.Fatalf("the insert was refused by something other than the provenance shape: %v", err)
+	}
+
+	// THE ALLOW ARM, same row, one column moved: a named agent is accepted.
+	actor := "agent:01J0000000000000000000000A"
+	if err := scheduleAs(t, owner, "agent", &actor); err != nil {
+		t.Fatalf("an agent-kind scheduled send naming its agent was refused: %v", err)
+	}
+
+	// And a HUMAN row still carries no agent provenance at all, which is the
+	// half the narrowed constraint must not have taken away.
+	if err := scheduleAs(t, owner, "human", nil); err != nil {
+		t.Fatalf("a human-kind scheduled send with no agent columns was refused: %v", err)
+	}
+}

--- a/backend/migrations/agentprovenanceshape_integration_test.go
+++ b/backend/migrations/agentprovenanceshape_integration_test.go
@@ -37,11 +37,14 @@ import (
 // the provenance shape.
 func scheduleAs(t *testing.T, owner *pgx.Conn, kind string, actorID *string) error {
 	t.Helper()
+	// A scheduler of this case's own. The address is drawn rather than spelled
+	// because app_user.email is unique and these cases differ by a value that
+	// does not make a distinct one — two of them name an actor.
 	var scheduledBy string
 	if err := owner.QueryRow(context.Background(),
 		`INSERT INTO app_user (email, display_name, status)
-		 VALUES ($1, 'Provenance Scheduler', 'active') RETURNING id`,
-		"provenance-"+kind+"-"+boolWord(actorID != nil)+"@example.test").Scan(&scheduledBy); err != nil {
+		 VALUES (gen_random_uuid()::text || '@example.test', 'Provenance Scheduler', 'active')
+		 RETURNING id`).Scan(&scheduledBy); err != nil {
 		t.Fatalf("seeding the scheduling user: %v", err)
 	}
 	_, err := owner.Exec(context.Background(), `
@@ -52,15 +55,6 @@ func scheduleAs(t *testing.T, owner *pgx.Conn, kind string, actorID *string) err
 		        'account', '[]'::jsonb, '{}'::jsonb, $1, $2, $3)`,
 		scheduledBy, kind, actorID)
 	return err
-}
-
-// boolWord keeps the seeded addresses distinct without a counter, which would
-// be state shared between the cases below.
-func boolWord(b bool) string {
-	if b {
-		return "named"
-	}
-	return "anonymous"
 }
 
 func TestAnAgentScheduledSendMustNameTheAgent(t *testing.T) {
@@ -78,6 +72,14 @@ func TestAnAgentScheduledSendMustNameTheAgent(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "scheduled_send_agent_provenance_shape") {
 		t.Fatalf("the insert was refused by something other than the provenance shape: %v", err)
+	}
+
+	// A BLANK actor is the same hole with a different spelling: the writers
+	// pass principal.ID through unchecked, and IS NOT NULL alone admits "".
+	blank := "   "
+	if err := scheduleAs(t, owner, "agent", &blank); err == nil {
+		t.Error("an agent-kind scheduled send whose actor id is whitespace was accepted — " +
+			"it names nobody, exactly as a NULL does")
 	}
 
 	// THE ALLOW ARM, same row, one column moved: a named agent is accepted.

--- a/backend/migrations/core/1789140100_an_agent_scheduled_send_names_the_agent.down.sql
+++ b/backend/migrations/core/1789140100_an_agent_scheduled_send_names_the_agent.down.sql
@@ -1,0 +1,11 @@
+SET LOCAL lock_timeout = '3s';
+
+-- Back to the arm that admitted an agent row carrying no provenance. Nothing
+-- has to move first: every row the narrowed constraint admits is also admitted
+-- by the wider one it is restored to.
+ALTER TABLE scheduled_send
+    DROP CONSTRAINT IF EXISTS scheduled_send_agent_provenance_shape,
+    ADD CONSTRAINT scheduled_send_agent_provenance_shape CHECK (
+        ((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL))
+        OR ((agent_actor_id IS NULL) AND (agent_passport_id IS NULL)
+            AND (agent_on_behalf_of IS NULL)));

--- a/backend/migrations/core/1789140100_an_agent_scheduled_send_names_the_agent.up.sql
+++ b/backend/migrations/core/1789140100_an_agent_scheduled_send_names_the_agent.up.sql
@@ -27,15 +27,20 @@ SET LOCAL lock_timeout = '3s';
 -- are facts an agent may legitimately lack, and requiring them would refuse
 -- writes the store makes on purpose (activities/scheduledsendprovenance.go
 -- states both rules). The actor id is the one thing no agent can lack, because
--- the actor is what "an agent scheduled this" means.
+-- the actor is what "an agent scheduled this" means — and it has to be a NAME
+-- rather than the empty string, which IS NOT NULL alone admits. The writers
+-- pass principal.ID through unchecked, so a blank would satisfy the column and
+-- then reach the fire path as an agent row naming nobody: the same hole with a
+-- different spelling.
 --
--- The change is four words: the all-NULL arm now says which rows it is for.
+-- The all-NULL arm now says which rows it is for, which is the change.
 -- Spelled as a plain disjunction rather than a CASE because pg_get_constraintdef
 -- renders a CASE across five lines, and testdata/head_catalog.txt is one
 -- constraint per line.
 ALTER TABLE scheduled_send
     DROP CONSTRAINT IF EXISTS scheduled_send_agent_provenance_shape,
     ADD CONSTRAINT scheduled_send_agent_provenance_shape CHECK (
-        ((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL))
+        ((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL)
+            AND (length(btrim(agent_actor_id)) > 0))
         OR ((principal_kind <> 'agent'::text) AND (agent_actor_id IS NULL)
             AND (agent_passport_id IS NULL) AND (agent_on_behalf_of IS NULL)));

--- a/backend/migrations/core/1789140100_an_agent_scheduled_send_names_the_agent.up.sql
+++ b/backend/migrations/core/1789140100_an_agent_scheduled_send_names_the_agent.up.sql
@@ -1,0 +1,41 @@
+SET LOCAL lock_timeout = '3s';
+
+-- An agent-scheduled message must say WHICH agent scheduled it.
+--
+-- The constraint this replaces permitted an agent row with no provenance at
+-- all. Its second arm — all three columns NULL — was written to keep rows from
+-- before the provenance columns existed valid, and it did not exclude
+-- `principal_kind = 'agent'`. So an agent row with nothing recorded satisfied
+-- it, and two very different things looked identical in the table: a row
+-- written before the columns existed, and a writer that forgot them.
+--
+-- The fire path could not tell them apart either, and resolved the ambiguity
+-- the only way it could — by deriving `agent:<human-uuid>`, an actor that never
+-- existed, which collapses every agent acting for one person into one identity
+-- and is the attribution defect that derivation was removed for. A future
+-- writer that forgot these columns would have degraded silently back into it.
+--
+-- There is nothing to grandfather. No installation predates the columns: a
+-- fresh install runs the baseline, which already creates the table carrying
+-- them, so every row on every install is a post-provenance row. The arm was
+-- protecting a population that does not exist, and it was the hole.
+--
+-- WHAT COMPLETE MEANS, stated here because this is the moment to say it: the
+-- ACTOR id is required and the other two are not. A passport records how an
+-- agent's scopes were granted and NULL says none was presented; on_behalf_of
+-- records the human behind the agent and NULL says there is none to name. Both
+-- are facts an agent may legitimately lack, and requiring them would refuse
+-- writes the store makes on purpose (activities/scheduledsendprovenance.go
+-- states both rules). The actor id is the one thing no agent can lack, because
+-- the actor is what "an agent scheduled this" means.
+--
+-- The change is four words: the all-NULL arm now says which rows it is for.
+-- Spelled as a plain disjunction rather than a CASE because pg_get_constraintdef
+-- renders a CASE across five lines, and testdata/head_catalog.txt is one
+-- constraint per line.
+ALTER TABLE scheduled_send
+    DROP CONSTRAINT IF EXISTS scheduled_send_agent_provenance_shape,
+    ADD CONSTRAINT scheduled_send_agent_provenance_shape CHECK (
+        ((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL))
+        OR ((principal_kind <> 'agent'::text) AND (agent_actor_id IS NULL)
+            AND (agent_passport_id IS NULL) AND (agent_on_behalf_of IS NULL)));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -5192,7 +5192,7 @@ public.scheduled_send.scheduled_at timestamp with time zone NOT NULL gen=- def=-
 public.scheduled_send.scheduled_by uuid NOT NULL gen=- def=-
 public.scheduled_send.scheduled_send_activity_id_fkey FOREIGN KEY (activity_id) REFERENCES activity(id) ON DELETE RESTRICT
 public.scheduled_send.scheduled_send_agent_on_behalf_of_fkey FOREIGN KEY (agent_on_behalf_of) REFERENCES app_user(id) ON DELETE SET NULL
-public.scheduled_send.scheduled_send_agent_provenance_shape CHECK ((((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL)) OR ((agent_actor_id IS NULL) AND (agent_passport_id IS NULL) AND (agent_on_behalf_of IS NULL))))
+public.scheduled_send.scheduled_send_agent_provenance_shape CHECK ((((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL)) OR ((principal_kind <> 'agent'::text) AND (agent_actor_id IS NULL) AND (agent_passport_id IS NULL) AND (agent_on_behalf_of IS NULL))))
 public.scheduled_send.scheduled_send_also_links_shape CHECK (((also_links IS NULL) OR ((origin_kind = 'reply'::text) AND (jsonb_typeof(also_links) = 'array'::text))))
 public.scheduled_send.scheduled_send_anchor_activity_id_fkey FOREIGN KEY (anchor_activity_id) REFERENCES activity(id) ON DELETE CASCADE
 public.scheduled_send.scheduled_send_delivery_id_fkey FOREIGN KEY (delivery_id) REFERENCES comms_outbound(id) ON DELETE RESTRICT

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -5192,7 +5192,7 @@ public.scheduled_send.scheduled_at timestamp with time zone NOT NULL gen=- def=-
 public.scheduled_send.scheduled_by uuid NOT NULL gen=- def=-
 public.scheduled_send.scheduled_send_activity_id_fkey FOREIGN KEY (activity_id) REFERENCES activity(id) ON DELETE RESTRICT
 public.scheduled_send.scheduled_send_agent_on_behalf_of_fkey FOREIGN KEY (agent_on_behalf_of) REFERENCES app_user(id) ON DELETE SET NULL
-public.scheduled_send.scheduled_send_agent_provenance_shape CHECK ((((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL)) OR ((principal_kind <> 'agent'::text) AND (agent_actor_id IS NULL) AND (agent_passport_id IS NULL) AND (agent_on_behalf_of IS NULL))))
+public.scheduled_send.scheduled_send_agent_provenance_shape CHECK ((((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL) AND (length(btrim(agent_actor_id)) > 0)) OR ((principal_kind <> 'agent'::text) AND (agent_actor_id IS NULL) AND (agent_passport_id IS NULL) AND (agent_on_behalf_of IS NULL))))
 public.scheduled_send.scheduled_send_also_links_shape CHECK (((also_links IS NULL) OR ((origin_kind = 'reply'::text) AND (jsonb_typeof(also_links) = 'array'::text))))
 public.scheduled_send.scheduled_send_anchor_activity_id_fkey FOREIGN KEY (anchor_activity_id) REFERENCES activity(id) ON DELETE CASCADE
 public.scheduled_send.scheduled_send_delivery_id_fkey FOREIGN KEY (delivery_id) REFERENCES comms_outbound(id) ON DELETE RESTRICT


### PR DESCRIPTION
Closes #1362.

## The hole

`scheduled_send_agent_provenance_shape` read:

```sql
((principal_kind = 'agent' AND agent_actor_id IS NOT NULL)
 OR (agent_actor_id IS NULL AND agent_passport_id IS NULL AND agent_on_behalf_of IS NULL))
```

The second arm exists to keep rows written before the provenance columns valid — and it **does not say which rows it is for**. So an agent-kind row recording no agent satisfies it, and two very different things are indistinguishable in the table: a row from before the columns existed, and a writer that forgot them.

The fire path could not tell them apart either, and resolved it the only way it could — `actor.ID = "agent:" + userID`, an actor that never existed and that every agent acting for one person collapses into. That is exactly the invented identity #1258 removed. **A future writer bug degraded silently into the defect that was just fixed**, with nothing to notice it.

## The fix

Four words, in a new migration: the all-NULL arm now says `principal_kind <> 'agent'`.

```sql
((principal_kind = 'agent'::text) AND (agent_actor_id IS NOT NULL))
OR ((principal_kind <> 'agent'::text) AND (agent_actor_id IS NULL)
    AND (agent_passport_id IS NULL) AND (agent_on_behalf_of IS NULL))
```

Spelled as a plain disjunction rather than a `CASE`, because `pg_get_constraintdef` renders a CASE across five lines and `head_catalog.txt` is one constraint per line — a detail worth a sentence in the migration rather than a surprise for the next person.

**What "complete" means**, which the issue asked to settle: the **actor id is required and the other two are not**. A passport records how an agent's scopes were granted and NULL says none was presented; `on_behalf_of` records the human behind the agent and NULL says there is none to name. `activities/scheduledsendprovenance.go` states both rules and writes each conditionally on purpose, so requiring them would refuse writes the store makes deliberately. The actor id is the one thing no agent can lack, because the actor is what "an agent scheduled this" *means*.

**No `legacy` state**, as ruled: it would be a permanent term standing in for a population that does not exist. There is no production installation, and a fresh install runs the baseline — which already creates the table with these columns — so every row on every install is a post-provenance row. That is also why this is free now and a migration with a population to reason about later.

## The fire path's fallback

It is unreachable once the constraint lands, and it does not become a silent branch. A row the database says cannot exist now **refuses the send** instead of inventing an identity for it: a message firing under a fabricated actor is worse than a message held, and a blank actor in the audit is worse than both.

## The test

`TestAnAgentScheduledSendMustNameTheAgent`, in `backend/migrations` — against the **database**, not the store, and that is the point. A store test proves today's writer fills the columns and nothing about tomorrow's; the assertion that survives a future writer is the one the database makes.

Three arms, because a constraint that refused everything would pass the refusal on its own:

- an agent row with no `agent_actor_id` is refused, **by name** (`scheduled_send_agent_provenance_shape`, not by some other constraint);
- the same row naming its agent is accepted;
- a human row with no agent provenance at all is still accepted.

**It fails on `main` and passes here** — run both ways, not assumed.

## One thing that came along

`head_catalog.txt` had to be regenerated, and doing so also drops `communication_review_approval_id_fkey` — a foreign key #5349's catalog records and #5349's own migration deliberately refuses to create. `main` is red on that line right now; it has its own one-line PR (#5356) since it is nothing to do with this change, and this branch cannot regenerate a correct catalog without also dropping it.

## Checks

`make check-backend` green, `make craft-static` 0/0/0, `make test-it DIR=backend/migrations` green (whole package).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled sends created by agents without actor provenance are now held as errors instead of receiving an automatically derived identity.
  - Agent scheduled sends must identify a named agent actor, while human scheduled sends remain supported without agent provenance.

- **Database**
  - Added validation to prevent agent scheduled-send records from omitting required actor information.
  - Removed an approval reference constraint from communication review records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->