### PR TITLE
An agent refusal names the review where a machine can read it

### DIFF
--- a/backend/internal/compose/commsstager.go
+++ b/backend/internal/compose/commsstager.go
@@ -215,7 +215,14 @@ func (s commsStager) RecordPendingReview(ctx context.Context, err error, intentI
 	if recordErr != nil || review.ID.IsZero() {
 		return pending.cause
 	}
-	return &consent.SendRefusedError{ReviewID: review.ID, Cause: pending.cause}
+	return &consent.SendRefusedError{
+		ReviewID: review.ID, Cause: pending.cause,
+		// DECIDED HERE, because this is where the principal is known. Routing a
+		// decision is human-only and bound to the review's own initiator, so
+		// naming it for an agent would promise a move it cannot make — and an
+		// agent that tries and is refused was sent there by us.
+		Actions: actionsForRefusal(ctx, review),
+	}
 }
 
 // StageChannelTx is the same staging for a channel reply: the channel-shaped row
@@ -304,4 +311,27 @@ func anyEnforcedDenial(denied []commsauthz.Decision) bool {
 		}
 	}
 	return false
+}
+
+// actionsForRefusal names what THIS caller may do about a refusal.
+//
+// One action today and a list on purpose: the shape is what a caller reads, and
+// a second action arriving later should not change it. An empty list is a real
+// answer — the caller may do nothing but stop and report, and the reference
+// still travels so a person reading their transcript can pick the review up.
+func actionsForRefusal(ctx context.Context, review consent.Review) []string {
+	// The review must have a message to decide about. One refused without an
+	// intent — a channel reply, whose shape the held row cannot carry — is not
+	// routable, and offering the route would send the caller into a refusal.
+	if review.IntentID.IsZero() {
+		return nil
+	}
+	// A PERSON, and the one whose message it was. Routing is human-only
+	// (agents and connectors are refused) and scoped to the initiator, so an
+	// agent acting for somebody is told nothing rather than told wrong.
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Type != principal.PrincipalHuman {
+		return nil
+	}
+	return []string{"request_decision"}
 }

--- a/backend/internal/compose/integration/refused_send_review_integration_test.go
+++ b/backend/internal/compose/integration/refused_send_review_integration_test.go
@@ -720,3 +720,114 @@ func TestAnotherSeatsReviewIsNotFound(t *testing.T) {
 			"which is a disclosure about a message this caller may not see", status)
 	}
 }
+
+// THE REFUSAL NAMES ITS REVIEW AS A FIELD, not only in a sentence.
+//
+// The reference has always travelled in the message, which serves a person
+// reading it and nothing else. An agent handed "consent not granted" in English
+// can do nothing with it: parsing an id out of prose is guesswork, and guessing
+// is worse than failing. Named as a field, the same refusal is something an
+// agent can act on — it can hand the question to a person.
+//
+// AND THE STATUS DOES NOT MOVE. This is the constraint the first attempt at a
+// structured refusal broke: implementing FieldFault flipped the send surface
+// from 409 to 422 across every client and test that already recognised it. The
+// reference is orthogonal to classification and must stay that way.
+func TestARefusedSendNamesItsReviewWhereAMachineCanReadIt(t *testing.T) {
+	c := setupConsent(t)
+
+	var problem struct {
+		Code    string `json:"code"`
+		Details struct {
+			ReviewID         string   `json:"review_id"`
+			AvailableActions []string `json:"available_actions"`
+		} `json:"details"`
+	}
+	status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", AnyMap{
+		"subject": "Re: Inbound question", "body": "answer",
+		"to": []string{"subject@consent.test"}, "consent_purpose": "marketing_email",
+	}, nil, &problem)
+
+	if status != http.StatusConflict {
+		t.Fatalf("a refused send answered %d, want 409 — the reference must not change what the "+
+			"refusal says happened", status)
+	}
+	if problem.Code != "consent_not_granted" {
+		t.Errorf("the refusal reads code %q, want consent_not_granted", problem.Code)
+	}
+	reviews := openReviews(t, c.AppEnv)
+	if len(reviews) != 1 {
+		t.Fatalf("%d review(s), want 1", len(reviews))
+	}
+	if problem.Details.ReviewID != reviews[0].id {
+		t.Errorf("the refusal names review %q as a field and opened %q — an agent reading the "+
+			"body cannot find the work this left behind",
+			problem.Details.ReviewID, reviews[0].id)
+	}
+	// NAMED EXACTLY, not merely non-empty. A test that accepted any list would
+	// pass while the refusal promised a move this caller cannot make — which is
+	// the bug it exists to catch.
+	//
+	// This caller is the human who pressed send, so routing a decision is
+	// theirs to do.
+	if len(problem.Details.AvailableActions) != 1 ||
+		problem.Details.AvailableActions[0] != "request_decision" {
+		t.Errorf("the refusal offers %v, want exactly [request_decision] — a rep who was refused "+
+			"is told what they may do about it", problem.Details.AvailableActions)
+	}
+}
+
+// NAMING THE KIND IS ENOUGH; THE LEGACY KEY IS NOT REQUIRED.
+//
+// The four send tools required consent_purpose, which is the legacy key. A1
+// made communication_context the field the engine decides on, so an agent that
+// knows what kind of message it is sending should say that and nothing else —
+// forced to name a legacy key as well, it names the wrong one.
+//
+// SAYING NEITHER IS STILL REFUSED, and that is the engine working rather than a
+// gap this slice left. Resolution from the thread alone cannot tell a quote
+// from a newsletter, so it answers unknown_purpose and opens a review instead
+// of guessing. Making the resolver cleverer is A1's question; what this slice
+// owes is that an agent naming the CANONICAL field is not also made to name the
+// legacy one.
+func TestNamingTheKindIsEnoughWithoutTheLegacyKey(t *testing.T) {
+	c := setupConsent(t)
+
+	status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", AnyMap{
+		"subject": "Re: Inbound question", "body": "answer",
+		"to":                    []string{"subject@consent.test"},
+		"communication_context": "reply_to_inbound",
+	}, nil, nil)
+	if status >= 300 {
+		var reason string
+		_ = c.Owner.QueryRow(context.Background(),
+			`SELECT reason_code FROM communication_review WHERE resolved_at IS NULL`).Scan(&reason)
+		t.Errorf("a reply naming its kind and no legacy key answered %d (%s), want it accepted — an agent "+
+			"that knows what it is sending should not also have to name a key it does not "+
+			"understand", status, reason)
+	}
+}
+
+// AND SAYING NOTHING AT ALL IS REFUSED WITH SOMETHING TO ACT ON. The engine
+// will not guess a category, which is right; what it owes is a review rather
+// than a dead end.
+func TestASendNamingNoKindAtAllIsRefusedWithAReview(t *testing.T) {
+	c := setupConsent(t)
+
+	var problem struct {
+		Details struct {
+			ReviewID string `json:"review_id"`
+		} `json:"details"`
+	}
+	status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", AnyMap{
+		"subject": "Re: Inbound question", "body": "answer",
+		"to": []string{"subject@consent.test"},
+	}, nil, &problem)
+	if status != http.StatusConflict {
+		t.Fatalf("a send naming no kind answered %d, want 409", status)
+	}
+	if problem.Details.ReviewID == "" {
+		t.Error("the refusal names no review, so an agent that cannot resolve its own purpose is " +
+			"left with nothing to hand to a person")
+	}
+}

--- a/backend/internal/compose/refusalactions_test.go
+++ b/backend/internal/compose/refusalactions_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a refused caller is told they may do about it.
+//
+// The reference a refusal carries is only useful if the action beside it is one
+// this caller can actually take. Routing a decision is human-only and bound to
+// the review's own initiator — so an agent told it may request one tries, is
+// refused, and was sent there by us rather than by its own mistake. That is
+// worse than being told nothing.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestARefusalOffersOnlyWhatThisCallerCanDo(t *testing.T) {
+	t.Parallel()
+	held := consent.Review{IntentID: ids.NewV7()}
+
+	for _, tc := range []struct {
+		name   string
+		actor  principal.Principal
+		review consent.Review
+		want   []string
+	}{
+		{
+			// The rep who pressed send. Routing is theirs to do.
+			name: "a person whose message it was", actor: principal.Principal{Type: principal.PrincipalHuman},
+			review: held, want: []string{"request_decision"},
+		},
+		{
+			// An agent cannot route: the door refuses non-humans outright.
+			name: "an agent", actor: principal.Principal{Type: principal.PrincipalAgent}, review: held,
+		},
+		{
+			// A connector runs with its granting human's grants and is still
+			// not a person at a keyboard.
+			name: "a connector", actor: principal.Principal{Type: principal.PrincipalConnector}, review: held,
+		},
+		{
+			name: "the system", actor: principal.Principal{Type: principal.PrincipalSystem}, review: held,
+		},
+		{
+			// A refusal with no held message has nothing to decide about — a
+			// channel reply, whose shape the held row cannot carry. Offering
+			// the route would send even a person into a refusal.
+			name:  "a person with no message to decide about",
+			actor: principal.Principal{Type: principal.PrincipalHuman}, review: consent.Review{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := principal.WithActor(context.Background(), tc.actor)
+			got := actionsForRefusal(ctx, tc.review)
+			if len(got) != len(tc.want) {
+				t.Fatalf("offered %v, want %v — a caller told it may do something it cannot was "+
+					"sent there by us", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("offered %q at %d, want %q", got[i], i, tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/modules/agents/explain.go
+++ b/backend/internal/modules/agents/explain.go
@@ -253,7 +253,8 @@ func (s *Dispatcher) explainClassified(tool string, err error) string {
 // elsewhere but absent from the table is a figure nobody knows to keep true.
 func faultExplanation(fault httperr.Fault) string {
 	if len(fault.Fields) == 0 {
-		return echoSafe(fault.Code, maxBadArgsDetail) + ": " + echoSafe(fault.Detail, MaxFaultDetail)
+		return echoSafe(fault.Code, maxBadArgsDetail) + ": " +
+			echoSafe(fault.Detail, MaxFaultDetail) + faultReferenceSuffix(fault)
 	}
 
 	parts := make([]string, 0, len(fault.Fields))
@@ -363,4 +364,49 @@ func stagedExplanation(staged *workflow.StagedApprovalError) string {
 		staged.ApprovalID.String() + "\". " +
 		"Blocks THIS call only — do the rest of what you were asked that does not depend on it, " +
 		"and report what you DID alongside what is waiting."
+}
+
+// faultReferenceSuffix names what a refusal left behind, in the one place an
+// agent reliably reads.
+//
+// THE TOOL SURFACE HAS NO STRUCTURED ERROR SHAPE. A tool failure is
+// `{isError: true, content: [text]}` — the MCP spec's shape — so a refusal's
+// Details map has nowhere to go on this door, and the seam that built it
+// (apperrors.ReferencedFault) would stop at the REST renderer.
+//
+// So the reference is appended to the text in a form an agent can act on: a
+// fixed prefix, a bare id, and the actions it may take. Not JSON, because the
+// content block is prose a model reads; a stable sentence is what it can be
+// asked to look for, and the id is a uuid that cannot be confused with the
+// words around it.
+//
+// AN EMPTY REFERENCE APPENDS NOTHING. Most faults carry none, and a trailing
+// "review:" with nothing after it is worse than silence.
+func faultReferenceSuffix(fault httperr.Fault) string {
+	if len(fault.Details) == 0 {
+		return ""
+	}
+	reference, ok := fault.Details["review_id"].(string)
+	if !ok || reference == "" {
+		return ""
+	}
+	suffix := " (review " + echoSafe(reference, maxBadArgsDetail)
+	if actions := faultActions(fault); actions != "" {
+		suffix += "; you may " + actions
+	}
+	return suffix + ")"
+}
+
+// faultActions renders what the caller may do about a refusal, or nothing when
+// the refusal names none.
+func faultActions(fault httperr.Fault) string {
+	raw, ok := fault.Details["available_actions"].([]string)
+	if !ok || len(raw) == 0 {
+		return ""
+	}
+	bounded := make([]string, 0, len(raw))
+	for _, action := range raw {
+		bounded = append(bounded, echoSafe(action, maxBadArgsDetail))
+	}
+	return strings.Join(bounded, ", ")
 }

--- a/backend/internal/modules/agents/tools_account_send.go
+++ b/backend/internal/modules/agents/tools_account_send.go
@@ -43,12 +43,12 @@ func (t sendAccountEmailTool) Spec() mcp.ToolSpec {
 		Description:   sendAccountEmailCopy.render(),
 		RequiredScope: principal.ScopeSend, Tier: mcp.TierAutoExecute, Egress: true,
 		OpenAPIOp: "sendAccountEmail",
-		InputSchema: schema(`{"type":"object","required":["to","subject","body","consent_purpose","links"],"properties":{
+		InputSchema: schema(`{"type":"object","required":["to","subject","body","links"],"properties":{
 			"to":{"type":"array","items":{"type":"string","format":"email"},"minItems":1},
 			"cc":{"type":"array","items":{"type":"string","format":"email"}},
 			"subject":{"type":"string"},
 			"body":{"type":"string"},
-			"consent_purpose":{"type":"string","description":"Purpose key the recipients must have granted"},
+			"consent_purpose":{"type":"string","description":"Legacy purpose key, optional. communication_context is what the engine decides on; this is read only where the context leaves the question open. Naming neither is allowed and the server resolves what it can from the thread, but a message it cannot place is refused rather than guessed at"},
 			"scheduled_at":{"type":"string","format":"date-time"` + timestampNote + `},
 			"scheduled_tz":{"type":"string","description":"IANA zone name the moment was chosen in (e.g. Europe/Berlin), required with scheduled_at. The send is deferred to that instant: no activity exists until it fires, and every gate re-runs then."},
 			"links":{"type":"array","minItems":1,"items":{"type":"object","required":["entity_type","entity_id"],"properties":{

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -320,13 +320,13 @@ func (t sendEmailTool) Spec() mcp.ToolSpec {
 		Description:   sendEmailCopy.render(),
 		RequiredScope: principal.ScopeSend, Tier: mcp.TierAutoExecute, Egress: true,
 		OpenAPIOp: "sendEmail",
-		InputSchema: schema(`{"type":"object","required":["activity_id","to","subject","body","consent_purpose"],"properties":{
+		InputSchema: schema(`{"type":"object","required":["activity_id","to","subject","body"],"properties":{
 			"activity_id":{"type":"string","format":"uuid"},
 			"to":{"type":"array","items":{"type":"string","format":"email"},"minItems":1},
 			"cc":{"type":"array","items":{"type":"string","format":"email"}},
 			"subject":{"type":"string"},
 			"body":{"type":"string"},
-			"consent_purpose":{"type":"string","description":"Purpose key the recipients must have granted"},
+			"consent_purpose":{"type":"string","description":"Legacy purpose key, optional. communication_context is what the engine decides on; this is read only where the context leaves the question open. Naming neither is allowed and the server resolves what it can from the thread, but a message it cannot place is refused rather than guessed at"},
 			"scheduled_at":{"type":"string","format":"date-time"` + timestampNote + `},
 			"scheduled_tz":{"type":"string","description":"IANA zone name the moment was chosen in (e.g. Europe/Berlin), required with scheduled_at. The send is deferred to that instant: no activity exists until it fires, and every gate re-runs then."},
 			"approval_id":{"type":"string","format":"uuid","description":"Set on approved retry"}` + sendContextProperties + `},
@@ -406,10 +406,10 @@ func (t sendMessageTool) Spec() mcp.ToolSpec {
 		Description:   sendMessageCopy.render(),
 		RequiredScope: principal.ScopeSend, Tier: mcp.TierAutoExecute, Egress: true,
 		OpenAPIOp: "sendMessage",
-		InputSchema: schema(`{"type":"object","required":["activity_id","body","consent_purpose"],"properties":{
+		InputSchema: schema(`{"type":"object","required":["activity_id","body"],"properties":{
 			"activity_id":{"type":"string","format":"uuid","description":"The captured conversation being replied to"},
 			"body":{"type":"string","minLength":1},
-			"consent_purpose":{"type":"string","description":"Purpose key the recipient must have granted"},
+			"consent_purpose":{"type":"string","description":"Legacy purpose key, optional. communication_context is what the engine decides on; this is read only where the context leaves the question open. Naming neither is allowed and the server resolves what it can from the thread, but a message it cannot place is refused rather than guessed at"},
 			"approval_id":{"type":"string","format":"uuid","description":"Set on approved retry"}` + sendContextProperties + `},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[SendMessageResult](),

--- a/backend/internal/modules/consent/review.go
+++ b/backend/internal/modules/consent/review.go
@@ -374,6 +374,12 @@ func (g *Gate) RecordRefusal(ctx context.Context, set commsauthz.DecisionSet, in
 type SendRefusedError struct {
 	ReviewID ids.UUID
 	Cause    error
+	// Actions is what THIS caller may do about the refusal, decided where the
+	// refusal is recorded because that is where the principal is known. Empty
+	// for a caller with nothing to do but stop and report, which is the honest
+	// answer for an agent: routing a decision is human-only and bound to the
+	// review's initiator.
+	Actions []string
 }
 
 func (e *SendRefusedError) Error() string {
@@ -449,3 +455,42 @@ func zeroSeatAsNull(seat ids.UUID) *ids.UUID {
 	}
 	return &seat
 }
+
+// FaultReference implements apperrors.ReferencedFault: the review this refusal
+// opened, as a field rather than as a sentence.
+//
+// STILL NO FieldFault, and the distinction matters. A field fault says "you
+// sent a bad input" and answers 422; this refusal is neither — the caller's
+// input was fine and the engine refused on consent grounds, which is the 409
+// every client and every test already recognises. Implementing FieldFault here
+// once flipped the whole send surface from 409 to 422.
+//
+// What a reference adds is orthogonal to that: the status and the code are
+// unchanged, and the id appears beside them where a machine can read it. The
+// tool surface is why — an agent handed a sentence can do nothing, and the same
+// refusal naming its review can hand the question to a person.
+func (e *SendRefusedError) FaultReference() map[string]any {
+	if e.ReviewID.IsZero() {
+		return nil
+	}
+	return map[string]any{
+		FieldReviewID: e.ReviewID.String(),
+		// WHAT THIS CALLER MAY DO, not what the route exists for.
+		//
+		// Routing a decision is human-only and bound to the review's own
+		// initiator, so naming it unconditionally would promise an agent a move
+		// it cannot make — and an agent that tries and is refused has been sent
+		// somewhere by us rather than by its own mistake. Worse than saying
+		// nothing.
+		//
+		// An empty list is the honest answer for a caller with nothing to do
+		// but stop and report: the reference still travels, and a person
+		// reading the agent's transcript can pick the review up.
+		"available_actions": e.Actions,
+	}
+}
+
+// Unreferenced answers the refusal without the reference, which is what decides
+// the status. It is the wrapped cause rather than this value, or classification
+// would come straight back here.
+func (e *SendRefusedError) Unreferenced() error { return e.Cause }

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -311,6 +311,36 @@ func (f Fault) Transient() bool {
 // named it. One tree and two renderers means the surfaces cannot drift apart
 // again.
 func Classify(err error) (Fault, bool) {
+	// A REFUSAL THAT CARRIES A REFERENCE renders it as a field rather than
+	// leaving it in prose.
+	//
+	// BEFORE the sentinel table and after nothing, because the sentinel is
+	// still what decides the STATUS: this branch changes what a caller is
+	// handed, never what they are told happened. A surface reading `details`
+	// gets an id it can act on; one reading only the message gets exactly what
+	// it got before.
+	//
+	// It exists for the tool surface. An agent handed "consent not granted" in
+	// a sentence can do nothing with it; the same refusal naming the review it
+	// opened can hand the question to a person.
+	var referenced apperrors.ReferencedFault
+	if errors.As(err, &referenced) {
+		if fault, ok := Classify(referenced.Unreferenced()); ok {
+			fault.Details = referenced.FaultReference()
+			// AND THE MESSAGE KEEPS THE REFERENCE TOO. Classifying the
+			// unreferenced cause is what preserves the status, and it also
+			// answers the CAUSE's own text — which no longer names the review.
+			//
+			// A person reading the prose must not lose what a machine just
+			// gained. Both carry it: the sentence for whoever reads it, the
+			// field for whatever parses it.
+			if detail := referenced.Error(); detail != "" && !infrastructureCause(err) {
+				fault.Detail = detail
+			}
+			return fault, true
+		}
+	}
+
 	var withDetails *DetailedError
 	if errors.As(err, &withDetails) {
 		return Fault{

--- a/backend/internal/shared/apperrors/apperrors.go
+++ b/backend/internal/shared/apperrors/apperrors.go
@@ -186,3 +186,26 @@ var ErrRetentionHold = errors.New("record is held under a statutory retention ob
 // "the diagnosis is in the process log" — true, and useless once the process
 // has restarted, which is exactly when an operator goes looking.
 var ErrProviderUnusable = errors.New("the provider returned no usable answer")
+
+// ReferencedFault is a refusal that leaves something behind a caller can act
+// on.
+//
+// THE STATUS IS NOT ITS BUSINESS. A refusal already classifies — through a
+// sentinel, a field fault, whatever it was going to do — and implementing this
+// changes none of that. What it adds is a structured reference beside the
+// message, so a surface that can only read prose is not the only one served.
+//
+// It exists because of the tool surface. An agent handed "consent not granted"
+// in a sentence can do nothing with it: it cannot parse an id out of English
+// reliably, and guessing is worse than failing. The same refusal naming the
+// review it opened can hand the question to a person, which is the whole
+// difference between an agent that stops and an agent that escalates.
+type ReferencedFault interface {
+	error
+	// FaultReference is what the caller may act on. Keys are wire names and
+	// values must be JSON-renderable; an empty map renders nothing.
+	FaultReference() map[string]any
+	// Unreferenced is the refusal without the reference, which is what decides
+	// the status and the code. A type returning itself here would recurse.
+	Unreferenced() error
+}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,9 +6,9 @@
   "catalog": {
     "tools": 76,
     "system_frame_tokens": 353,
-    "tokens": 24098,
+    "tokens": 24267,
     "median_tool_tokens": 272,
-    "mean_tool_tokens": 316
+    "mean_tool_tokens": 318
   },
   "agents": [
     {
@@ -76,27 +76,27 @@
     },
     {
       "name": "send_account_email",
-      "tokens": 767
+      "tokens": 823
+    },
+    {
+      "name": "send_email",
+      "tokens": 754
     },
     {
       "name": "preview_import",
       "tokens": 723
     },
     {
-      "name": "send_email",
-      "tokens": 698
-    },
-    {
       "name": "log_activity",
       "tokens": 676
     },
     {
-      "name": "update_record",
-      "tokens": 581
+      "name": "send_message",
+      "tokens": 603
     },
     {
-      "name": "send_message",
-      "tokens": 546
+      "name": "update_record",
+      "tokens": 581
     },
     {
       "name": "forecast_readings",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1626 | 4% | 21584 | 6 | 6 |
 | `overnight_at_risk_sweep` | 7 | 2499 | 7% | 20711 | 15 | 10 |
-| _whole served catalog, for scale_ | 76 | 24098 | 73% | — | — | — |
+| _whole served catalog, for scale_ | 76 | 24267 | 74% | — | — | — |
 
 ### `morning_brief`
 
@@ -126,7 +126,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 272 tokens, mean 316, across 76 served tools.
+Median 272 tokens, mean 318, across 76 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -136,12 +136,12 @@ a term in an addition.
 | Tool | Tokens | Named as the wrong reach in |
 |---|---:|---:|
 | `run_report` | 1010 | 3 scenarios |
-| `send_account_email` | 767 | — |
+| `send_account_email` | 823 | — |
+| `send_email` | 754 | 1 scenario |
 | `preview_import` | 723 | — |
-| `send_email` | 698 | 1 scenario |
 | `log_activity` | 676 | 1 scenario |
+| `send_message` | 603 | — |
 | `update_record` | 581 | 4 scenarios |
-| `send_message` | 546 | — |
 | `forecast_readings` | 509 | — |
 | `progress_deal` | 505 | 3 scenarios |
 | `list_records` | 503 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 76,
     "resources": 12,
-    "tool_catalog_bytes": 222866,
+    "tool_catalog_bytes": 223542,
     "resource_catalog_bytes": 4584,
-    "approx_wire_tokens_total": 56862,
+    "approx_wire_tokens_total": 57031,
     "largest_tool_bytes": 8975,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 58858,
-      "input_schema_bytes": 45629,
+      "input_schema_bytes": 46305,
       "output_schema_bytes": 101954,
-      "description_plus_input_schema_bytes": 104487
+      "description_plus_input_schema_bytes": 105163
     }
   },
   "tools": {
@@ -12681,7 +12681,7 @@
               "type": "string"
             },
             "consent_purpose": {
-              "description": "Purpose key the recipients must have granted",
+              "description": "Legacy purpose key, optional. communication_context is what the engine decides on; this is read only where the context leaves the question open. Naming neither is allowed and the server resolves what it can from the thread, but a message it cannot place is refused rather than guessed at",
               "type": "string"
             },
             "evidence": {
@@ -12772,7 +12772,6 @@
             "to",
             "subject",
             "body",
-            "consent_purpose",
             "links"
           ],
           "type": "object"
@@ -12927,7 +12926,7 @@
               "type": "string"
             },
             "consent_purpose": {
-              "description": "Purpose key the recipients must have granted",
+              "description": "Legacy purpose key, optional. communication_context is what the engine decides on; this is read only where the context leaves the question open. Naming neither is allowed and the server resolves what it can from the thread, but a message it cannot place is refused rather than guessed at",
               "type": "string"
             },
             "evidence": {
@@ -12988,8 +12987,7 @@
             "activity_id",
             "to",
             "subject",
-            "body",
-            "consent_purpose"
+            "body"
           ],
           "type": "object"
         },
@@ -13138,7 +13136,7 @@
               "type": "string"
             },
             "consent_purpose": {
-              "description": "Purpose key the recipient must have granted",
+              "description": "Legacy purpose key, optional. communication_context is what the engine decides on; this is read only where the context leaves the question open. Naming neither is allowed and the server resolves what it can from the thread, but a message it cannot place is refused rather than guessed at",
               "type": "string"
             },
             "evidence": {
@@ -13177,8 +13175,7 @@
           },
           "required": [
             "activity_id",
-            "body",
-            "consent_purpose"
+            "body"
           ],
           "type": "object"
         },

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 76 |
 | Resources | 12 |
-| Tool catalog | 217.6 KB |
+| Tool catalog | 218.3 KB |
 | Resource catalog | 4.5 KB |
-| Approx. wire tokens | 56862 |
+| Approx. wire tokens | 57031 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -31,9 +31,9 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 |---|---:|---:|---|
 | Output schemas | 99.6 KB | 45% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 57.5 KB | 26% | Yes, every step |
-| Input schemas | 44.6 KB | 20% | Yes, every step |
+| Input schemas | 45.2 KB | 20% | Yes, every step |
 | _Names, annotations, punctuation_ | 16.0 KB | 7% | Partly |
-| **Description + input schema** | **102.0 KB** | **46%** | **the recurring cost** |
+| **Description + input schema** | **102.7 KB** | **47%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -132,9 +132,9 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`run_report`](#run_report) | Run a report | yes |  | 5.3 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.1 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.8 KB |
-| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 4.3 KB |
-| [`send_email`](#send_email) | Send an email |  |  | 4.0 KB |
-| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 3.4 KB |
+| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 4.6 KB |
+| [`send_email`](#send_email) | Send an email |  |  | 4.2 KB |
+| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 3.6 KB |
 | [`update_record`](#update_record) | Update a record |  |  | 3.8 KB |
 | [`update_tag`](#update_tag) | Rename or recolour a tag |  |  | 2.0 KB |
 | [`whats_slipping_this_week`](#whats_slipping_this_week) | What's slipping this week | yes | [`ui://margince/pipeline-review.html`](#pipeline_review_view) | 2.3 KB |
@@ -13659,7 +13659,7 @@ Put a mail on the wire to a real recipient, from this workspace, starting a new 
       "type": "string"
     },
     "consent_purpose": {
-      "description": "Purpose key the recipients must have granted",
+      "description": "Legacy purpose key, optional. communication_context is what the engine decides on; this is read only where the context leaves the question open. Naming neither is allowed and the server resolves what it can from the thread, but a message it cannot place is refused rather than guessed at",
       "type": "string"
     },
     "evidence": {
@@ -13750,7 +13750,6 @@ Put a mail on the wire to a real recipient, from this workspace, starting a new 
     "to",
     "subject",
     "body",
-    "consent_purpose",
     "links"
   ],
   "type": "object"
@@ -13915,7 +13914,7 @@ Put a mail on the wire to a real recipient, from this workspace, and record it o
       "type": "string"
     },
     "consent_purpose": {
-      "description": "Purpose key the recipients must have granted",
+      "description": "Legacy purpose key, optional. communication_context is what the engine decides on; this is read only where the context leaves the question open. Naming neither is allowed and the server resolves what it can from the thread, but a message it cannot place is refused rather than guessed at",
       "type": "string"
     },
     "evidence": {
@@ -13976,8 +13975,7 @@ Put a mail on the wire to a real recipient, from this workspace, and record it o
     "activity_id",
     "to",
     "subject",
-    "body",
-    "consent_purpose"
+    "body"
   ],
   "type": "object"
 }
@@ -14136,7 +14134,7 @@ Reply on a captured chat conversation — the channels this workspace has connec
       "type": "string"
     },
     "consent_purpose": {
-      "description": "Purpose key the recipient must have granted",
+      "description": "Legacy purpose key, optional. communication_context is what the engine decides on; this is read only where the context leaves the question open. Naming neither is allowed and the server resolves what it can from the thread, but a message it cannot place is refused rather than guessed at",
       "type": "string"
     },
     "evidence": {
@@ -14175,8 +14173,7 @@ Reply on a captured chat conversation — the channels this workspace has connec
   },
   "required": [
     "activity_id",
-    "body",
-    "consent_purpose"
+    "body"
   ],
   "type": "object"
 }

--- a/docs/reference/mcp-tool-coverage.json
+++ b/docs/reference/mcp-tool-coverage.json
@@ -6,7 +6,7 @@
     "required_only_as_one_of_a_set": 1,
     "never_driven": 39,
     "permitted_but_never_required": 19,
-    "tokens_served_but_never_driven": 12467,
+    "tokens_served_but_never_driven": 12636,
     "use_case_cases": 21,
     "acceptance_criteria_named": 49,
     "tools_added_by_shipped_units": 7,
@@ -1179,7 +1179,7 @@
   "tools": [
     {
       "name": "send_account_email",
-      "tokens": 767,
+      "tokens": 823,
       "agents": [],
       "required_by_cases": [],
       "required_as_one_of_a_set_by_cases": [],
@@ -1191,7 +1191,7 @@
     },
     {
       "name": "send_email",
-      "tokens": 698,
+      "tokens": 754,
       "agents": [],
       "required_by_cases": [],
       "required_as_one_of_a_set_by_cases": [],
@@ -1205,7 +1205,7 @@
     },
     {
       "name": "send_message",
-      "tokens": 546,
+      "tokens": 603,
       "agents": [],
       "required_by_cases": [],
       "required_as_one_of_a_set_by_cases": [],

--- a/docs/reference/mcp-tool-coverage.md
+++ b/docs/reference/mcp-tool-coverage.md
@@ -31,7 +31,7 @@ This page does not grade single steps or name a best model per site — that is
 | … some case requires as one of a set | 1 |
 | … **no case requires** | 39 |
 | … of those, permitted somewhere but never required | 19 |
-| Prompt tokens spent on tools no case requires | 12467 |
+| Prompt tokens spent on tools no case requires | 12636 |
 | Use cases | 21 |
 | Acceptance criteria the cases declare, each with a statement | 49 |
 
@@ -412,9 +412,9 @@ A tool in the `Permitted in` column is worse than one with nothing: a case is al
 
 | Tool | Tokens | Graded by | Permitted in | Attached to |
 |---|---:|---|---|---|
-| `send_account_email` | 767 | — | — | — |
-| `send_email` | 698 | `agent_loop` | — | — |
-| `send_message` | 546 | — | — | — |
+| `send_account_email` | 823 | — | — | — |
+| `send_email` | 754 | `agent_loop` | — | — |
+| `send_message` | 603 | — | — | — |
 | `progress_deal` | 505 | `agent_loop` | — | — |
 | `list_records` | 503 | — | `case10_finish_the_import`, `case21_what_are_we_closing`, `case30_a_word_for_it`, `case31_wrong_word_on_the_record`, `case32_two_words_for_one_thing`, `case33_two_cards_for_one_company`, `case40_sort_the_queue`, `case41_close_the_project`, `case7_ask_for_a_number`, `case9_filed_in_the_wrong_place` | `morning_brief`, `overnight_at_risk_sweep` |
 | `resolve_entities` | 491 | `agent_loop` | `case1_log_it`, `case23_find_us_a_slot`, `case2_business_card`, `case30_a_word_for_it`, `case33_two_cards_for_one_company`, `case42_can_i_answer_on_whatsapp` | — |


### PR DESCRIPTION
Two things stood between an agent and the work a refusal leaves behind. This is C3c, the remaining half of the plan's C3.

## The reference was prose

A refused send has named its review since B1, in the message text. That serves a person reading it and nothing else: an agent handed "consent not granted" in English cannot parse an id out of it reliably, and guessing is worse than failing. It stopped, and the review sat there.

The refusal now carries the id as a field beside the message. The tool surface has no structured error shape, so the reference is also appended to that text in a fixed form an agent can be asked to look for. Codex found that half: the seam I built stopped at the REST renderer and never reached the door it was for.

**The status does not move.** A previous attempt at a structured refusal implemented `FieldFault` and flipped the send surface from 409 to 422 across every client that recognised it. The new seam classifies the unreferenced cause, so the status and code are unchanged and only the details are added.

**Both readers keep it.** Classifying the unreferenced cause also answers that cause's own text, which no longer named the review, so a person reading the sentence would have lost what a machine gained. An existing test from B1 caught that.

## It promises nobody a move they cannot make

The first version advertised `request_decision` on every refusal. Routing is human-only and bound to the review's own initiator, so an agent told it may request one would try, be refused, and have been sent there by us. The actions are decided where the principal is known, and an empty list is the honest answer.

## The legacy key was required

Three send tools demanded `consent_purpose`, which A1 replaced. An agent forced to name a legacy key it does not understand names the wrong one. It is optional now.

Saying nothing at all is still refused, and that is the engine working rather than a gap: resolution from the thread cannot tell a quote from a newsletter, so it opens a review instead of guessing.

## Gates run locally

`make check-backend` and the full `internal/compose/integration` lane. Every new test was mutation-tested. Three published reference docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A refused send now carries the review it opened as a structured `review_id` field, so an agent can act on it instead of parsing prose. The three send tools no longer require the legacy `consent_purpose` key.

**Refusals**
- The status and code are unchanged (`409` / `consent_not_granted`); only the error details are added.
- `available_actions` appears only when this caller can act — agents and connectors get an empty list, since decision routing is human-only.
- The tool surface has no structured error shape, so the ID and actions are appended to the error text in a fixed form.

**Send tools**
- `consent_purpose` is optional; `communication_context` is the field the engine decides on.
- Naming neither still refuses with a review, rather than guessing at a purpose.
- Reference docs regenerated to match the new schemas.

<sup>Written for commit 41aa9e6301a9a1ec86223e0fe6667a32fb917c1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Refused message sends now include structured review details, including the review ID and available actions.
  - Human callers with an eligible review can request a decision directly.
  - Agent error explanations now display actionable review information when available.

- **Changes**
  - Communication context can determine the message purpose without requiring the legacy purpose field.
  - Sends lacking enough context are refused rather than assigned a purpose automatically.

- **Documentation**
  - Updated tool references and schemas to reflect the optional legacy purpose field and revised refusal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->