### PR TITLE
fix(tests): a diagnostic read inside a failing assertion says why it failed

### DIFF
--- a/backend/internal/compose/integration/refused_send_review_integration_test.go
+++ b/backend/internal/compose/integration/refused_send_review_integration_test.go
@@ -800,8 +800,13 @@ func TestNamingTheKindIsEnoughWithoutTheLegacyKey(t *testing.T) {
 	}, nil, nil)
 	if status >= 300 {
 		var reason string
-		_ = c.Owner.QueryRow(context.Background(),
-			`SELECT reason_code FROM communication_review WHERE resolved_at IS NULL`).Scan(&reason)
+		// Read to sharpen the failure below, so a refusal that wrote no review
+		// row says so instead of reporting an empty reason as if one had been
+		// recorded — which is the same "answered nothing" this case is about.
+		if err := c.Owner.QueryRow(context.Background(),
+			`SELECT reason_code FROM communication_review WHERE resolved_at IS NULL`).Scan(&reason); err != nil {
+			reason = "no open review to read: " + err.Error()
+		}
 		t.Errorf("a reply naming its kind and no legacy key answered %d (%s), want it accepted — an agent "+
 			"that knows what it is sending should not also have to name a key it does not "+
 			"understand", status, reason)


### PR DESCRIPTION
`main` is craft-red. `make craft-static` blocks on

```
backend/internal/compose/integration/refused_send_review_integration_test.go
  803: [BLOCKER] swallowed-errors — blank-assigning a call result discards a possible error
```

and it blocks on pristine `main` at `93984d3f4` — checked before touching anything, and no open PR is fixing it. Every open PR's `craftsmanship` job fails on it, mine included.

## The fix, and why it is not just a waiver

The read exists to sharpen the failure message beside it: when the send is refused, the test reports the review's `reason_code`. Discarding the error costs that message something real — a refusal that wrote **no review row at all** produced an empty reason, indistinguishable from a row whose `reason_code` is blank, and "no review was written" is the same *answered nothing* the case is about.

So it handles the error rather than waiving it, and the failure now says which of the two happened.

`make craft-static` is 0/0/0 on this branch.