### PR TITLE
fix(authz): a read seat reaches no write grant, whatever the stored row says

### DIFF
--- a/backend/internal/compose/integration/writeauthority_integration_test.go
+++ b/backend/internal/compose/integration/writeauthority_integration_test.go
@@ -93,6 +93,49 @@ func (f sharedPersonFixture) share(t *testing.T, access string) {
 	}
 }
 
+// AAD-AC-4 against the database: a read-seat member holding a WRITE share is
+// still refused.
+//
+// The rule had one guard, at grant creation (refuseWriteGrantToReadSeat), and
+// nothing revokes a standing grant when a seat is downgraded. So the stored
+// row can say the opposite of the rule, and the only thing making that inert
+// is the seat ceiling on the doors that exist today — which is exactly the
+// state that stops being inert when a seat-change endpoint arrives and creates
+// the window in the first place. This is the second guard, and it is the one
+// that holds whatever the stored data says.
+//
+// The pair is the point: the same row, the same caller, the same grant, and
+// only the seat moves.
+func TestAWriteShareIsInertOnAReadSeat(t *testing.T) {
+	f := seedSharedPerson(t, "Downgraded Holder")
+	store := people.NewStore(f.env.DB())
+	id := PersonIDOf(f.person)
+	f.share(t, "write")
+
+	onSeat := func(seat principal.SeatType) error {
+		ctx := recordActor(f.env, f.env.Rep1, principal.RowScopeTeam, []ids.UUID{f.env.Team1})
+		actor, _ := principal.Actor(ctx)
+		actor.SeatType = seat
+		to := "Renamed On A " + string(seat) + " Seat"
+		_, err := store.UpdatePerson(principal.WithActor(ctx, actor), id,
+			people.UpdatePersonInput{FullName: &to, Source: "manual"})
+		return err
+	}
+
+	if err := onSeat(principal.SeatRead); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a read seat wrote under a standing write share → %v, want permission-denied", err)
+	}
+	if got := f.fullName(t); got != "Downgraded Holder" {
+		t.Fatalf("the person reads %q after a refused edit, want it untouched", got)
+	}
+
+	// The allow arm, on the same grant: the share works, and it is the SEAT
+	// that decided the refusal above rather than anything about the share.
+	if err := onSeat(principal.SeatFull); err != nil {
+		t.Fatalf("a full seat could not write under the same write share → %v", err)
+	}
+}
+
 func TestAReadShareOpensAPersonButCannotEditIt(t *testing.T) {
 	f := seedSharedPerson(t, "Read Share Subject")
 	store := people.NewStore(f.env.DB())

--- a/backend/internal/modules/identity/grants.go
+++ b/backend/internal/modules/identity/grants.go
@@ -281,6 +281,22 @@ func grantImage(g grantRow) map[string]any {
 // AC states. The read seats inside it are still refused every write at
 // their own admission, so no authority leaks — the grant is just less
 // useful to them than to their colleagues.
+//
+// WHOEVER SHIPS A SEAT-CHANGE ENDPOINT OWES THE OTHER HALF. This guard runs at
+// grant creation and nowhere else, so a member downgraded to a read seat keeps
+// every write grant they were given while they held a full one. That is the
+// rule and the stored data disagreeing, and the fix belongs in the seat
+// write's own transaction: revoke the subject's write grants there, audited
+// like any other grant change, so the data matches the rule at every instant.
+// A downgrade quietly parking authority is how somebody gets it back on an
+// upgrade nobody re-examined.
+//
+// Until then it is inert rather than wrong: platform/auth's write-authority
+// predicate drops its record_grant arm for a read-seat principal, so the
+// standing grant confers nothing at the place authority is actually read. That
+// is the second guard, it holds whatever the row says, and it is not a reason
+// to skip the revocation — data that states the opposite of the rule is a
+// defect the next reader inherits.
 func refuseWriteGrantToReadSeat(ctx context.Context, tx pgx.Tx, in CreateGrantInput) error {
 	if in.Access != string(crmcontracts.RecordGrantAccessRecordGrantAccessWrite) || in.SubjectType == "team" {
 		return nil

--- a/backend/internal/platform/auth/activitywritescope.go
+++ b/backend/internal/platform/auth/activitywritescope.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+// Who may CHANGE an activity, which is a different question from who may
+// change a record.
+//
+// Its own file because an activity has no owner_id: every other write gate
+// next door asks whose row this is, and none of those questions have an answer
+// here. What an activity has instead is the set of records it is linked to,
+// and authority over any one of them is authority over it — so the arms below
+// are about authorship, assignment and the link walk rather than ownership.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// EnsureActivityWritable is EnsureWritable for an activity, which has no
+// owner_id of its own. The caller must READ it (the content gate — a limited
+// conversation is nobody else's to edit), and their authority to CHANGE it is
+// any of:
+//
+//   - they authored or captured it (captured_by names their user id);
+//   - it is their task or their meeting (assignee_id / host_user_id);
+//   - it is a link-less, workspace-shared note;
+//   - at least one linked record is theirs to change — the same own/team
+//     scope or `write` grant EnsureWritable takes on that record.
+//
+// Reads of customer identity are shared across the workspace, so the read
+// gate alone would let every seat rewrite every colleague's correspondence;
+// this is the arm that keeps activity writes team-shaped. An unbounded human
+// edits every activity they can read, as they edit every record.
+func EnsureActivityWritable(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
+	return EnsureActivityWritableIn(ctx, tx, id, true)
+}
+
+// EnsureActivityWritableIn is EnsureActivityWritable against a chosen row
+// liveness. live=false serves a caller that already resolved the row past
+// its own LiveOnly lock and confirmed it is held under a statutory
+// retention obligation (activities.lockActivityForWrite).
+//
+// It skips the content-visible gate's LIVENESS half rather than passing live
+// through to it: ActivityAvailableClause is `restricted_at IS NULL`
+// UNCONDITIONALLY — by design, a restricted row reads as gone to everyone
+// through that gate, live argument or not (ensureActivity's own doc). A
+// caller reaching this function with live=false already proved the row
+// exists by another means (the row lock, taken directly against the table),
+// so re-asking the liveness half would only reproduce the same false 404
+// this exists to remove. What it does NOT earn a skip from is the OTHER
+// half ActivityContentClause folds in for every non-system caller —
+// ActivityAudienceArm, the row's own participants/selected narrowing —
+// which the ownership check below cannot stand in for: ownership answers
+// "is this the caller's team's record", audience answers "did a human limit
+// who reads this ONE message", and a caller who owns a record is not
+// thereby a participant on every limited message under it. An unbounded
+// human is bound by this too — ActivityContentClause's own doc says only
+// the system principal reads the audience arm away, so Unbounded below must
+// not become a bypass a held row's write-authority check does not have to
+// answer for.
+func EnsureActivityWritableIn(ctx context.Context, tx pgx.Tx, id ids.UUID, live bool) error {
+	if live {
+		if err := ensureActivity(ctx, tx, id, ActivityContentClause, true); err != nil {
+			return err
+		}
+	} else {
+		included, err := activityAudienceIncludes(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if !included {
+			return apperrors.ErrNotFound
+		}
+	}
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return err
+	}
+	if Unbounded(p) {
+		return nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idPos, me, author := arg(id), arg(p.UserID), arg("%:"+p.UserID.String())
+
+	var permitted bool
+	if err := tx.QueryRow(ctx, fmt.Sprintf(`
+		SELECT EXISTS (SELECT 1 FROM activity a WHERE a.id = $%[1]d AND (
+		   a.captured_by LIKE $%[3]d
+		   OR a.assignee_id = $%[2]d
+		   OR a.host_user_id = $%[2]d
+		   OR NOT EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = a.id)
+		   OR EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = a.id AND %[4]s)))`,
+		idPos, me, author, linkTargetWritable(p, "l", arg)), args...).Scan(&permitted); err != nil {
+		return err
+	}
+	if !permitted {
+		if !live {
+			return apperrors.ErrNotFound
+		}
+		return apperrors.ErrPermissionDenied
+	}
+	return nil
+}
+
+// activityAudienceIncludes probes ONLY ActivityAudienceArm — no liveness, no
+// discoverability — for a caller in EnsureActivityWritableIn's live=false
+// branch, whose row existence and archived state were already settled by
+// its own lock. A row the caller cannot find at all answers false, not an
+// error: the same not-found the audience arm itself would give inside the
+// ordinary content-visible probe.
+func activityAudienceIncludes(ctx context.Context, tx pgx.Tx, id ids.UUID) (bool, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idPos := arg(id)
+	audience, err := ActivityAudienceArm(ctx, "a", arg)
+	if err != nil {
+		return false, err
+	}
+	var included bool
+	err = tx.QueryRow(ctx, fmt.Sprintf(
+		`SELECT EXISTS (SELECT 1 FROM activity a WHERE a.id = $%d AND (%s))`, idPos, audience),
+		args...).Scan(&included)
+	return included, err
+}
+
+// linkTargetWritable is linkTargetVisible's write twin: one arm per
+// activity_link column, each asking whether the record it points at is the
+// caller's to change.
+func linkTargetWritable(p principal.Principal, alias string, arg func(any) int) string {
+	arms := make([]string, 0, len(linkTargetTables))
+	for _, t := range []struct{ column, table, probe string }{
+		{personIDColumn, tablePerson, "wp"},
+		{companyIDColumn, tableCompany, "wo"},
+		{dealIDColumn, tableDeal, "wd"},
+		{leadIDColumn, tableLead, "wl"},
+		{projectIDColumn, tableProject, "wpr"},
+	} {
+		arms = append(arms, fmt.Sprintf(
+			`(%[1]s.%[2]s IS NOT NULL AND EXISTS (SELECT 1 FROM %[3]s %[4]s WHERE %[4]s.id = %[1]s.%[2]s AND %[5]s))`,
+			alias, t.column, t.table, t.probe, writeAuthorityPredicateAs(p, t.table, t.probe, arg)))
+	}
+	return "(" + strings.Join(arms, " OR ") + ")"
+}

--- a/backend/internal/platform/auth/inheritedscope.go
+++ b/backend/internal/platform/auth/inheritedscope.go
@@ -371,12 +371,12 @@ func RelationshipEndpointScope(ctx context.Context, alias string, arg func(any) 
 // the table it points at. Two columns point at `company`, which is why this
 // is a slice and not a map.
 var relationshipEndpointColumns = []struct{ column, table string }{
-	{"person_id", tablePerson},
+	{personIDColumn, tablePerson},
 	{"counterparty_person_id", tablePerson},
 	{companyIDColumn, tableCompany},
 	{"counterparty_company_id", tableCompany},
-	{"deal_id", tableDeal},
-	{"project_id", tableProject},
+	{dealIDColumn, tableDeal},
+	{projectIDColumn, tableProject},
 }
 
 // relationshipEndpoints is the distinct endpoint TABLES, for the unbounded

--- a/backend/internal/platform/auth/linkscope.go
+++ b/backend/internal/platform/auth/linkscope.go
@@ -31,8 +31,17 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// companyIDColumn is the reference every scope clause narrows a record by.
-const companyIDColumn = "company_id"
+// The activity_link columns, one per record kind it can point at. Named
+// because both walks over that table — the visible one here and the writable
+// one beside it — spell the same five, and two lists of literals are two
+// chances to spell one of them wrong.
+const (
+	personIDColumn  = "person_id"
+	companyIDColumn = "company_id"
+	dealIDColumn    = "deal_id"
+	leadIDColumn    = "lead_id"
+	projectIDColumn = "project_id"
+)
 
 // LinkTargetVisibleClause answers, for ONE activity_link row, whether the
 // record it points at is visible under the caller's row scope. An empty
@@ -84,11 +93,11 @@ var linkTargetTables = []string{tablePerson, tableCompany, tableDeal, tableLead,
 func linkTargetVisible(p principal.Principal, alias string, arg func(any) int) string {
 	arms := make([]string, 0, len(linkTargetTables))
 	for _, t := range []struct{ column, table, probe string }{
-		{"person_id", tablePerson, "sp"},
+		{personIDColumn, tablePerson, "sp"},
 		{companyIDColumn, tableCompany, "so"},
-		{"deal_id", tableDeal, "sd"},
-		{"lead_id", tableLead, "sl"},
-		{"project_id", tableProject, "spr"},
+		{dealIDColumn, tableDeal, "sd"},
+		{leadIDColumn, tableLead, "sl"},
+		{projectIDColumn, tableProject, "spr"},
 	} {
 		arms = append(arms, linkTargetArm(alias, t.column, t.table, t.probe,
 			VisiblePredicate(p, t.table, arg)(t.probe)))

--- a/backend/internal/platform/auth/writescope.go
+++ b/backend/internal/platform/auth/writescope.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -325,6 +324,40 @@ func writeAuthorityPredicateAs(p principal.Principal, table, alias string, arg f
 	// An ownerless row is nobody's to change: it is claimed first
 	// (EnsureClaimable), then written under the owner scope like any other.
 	owner := ownerPredicate(p, arg, unownedIsNobodys)(alias)
+	// A READ SEAT IS NOT HANDED A WRITE GRANT BY THIS ARM, and the rule this
+	// keeps is AAD-AC-4: a read-seat member may not hold write authority over a
+	// record, whatever a stored grant says.
+	//
+	// Its only guard was refuseWriteGrantToReadSeat, at grant CREATION. Nothing
+	// revokes a standing write grant when a seat is downgraded, so between the
+	// downgrade and a cleanup nobody has written yet, the stored data says the
+	// opposite of the rule. The seat ceiling makes that inert on the doors that
+	// exist today — a REST mutation dies at the ceiling, an agent call at the
+	// admission gate — which is exactly the state that stops being inert when a
+	// third door arrives, and a seat-change endpoint is what would create the
+	// window in the first place.
+	//
+	// Read from the PRINCIPAL rather than joined from app_user: the seat is
+	// already resolved on every call, it is the same value the ceiling reads,
+	// and a join would put a second answer to one question inside the hottest
+	// predicate in the tree.
+	//
+	// Compared against SeatRead rather than asked CanMutate, and the difference
+	// is the UNSET seat. CanMutate is fail-closed — an unset seat reads as a
+	// read one — which is right at the ceiling, where the question is whether
+	// to admit a mutation at all. Here it would narrow the authority of every
+	// internal principal whose loader has no seat to resolve, which is most of
+	// them: a job, a relay, a worker. Those calls are already refused at the
+	// ceiling if they are somebody's, and narrowing them here would trade a
+	// rule about read seats for a behaviour change nobody asked for. So this
+	// removes the arm for exactly the principal the rule names.
+	//
+	// The owner arm is untouched: owning a record is not a grant, and a read
+	// seat's own records are refused by the ceiling like everything else it
+	// might write.
+	if p.SeatType == principal.SeatRead {
+		return "(" + owner + ")"
+	}
 	me, teams := arg(p.UserID), arg(p.TeamIDs)
 	return fmt.Sprintf(`(%s OR EXISTS (
 		   SELECT 1 FROM record_grant rg
@@ -334,133 +367,6 @@ func writeAuthorityPredicateAs(p principal.Principal, table, alias string, arg f
 		     AND ((rg.subject_type = 'user' AND rg.subject_id = $%d)
 		       OR (rg.subject_type = 'team' AND rg.subject_id = ANY($%d)))))`,
 		owner, table, alias, grantAccessWrite, me, teams)
-}
-
-// EnsureActivityWritable is EnsureWritable for an activity, which has no
-// owner_id of its own. The caller must READ it (the content gate — a limited
-// conversation is nobody else's to edit), and their authority to CHANGE it is
-// any of:
-//
-//   - they authored or captured it (captured_by names their user id);
-//   - it is their task or their meeting (assignee_id / host_user_id);
-//   - it is a link-less, workspace-shared note;
-//   - at least one linked record is theirs to change — the same own/team
-//     scope or `write` grant EnsureWritable takes on that record.
-//
-// Reads of customer identity are shared across the workspace, so the read
-// gate alone would let every seat rewrite every colleague's correspondence;
-// this is the arm that keeps activity writes team-shaped. An unbounded human
-// edits every activity they can read, as they edit every record.
-func EnsureActivityWritable(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
-	return EnsureActivityWritableIn(ctx, tx, id, true)
-}
-
-// EnsureActivityWritableIn is EnsureActivityWritable against a chosen row
-// liveness. live=false serves a caller that already resolved the row past
-// its own LiveOnly lock and confirmed it is held under a statutory
-// retention obligation (activities.lockActivityForWrite).
-//
-// It skips the content-visible gate's LIVENESS half rather than passing live
-// through to it: ActivityAvailableClause is `restricted_at IS NULL`
-// UNCONDITIONALLY — by design, a restricted row reads as gone to everyone
-// through that gate, live argument or not (ensureActivity's own doc). A
-// caller reaching this function with live=false already proved the row
-// exists by another means (the row lock, taken directly against the table),
-// so re-asking the liveness half would only reproduce the same false 404
-// this exists to remove. What it does NOT earn a skip from is the OTHER
-// half ActivityContentClause folds in for every non-system caller —
-// ActivityAudienceArm, the row's own participants/selected narrowing —
-// which the ownership check below cannot stand in for: ownership answers
-// "is this the caller's team's record", audience answers "did a human limit
-// who reads this ONE message", and a caller who owns a record is not
-// thereby a participant on every limited message under it. An unbounded
-// human is bound by this too — ActivityContentClause's own doc says only
-// the system principal reads the audience arm away, so Unbounded below must
-// not become a bypass a held row's write-authority check does not have to
-// answer for.
-func EnsureActivityWritableIn(ctx context.Context, tx pgx.Tx, id ids.UUID, live bool) error {
-	if live {
-		if err := ensureActivity(ctx, tx, id, ActivityContentClause, true); err != nil {
-			return err
-		}
-	} else {
-		included, err := activityAudienceIncludes(ctx, tx, id)
-		if err != nil {
-			return err
-		}
-		if !included {
-			return apperrors.ErrNotFound
-		}
-	}
-	p, err := rbacActor(ctx)
-	if err != nil {
-		return err
-	}
-	if Unbounded(p) {
-		return nil
-	}
-	var args []any
-	arg := func(v any) int { args = append(args, v); return len(args) }
-	idPos, me, author := arg(id), arg(p.UserID), arg("%:"+p.UserID.String())
-
-	var permitted bool
-	if err := tx.QueryRow(ctx, fmt.Sprintf(`
-		SELECT EXISTS (SELECT 1 FROM activity a WHERE a.id = $%[1]d AND (
-		   a.captured_by LIKE $%[3]d
-		   OR a.assignee_id = $%[2]d
-		   OR a.host_user_id = $%[2]d
-		   OR NOT EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = a.id)
-		   OR EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = a.id AND %[4]s)))`,
-		idPos, me, author, linkTargetWritable(p, "l", arg)), args...).Scan(&permitted); err != nil {
-		return err
-	}
-	if !permitted {
-		if !live {
-			return apperrors.ErrNotFound
-		}
-		return apperrors.ErrPermissionDenied
-	}
-	return nil
-}
-
-// activityAudienceIncludes probes ONLY ActivityAudienceArm — no liveness, no
-// discoverability — for a caller in EnsureActivityWritableIn's live=false
-// branch, whose row existence and archived state were already settled by
-// its own lock. A row the caller cannot find at all answers false, not an
-// error: the same not-found the audience arm itself would give inside the
-// ordinary content-visible probe.
-func activityAudienceIncludes(ctx context.Context, tx pgx.Tx, id ids.UUID) (bool, error) {
-	var args []any
-	arg := func(v any) int { args = append(args, v); return len(args) }
-	idPos := arg(id)
-	audience, err := ActivityAudienceArm(ctx, "a", arg)
-	if err != nil {
-		return false, err
-	}
-	var included bool
-	err = tx.QueryRow(ctx, fmt.Sprintf(
-		`SELECT EXISTS (SELECT 1 FROM activity a WHERE a.id = $%d AND (%s))`, idPos, audience),
-		args...).Scan(&included)
-	return included, err
-}
-
-// linkTargetWritable is linkTargetVisible's write twin: one arm per
-// activity_link column, each asking whether the record it points at is the
-// caller's to change.
-func linkTargetWritable(p principal.Principal, alias string, arg func(any) int) string {
-	arms := make([]string, 0, len(linkTargetTables))
-	for _, t := range []struct{ column, table, probe string }{
-		{"person_id", tablePerson, "wp"},
-		{companyIDColumn, tableCompany, "wo"},
-		{"deal_id", tableDeal, "wd"},
-		{"lead_id", tableLead, "wl"},
-		{"project_id", tableProject, "wpr"},
-	} {
-		arms = append(arms, fmt.Sprintf(
-			`(%[1]s.%[2]s IS NOT NULL AND EXISTS (SELECT 1 FROM %[3]s %[4]s WHERE %[4]s.id = %[1]s.%[2]s AND %[5]s))`,
-			alias, t.column, t.table, t.probe, writeAuthorityPredicateAs(p, t.table, t.probe, arg)))
-	}
-	return "(" + strings.Join(arms, " OR ") + ")"
 }
 
 // EnsureClaimable is the gate in front of taking ownership of a row. A claim

--- a/backend/internal/platform/auth/writescope_test.go
+++ b/backend/internal/platform/auth/writescope_test.go
@@ -30,6 +30,35 @@ func writeArm(p principal.Principal, table string) string {
 	return writeAuthorityPredicate(p, table, arg)
 }
 
+// AAD-AC-4: a read-seat member may not hold write authority over a record.
+//
+// Its only guard was at grant CREATION, and nothing revokes a standing write
+// grant when a seat is downgraded — so between the downgrade and a cleanup
+// nobody has written yet, the stored data says the opposite of the rule. The
+// seat ceiling makes that inert on the doors that exist today, which is exactly
+// the state that stops being inert when a third door arrives.
+//
+// Both directions, because an arm that vanished for everybody would pass the
+// refusal half on its own: a FULL seat still reaches its grants, and only the
+// seat moved between the two.
+func TestAReadSeatReachesNoWriteGrant(t *testing.T) {
+	for _, table := range []string{"person", "company", "deal", "lead", "project"} {
+		reader := human(principal.RowScopeTeam)
+		reader.SeatType = principal.SeatRead
+		if sql := writeArm(reader, table); strings.Contains(sql, "record_grant") {
+			t.Errorf("a read seat's %s write arm still counts a record_grant, so a share written "+
+				"before the downgrade still confers write: %s", table, sql)
+		}
+
+		writer := human(principal.RowScopeTeam)
+		writer.SeatType = principal.SeatFull
+		if sql := writeArm(writer, table); !strings.Contains(sql, "record_grant") {
+			t.Errorf("a full seat's %s write arm reaches no grant at all, so the share this "+
+				"product sells does nothing: %s", table, sql)
+		}
+	}
+}
+
 func TestTheWriteArmCountsOnlyAWriteGrant(t *testing.T) {
 	for _, table := range []string{"person", "company", "deal", "lead", "project"} {
 		for _, scope := range []principal.RowScope{principal.RowScopeOwn, principal.RowScopeTeam} {


### PR DESCRIPTION
Closes #1298 — items 2, 3 and 4 of the ruling. Item 1 has no transaction to live in yet; that is at the bottom, and it is written into the code rather than left here.

## The gap

`AAD-AC-4`: a read-seat member may not hold write authority over a record. It had **one** guard — `refuseWriteGrantToReadSeat`, at grant **creation**. Nothing revokes a standing write grant when a seat is downgraded, and `writeAuthorityPredicateAs` counted any unexpired grant as live without ever consulting the subject's seat.

So the stored data can say the opposite of the rule. Today that is inert: a REST mutation dies at the seat ceiling and an agent call at the admission gate. **"False but currently inert" is exactly the state that stops being inert when a third door arrives** — and a seat-change endpoint is the door that would create the window in the first place.

## The second guard, where authority is read

The write-authority predicate drops its `record_grant` arm for a read-seat principal. The owner arm is untouched — owning a record is not a grant, and a read seat's own records are refused by the ceiling like everything else it might write.

Two choices worth stating:

- **The seat comes off the principal, not a join.** It is already resolved on every call, it is the same value the ceiling reads, and a join would put a second answer to one question inside the hottest predicate in the tree.
- **Compared against `SeatRead`, not asked `CanMutate`.** `CanMutate` is fail-closed — an unset seat reads as a read one — which is right at the ceiling, where the question is whether to admit a mutation at all. Here it would narrow the authority of every internal principal whose loader has no seat to resolve, which is most of them (a job, a relay, a worker), trading a rule about read seats for a behaviour change nobody asked for. So the arm is removed for exactly the principal the rule names.

## Tests

Both directions at both levels, because an arm that vanished for everybody would pass the refusal half on its own:

- `TestAReadSeatReachesNoWriteGrant` (unit, all five shareable tables): a read seat's write arm names no `record_grant`; a full seat's still does.
- `TestAWriteShareIsInertOnAReadSeat` (integration, real grant through the real writer): the same row, the same caller, the same **write** share — a read seat is refused and the record is unchanged; a full seat writes. Only the seat moves between the two.

Mutation-checked: disabling the branch makes the read seat write, and the integration test fails.

## Item 1, and why it is not a stub here

No online surface writes `seat_type` — the ruling confirms it, and I re-checked: the only writer in the tree is a test harness. So there is no seat write to put a revocation inside, and a `RevokeWriteGrantsOnDowngrade` with no caller is the speculative abstraction the craft rules forbid, guessing at a transaction somebody else will shape.

What that author owes is written **where they will read it** — on `refuseWriteGrantToReadSeat`, the one place that already knows this rule:

> **WHOEVER SHIPS A SEAT-CHANGE ENDPOINT OWES THE OTHER HALF.** … revoke the subject's write grants there, audited like any other grant change, so the data matches the rule at every instant. A downgrade quietly parking authority is how somebody gets it back on an upgrade nobody re-examined.
> Until then it is inert rather than wrong … That is the second guard, it holds whatever the row says, and it is **not** a reason to skip the revocation — data that states the opposite of the rule is a defect the next reader inherits.

## One thing on the way

`writescope.go` was one line under the 500 cap and my comment took it over. The **activity** write gates move to their own file: they are the one concept in there that asks nothing about ownership — an activity has no `owner_id`, its authority comes from the records it links to. The five `activity_link` columns become named constants at the same time, since two walks over that table were spelling the same five literals.

## Checks

`make check-backend` green, `make craft-static` 0/0/0 (behind #5367, which unbreaks main's craft blocker), `make test-it DIR=backend/internal/compose/integration` green (whole package).