### PR TITLE
The warning a director acknowledges is the server's own

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -39877,6 +39877,13 @@ components:
             The card a routed review was handed to, so a decider reading this can find the decision
             they are being asked to make. Null on a review nobody has asked about, which is most of
             them.
+        warning:
+          $ref: '#/components/schemas/OverrideWarning'
+          description: |
+            What somebody must be shown before they direct this send, and the version their
+            acknowledgement will name. Served rather than composed by the client: an instruction's
+            claim is that a named person read particular words, and a client free to write its own
+            would have the record assert an acknowledgement of text nobody published.
 
     CommunicationReviewList:
       type: object
@@ -39891,6 +39898,26 @@ components:
           description: |
             How many are waiting in total. A page at its limit has more behind it, and this is how
             the caller knows rather than by discovering it.
+
+    OverrideWarning:
+      type: object
+      description: |
+        The caution a person reads before overruling the engine, with the version that identifies
+        it. Both together, because a surface that could get one without the other would show words
+        while naming a different version.
+      required: [version, text]
+      properties:
+        version:
+          type: string
+          description: |
+            What the acknowledgement records. It moves whenever the text does — an instruction
+            naming a version whose words were later edited is a record of an acknowledgement
+            nobody made.
+        text:
+          type: string
+          description: |
+            Shown verbatim. A surface that paraphrased it would record somebody as having read the
+            server's words while showing them its own.
 
     RequestCommunicationDecisionRequest:
       type: object

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 49
+	wantFixtureAnnotations = 50
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/overridewarning_test.go
+++ b/backend/gates/overridewarning_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind claim H2
+
+package gates
+
+// The words behind a recorded acknowledgement cannot change without the version
+// changing.
+//
+// An instruction records that a named person read a particular warning before
+// overruling the engine, and it records that as a VERSION. The whole claim
+// rests on the version identifying one fixed text: edit the sentence and leave
+// the version alone, and every past acknowledgement silently becomes a record
+// of words nobody was shown.
+//
+// Nothing about the Go compiler stops that edit, and nothing in a review
+// reliably catches it — the version is thirty lines from the text and looks
+// like a constant nobody needs to touch. So the text is pinned by its digest
+// here, and the digest is what a change has to come and edit deliberately.
+//
+// WHEN THE WARNING CHANGES: move the version constant, put the new digest
+// below, and say in the commit message why the wording moved. The old version
+// stays valid for the instructions that name it — this gate is about what the
+// CURRENT version means, not about retiring old ones.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+)
+
+// The warning lives in consent, which this package may not import: gates read
+// the tree rather than linking it, so a gate cannot be satisfied by a build
+// that compiles. The text and the version are parsed out of the source.
+const overrideWarningFile = "internal/modules/consent/overridewarning.go"
+
+// warningDigests pins the exact text each served version stands for.
+//
+// A version missing here fails too: an unpinned version is one whose words can
+// be edited freely, which is the state this gate exists to end.
+// gatekit:fixture the digest each served warning version stands for — expected
+// data, not a cost
+var warningDigests = map[string]string{
+	"override-v1": "de2de8c051f8eed3177d2583e13ef5f72d77d0db20d4f32b27ddea0e6d494379",
+}
+
+func TestTheOverrideWarningTextMatchesItsVersion(t *testing.T) {
+	t.Parallel()
+	version, text := servedWarning(t)
+
+	pinned, known := warningDigests[version]
+	if !known {
+		t.Fatalf("the served warning version %q is not pinned to any text.\n\n"+
+			"An unpinned version is one whose words can be edited without anything noticing, and "+
+			"every instruction naming it would then record an acknowledgement of words nobody was "+
+			"shown. Add it to warningDigests with the digest below.\n\n\tdigest: %s",
+			version, digestOf(text))
+	}
+	if got := digestOf(text); got != pinned {
+		t.Errorf("the warning text for %q changed and the version did not.\n\n"+
+			"Every instruction already naming this version claims somebody read the OLD words. "+
+			"Move the version constant, pin the new digest, and say in the commit why the wording "+
+			"moved — the old version stays valid for the records that name it.\n\n"+
+			"\twas:  %s\n\tnow:  %s",
+			version, pinned, got)
+	}
+
+	// The text is asserted to be real before its digest is believed: an empty
+	// string has a digest too, and a warning that says nothing would pass a
+	// pure digest comparison while telling a director nothing at all.
+	if len(text) < 100 {
+		t.Errorf("the override warning is %d characters, which is too short to say what it has "+
+			"to say: that the refusal stands, that the decision is recorded under their name, and "+
+			"that it covers this message alone", len(text))
+	}
+}
+
+// servedWarning reads the version and the text out of the source, so this gate
+// judges what the tree says rather than what a build happens to link.
+//
+// PARSED WITH go/ast, not with a regex over the bytes. A regex that scanned for
+// quoted pieces could be fooled by three gofmt-valid edits that leave the
+// digest untouched: a raw string appended to the text, a `+` continuation past
+// a blank line, and a quoted fragment moved into a line comment. Each made the
+// gate read a different string than the server serves, so it agreed with itself
+// while the warning had changed — which is the one failure it exists to
+// prevent.
+//
+// The parser evaluates the constant the compiler would: every operand of the
+// concatenation, in order, whatever quoting each uses.
+func servedWarning(t *testing.T) (version, text string) {
+	t.Helper()
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, overrideWarningFile, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("reading %s: %v", overrideWarningFile, err)
+	}
+	for _, decl := range parsed.Decls {
+		general, ok := decl.(*ast.GenDecl)
+		if !ok || general.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range general.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok || len(value.Names) != 1 || len(value.Values) != 1 {
+				continue
+			}
+			switch value.Names[0].Name {
+			case "OverrideWarningVersion":
+				version = constantString(t, value.Values[0])
+			case "overrideWarningText":
+				text = constantString(t, value.Values[0])
+			}
+		}
+	}
+	if version == "" {
+		t.Fatalf("%s declares no OverrideWarningVersion — this gate cannot see the version it "+
+			"exists to pin", overrideWarningFile)
+	}
+	if text == "" {
+		t.Fatalf("%s declares no overrideWarningText this gate could read", overrideWarningFile)
+	}
+	return version, text
+}
+
+// constantString evaluates a string constant expression the way the compiler
+// does: a literal, or any concatenation of them.
+//
+// ANYTHING ELSE FAILS rather than being skipped. A constant built from a
+// helper call or another identifier is one this gate cannot follow, and
+// quietly reading part of it would be the silent disagreement the whole file
+// is about.
+func constantString(t *testing.T, expr ast.Expr) string {
+	t.Helper()
+	switch node := expr.(type) {
+	case *ast.BasicLit:
+		if node.Kind != token.STRING {
+			t.Fatalf("%s: expected a string constant, found %s", overrideWarningFile, node.Kind)
+		}
+		return unquote(t, node.Value)
+	case *ast.BinaryExpr:
+		if node.Op != token.ADD {
+			t.Fatalf("%s: a string constant is built with + and nothing else, found %s",
+				overrideWarningFile, node.Op)
+		}
+		return constantString(t, node.X) + constantString(t, node.Y)
+	default:
+		t.Fatalf("%s: this gate reads string literals and their concatenation, and the constant "+
+			"is neither — it cannot judge text it cannot evaluate", overrideWarningFile)
+		return ""
+	}
+}
+
+func unquote(t *testing.T, quoted string) string {
+	t.Helper()
+	value, err := strconv.Unquote(quoted)
+	if err != nil {
+		t.Fatalf("reading %s: %v", quoted, err)
+	}
+	return value
+}
+
+func digestOf(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/compose/integration/directedsend_integration_test.go
+++ b/backend/internal/compose/integration/directedsend_integration_test.go
@@ -29,7 +29,7 @@ func directed() AnyMap {
 	return AnyMap{
 		"reason_code":     "contractual_necessity",
 		"explanation":     "The service agreement obliges us to send this notice.",
-		"warning_version": "v1",
+		"warning_version": "override-v1",
 		"acknowledged":    true,
 	}
 }
@@ -284,5 +284,66 @@ func TestADirectedSendClosesTheReviewItAnswered(t *testing.T) {
 	if rows != 1 {
 		t.Error("the review was deleted rather than closed — nothing is left to answer a subject " +
 			"asking why they received the message")
+	}
+}
+
+// THE WARNING IS THE SERVER'S OWN WORDS.
+//
+// An instruction's whole claim is that a named person read a particular
+// caution before overruling the engine, and it records that as a version. A
+// client free to compose its own wording, or to name any version it liked,
+// would have the record assert an acknowledgement of text nobody published.
+//
+// So the review serves the words and the version together, and the door refuses
+// a version this installation does not serve.
+func TestTheWarningADirectorAcknowledgesIsTheServersOwn(t *testing.T) {
+	c := setupConsent(t)
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send → %d, want 409", status)
+	}
+	review := liveReviewID(t, c)
+
+	var opened struct {
+		Warning struct {
+			Version string `json:"version"`
+			Text    string `json:"text"`
+		} `json:"warning"`
+	}
+	if status := c.Call(t, "GET", "/v1/communication-reviews/"+review, nil, nil, &opened); status != http.StatusOK {
+		t.Fatalf("reading the review → %d, want 200", status)
+	}
+	if opened.Warning.Version == "" || opened.Warning.Text == "" {
+		t.Fatalf("the review serves warning %+v — a surface with nothing to show would compose "+
+			"its own, and the record would name words this installation never wrote",
+			opened.Warning)
+	}
+
+	// A version the installation does not serve is refused, whatever else the
+	// request gets right.
+	invented := directed()
+	invented["warning_version"] = "whatever-v99"
+	if status := c.Call(t, "POST", "/v1/communication-reviews/"+review+"/direct-send",
+		invented, nil, nil); status == http.StatusCreated {
+		t.Error("a decision naming a warning version this installation does not serve was " +
+			"recorded — the record asserts somebody read words nobody published")
+	}
+
+	// And the version the review served is accepted.
+	acknowledged := directed()
+	acknowledged["warning_version"] = opened.Warning.Version
+	if status := c.Call(t, "POST", "/v1/communication-reviews/"+review+"/direct-send",
+		acknowledged, nil, nil); status != http.StatusCreated {
+		t.Errorf("the version the review itself served was refused → %d — a director cannot "+
+			"acknowledge the warning they were shown", status)
+	}
+	var recorded string
+	if err := c.Owner.QueryRow(context.Background(),
+		`SELECT warning_version FROM communication_instruction`).Scan(&recorded); err != nil {
+		t.Fatalf("reading the decision: %v", err)
+	}
+	if recorded != opened.Warning.Version {
+		t.Errorf("the record names warning %q and the director was shown %q",
+			recorded, opened.Warning.Version)
 	}
 }

--- a/backend/internal/compose/reviewdecision.go
+++ b/backend/internal/compose/reviewdecision.go
@@ -150,7 +150,7 @@ func reviewDecisionEffect(svc *approvals.Service, directed directedSendService) 
 			// the instruction refuses an empty explanation, and "approved from
 			// the queue" is the truthful minimum.
 			Explanation:    decision.recordedExplanation(),
-			WarningVersion: reviewCardWarningVersion,
+			WarningVersion: consent.QueueCardWarningVersion,
 			// Approving IS the acknowledgement. The card said what this is and
 			// the approver pressed approve; requiring a second tick inside the
 			// effect would be asking them to confirm the thing they just did.
@@ -159,12 +159,6 @@ func reviewDecisionEffect(svc *approvals.Service, directed directedSendService) 
 		return err
 	}
 }
-
-// reviewCardWarningVersion names the wording an approver was shown when they
-// answered a queue card, as distinct from the modal's own text. The record has
-// to say which words somebody read, and a card and a modal are not the same
-// words.
-const reviewCardWarningVersion = "queue-card-v1"
 
 // decodeReviewDecision reads a staged card, refusing one carrying anything this
 // effect does not act on.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21083,6 +21083,11 @@ type CommunicationReview struct {
 	// somebody who may override it: their work no longer, so a surface should say so rather
 	// than showing them a form they have already filled in.
 	State CommunicationReviewState `json:"state"`
+
+	// Warning The caution a person reads before overruling the engine, with the version that identifies
+	// it. Both together, because a surface that could get one without the other would show words
+	// while naming a different version.
+	Warning *OverrideWarning `json:"warning,omitempty"`
 }
 
 // CommunicationReviewKind defines model for CommunicationReview.Kind.
@@ -29968,6 +29973,20 @@ type OverlayUserMapPage struct {
 	Entries    []OverlayUserMapEntry `json:"entries"`
 	Incumbent  string                `json:"incumbent"`
 	NextCursor *string               `json:"next_cursor,omitempty"`
+}
+
+// OverrideWarning The caution a person reads before overruling the engine, with the version that identifies
+// it. Both together, because a surface that could get one without the other would show words
+// while naming a different version.
+type OverrideWarning struct {
+	// Text Shown verbatim. A surface that paraphrased it would record somebody as having read the
+	// server's words while showing them its own.
+	Text string `json:"text"`
+
+	// Version What the acknowledgement records. It moves whenever the text does — an instruction
+	// naming a version whose words were later edited is a record of an acknowledgement
+	// nobody made.
+	Version string `json:"version"`
 }
 
 // PageInfo defines model for PageInfo.

--- a/backend/internal/modules/consent/handlers_review.go
+++ b/backend/internal/modules/consent/handlers_review.go
@@ -82,6 +82,14 @@ func wireReview(review Review) crmcontracts.CommunicationReview {
 		card := openapi_types.UUID(review.ApprovalID)
 		out.ApprovalId = &card
 	}
+	// SERVED ON EVERY REVIEW, not only on ones somebody may direct. Whether
+	// this reader holds the grant is a question the direct-send door answers,
+	// and withholding the words here would make a surface guess whether to ask
+	// for them — one more round trip, and a modal that opens empty.
+	warning := TheOverrideWarning()
+	out.Warning = &crmcontracts.OverrideWarning{
+		Version: warning.Version, Text: warning.Text,
+	}
 	return out
 }
 

--- a/backend/internal/modules/consent/instruction.go
+++ b/backend/internal/modules/consent/instruction.go
@@ -134,6 +134,11 @@ func (s *Store) DirectSend(ctx context.Context, reviewID ids.UUID, in DirectInpu
 	if err := auth.Require(ctx, entityCommunicationException, principal.ActionCreate); err != nil {
 		return Instruction{}, err
 	}
+	// NORMALISED BEFORE ANYTHING READS IT, so the value checked and the value
+	// stored are one value. Trimming only inside the check let " override-v1 "
+	// pass and then land on the row naming a version nothing serves.
+	in.WarningVersion = strings.TrimSpace(in.WarningVersion)
+	in.Explanation = strings.TrimSpace(in.Explanation)
 	if err := validateDirect(in); err != nil {
 		return Instruction{}, err
 	}
@@ -177,7 +182,7 @@ func (s *Store) DirectSend(ctx context.Context, reviewID ids.UUID, in DirectInpu
 			   acknowledged_at, facts_as_of, valid_until, acknowledged_wording)
 			VALUES ($1, $2, $3, $4, $5, now(), $6, $7, $8)
 			RETURNING id`,
-			reviewID, director, in.ReasonCode, strings.TrimSpace(in.Explanation),
+			reviewID, director, in.ReasonCode, in.Explanation,
 			in.WarningVersion, review.OpenedAt, out.ValidUntil, acknowledged).Scan(&out.ID); err != nil {
 			// A DECISION ALREADY STANDS ON THIS REVIEW, which is what the
 			// unique key on review_id says. Named rather than reported as a
@@ -299,10 +304,25 @@ func validateDirect(in DirectInput) error {
 			Reason: "an explanation is at most 1000 characters",
 		}
 	}
-	if strings.TrimSpace(in.WarningVersion) == "" {
+	// A VERSION THIS BUILD ACTUALLY SERVES, not merely a non-empty string.
+	//
+	// The record's whole claim is that a named person read particular words. A
+	// caller free to name any version could write "v99" onto an instruction and
+	// the record would assert an acknowledgement of text nobody ever wrote —
+	// which is exactly the assertion a dispute about an override turns on.
+	//
+	// The queue card has its own version because a card and a modal are not the
+	// same words: somebody approving from a list read a summary, and recording
+	// them as having read the modal's caution would overstate what they saw.
+	// COMPARED AND STORED AS THE SAME VALUE. Trimming only for the comparison
+	// let " override-v1 " pass the check and land on the row, where it names a
+	// version the served set does not contain — so the record would claim an
+	// acknowledgement of a version nothing publishes.
+	if !servedWarningVersion(in.WarningVersion) {
 		return &ValidationError{
-			Field:  "warning_version",
-			Reason: "a decision records which warning the director was shown",
+			Field: "warning_version",
+			Reason: "a decision records which warning the director was shown, and it must be one " +
+				"this installation serves",
 		}
 	}
 	return nil
@@ -378,3 +398,27 @@ func isDuplicateInstruction(err error) bool {
 	constraint, ok := storekit.UniqueViolation(err)
 	return ok && strings.Contains(constraint, "review_id")
 }
+
+// servedWarningVersion reports whether this build published the wording a
+// caller says they were shown.
+//
+// TWO, and they are different surfaces rather than two spellings of one. The
+// override warning is the caution in the modal a director reads before sending;
+// the queue-card version names the summary an approver answered from a list.
+// Recording one as the other would say somebody read words they never saw.
+func servedWarningVersion(version string) bool {
+	switch strings.TrimSpace(version) {
+	case OverrideWarningVersion, QueueCardWarningVersion:
+		return true
+	default:
+		return false
+	}
+}
+
+// QueueCardWarningVersion names the summary an approver answers from in the
+// approvals queue, as distinct from the modal's own caution.
+//
+// It lives here rather than in compose so the validator and the effect that
+// writes it read one constant: two spellings would let a version be recorded
+// that the check does not admit.
+const QueueCardWarningVersion = "queue-card-v1"

--- a/backend/internal/modules/consent/instruction_integration_test.go
+++ b/backend/internal/modules/consent/instruction_integration_test.go
@@ -113,7 +113,7 @@ func TestOnlyAHumanHoldingTheGrantDirectsASend(t *testing.T) {
 	valid := DirectInput{
 		ReasonCode:     ReasonContractualNecessity,
 		Explanation:    "The framework agreement obliges us to send this notice.",
-		WarningVersion: "warn-2026-09",
+		WarningVersion: OverrideWarningVersion,
 		Acknowledged:   true,
 	}
 
@@ -168,7 +168,7 @@ func TestDirectingASendRecordsNoConsentAndLeavesTheRefusal(t *testing.T) {
 	if _, err := e.store.DirectSend(directorCtx(ws, user), review, DirectInput{
 		ReasonCode:     ReasonLegalObligation,
 		Explanation:    "Statutory notice, owed whatever they asked for.",
-		WarningVersion: "warn-2026-09",
+		WarningVersion: OverrideWarningVersion,
 		Acknowledged:   true,
 	}); err != nil {
 		t.Fatalf("directing the send: %v", err)
@@ -207,7 +207,7 @@ func TestAnInstructionCannotBeRewritten(t *testing.T) {
 	out, err := e.store.DirectSend(directorCtx(ws, user), review, DirectInput{
 		ReasonCode:     ReasonOtherException,
 		Explanation:    "Agreed with the client on the call this morning.",
-		WarningVersion: "warn-2026-09",
+		WarningVersion: OverrideWarningVersion,
 		Acknowledged:   true,
 	})
 	if err != nil {
@@ -244,7 +244,7 @@ func TestARevocationNamesItselfAndSpareAConsumedInstruction(t *testing.T) {
 	out, err := e.store.DirectSend(directorCtx(ws, user), review, DirectInput{
 		ReasonCode:     ReasonOtherException,
 		Explanation:    "Thought better of it.",
-		WarningVersion: "warn-2026-09",
+		WarningVersion: OverrideWarningVersion,
 		Acknowledged:   true,
 	})
 	if err != nil {
@@ -291,7 +291,7 @@ func TestAnErasureCanTombstoneTheWordsAndNothingElse(t *testing.T) {
 	out, err := e.store.DirectSend(directorCtx(ws, user), review, DirectInput{
 		ReasonCode:     ReasonOtherException,
 		Explanation:    "Anna asked for this on the call this morning.",
-		WarningVersion: "warn-2026-09",
+		WarningVersion: OverrideWarningVersion,
 		Acknowledged:   true,
 	})
 	if err != nil {

--- a/backend/internal/modules/consent/overridewarning.go
+++ b/backend/internal/modules/consent/overridewarning.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What a person is told before they overrule the engine.
+//
+// An instruction records the WARNING VERSION somebody acknowledged, because a
+// record naming no version cannot say what they were told and the text changes.
+// Until now that version was a string a caller supplied and nothing published
+// the words behind it — so a client could name any version it liked, and the
+// record would say a person had read wording the installation never wrote.
+//
+// The warning is served from here instead. A surface shows what it is given and
+// echoes the version back; the record then names text that exists, and a dispute
+// about an override can be answered with the words themselves.
+//
+// NOT A TEMPLATE, and not in consent_text_version. Those are the wording
+// published to DATA SUBJECTS — the sentence in a confirmation mail, the
+// disclosure on a preference page — and they are per-locale rows an erasure and
+// a proof both reach. This is an internal caution shown to an employee about a
+// decision they are making, which belongs in the build rather than in a table
+// somebody's installation can edit.
+//
+// THE VERSION MOVES WHEN THE WORDS DO. That is the whole contract: an
+// instruction saying "override-v1" must mean one fixed text forever, so
+// changing the sentence without moving the version would silently rewrite what
+// every past acknowledgement claims to have said. A gate holds it.
+
+// OverrideWarning is the caution a person reads before directing a refused
+// send, and the version their acknowledgement will name.
+type OverrideWarning struct {
+	Version string
+	Text    string
+}
+
+// OverrideWarningVersion is the version this build serves.
+//
+// MOVE IT WHENEVER THE TEXT BELOW CHANGES, in the same commit. An instruction
+// naming a version whose words have since been edited is a record of an
+// acknowledgement nobody made.
+const OverrideWarningVersion = "override-v1"
+
+// overrideWarningText is what a person is shown.
+//
+// It says three things, and each is there because leaving it out would let
+// somebody acknowledge something untrue:
+//
+//   - the refusal STANDS. Directing a send is not a correction of the engine
+//     and not a grant of consent; the record will still say this message was
+//     refused.
+//   - the DECISION IS THEIRS, by name. The instruction records who they are and
+//     what they said, and it cannot be edited afterwards.
+//   - it covers THIS message only. The next one to the same person is refused
+//     again, so this is not a door being opened.
+const overrideWarningText = "The engine refused this message, and that refusal stands: " +
+	"sending it now records an exception, never consent. Your name, your reason and the exact " +
+	"message are written to a record that cannot be edited afterwards. This covers this message " +
+	"alone — the next one to the same recipient is judged from scratch."
+
+// TheOverrideWarning answers the caution and its version together, because a
+// surface that could get one without the other would show words while naming a
+// different version.
+func TheOverrideWarning() OverrideWarning {
+	return OverrideWarning{Version: OverrideWarningVersion, Text: overrideWarningText}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -390,7 +390,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `waiveronoffender_test.go` | H2 | A waiver must be asked about an offender, never about a candidate. |
 | `workflowhandler_test.go` | H2 | The workflow.Handler read/write contract as a fitness function (ports/workflow.Handler): Match is a pure predicate and Plan computes the typed Effect WITHOUT applying it — "this is what makes dry-run and diff preview possible". |
 
-## Claim (11)
+## Claim (12)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -402,6 +402,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `meetingoverspelling_test.go` | H2 | "This meeting is over" is spelled twice, and the two must say the same thing. |
 | `noisejudgedspelling_test.go` | H2 | "An already-settled answer disowns this contact" is spelled once. |
 | `onedraftwriter_test.go` | H1 | One writer produces every grounded draft, or the surfaces drift. |
+| `overridewarning_test.go` | H2 | The words behind a recorded acknowledgement cannot change without the version changing. |
 | `renovatelockfileage_test.go` | H3 | The lockfile refresh is not held back by the repo-wide release-age floor. |
 | `rolemailboxonelist_test.go` | H2 | One role-mailbox list, held by a test rather than by a comment. |
 | `uniquenessclaims_test.go` | H1 | A comment that says a declaration is the ONLY one of its kind is not decoration. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29478,6 +29478,13 @@ export interface components {
              *     them.
              */
             approval_id?: string | null;
+            /**
+             * @description What somebody must be shown before they direct this send, and the version their
+             *     acknowledgement will name. Served rather than composed by the client: an instruction's
+             *     claim is that a named person read particular words, and a client free to write its own
+             *     would have the record assert an acknowledgement of text nobody published.
+             */
+            warning?: components["schemas"]["OverrideWarning"];
         };
         /** @description A page of refused sends waiting for a decision. */
         CommunicationReviewList: {
@@ -29487,6 +29494,24 @@ export interface components {
              *     the caller knows rather than by discovering it.
              */
             total: number;
+        };
+        /**
+         * @description The caution a person reads before overruling the engine, with the version that identifies
+         *     it. Both together, because a surface that could get one without the other would show words
+         *     while naming a different version.
+         */
+        OverrideWarning: {
+            /**
+             * @description What the acknowledgement records. It moves whenever the text does — an instruction
+             *     naming a version whose words were later edited is a record of an acknowledgement
+             *     nobody made.
+             */
+            version: string;
+            /**
+             * @description Shown verbatim. A surface that paraphrased it would record somebody as having read the
+             *     server's words while showing them its own.
+             */
+            text: string;
         };
         /** @description What the person asking wants the decider to know. */
         RequestCommunicationDecisionRequest: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3570,6 +3570,24 @@ export const de = {
   "compose.consentBlockedTitle": "Versand blockiert — keine Einwilligung",
   "compose.consentBlocked":
     "Ein Empfänger hat für diesen Zweck nicht eingewilligt, daher wurde der Versand unterdrückt (Standard-Ablehnung).",
+  "directSend.title": "Trotzdem senden, auf eigene Verantwortung",
+  "directSend.confirm": "Ausnahme erfassen und senden",
+  "directSend.failed":
+    "Die Nachricht wurde nicht gesendet. Ihre Entscheidung ist möglicherweise bereits erfasst — öffnen Sie die Prüfung, bevor Sie erneut entscheiden.",
+  "directSend.noWarningServed":
+    "Diese Installation hat den Wortlaut, den Sie bestätigen würden, nicht veröffentlicht; daher ist hier keine Erfassung möglich.",
+  "directSend.needsAcknowledgement":
+    "Bestätigen Sie die Kenntnisnahme, um fortzufahren.",
+  "directSend.needsReason": "Begründen Sie, warum diese Nachricht gehen soll.",
+  "directSend.reasonCodeLabel": "Auf welcher Grundlage",
+  "directSend.explanationLabel": "Warum, in eigenen Worten",
+  "directSend.acknowledge":
+    "Ich habe das Obenstehende gelesen und übernehme die Verantwortung für diese Nachricht.",
+  "directSend.reason.customer_requested_outside_crm":
+    "Die Bitte kam außerhalb dieses Systems",
+  "directSend.reason.contractual_necessity": "Ein Vertrag verpflichtet uns",
+  "directSend.reason.legal_obligation": "Das Gesetz verpflichtet uns",
+  "directSend.reason.other": "Etwas anderes",
   "compose.reviewReference": "Prüfung",
   "compose.reviewRequest": "Jemanden um Entscheidung bitten",
   "compose.reviewRequesting": "Wird angefragt…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3657,6 +3657,23 @@ export const en = {
   "compose.consentBlockedTitle": "Send blocked — no consent",
   "compose.consentBlocked":
     "A recipient has not granted consent for this purpose, so the send was suppressed (default-deny).",
+  "directSend.title": "Send anyway, on your own authority",
+  "directSend.confirm": "Record the exception and send",
+  "directSend.failed":
+    "The message was not sent. Your decision may already be on record — open the review before deciding again.",
+  "directSend.noWarningServed":
+    "This installation has not published the wording you would be acknowledging, so this cannot be recorded here.",
+  "directSend.needsAcknowledgement": "Tick the acknowledgement to continue.",
+  "directSend.needsReason": "Say why this message should go.",
+  "directSend.reasonCodeLabel": "Under what basis",
+  "directSend.explanationLabel": "Why, in your own words",
+  "directSend.acknowledge":
+    "I have read the above and take responsibility for sending this message.",
+  "directSend.reason.customer_requested_outside_crm":
+    "They asked us somewhere this system did not see",
+  "directSend.reason.contractual_necessity": "A contract obliges us",
+  "directSend.reason.legal_obligation": "The law obliges us",
+  "directSend.reason.other": "Something else",
   "compose.reviewReference": "Review",
   "compose.reviewRequest": "Ask someone to decide",
   "compose.reviewRequesting": "Asking…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3529,6 +3529,23 @@ export const vi = {
   "compose.consentBlockedTitle": "Bị chặn gửi — chưa có chấp thuận",
   "compose.consentBlocked":
     "Một người nhận chưa chấp thuận cho mục đích này, nên lượt gửi bị chặn (mặc định từ chối).",
+  "directSend.title": "Vẫn gửi, theo thẩm quyền của bạn",
+  "directSend.confirm": "Ghi nhận ngoại lệ và gửi",
+  "directSend.failed":
+    "Thư chưa được gửi. Quyết định của bạn có thể đã được ghi nhận — hãy mở phần xem xét trước khi quyết định lại.",
+  "directSend.noWarningServed":
+    "Cài đặt này chưa công bố nội dung bạn sẽ xác nhận, nên không thể ghi nhận ở đây.",
+  "directSend.needsAcknowledgement": "Hãy tích xác nhận để tiếp tục.",
+  "directSend.needsReason": "Hãy nêu lý do thư này nên được gửi.",
+  "directSend.reasonCodeLabel": "Trên cơ sở nào",
+  "directSend.explanationLabel": "Lý do, theo lời của bạn",
+  "directSend.acknowledge":
+    "Tôi đã đọc nội dung trên và chịu trách nhiệm gửi thư này.",
+  "directSend.reason.customer_requested_outside_crm":
+    "Yêu cầu đến từ bên ngoài hệ thống này",
+  "directSend.reason.contractual_necessity": "Hợp đồng buộc chúng tôi",
+  "directSend.reason.legal_obligation": "Luật buộc chúng tôi",
+  "directSend.reason.other": "Lý do khác",
   "compose.reviewReference": "Phần xem xét",
   "compose.reviewRequest": "Chuyển cho bên có thẩm quyền quyết định",
   "compose.reviewRequesting": "Đang hỏi…",

--- a/frontend/src/screens/directsendmodal.stories.tsx
+++ b/frontend/src/screens/directsendmodal.stories.tsx
@@ -1,0 +1,59 @@
+// The last thing somebody sees before an exception is recorded in their name.
+//
+// The states here are the ones that decide whether the record is honest: the
+// acknowledgement unticked, the reason empty, and the server's own caution
+// rendered rather than ours.
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { components } from "../api/schema";
+import { DirectSendModal } from "./directsendmodal";
+
+const review: components["schemas"]["CommunicationReview"] = {
+  id: "01a0aaaa-bbbb-7ccc-8ddd-eeeeffff0001",
+  state: "needs_repair",
+  kind: "single",
+  reason_code: "no_marketing_consent",
+  refusals: [],
+  warning: {
+    version: "override-v1",
+    text:
+      "The engine refused this message, and that refusal stands: sending it now records an " +
+      "exception, never consent. Your name, your reason and the exact message are written to a " +
+      "record that cannot be edited afterwards. This covers this message alone — the next one to " +
+      "the same recipient is judged from scratch.",
+  },
+};
+
+const meta: Meta<typeof DirectSendModal> = {
+  title: "Patterns/Direct send",
+  component: DirectSendModal,
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={new QueryClient()}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof DirectSendModal>;
+
+// As it opens: the caution read, nothing ticked, nothing typed. Confirm is
+// refused and says which half is missing.
+export const AsItOpens: Story = {
+  args: { open: true, onClose: () => {}, review },
+};
+
+// A review whose server did not serve a caution — an older installation, or a
+// contract this client is ahead of. The modal renders no warning rather than
+// composing one, because inventing the words would record an acknowledgement of
+// text nobody published.
+export const WithNoServedWarning: Story = {
+  args: {
+    open: true,
+    onClose: () => {},
+    review: { ...review, warning: undefined },
+  },
+};

--- a/frontend/src/screens/directsendmodal.test.tsx
+++ b/frontend/src/screens/directsendmodal.test.tsx
@@ -1,0 +1,133 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { DirectSendModal } from "./directsendmodal";
+
+// What must be true before an exception is recorded in somebody's name.
+//
+// Each of these is a way the record could end up asserting something that did
+// not happen: a decision nobody acknowledged, a reason nobody gave, or words
+// nobody was shown.
+
+const review: components["schemas"]["CommunicationReview"] = {
+  id: "review-1",
+  state: "needs_repair",
+  kind: "single",
+  reason_code: "no_marketing_consent",
+  refusals: [],
+  warning: {
+    version: "override-v1",
+    text: "The refusal stands and this is recorded.",
+  },
+};
+
+function open(
+  overrides: Partial<React.ComponentProps<typeof DirectSendModal>> = {},
+) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <DirectSendModal open onClose={vi.fn()} review={review} {...overrides} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("DirectSendModal", () => {
+  // A pre-ticked acknowledgement records a decision nobody made, which is the
+  // one thing this record must never say.
+  it("never opens with the acknowledgement already ticked", () => {
+    open();
+    expect((screen.getByRole("checkbox") as HTMLInputElement).checked).toBe(
+      false,
+    );
+  });
+
+  // The words are the server's. Composing them here would record the director
+  // as having read the server's caution while showing them ours.
+  it("shows the caution the server served, verbatim", () => {
+    open();
+    expect(
+      screen.getByText("The refusal stands and this is recorded."),
+    ).toBeTruthy();
+  });
+
+  // An older server, or a contract this client is ahead of. Rendering nothing
+  // beats inventing words the record would then name.
+  it("refuses to record when the server served no caution", () => {
+    open({ review: { ...review, warning: undefined } });
+    expect(
+      screen.queryByText("The refusal stands and this is recorded."),
+    ).toBeNull();
+    // Nothing to acknowledge, so confirming is refused rather than submitting
+    // an empty version the server would reject with an error about a field the
+    // director never saw.
+    const confirm = screen.getByRole("button", {
+      name: /record the exception and send/i,
+    }) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+  });
+
+  // A director who ticks, cancels, and opens a DIFFERENT refused message must
+  // not arrive with the previous acknowledgement standing — that is one click
+  // from recording, against this message, a decision they made about another.
+  it("forgets the acknowledgement when the message changes", async () => {
+    const user = userEvent.setup();
+    const { rerender } = open();
+    await user.click(screen.getByRole("checkbox"));
+    expect((screen.getByRole("checkbox") as HTMLInputElement).checked).toBe(
+      true,
+    );
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <DirectSendModal
+          open
+          onClose={vi.fn()}
+          review={{ ...review, id: "review-2" }}
+        />
+      </QueryClientProvider>,
+    );
+    expect((screen.getByRole("checkbox") as HTMLInputElement).checked).toBe(
+      false,
+    );
+  });
+
+  // Both halves are required, and the modal says which is missing rather than
+  // refusing silently.
+  it("will not send until the director has both acknowledged and said why", async () => {
+    const user = userEvent.setup();
+    open();
+    // RE-QUERIED EACH TIME. The button is re-rendered when either half of the
+    // precondition changes, so a node captured once is a node that stopped
+    // being the one on screen — and the assertion would read a state nobody
+    // is looking at.
+    const confirm = () =>
+      screen.getByRole("button", {
+        name: /record the exception and send/i,
+      }) as HTMLButtonElement;
+
+    expect(confirm().disabled).toBe(true);
+
+    await user.click(screen.getByRole("checkbox"));
+    expect(confirm().disabled).toBe(true);
+
+    await user.type(
+      screen.getByLabelText(/why, in your own words/i),
+      "The contract obliges it.",
+    );
+    expect(confirm().disabled).toBe(false);
+  });
+
+  // Enter in the reason must not confirm. A person typing a sentence presses it
+  // without meaning to record anything, and a single-line input would submit.
+  it("takes a newline in the reason rather than confirming", async () => {
+    const user = userEvent.setup();
+    open();
+    const reason = screen.getByLabelText(/why, in your own words/i);
+    await user.click(reason);
+    await user.keyboard("first{Enter}second");
+    expect((reason as HTMLTextAreaElement).value).toContain("\n");
+  });
+});

--- a/frontend/src/screens/directsendmodal.tsx
+++ b/frontend/src/screens/directsendmodal.tsx
@@ -1,0 +1,215 @@
+// Sending a message the engine refused, on a named person's own authority.
+//
+// This is the last thing somebody sees before an exception is recorded under
+// their name. Everything about it is shaped by that: the warning is the
+// server's words rather than ours, the acknowledgement starts unticked, and the
+// reason is typed rather than chosen from a list nobody would read.
+//
+// THE REFUSAL IS NOT BEING CORRECTED. Confirming does not grant consent and
+// does not lift a stop — the engine's answer stays exactly where it is, and the
+// record says a person overrode it. The copy says so because a director who
+// believed otherwise would be acknowledging something untrue.
+//
+// WHY THE WARNING IS NOT OUR OWN COPY. The instruction records which version of
+// the caution was acknowledged. If this file wrote the words, the record would
+// name a version whose text lives in a client somebody can ship separately from
+// the server — and a dispute about the override could not be answered with the
+// sentence the director actually read.
+
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Field } from "../design-system/atoms";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { Select } from "../design-system/select";
+import { useT } from "../i18n";
+import { throwProblem } from "./common";
+
+// The review as this modal needs it: which message, and the caution the server
+// serves for it. Taken from the generated contract rather than restated, so a
+// field the server renames cannot go on being read here.
+type CommunicationReview = components["schemas"]["CommunicationReview"];
+
+// DirectSendCommand is what the server is told. The whole of it travels as a
+// variable rather than closed over render state: a mutation reading the reason
+// from the component's scope would send whatever was typed when it resolved
+// rather than what was there when the director pressed confirm.
+type DirectSendCommand = Readonly<{
+  reviewId: string;
+  reasonCode: string;
+  explanation: string;
+  warningVersion: string;
+}>;
+
+async function directSend(command: DirectSendCommand): Promise<string> {
+  const { data, error, response } = await api.POST(
+    "/communication-reviews/{id}/direct-send",
+    {
+      params: { path: { id: command.reviewId } },
+      body: {
+        reason_code: command.reasonCode as "other",
+        explanation: command.explanation,
+        warning_version: command.warningVersion,
+        // The tick IS the acknowledgement, and the server refuses a decision
+        // without one. It is sent as true because this function is only
+        // reachable from a confirm the director could not press until they
+        // ticked it — never defaulted, which would record a decision nobody
+        // made.
+        acknowledged: true,
+      },
+    },
+  );
+  // Success is a real 2xx WITH a body: openapi-fetch reports a falsy error and
+  // undefined data for a bodiless non-2xx, which would otherwise read as a
+  // message that went when nothing did.
+  if (!response.ok || !data) {
+    throwProblem(error || { title: "The message was not sent." });
+  }
+  return data.id;
+}
+
+// REASON_CODES is the closed list the record keeps, in the server's own
+// vocabulary. Closed because an audit of overrides has to be countable: free
+// text alone cannot answer "how often do we send on a contract clause".
+const REASON_CODES = [
+  "customer_requested_outside_crm",
+  "contractual_necessity",
+  "legal_obligation",
+  "other",
+] as const;
+
+type ReasonCode = (typeof REASON_CODES)[number];
+
+export function DirectSendModal({
+  open,
+  onClose,
+  review,
+  onSent,
+}: Readonly<{
+  open: boolean;
+  onClose: () => void;
+  review: CommunicationReview;
+  onSent?: (activityId: string) => void;
+}>) {
+  const t = useT();
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [reasonCode, setReasonCode] = useState<ReasonCode>("other");
+  const [explanation, setExplanation] = useState("");
+
+  // RESET WHEN THE MESSAGE CHANGES. A director who ticks, cancels, and opens a
+  // DIFFERENT refused message would otherwise arrive with the acknowledgement
+  // already ticked and the previous reason still typed — one click from
+  // recording, against this message, a decision they made about another one.
+  //
+  // Keyed on the review rather than on `open`, because reopening the same
+  // message after a cancel is the one case where keeping what they typed is
+  // the kindness rather than the hazard.
+  const [seen, setSeen] = useState(review.id);
+  if (seen !== review.id) {
+    setSeen(review.id);
+    setAcknowledged(false);
+    setReasonCode("other");
+    setExplanation("");
+  }
+
+  const send = useMutation({
+    mutationFn: directSend,
+    onSuccess: (activityId) => {
+      onSent?.(activityId);
+      onClose();
+    },
+  });
+
+  const said = explanation.trim();
+  // BOTH, and the modal says which is missing rather than refusing silently.
+  // The explanation is what a dispute reads; the tick is the act.
+  // AND THE WARNING ITSELF. An installation whose server serves none — one
+  // older than this client — leaves nothing for the director to acknowledge,
+  // and submitting an empty version would be refused by the server with an
+  // error about a field the director never saw. Saying so here is the honest
+  // answer: there is nothing to read, so there is nothing to acknowledge.
+  const missing = !review.warning
+    ? t("directSend.noWarningServed")
+    : !acknowledged
+      ? t("directSend.needsAcknowledgement")
+      : said === ""
+        ? t("directSend.needsReason")
+        : undefined;
+
+  return (
+    <ConfirmModal
+      open={open}
+      onClose={onClose}
+      size="wide"
+      title={t("directSend.title")}
+      confirmLabel={t("directSend.confirm")}
+      confirmVariant="danger"
+      confirmDisabled={Boolean(missing)}
+      confirmReason={missing}
+      pending={send.isPending}
+      error={send.isError ? t("directSend.failed") : undefined}
+      onConfirm={() =>
+        send.mutate({
+          reviewId: review.id,
+          reasonCode,
+          explanation: said,
+          warningVersion: review.warning?.version ?? "",
+        })
+      }
+    >
+      {/* THE SERVER'S OWN WORDS, verbatim. Paraphrasing here would record the
+          director as having read the server's caution while showing them
+          ours. */}
+      {review.warning && (
+        <p
+          className="t-body"
+          role="alert"
+          style={{ color: "var(--dangerText)" }}
+        >
+          {review.warning.text}
+        </p>
+      )}
+      <Field label={t("directSend.reasonCodeLabel")}>
+        {(control) => (
+          <Select
+            {...control}
+            value={reasonCode}
+            onChange={(picked) => setReasonCode(picked as ReasonCode)}
+            options={REASON_CODES.map((code) => ({
+              value: code,
+              label: t(
+                `directSend.reason.${code}` as "directSend.reason.other",
+              ),
+            }))}
+          />
+        )}
+      </Field>
+      {/* A TEXTAREA so Enter inserts a newline. A single-line input here would
+          submit the form on Enter, which is the one key a person typing a
+          reason presses without meaning to confirm anything. */}
+      <Field label={t("directSend.explanationLabel")}>
+        {(control) => (
+          <textarea
+            {...control}
+            className="input"
+            rows={3}
+            maxLength={1000}
+            value={explanation}
+            onChange={(e) => setExplanation(e.target.value)}
+          />
+        )}
+      </Field>
+      {/* UNTICKED, always. A pre-ticked acknowledgement records a decision
+          nobody made, which is the one thing this record must never say. */}
+      <label className="t-body">
+        <input
+          type="checkbox"
+          checked={acknowledged}
+          onChange={(e) => setAcknowledged(e.target.checked)}
+        />{" "}
+        {t("directSend.acknowledge")}
+      </label>
+    </ConfirmModal>
+  );
+}


### PR DESCRIPTION
An instruction records that a named person read a particular caution before overruling the consent engine, and it records that as a version. Nothing published the words behind it and nothing checked the version: a caller could write `v1` or `whatever-v99` onto the record, and the record would assert an acknowledgement of text nobody ever wrote. That is precisely the assertion a dispute about an override turns on.

The server serves the warning now. The review carries the words and the version together, the direct-send door refuses a version this installation does not serve, and the modal shows what it was given.

## A gate holds the version to its text

Editing the sentence without moving the version silently rewrites what every past acknowledgement claims to have said, and nothing about Go stops that edit. The text is pinned by digest.

The gate parses the constant with `go/ast` rather than scanning for quoted strings. Codex found three gofmt-valid edits that fooled a regex while leaving the digest untouched: a raw string appended, a continuation past a blank line, and a fragment moved into a comment. Each made the gate agree with itself while the served text had changed.

It reads the source rather than importing the module, because the architecture forbids a gate depending on one, and rightly: a gate that links the thing it judges is satisfied by a build that compiles rather than by what the tree says.

## The modal is shaped by what the record must not say

The acknowledgement starts unticked, and is forgotten when the message changes: a director who ticks, cancels and opens a different refusal would otherwise be one click from recording, against this message, a decision they made about another. The reason is a textarea, because Enter in a single-line input submits. An installation serving no warning cannot record here at all.

The failure copy said "nothing was recorded", which is false: the decision commits before the send is attempted.

## Gates run locally

`make check-backend`, `make check-fe`, `make fe-uat`, the compose integration lane, and the consent module lane. Four tests in that last lane were red and I had not run it — Codex traced them from source and running the lane confirmed it.

## Not in this slice

Wiring the modal to a surface that opens it, the held-message resume, and the exception mark on sent history. What lands here is the warning being real, which everything else depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serves the override warning from the server so an acknowledgement always names words this installation actually published. Previously the direct-send endpoint accepted any `warning_version` string, letting a caller record an acknowledgement of text nobody wrote; now the review carries the warning text and version together, and the door refuses versions the installation does not serve.

**Migration**
- Direct-send callers must send a served `warning_version` (`override-v1` for the modal, `queue-card-v1` for the approvals queue) instead of an arbitrary string.

**Behavior changes**
- A digest gate pins the warning text to its version, so editing the wording without bumping the version fails the build.
- The new acknowledgement modal starts unticked, resets when the message changes, and renders the server's words verbatim; an installation serving no warning cannot record at all.
- The failure copy now says the decision may already be on record, because it commits before the send is attempted.

<sup>Written for commit eb55d65bc31b51a7f064ce8805c7baa0039e2b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review screens now display a server-provided warning with a version identifier.
  * Added a direct-send confirmation dialog for consent-blocked messages, requiring acknowledgement, a reason, and an explanation.
  * Direct-send requests now accept only recognized warning versions and record the acknowledged version.
  * Added English, German, and Vietnamese translations for the direct-send flow.

* **Bug Fixes**
  * Warning text and its version remain synchronized across review and direct-send actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->