### PR TITLE
feat(overlay): sync-status counts the rows no declaration can project

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24705,6 +24705,17 @@ components:
                   the sweep skips this workspace entirely, so staleness grows
                   on purpose. Stated rather than left to be inferred from a
                   mirror that merely looks idle.
+              unprojectableRows:
+                type: integer
+                description: >-
+                  How many of the class's mirror rows the CURRENT declaration cannot project.
+                  It is what tells the two readings of `stale` apart, and they want opposite
+                  responses: `stale` with ZERO here is converging — the sweep has not reached
+                  those rows and will — while `stale` with a NON-ZERO count never converges on
+                  its own and holds `force_fresh_incomplete` shut until somebody repairs the
+                  mapping. Zero means wait; non-zero means look.
+                  A count and not a list, because the question an operator is answering is
+                  whether anything needs them, not which ids.
     OverlayBudget:
       type: object
       description: >-
@@ -24784,6 +24795,15 @@ components:
           items:
             type: string
             enum: [incumbent_unreachable, force_fresh_incomplete, pending_sync_draining, unresolved_conflicts, export_missing]
+        unprojectable_rows:
+          type: integer
+          description: >-
+            How many mirror rows the CURRENT declaration cannot project — a SUBSET of what holds
+            `force_fresh_incomplete`, and the only part of it that never clears on its own. It is
+            sent whether or not the flip is blocked, and zero is a real answer: an operator waiting
+            on `force_fresh_incomplete` with zero here is waiting on a sweep that will finish, while
+            a non-zero count is waiting on somebody repairing the mapping. Which class holds them is
+            on the sync-status read, per object.
         unresolved_conflicts:
           type: array
           description: >-

--- a/backend/internal/compose/flip.go
+++ b/backend/internal/compose/flip.go
@@ -142,10 +142,18 @@ func (f *flipRunner) Preflight(ctx context.Context) (verdictOut crmcontracts.Ove
 	if err != nil {
 		return crmcontracts.OverlayFlipPreflight{}, err
 	}
+	// The stuck count travels whether or not the flip is blocked, and zero is
+	// a real answer rather than a missing one: an operator held by
+	// force_fresh_incomplete is waiting on a sweep that will finish OR on
+	// somebody repairing a mapping that never will, and this is the number
+	// that says which. Telling them the preflight failed without it is what
+	// leaves them waiting on the wrong thing.
+	stuck := v.checks.UnprojectableRows
 	out := crmcontracts.OverlayFlipPreflight{
 		Ready:               len(v.blocking) == 0,
 		Blocking:            v.blocking,
 		UnresolvedConflicts: []crmcontracts.OverlayFlipUnresolvedConflict{},
+		UnprojectableRows:   &stuck,
 	}
 	if !out.Ready {
 		if blockingContains(v.blocking, crmcontracts.OverlayFlipPreflightBlockingIncumbentUnreachable) {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -29879,6 +29879,9 @@ type OverlayFlipPreflight struct {
 	// Snapshot The sealed frozen-mirror snapshot the flip imports.
 	Snapshot *OverlayFlipSnapshot `json:"snapshot,omitempty"`
 
+	// UnprojectableRows How many mirror rows the CURRENT declaration cannot project — a SUBSET of what holds `force_fresh_incomplete`, and the only part of it that never clears on its own. It is sent whether or not the flip is blocked, and zero is a real answer: an operator waiting on `force_fresh_incomplete` with zero here is waiting on a sweep that will finish, while a non-zero count is waiting on somebody repairing the mapping. Which class holds them is on the sync-status read, per object.
+	UnprojectableRows *int `json:"unprojectable_rows,omitempty"`
+
 	// UnresolvedConflicts Open incumbent-wins conflicts awaiting acceptance; each blocks the flip. Empty in this build: branch 1 reconciliation resolves incumbent-wins at ingest and persists no conflict queue, so the producer arrives with write-back (branch 2). The field is required by OVA-WIRE-7's response shape.
 	UnresolvedConflicts []OverlayFlipUnresolvedConflict `json:"unresolved_conflicts"`
 }
@@ -29935,6 +29938,9 @@ type OverlaySyncStatus struct {
 		LastSyncedAt  *time.Time                     `json:"lastSyncedAt,omitempty"`
 		Object        *string                        `json:"object,omitempty"`
 		State         *OverlaySyncStatusObjectsState `json:"state,omitempty"`
+
+		// UnprojectableRows How many of the class's mirror rows the CURRENT declaration cannot project. It is what tells the two readings of `stale` apart, and they want opposite responses: `stale` with ZERO here is converging — the sweep has not reached those rows and will — while `stale` with a NON-ZERO count never converges on its own and holds `force_fresh_incomplete` shut until somebody repairs the mapping. Zero means wait; non-zero means look. A count and not a list, because the question an operator is answering is whether anything needs them, not which ids.
+		UnprojectableRows *int `json:"unprojectableRows,omitempty"`
 	} `json:"objects,omitempty"`
 }
 

--- a/backend/internal/modules/overlay/flipstate.go
+++ b/backend/internal/modules/overlay/flipstate.go
@@ -66,6 +66,16 @@ type FlipChecks struct {
 	// PendingSyncCount: rows with un-drained local writes — the flip
 	// waits until they drain (AC-mode-flip-4).
 	PendingSyncCount int
+	// UnprojectableRows: how many mirror rows the CURRENT declaration cannot
+	// project, across every class.
+	//
+	// It is a SUBSET of what holds ForceFreshDone shut, and the useful one:
+	// the rest of that staleness drains by itself, while these rows never do.
+	// An operator blocked by force_fresh_incomplete is exactly the person who
+	// needs to know which of the two they are waiting on, and telling them
+	// the preflight failed without telling them how much is stuck leaves them
+	// waiting on a sweep that will never clear it.
+	UnprojectableRows int
 	// LastSyncedAt is the mirror's freshest watermark (zero on an empty
 	// mirror) — the emergency cutover's staleness disclosure and the
 	// export-recency check both read it.
@@ -118,18 +128,20 @@ func (s *Service) FlipChecks(ctx context.Context) (FlipChecks, error) {
 			return err
 		}
 
-		var pending, stale int
+		var pending, stale, unprojectable int
 		var lastSynced *time.Time
 		if err := tx.QueryRow(
 			ctx, `
 			SELECT count(*) FILTER (WHERE sync_state = $1),
 			       count(*) FILTER (WHERE sync_state = $2 OR `+staleProjectionSQL+`),
+			       count(*) FILTER (WHERE `+staleProjectionSQL+`),
 			       count(*), max(last_synced_at)
 			FROM overlay_mirror`, syncStatePendingSync, syncStateStale, currentFingerprints,
-		).Scan(&pending, &stale, &checks.MirrorRows, &lastSynced); err != nil {
+		).Scan(&pending, &stale, &unprojectable, &checks.MirrorRows, &lastSynced); err != nil {
 			return fmt.Errorf("overlay: aggregating mirror state for the flip preflight: %w", err)
 		}
 		checks.PendingSyncCount = pending
+		checks.UnprojectableRows = unprojectable
 		if lastSynced != nil {
 			checks.LastSyncedAt = *lastSynced
 		}

--- a/backend/internal/modules/overlay/flipstate_integration_test.go
+++ b/backend/internal/modules/overlay/flipstate_integration_test.go
@@ -194,6 +194,41 @@ func TestFlipChecksRefuseAProjectionAnOlderDeclarationProduced(t *testing.T) {
 	}
 }
 
+// An operator held by force_fresh_incomplete is waiting on one of two things,
+// and they need opposite actions: a sweep that has not finished, or a mapping
+// nobody has repaired. The preflight told them neither — only that it failed.
+//
+// Both arms, because the count is only useful if zero is trustworthy: a
+// PENDING row blocks the flip too and is not stuck, so reporting it here would
+// send somebody looking for a declaration to fix that is already correct.
+func TestFlipChecksCountTheRowsNoDeclarationCanProject(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	seedOverlayWorkspace(ctx, t, pool)
+	db := database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
+	svc := flipServiceJudgingContacts(db)
+	ms := NewMirrorStore(db, nil)
+	recordSweepSuccess(ctx, t, pool)
+	markBackfillDone(ctx, t, pool, IncumbentClassContacts)
+
+	baseline := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	ingestMirrorRow(ctx, t, ms, "person", "p-old-1", oldContactsDeclaration, baseline)
+	ingestMirrorRow(ctx, t, ms, "person", "p-old-2", oldContactsDeclaration, baseline)
+	ingestMirrorRow(ctx, t, ms, "person", "p-current", currentContactsDeclaration, baseline)
+
+	checks, err := svc.FlipChecks(ctx)
+	if err != nil {
+		t.Fatalf("FlipChecks: %v", err)
+	}
+	if checks.ForceFreshDone {
+		t.Fatal("force-fresh reported done with rows the current declaration cannot project")
+	}
+	if checks.UnprojectableRows != 2 {
+		t.Errorf("the preflight reports %d un-projectable rows, want 2 — an operator blocked by "+
+			"force_fresh_incomplete is told the flip failed and not how much is stuck",
+			checks.UnprojectableRows)
+	}
+}
+
 // TestFlipChecksBlockOnARowWhoseReprojectionFailed is the line the sweep's
 // skip must not cross. Recording that a row could not be re-projected spares it
 // the incumbent call a re-read would waste; it says nothing about the payload,

--- a/backend/internal/modules/overlay/handlers.go
+++ b/backend/internal/modules/overlay/handlers.go
@@ -148,11 +148,12 @@ func (h Handlers) GetOverlaySyncStatus(w http.ResponseWriter, r *http.Request) {
 // []struct{...} api_gen.go declares and assigns straight into
 // crmcontracts.OverlaySyncStatus.Objects with no per-field copy.
 type wireSyncObject = struct {
-	BackfillComplete *bool                                       `json:"backfillComplete,omitempty"` //nolint:tagliatelle // must match the generated OverlaySyncStatus.Objects element shape verbatim (crm.yaml's own camelCase)
-	FrozenForFlip    *bool                                       `json:"frozenForFlip,omitempty"`    //nolint:tagliatelle // see above
-	LastSyncedAt     *time.Time                                  `json:"lastSyncedAt,omitempty"`     //nolint:tagliatelle // see above
-	Object           *string                                     `json:"object,omitempty"`
-	State            *crmcontracts.OverlaySyncStatusObjectsState `json:"state,omitempty"`
+	BackfillComplete  *bool                                       `json:"backfillComplete,omitempty"` //nolint:tagliatelle // must match the generated OverlaySyncStatus.Objects element shape verbatim (crm.yaml's own camelCase)
+	FrozenForFlip     *bool                                       `json:"frozenForFlip,omitempty"`    //nolint:tagliatelle // see above
+	LastSyncedAt      *time.Time                                  `json:"lastSyncedAt,omitempty"`     //nolint:tagliatelle // see above
+	Object            *string                                     `json:"object,omitempty"`
+	State             *crmcontracts.OverlaySyncStatusObjectsState `json:"state,omitempty"`
+	UnprojectableRows *int                                        `json:"unprojectableRows,omitempty"` //nolint:tagliatelle // see above
 }
 
 // syncStatusToWire maps the domain []ObjectSyncStatus onto the contract's
@@ -167,9 +168,15 @@ func syncStatusToWire(objects []ObjectSyncStatus) crmcontracts.OverlaySyncStatus
 	for i, o := range objects {
 		object, lastSyncedAt, complete, frozen := o.Object, o.LastSyncedAt, o.BackfillComplete, o.FrozenForFlip
 		state := crmcontracts.OverlaySyncStatusObjectsState(o.State)
+		// Sent on every entry, including zero. Zero is the answer an operator
+		// needs most — it is what says a stale class is converging and wants
+		// nothing from them — so omitting it would withhold the reassurance
+		// and leave the field looking like one that only appears in trouble.
+		unprojectable := o.Unprojectable
 		wire[i] = wireSyncObject{
 			BackfillComplete: &complete, FrozenForFlip: &frozen,
 			LastSyncedAt: &lastSyncedAt, Object: &object, State: &state,
+			UnprojectableRows: &unprojectable,
 		}
 	}
 	return crmcontracts.OverlaySyncStatus{Objects: &wire}

--- a/backend/internal/modules/overlay/syncstatus.go
+++ b/backend/internal/modules/overlay/syncstatus.go
@@ -46,6 +46,21 @@ type ObjectSyncStatus struct {
 	// is the difference between "sync is paused for the cutover" and a
 	// mirror that merely looks idle.
 	FrozenForFlip bool
+	// Unprojectable is how many of the class's rows the CURRENT declaration
+	// cannot map — rows whose projection_fingerprint no live declaration
+	// could have stamped.
+	//
+	// It is what separates the two readings `stale` collapses, and they need
+	// opposite responses: rows the sweep has not reached converge on their
+	// own and need nothing, while rows the mapping cannot project never
+	// converge and hold force_fresh_incomplete shut until somebody repairs
+	// the declaration. Zero means wait; non-zero means look.
+	//
+	// A count rather than a list, deliberately: the operator's question is
+	// "is anything stuck, and does this need me", not "which ids". The ids
+	// matter at the next step, and that step should be built by somebody
+	// whose count was actually non-zero.
+	Unprojectable int
 }
 
 // SyncStatus states (overlay_mirror.sync_state's CHECK vocabulary,
@@ -112,10 +127,16 @@ func (s *Service) resolveOverlayMode(ctx context.Context) (incumbent string, err
 // mean the mirror holds a payload the current mapping would not produce, and
 // both hold the flip's force-fresh check open — so reading this surface is how
 // an operator sees WHICH class keeps force_fresh_incomplete from clearing.
+//
+// The same predicate is also COUNTED, and that is the difference between
+// knowing a class is stale and knowing whether waiting will fix it. The two
+// situations `stale` collapses need opposite responses, and the count is the
+// one number that tells them apart.
 const selectMirrorSyncAggregateSQL = `
 SELECT object_class, max(last_synced_at),
        bool_or(sync_state = $1) AS any_pending,
-       bool_or(sync_state = $2 OR ` + staleProjectionSQL + `) AS any_stale
+       bool_or(sync_state = $2 OR ` + staleProjectionSQL + `) AS any_stale,
+       count(*) FILTER (WHERE ` + staleProjectionSQL + `) AS unprojectable
 FROM overlay_mirror
 GROUP BY object_class
 ORDER BY object_class`
@@ -161,14 +182,16 @@ func (s *Service) SyncStatus(ctx context.Context) ([]ObjectSyncStatus, error) {
 			var objectClass string
 			var lastSyncedAt time.Time
 			var flags mirrorStateFlags
-			if err := rows.Scan(&objectClass, &lastSyncedAt, &flags.anyPending, &flags.anyStale); err != nil {
+			var unprojectable int
+			if err := rows.Scan(&objectClass, &lastSyncedAt, &flags.anyPending, &flags.anyStale, &unprojectable); err != nil {
 				rows.Close()
 				return fmt.Errorf("overlay: scanning a mirror sync aggregate row: %w", err)
 			}
 			out = append(out, ObjectSyncStatus{
-				Object:       objectClass,
-				LastSyncedAt: lastSyncedAt,
-				State:        aggregateState(flags),
+				Object:        objectClass,
+				LastSyncedAt:  lastSyncedAt,
+				State:         aggregateState(flags),
+				Unprojectable: unprojectable,
 			})
 		}
 		if err := rows.Err(); err != nil {

--- a/backend/internal/modules/overlay/syncstatus_integration_test.go
+++ b/backend/internal/modules/overlay/syncstatus_integration_test.go
@@ -141,6 +141,71 @@ func TestSyncStatusShowsWhichClassHoldsAnOlderProjection(t *testing.T) {
 	}
 }
 
+// `stale` collapses two situations that want opposite responses, and the count
+// is what tells them apart: rows the sweep has not reached converge on their
+// own, while rows the current declaration cannot project never do — they hold
+// force_fresh_incomplete shut until somebody repairs the mapping. Zero means
+// wait; non-zero means look.
+//
+// Both arms, because a count that was always non-zero would pass the stuck half
+// on its own: the class that cannot be judged at all reports zero, and reporting
+// its rows as stuck would send an operator hunting for a mapping nobody has.
+func TestSyncStatusCountsTheRowsNoDeclarationCanProject(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	seedOverlayWorkspace(ctx, t, pool)
+	db := database.BindTo(pool, ids.From[ids.WorkspaceKind](ws))
+	store := NewMirrorStore(db, noOwnerEmails{})
+	svc := NewService(db, keyvault.NewMemory(), store).
+		WithIncumbentClassesTranslator(func(canonical string) ([]string, bool) {
+			switch canonical {
+			case "person":
+				return []string{IncumbentClassContacts}, true
+			case "company":
+				return []string{IncumbentClassCompanies}, true
+			default:
+				return nil, false
+			}
+		}).
+		WithProjectionFingerprints(map[string]string{IncumbentClassContacts: "contacts-declaration-current"})
+
+	baseline := time.Date(2026, 5, 13, 6, 44, 38, 0, time.UTC)
+	for _, row := range []struct{ objectClass, ext, fingerprint string }{
+		// Two people the current declaration cannot project, and one it can.
+		{"person", "p-legacy-1", "contacts-declaration-superseded"},
+		{"person", "p-legacy-2", "contacts-declaration-superseded"},
+		{"person", "p-current", "contacts-declaration-current"},
+		// No current declaration for companies, so the class cannot be judged.
+		{"company", "company-1", "companies-declaration-retired"},
+	} {
+		if err := store.Ingest(ctx, Record{
+			ObjectClass: row.objectClass, ExternalID: row.ext,
+			Fields:                map[string]any{"full_name": "Ingested Row"},
+			ModifiedAt:            baseline,
+			ProjectionFingerprint: row.fingerprint,
+		}); err != nil {
+			t.Fatalf("ingesting %s/%s: %v", row.objectClass, row.ext, err)
+		}
+	}
+
+	statuses, err := svc.SyncStatus(ctx)
+	if err != nil {
+		t.Fatalf("SyncStatus: %v", err)
+	}
+	stuck := make(map[string]int, len(statuses))
+	for _, s := range statuses {
+		stuck[s.Object] = s.Unprojectable
+	}
+	if stuck["person"] != 2 {
+		t.Errorf("person reports %d un-projectable rows, want 2 — an operator reading a stale class "+
+			"cannot tell whether waiting will fix it (all counts: %v)", stuck["person"], stuck)
+	}
+	if stuck["company"] != 0 {
+		t.Errorf("company reports %d un-projectable rows, want 0: this deployment has no declaration "+
+			"for the class at all, so its rows are unjudged rather than stuck, and calling them stuck "+
+			"sends an operator after a mapping nobody has", stuck["company"])
+	}
+}
+
 func TestSyncStatusAndBudgetRefuseANativeModeWorkspace(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t) // never flips to overlay mode
 	svc := NewService(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), keyvault.NewMemory(), NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})).

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17193,6 +17193,8 @@ export interface components {
                 backfillComplete?: boolean;
                 /** @description The mirror is held still by a pending overlay→native flip: the sweep skips this workspace entirely, so staleness grows on purpose. Stated rather than left to be inferred from a mirror that merely looks idle. */
                 frozenForFlip?: boolean;
+                /** @description How many of the class's mirror rows the CURRENT declaration cannot project. It is what tells the two readings of `stale` apart, and they want opposite responses: `stale` with ZERO here is converging — the sweep has not reached those rows and will — while `stale` with a NON-ZERO count never converges on its own and holds `force_fresh_incomplete` shut until somebody repairs the mapping. Zero means wait; non-zero means look. A count and not a list, because the question an operator is answering is whether anything needs them, not which ids. */
+                unprojectableRows?: number;
             }[];
         };
         /** @description The incumbent REST budget window's consumption and degradation band, its per-source breakdown, honest headroom, and the per-second Search window (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5). */
@@ -17237,6 +17239,8 @@ export interface components {
             ready: boolean;
             /** @description Why the flip cannot run, empty when ready. `incumbent_unreachable` is the OVA-AC-6(a) honest block — the connection is revoked/error, so the force-fresh sync cannot pass; the workspace stays in overlay on its last mirror. */
             blocking: ("incumbent_unreachable" | "force_fresh_incomplete" | "pending_sync_draining" | "unresolved_conflicts" | "export_missing")[];
+            /** @description How many mirror rows the CURRENT declaration cannot project — a SUBSET of what holds `force_fresh_incomplete`, and the only part of it that never clears on its own. It is sent whether or not the flip is blocked, and zero is a real answer: an operator waiting on `force_fresh_incomplete` with zero here is waiting on a sweep that will finish, while a non-zero count is waiting on somebody repairing the mapping. Which class holds them is on the sync-status read, per object. */
+            unprojectable_rows?: number;
             /** @description Open incumbent-wins conflicts awaiting acceptance; each blocks the flip. Empty in this build: branch 1 reconciliation resolves incumbent-wins at ingest and persists no conflict queue, so the producer arrives with write-back (branch 2). The field is required by OVA-WIRE-7's response shape. */
             unresolved_conflicts: components["schemas"]["OverlayFlipUnresolvedConflict"][];
             snapshot?: components["schemas"]["OverlayFlipSnapshot"];


### PR DESCRIPTION
Closes #1221 — items 1, 2 and 3. The listing surface stays deferred, as ruled.

## What `stale` was hiding

Two situations, collapsed into one word, wanting **opposite responses**:

- rows the sweep has not reached — they converge on their own and need nothing;
- rows the current declaration cannot map at all — they never converge, and they hold `force_fresh_incomplete` shut until somebody repairs the mapping.

An operator reading sync-status, which is the surface designed to answer exactly this question, could not tell which they were looking at. The flip preflight was no better: it said the flip was blocked and not how much was stuck.

## One number, and the predicate already existed

`staleProjectionSQL` — the predicate both aggregations already apply to find a row whose `projection_fingerprint` no live declaration could have stamped — is now **counted** as well as folded into the state:

- `OverlaySyncStatus.objects[].unprojectableRows`, per object class;
- `OverlayFlipPreflight.unprojectable_rows`, across the mirror.

Zero means wait; non-zero means look. No new source of truth, no second predicate to drift.

**A count and not a listing**, as ruled: the operator's question is whether anything is stuck and whether it needs them, not which ids. The ids matter at the next step, and that step should be built by somebody whose count was actually non-zero rather than guessed at now — this state should be rare.

**Both fields are sent even at zero.** Zero is the answer an operator needs most: it is what says a stale class is converging and wants nothing from them. A field that only appeared in trouble would withhold the reassurance and read as an error marker.

## Tests

Each surface, and each in **both directions** — the count is only useful if zero is trustworthy:

- `TestSyncStatusCountsTheRowsNoDeclarationCanProject`: a class with two superseded rows and one current reports **2**; a class this deployment has no declaration for reports **0** rather than reporting its rows as stuck, which would send an operator hunting for a mapping nobody has.
- `TestFlipChecksCountTheRowsNoDeclarationCanProject`: the preflight reports 2 while `ForceFreshDone` is false, so the operator learns which of the two things they are waiting on.

Both mutation-checked — hard-coding the count to zero fails each.

## Checks

`make check-backend` and `make check-fe` green. `make craft-static` has one blocker, and it is `main`'s (`refused_send_review_integration_test.go`, fixed in #5367); nothing this branch touches is in it.