### PR TITLE
A rep who may overrule the engine is offered the send

### DIFF
--- a/backend/internal/compose/commsstager.go
+++ b/backend/internal/compose/commsstager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/comms"
 	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -326,12 +327,27 @@ func actionsForRefusal(ctx context.Context, review consent.Review) []string {
 	if review.IntentID.IsZero() {
 		return nil
 	}
-	// A PERSON, and the one whose message it was. Routing is human-only
-	// (agents and connectors are refused) and scoped to the initiator, so an
-	// agent acting for somebody is told nothing rather than told wrong.
+	// A PERSON, and the one whose message it was. Both doors below are
+	// human-only (agents and connectors are refused), so an agent acting for
+	// somebody is told nothing rather than told wrong.
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.Type != principal.PrincipalHuman {
 		return nil
+	}
+	// A HOLDER OF THE GRANT IS OFFERED THE SEND, not the ask.
+	//
+	// Directing a send and asking somebody to are answers to the same question
+	// — "this was refused, now what" — and which one a person is shown is
+	// decided by what they may actually do. Offering a rep who holds the
+	// authority the chance to ask a colleague would be telling them to go
+	// around themselves; offering one who does not the direct send would be a
+	// button that fails when pressed.
+	//
+	// ONE OR THE OTHER, never both. A person holding the grant can still route
+	// a review from the review itself if they want a second opinion, which is a
+	// deliberate act rather than a choice a refusal should press on them.
+	if auth.Require(ctx, consent.EntityCommunicationException, principal.ActionCreate) == nil {
+		return []string{"direct_send"}
 	}
 	return []string{"request_decision"}
 }

--- a/backend/internal/compose/integration/refused_send_review_integration_test.go
+++ b/backend/internal/compose/integration/refused_send_review_integration_test.go
@@ -768,12 +768,50 @@ func TestARefusedSendNamesItsReviewWhereAMachineCanReadIt(t *testing.T) {
 	// pass while the refusal promised a move this caller cannot make — which is
 	// the bug it exists to catch.
 	//
-	// This caller is the human who pressed send, so routing a decision is
-	// theirs to do.
+	// The fixture signs in as an admin, who holds communication_exception — so
+	// the move offered is the SEND rather than the ask. Which one a person sees
+	// is the server's decision and turns on that grant; the test below takes
+	// the grant away and watches the offer change.
+	if len(problem.Details.AvailableActions) != 1 ||
+		problem.Details.AvailableActions[0] != "direct_send" {
+		t.Errorf("the refusal offers %v, want exactly [direct_send] — a rep who may overrule the "+
+			"engine is offered the send, not a note asking somebody else to",
+			problem.Details.AvailableActions)
+	}
+}
+
+// A REP WHO CANNOT OVERRULE THE ENGINE IS OFFERED THE ASK INSTEAD.
+//
+// The two are answers to one question — "this was refused, now what" — and
+// which a person sees is decided by what they may actually do. Offering a
+// holder the ask would tell them to go around themselves; offering somebody
+// without the grant the send would be a button that fails when pressed.
+func TestARepWhoCannotOverruleTheEngineIsOfferedTheAsk(t *testing.T) {
+	c := setupConsent(t)
+
+	// The seat loses the grant that makes somebody a director.
+	if _, err := c.Owner.Exec(context.Background(), `
+		UPDATE role SET permissions = jsonb_set(
+			permissions, '{objects,communication_exception}',
+			'{"create":false,"read":false,"update":false,"delete":false}'::jsonb, true)`); err != nil {
+		t.Fatalf("removing the grant: %v", err)
+	}
+
+	var problem struct {
+		Details struct {
+			AvailableActions []string `json:"available_actions"`
+		} `json:"details"`
+	}
+	if status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", AnyMap{
+		"subject": "Re: Inbound question", "body": "answer",
+		"to": []string{"subject@consent.test"}, "consent_purpose": "marketing_email",
+	}, nil, &problem); status != http.StatusConflict {
+		t.Fatalf("marketing send with no grant → %d, want 409", status)
+	}
 	if len(problem.Details.AvailableActions) != 1 ||
 		problem.Details.AvailableActions[0] != "request_decision" {
-		t.Errorf("the refusal offers %v, want exactly [request_decision] — a rep who was refused "+
-			"is told what they may do about it", problem.Details.AvailableActions)
+		t.Errorf("the refusal offers %v, want exactly [request_decision] — a rep who cannot "+
+			"direct a send would press a button that fails", problem.Details.AvailableActions)
 	}
 }
 

--- a/backend/internal/compose/refusalactions_test.go
+++ b/backend/internal/compose/refusalactions_test.go
@@ -31,9 +31,39 @@ func TestARefusalOffersOnlyWhatThisCallerCanDo(t *testing.T) {
 		want   []string
 	}{
 		{
-			// The rep who pressed send. Routing is theirs to do.
-			name: "a person whose message it was", actor: principal.Principal{Type: principal.PrincipalHuman},
+			// A rep with no authority to overrule the engine. Asking somebody
+			// who has is the move they can make.
+			name: "a person who cannot direct a send", actor: principal.Principal{Type: principal.PrincipalHuman},
 			review: held, want: []string{"request_decision"},
+		},
+		{
+			// A rep who holds the grant is offered the SEND, not the ask.
+			// Telling them to ask a colleague would be telling them to go
+			// around themselves.
+			name: "a person who may direct a send",
+			actor: principal.Principal{
+				Type: principal.PrincipalHuman,
+				Permissions: principal.Permissions{
+					Objects: map[string]principal.ObjectGrant{
+						consent.EntityCommunicationException: {Create: true},
+					},
+				},
+			},
+			review: held, want: []string{"direct_send"},
+		},
+		{
+			// Holding the grant does not conjure a message to send. A refusal
+			// with nothing held offers nothing, whoever is asking.
+			name: "a grant holder with no message to decide about",
+			actor: principal.Principal{
+				Type: principal.PrincipalHuman,
+				Permissions: principal.Permissions{
+					Objects: map[string]principal.ObjectGrant{
+						consent.EntityCommunicationException: {Create: true},
+					},
+				},
+			},
+			review: consent.Review{},
 		},
 		{
 			// An agent cannot route: the door refuses non-humans outright.

--- a/backend/internal/modules/consent/instruction.go
+++ b/backend/internal/modules/consent/instruction.go
@@ -45,6 +45,12 @@ import (
 // installation that delegates the first has not thereby delegated the second.
 const entityCommunicationException = "communication_exception"
 
+// EntityCommunicationException is the same object, exported because compose
+// decides which action to OFFER a refused caller and that decision turns on
+// this grant. Two spellings would let the offer and the door disagree about
+// who may direct a send.
+const EntityCommunicationException = entityCommunicationException
+
 // The reasons a director may give. CLOSED, because the row is read in an audit
 // and a free-text-only reason cannot be counted — an installation asking "how
 // often do we override, and for what" needs an answer it can group.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3570,6 +3570,12 @@ export const de = {
   "compose.consentBlockedTitle": "Versand blockiert — keine Einwilligung",
   "compose.consentBlocked":
     "Ein Empfänger hat für diesen Zweck nicht eingewilligt, daher wurde der Versand unterdrückt (Standard-Ablehnung).",
+  "directSend.open": "Mit erfasster Ausnahme senden",
+  "directSend.opening": "Wird geöffnet…",
+  "directSend.alreadySettled":
+    "Darüber wurde bereits entschieden. Öffnen Sie die Prüfung, um zu sehen, was geschah.",
+  "directSend.couldNotOpen":
+    "Die Prüfung konnte nicht geöffnet werden. Versuchen Sie es erneut.",
   "directSend.title": "Trotzdem senden, auf eigene Verantwortung",
   "directSend.confirm": "Ausnahme erfassen und senden",
   "directSend.failed":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3657,6 +3657,11 @@ export const en = {
   "compose.consentBlockedTitle": "Send blocked — no consent",
   "compose.consentBlocked":
     "A recipient has not granted consent for this purpose, so the send was suppressed (default-deny).",
+  "directSend.open": "Send with a recorded exception",
+  "directSend.opening": "Opening…",
+  "directSend.alreadySettled":
+    "This has already been decided. Open the review to see what happened.",
+  "directSend.couldNotOpen": "The review could not be opened. Try again.",
   "directSend.title": "Send anyway, on your own authority",
   "directSend.confirm": "Record the exception and send",
   "directSend.failed":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3529,6 +3529,11 @@ export const vi = {
   "compose.consentBlockedTitle": "Bị chặn gửi — chưa có chấp thuận",
   "compose.consentBlocked":
     "Một người nhận chưa chấp thuận cho mục đích này, nên lượt gửi bị chặn (mặc định từ chối).",
+  "directSend.open": "Gửi kèm ngoại lệ được ghi nhận",
+  "directSend.opening": "Đang mở…",
+  "directSend.alreadySettled":
+    "Việc này đã được quyết định. Hãy mở phần xem xét để biết điều gì đã xảy ra.",
+  "directSend.couldNotOpen": "Không mở được phần xem xét. Hãy thử lại.",
   "directSend.title": "Vẫn gửi, theo thẩm quyền của bạn",
   "directSend.confirm": "Ghi nhận ngoại lệ và gửi",
   "directSend.failed":

--- a/frontend/src/screens/directsendaction.stories.tsx
+++ b/frontend/src/screens/directsendaction.stories.tsx
@@ -1,0 +1,47 @@
+// The two answers to "this was refused, now what", and who sees which.
+//
+// A rep who holds the authority is offered the send. One who does not is
+// offered the ask, which is a different component — so this one draws nothing,
+// and that absence is the story worth looking at.
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DirectSendAction } from "./directsendaction";
+
+const meta: Meta<typeof DirectSendAction> = {
+  title: "Patterns/Direct send action",
+  component: DirectSendAction,
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={new QueryClient()}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof DirectSendAction>;
+
+// A rep who may overrule the engine. Danger-variant, because pressing it ends
+// in a message going out against a refusal.
+export const CanSendAnyway: Story = {
+  args: {
+    review: {
+      reviewId: "01a0aaaa-bbbb-7ccc-8ddd-eeeeffff0001",
+      actions: ["direct_send"],
+    },
+  },
+};
+
+// A rep who may not. They are offered the ask elsewhere; here there is nothing
+// to draw, and a disabled button would be a question they have to answer before
+// they can ignore it.
+export const OffersNothing: Story = {
+  args: {
+    review: {
+      reviewId: "01a0aaaa-bbbb-7ccc-8ddd-eeeeffff0002",
+      actions: ["request_decision"],
+    },
+  },
+};

--- a/frontend/src/screens/directsendaction.test.tsx
+++ b/frontend/src/screens/directsendaction.test.tsx
@@ -1,0 +1,120 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DirectSendAction } from "./directsendaction";
+import type { SendReview } from "./sendreview";
+
+// Which answer a refused rep is offered is the SERVER's decision, because it is
+// the side that knows whether they may overrule the engine. This surface draws
+// what it was told and nothing else.
+
+const review = (actions: SendReview["actions"]): SendReview => ({
+  reviewId: "review-1",
+  actions,
+});
+
+function draw(actions: SendReview["actions"]) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <DirectSendAction review={review(actions)} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("DirectSendAction", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("offers the send when the server says this caller may", () => {
+    draw(["direct_send"]);
+    expect(
+      screen.getByRole("button", { name: /send with a recorded exception/i }),
+    ).toBeTruthy();
+  });
+
+  // A rep who cannot overrule the engine sees the ask instead, which is a
+  // different component. Drawing a button here that fails when pressed would
+  // be worse than drawing none.
+  it("offers nothing when the server offered the ask instead", () => {
+    draw(["request_decision"]);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  // An agent, or a refusal with no message to decide about.
+  it("offers nothing when the server offered nothing", () => {
+    draw([]);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  // The modal needs the review itself — the held message and the served
+  // caution — and opening it over a pending fetch would show an
+  // acknowledgement before the warning it exists to be read against arrived.
+  it("does not open the modal before the review is in hand", () => {
+    draw(["direct_send"]);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // A review can be resolved between the refusal and the click: the message
+  // sent from another tab, a colleague directing it. Opening the confirm form
+  // over one walks somebody through an acknowledgement the server then
+  // refuses, which is worse than saying plainly that it is already decided.
+  it("says so rather than opening a form for a review already decided", async () => {
+    const settled = {
+      id: "review-1",
+      state: "resolved",
+      kind: "single",
+      reason_code: "no_marketing_consent",
+      refusals: [],
+      warning: { version: "override-v1", text: "The refusal stands." },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(settled), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    const user = userEvent.setup();
+    draw(["direct_send"]);
+    await user.click(
+      screen.getByRole("button", { name: /send with a recorded exception/i }),
+    );
+    expect(await screen.findByText(/already been decided/i)).toBeTruthy();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // A failed fetch must be retryable. Setting `open` again changes nothing
+  // when it is already true, so without an explicit refetch the button is a
+  // dead end after the first failure.
+  it("tries again when the first attempt failed", async () => {
+    let attempts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        attempts += 1;
+        return new Response(null, { status: 503 });
+      }),
+    );
+    const user = userEvent.setup();
+    draw(["direct_send"]);
+    const button = () =>
+      screen.getByRole("button", { name: /send with a recorded exception/i });
+
+    await user.click(button());
+    // React Query retries on its own, so the count is whatever it has reached
+    // when the error settles. What matters is that a SECOND press adds to it:
+    // without the explicit refetch, setting `open` again changes nothing and
+    // the button is a dead end.
+    await vi.waitFor(() => expect(attempts).toBeGreaterThan(0));
+    const afterFirst = attempts;
+
+    await user.click(button());
+    await vi.waitFor(() => expect(attempts).toBeGreaterThan(afterFirst));
+  });
+});

--- a/frontend/src/screens/directsendaction.tsx
+++ b/frontend/src/screens/directsendaction.tsx
@@ -1,0 +1,126 @@
+// The button a rep who may overrule the engine presses.
+//
+// The refusal names the review it left behind; the modal needs the review
+// itself — the message being held, and the caution the server serves for it.
+// This is the step between: it fetches one and opens the other.
+//
+// FETCHED WHEN THEY ASK FOR IT, not when the refusal appears. Most refusals are
+// read and abandoned, and a request fired on every one would be work done for
+// nothing. The button opens the modal and the modal waits a moment, which is
+// the honest order: the person has already decided to look.
+
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import { Button } from "../design-system/atoms";
+import { useT } from "../i18n";
+import { throwProblem } from "./common";
+import { DirectSendModal } from "./directsendmodal";
+import type { SendReview } from "./sendreview";
+
+async function fetchReview(reviewId: string) {
+  const { data, error, response } = await api.GET(
+    "/communication-reviews/{id}",
+    {
+      params: { path: { id: reviewId } },
+    },
+  );
+  // Success is a real 2xx WITH a body: openapi-fetch reports a falsy error and
+  // undefined data for a bodiless non-2xx, which would otherwise open a modal
+  // with nothing in it.
+  if (!response.ok || !data) {
+    throwProblem(error || { title: "The review could not be opened." });
+  }
+  return data;
+}
+
+// SETTLED_STATES are the review states with nothing left to decide. The server
+// refuses a decision on any of them, so offering the form would be walking
+// somebody through an acknowledgement that cannot be recorded.
+const SETTLED_STATES = ["resolved", "superseded", "cancelled"];
+
+export function DirectSendAction({
+  review,
+  onSent,
+}: Readonly<{ review: SendReview; onSent?: (activityId: string) => void }>) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+
+  const opened = useQuery({
+    queryKey: ["communication-review", review.reviewId],
+    queryFn: () => fetchReview(review.reviewId),
+    // Only once the person has asked to see it. A refusal read and abandoned
+    // should cost nothing.
+    enabled: open,
+    // ONE ATTEMPT, and the button is the retry. React Query's own retries
+    // leave the control looking busy for seconds with nothing to press, and a
+    // person who has decided to overrule the engine should be told promptly
+    // that the review would not open rather than watched to wait.
+    retry: false,
+  });
+
+  if (!review.actions.includes("direct_send")) {
+    return null;
+  }
+  // A REVIEW THAT IS NO LONGER WAITING is not one to decide. It can be
+  // resolved, superseded or cancelled between the refusal and the click — the
+  // message sent from another tab, a colleague directing it — and opening the
+  // confirm form over one would walk somebody through an acknowledgement the
+  // server then refuses.
+  const settled = opened.data
+    ? SETTLED_STATES.includes(opened.data.state)
+    : false;
+  return (
+    <>
+      {/* PENDING, not disabled: the shared contract keeps the control
+          focusable and announces aria-busy, and a fetch is exactly the wait it
+          exists for. */}
+      <Button
+        variant="danger"
+        onClick={() => {
+          setOpen(true);
+          // A FAILED FETCH MUST BE RETRYABLE. Setting `open` again changes
+          // nothing when it is already true, so without this the button is a
+          // dead end after the first failure.
+          //
+          // Asked of anything not currently in flight rather than of isError
+          // alone: a query that has settled without data — refetched to
+          // nothing, evicted from the cache — is the same dead end wearing a
+          // different state.
+          if (!opened.isFetching && !opened.data) {
+            void opened.refetch();
+          }
+        }}
+        pending={open && opened.isFetching}
+        busyLabel={t("directSend.opening")}
+      >
+        {t("directSend.open")}
+      </Button>
+      {opened.isError && (
+        <p
+          className="t-body"
+          style={{ color: "var(--dangerText)" }}
+          role="alert"
+        >
+          {t("directSend.couldNotOpen")}
+        </p>
+      )}
+      {/* MOUNTED ONLY WITH THE REVIEW IN HAND. A modal opened over a pending
+          fetch would show its acknowledgement and its confirm button before the
+          warning those exist to be read against had arrived. */}
+      {settled && (
+        <p className="t-body" role="status">
+          {t("directSend.alreadySettled")}
+        </p>
+      )}
+      {open && opened.data && !settled && (
+        <DirectSendModal
+          open
+          onClose={() => setOpen(false)}
+          review={opened.data}
+          onSent={onSent}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/screens/sendrefusal.tsx
+++ b/frontend/src/screens/sendrefusal.tsx
@@ -7,6 +7,7 @@
 
 import { useT } from "../i18n";
 import type { Refusal } from "./compose";
+import { DirectSendAction } from "./directsendaction";
 import type { SendReview } from "./sendreview";
 import { ReviewReference, SendReviewActions } from "./sendreviewaction";
 
@@ -44,6 +45,11 @@ export function SendRefusal({
             gets a fresh control rather than the first one's success state —
             which would show "Asked" for a message nobody has asked about. */}
         {review && <SendReviewActions key={review.reviewId} review={review} />}
+        {/* The other answer to the same question, for a rep who holds the
+            authority. The server offers one or the other, never both. */}
+        {review && (
+          <DirectSendAction key={`direct-${review.reviewId}`} review={review} />
+        )}
         {/* AND THE REFERENCE, whether or not there is an action to offer. A
             server naming an action this build cannot draw leaves the rep with
             this, which is what makes dropping the action safe. */}

--- a/frontend/src/screens/sendreview.ts
+++ b/frontend/src/screens/sendreview.ts
@@ -31,10 +31,14 @@ export type SendReview = Readonly<{
 // English, and putting `request_decision` in front of a reader as a button
 // label tells them nothing.
 //
+// TWO, and a caller sees one of them. Which depends on whether they hold the
+// authority to overrule the engine themselves — the server decides, because it
+// is the side that knows.
+//
 // Dropping is safe because the reference survives. A rep still sees that a
 // review exists and can open it; what they lose is one shortcut, which is the
 // cost of a client older than its server.
-export const SEND_REVIEW_ACTIONS = ["request_decision"] as const;
+export const SEND_REVIEW_ACTIONS = ["request_decision", "direct_send"] as const;
 export type SendReviewAction = (typeof SEND_REVIEW_ACTIONS)[number];
 
 // sendReviewOf reads the review a refusal named, or null when it named none.

--- a/frontend/src/screens/sendreviewaction.tsx
+++ b/frontend/src/screens/sendreviewaction.tsx
@@ -63,6 +63,10 @@ export function SendReviewActions({
       queryClient.invalidateQueries({ queryKey: ["communication-review"] }),
   });
 
+  // THE DIRECT SEND IS THE OTHER ANSWER to the same question, and it is not
+  // this component's to draw: it needs the review itself — the held message,
+  // the served warning — which a refusal does not carry. SendRefusal fetches
+  // that and opens the modal.
   if (!review.actions.includes("request_decision")) {
     return null;
   }


### PR DESCRIPTION
The direct-send modal, its served warning and the backend door all existed and nothing opened any of them. A refused rep was offered one move, ask somebody who may decide, whether or not they were that somebody. A person holding the authority was being told to go around themselves.

The server decides which move a refused caller is shown, because it is the side that knows what they may do. A holder of `communication_exception` is offered the send; everybody else is offered the ask. One or the other, never both.

## The fetch is lazy and the modal waits for it

Most refusals are read and abandoned, so the review is fetched when somebody asks to see it rather than when the refusal appears. The modal mounts only once the review is in hand: opened over a pending fetch it would show its acknowledgement and confirm button before the warning those exist to be read against had arrived.

## Two fixes from the review

A settled review gets a sentence, not a form. It can be resolved between the refusal and the click, and opening the confirm form over one walks somebody through an acknowledgement the server then refuses.

A failed fetch is retryable. Setting `open` again changes nothing when it is already true, so the button was a dead end after the first failure. React Query's own retries are off, because they leave the control busy for seconds with nothing to press.

## An existing test caught the change

A test from the previous slice pinned "the refusal offers exactly `request_decision`" against a fixture that signs in as an admin, who holds the grant and is now offered the send. I widened it to pin both branches rather than updating it to whichever answer the fixture happens to produce.

Codex also cleared the part I was least sure of: the RBAC check in the refusal path reads permissions already on the request context, sees the same principal before and after the rollback, and the exported object constant is an alias rather than a second definition.

## Gates run locally

`make check-backend`, `make check-fe`, `make fe-uat`, and the compose integration lane. Every new test was mutation-tested.

## Not in this slice

The held-message resume on scheduled rows and the exception mark on sent history. Both are their own surfaces; this is the door from a refusal to the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the direct-send path for a refused rep who holds the authority to overrule the engine. Previously, any refused human rep was offered "Request decision" even if they could record the exception themselves; now the server offers `direct_send` to holders of `communication_exception` and `request_decision` to everyone else.

Behavior changes:
- The refusal action is decided by the server based on the caller's grant, one or the other, never both.
- Frontend adds `DirectSendAction` which fetches the held review only when clicked, then opens the existing direct-send modal.
- The modal mounts only after the review is in hand, so its warning text is always visible.
- Reviews already resolved, superseded, or cancelled get a sentence instead of a form.
- A failed review fetch is retryable by pressing the button again.
- The integration test now covers both grant-holder and non-grant-holder branches.

<sup>Written for commit 8fcfe5a0fd0b6cc504608b2cc08d4e95f008275f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorized reviewers can send communications with a recorded exception directly from a refusal review.
  * Refusal reviews now offer either direct sending or requesting a decision based on reviewer permissions.
  * Added handling for loading, already-decided, and failed review-opening states, including retry support.

* **Localization**
  * Added English, German, and Vietnamese translations for the direct-send workflow and its status messages.

* **Bug Fixes**
  * Review actions now accurately reflect what each reviewer is permitted to do.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->