### PR TITLE
feat(metrics): a failing job publishes WHAT went wrong, not only that it did

### DIFF
--- a/backend/internal/compose/jobfailuremetrics.go
+++ b/backend/internal/compose/jobfailuremetrics.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// WHAT is failing, in the vocabulary an operator already filters by.
+//
+// The gauges beside it say how much work is stuck. This says why, which is the
+// difference between an outage somebody reads on a screen and one a monitor can
+// act on: the only alertable signal before this was the discarded count going
+// up, and that rises identically for a provider outage, a revoked credential
+// and a bug. Those three want three different responses, and an alert that
+// cannot tell them apart is one an operator learns to ignore.
+//
+// A GAUGE, though the ticket asked for a counter, and the reason is what the
+// number is. Every family in this exposition is derived from the live job
+// table, so this value falls when the rows are retried or cleaned — declaring
+// it a counter would tell every rate() downstream to read a decrease as a
+// counter reset and invent a spike. `margince_job_failures > 0` is the alert
+// either way; a wrong type would break the arithmetic around it.
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
+)
+
+// unclassifiedFailureClass is the class a failure gets when nothing recognises
+// its text.
+//
+// It counts. A failure in a shape nobody enumerated is exactly the one an
+// outage arrives in, and dropping it would make that outage invisible to the
+// alert as well as to the screen — the surface would go quiet in the one case
+// it exists for. It costs one series, and it is reserved rather than derived so
+// no unit can declare a class that silently merges with it.
+const unclassifiedFailureClass = "unclassified"
+
+// failureKey is one published series: a kind and the class of what went wrong.
+type failureKey struct {
+	kind  string
+	class string
+}
+
+// writeJobFailureGauge renders the failing rows by kind and class.
+//
+// THE CLASS IS RESOLVED THE WAY THE SCREEN RESOLVES IT — jobs.VettedFailure,
+// from the row's kind and its stored sentence — rather than from a second table
+// here. Two classifiers over one vocabulary is two answers to one question, and
+// the one an alert fired on would be the one nobody was reading.
+//
+// SERIES BOUND, stated because the exposition values a knowable cardinality and
+// nothing was checking this one: at most (core classes + every composed unit's
+// own + one reserved) × the kinds that are failing. Both halves of that product
+// grow when somebody adds a unit, which is the growth
+// TestTheFailureSeriesBoundIsWhatTheVocabulariesAllow turns from a surprise
+// into a number a reviewer sees. Nothing here is keyed by workspace: a class is
+// a fact about the failure, not about whose work it was, and the tenant split is
+// already published by the gauges above.
+func writeJobFailureGauge(w io.Writer, failures []jobs.FailureCount) error {
+	if err := writeFamilyHeader(w, "margince_job_failures",
+		"Jobs in a failed state (retryable or discarded) per kind and failure class. Cancelled work is counted apart by margince_job_cancelled: a deliberate stop is not an outage. The class is the same vocabulary the failure list shows, and "+unclassifiedFailureClass+" is a failure whose recorded text nothing recognises -- which is what an outage nobody has enumerated looks like."); err != nil {
+		return err
+	}
+	series := map[failureKey]int64{}
+	for _, f := range failures {
+		series[failureKey{kind: f.Kind, class: failureClassOf(f)}] += f.Count
+	}
+	keys := sortedKeysOf(series, func(a, b failureKey) int {
+		return cmp.Or(cmp.Compare(a.kind, b.kind), cmp.Compare(a.class, b.class))
+	})
+	for _, k := range keys {
+		if _, err := fmt.Fprintf(w, "margince_job_failures{kind=%s,class=%s} %d\n",
+			label(k.kind), label(k.class), series[k]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// failureClassOf answers the class token one group publishes under.
+//
+// A row recording NO cause and a row recording an unrecognised one both land on
+// the reserved class, and that is a deliberate flattening: the difference
+// matters to somebody reading one failure and not to an alert counting them,
+// which is asking whether anything is failing in a shape nobody named.
+func failureClassOf(f jobs.FailureCount) string {
+	if detail, ok := jobs.VettedFailure(f.Kind, f.Stored); ok {
+		return detail.Class
+	}
+	return unclassifiedFailureClass
+}
+
+// failureSeriesBound is the most series margince_job_failures can publish for a
+// given set of failing kinds: every class any vocabulary declares, plus the
+// reserved one, for each kind.
+//
+// It is deliberately an over-count — one kind's rows can only carry the core
+// vocabulary and its own unit's, never another unit's — so a fleet that stayed
+// under it proves the bound rather than merely agreeing with it.
+func failureSeriesBound(kinds int) int {
+	classes := len(jobs.CoreFailureClasses()) + 1
+	for _, kind := range jobs.ComposedFailureKinds() {
+		classes += len(jobs.ComposedFailureClasses(kind))
+	}
+	return kinds * classes
+}

--- a/backend/internal/compose/jobfailuremetrics_test.go
+++ b/backend/internal/compose/jobfailuremetrics_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What an alert can see.
+//
+// Before this family the only monitorable signal was the discarded count going
+// up, which rises identically for a provider outage, a revoked credential and a
+// bug. These hold the three properties that make the class worth publishing: it
+// is the SAME class the screen shows, a failure nobody classified still counts,
+// and the number of series stays inside a bound somebody stated.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
+)
+
+// renderFailures answers the exposition for one set of failure groups.
+func renderFailures(t *testing.T, failures ...jobs.FailureCount) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := writeJobFailureGauge(&buf, failures); err != nil {
+		t.Fatalf("writeJobFailureGauge: %v", err)
+	}
+	return buf.String()
+}
+
+// The class an alert matches has to be the class the screen shows, or an
+// operator paged by one goes looking for the other.
+func TestAFailureIsPublishedUnderTheClassTheScreenShows(t *testing.T) {
+	// A core sentinel's own sentence, read back through the same table the
+	// failure list reads. Taken from the vocabulary rather than typed here:
+	// a literal would pass while the sentence it copies changed underneath.
+	detail, ok := jobs.VettedFailure("any_kind", jobs.SentenceForClass("record_gone"))
+	if !ok {
+		t.Fatal("the core vocabulary no longer answers for record_gone, so this case is testing nothing")
+	}
+	got := renderFailures(t, jobs.FailureCount{Kind: "person_enrich", Stored: detail.Sentence, Count: 3})
+	want := `margince_job_failures{kind="person_enrich",class="record_gone"} 3`
+	if !strings.Contains(got, want) {
+		t.Errorf("the exposition does not publish the screen's own class\nwant: %s\ngot:\n%s", want, got)
+	}
+}
+
+// A failure in a shape nobody enumerated is exactly the one an outage arrives
+// in. Dropping it would make that outage invisible to the alert as well as to
+// the screen — the surface going quiet in the one case it exists for.
+func TestAFailureNobodyClassifiedStillCounts(t *testing.T) {
+	got := renderFailures(t,
+		jobs.FailureCount{Kind: "person_enrich", Stored: "dial tcp 10.0.0.1:443: i/o timeout", Count: 2},
+		// And a row that recorded no cause at all, which lands on the same
+		// class: the difference matters to somebody reading one failure and
+		// not to a count of how many are failing unnamed.
+		jobs.FailureCount{Kind: "person_enrich", Stored: "", Count: 1},
+	)
+	want := `margince_job_failures{kind="person_enrich",class="` + unclassifiedFailureClass + `"} 3`
+	if !strings.Contains(got, want) {
+		t.Errorf("an unrecognised failure was not counted\nwant: %s\ngot:\n%s", want, got)
+	}
+}
+
+// One series per (kind, class), summed — not one per stored sentence. Two
+// sentences of one class are one fact to an alert, and publishing them apart
+// would make the class label mean nothing.
+func TestTwoSentencesOfOneClassAreOneSeries(t *testing.T) {
+	got := renderFailures(t,
+		jobs.FailureCount{Kind: "person_enrich", Stored: "one unrecognised thing", Count: 2},
+		jobs.FailureCount{Kind: "person_enrich", Stored: "another unrecognised thing", Count: 5},
+	)
+	if strings.Count(got, "margince_job_failures{kind=") != 1 {
+		t.Errorf("want one series for one kind and class, got:\n%s", got)
+	}
+	if !strings.Contains(got, `class="`+unclassifiedFailureClass+`"} 7`) {
+		t.Errorf("the two sentences did not sum onto one series:\n%s", got)
+	}
+}
+
+// The exposition's cardinality is meant to be KNOWABLE, not small — and
+// nothing was checking this family's. Both halves of the product grow when
+// somebody adds a composed unit, which is the growth this turns from a
+// surprise into a number a reviewer sees.
+func TestTheFailureSeriesBoundIsWhatTheVocabulariesAllow(t *testing.T) {
+	kinds := []string{"person_enrich", "company_enrich"}
+	var failures []jobs.FailureCount
+	for _, kind := range kinds {
+		for _, class := range jobs.CoreFailureClasses() {
+			failures = append(failures,
+				jobs.FailureCount{Kind: kind, Stored: jobs.SentenceForClass(class), Count: 1})
+		}
+		failures = append(failures,
+			jobs.FailureCount{Kind: kind, Stored: "nothing recognises this", Count: 1})
+	}
+	got := strings.Count(renderFailures(t, failures...), "margince_job_failures{kind=")
+	if bound := failureSeriesBound(len(kinds)); got > bound {
+		t.Errorf("the exposition published %d series against a stated bound of %d — "+
+			"a cardinality nobody can count is a cardinality nobody is keeping", got, bound)
+	}
+	// And the bound is not vacuous: every core class plus the reserved one,
+	// for each kind, is what was rendered.
+	if want := len(kinds) * (len(jobs.CoreFailureClasses()) + 1); got != want {
+		t.Errorf("rendered %d series, want %d — the case is no longer exercising the whole vocabulary", got, want)
+	}
+}

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -245,6 +245,9 @@ func writeJobMetrics(w io.Writer, snap jobs.Snapshot) error {
 	if err := writeSweepUnitGauges(w, snap.Units); err != nil {
 		return err
 	}
+	if err := writeJobFailureGauge(w, snap.Failures); err != nil {
+		return err
+	}
 	if err := writeUnrecognisedStateGauge(w, unrecognised); err != nil {
 		return err
 	}

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -240,6 +240,7 @@ func TestAnEmptySnapshotWritesEveryFamilyHeaderAndNoSeries(t *testing.T) {
 		"margince_sweep_workspaces_failed",
 		"margince_sweep_units",
 		"margince_sweep_units_failed",
+		"margince_job_failures",
 	} {
 		if !strings.Contains(buf.String(), "# TYPE "+family+" gauge") {
 			t.Errorf("family header for %s missing from an empty snapshot\ngot:\n%s", family, buf.String())

--- a/backend/internal/platform/jobs/failurestats.go
+++ b/backend/internal/platform/jobs/failurestats.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package jobs
+
+// How many jobs are failing, and of WHAT.
+//
+// The runtime gauges next door answer how much work is stuck; this answers why,
+// in the vocabulary an operator already filters by. The difference is what makes
+// an outage alertable rather than merely readable: until now the only signal a
+// monitor could see was the discarded count going up, and that fires identically
+// for a provider outage, a revoked credential and a bug. Those three want three
+// different responses.
+//
+// The class is not stored. A failure row holds a vetted SENTENCE and nothing
+// else — no class prefix, no envelope — so the class is derived on read from the
+// row's kind and its text, exactly as the failure list derives it. This read
+// therefore returns the stored text and lets its caller classify, rather than
+// putting a second classifier in SQL that could disagree with the first.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// FailureCount is one (kind, stored sentence) pair and how many jobs are
+// sitting on it.
+type FailureCount struct {
+	Kind string
+	// Stored is river_job.errors' newest message VERBATIM, which is what the
+	// class is resolved from. Empty when the row records no cause at all —
+	// a state its own, and not the same as a cause nobody has classified.
+	Stored string
+	Count  int64
+}
+
+// failureStates are the states this count is ABOUT: work that failed and is
+// either waiting to try again or has given up.
+//
+// `cancelled` is deliberately not among them. A cancellation is a deliberate
+// stop — the exposition already counts those apart for exactly that reason —
+// and an alert that could not tell an operator's own decision from a provider
+// outage is the confusion this metric exists to end, not one to introduce a
+// second time.
+//
+// `retryable` IS among them, and that is the half that makes the metric worth
+// having: a connector unreachable all night spends the night retrying, and an
+// alert that waited for every attempt to be spent would fire the morning after
+// the outage it was supposed to catch.
+const failureStates = `('retryable','discarded')`
+
+// statsByFailure groups the failing rows by kind and by the sentence they
+// recorded.
+//
+// Grouped in SQL rather than counted in Go over the failure LIST, because that
+// list is capped at the newest few hundred rows for a screen: a metric read off
+// it would under-report exactly when a fleet is failing most, which is the one
+// time it is being watched.
+func statsByFailure(ctx context.Context, pool *pgxpool.Pool) ([]FailureCount, error) {
+	const q = `
+		SELECT kind,
+		       coalesce(errors[cardinality(errors)]->>'error', ''),
+		       count(*)::bigint
+		FROM river_job
+		WHERE state::text IN ` + failureStates + `
+		GROUP BY 1, 2`
+
+	cursor, err := pool.Query(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("jobs: reading job failures by class: %w", err)
+	}
+	defer cursor.Close()
+
+	var out []FailureCount
+	for cursor.Next() {
+		var f FailureCount
+		if err := cursor.Scan(&f.Kind, &f.Stored, &f.Count); err != nil {
+			return nil, fmt.Errorf("jobs: scanning job failures by class: %w", err)
+		}
+		out = append(out, f)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("jobs: reading job failures by class: %w", err)
+	}
+	return out, nil
+}
+
+// CoreFailureClasses answers the core vocabulary's class tokens.
+//
+// Exported for the exposition's series bound: the number of series this metric
+// can publish is (core classes + each unit's own + one reserved) × the kinds
+// that fail, and a bound nobody can count is a bound nobody is keeping.
+func CoreFailureClasses() []string {
+	out := make([]string, 0, len(vocabulary))
+	for _, known := range vocabulary {
+		out = append(out, known.class)
+	}
+	return out
+}
+
+// SentenceForClass answers the sentence a core class is recorded as, or the
+// empty string for a token the core vocabulary does not own.
+//
+// Exported for the metric's own cases: a test that typed the sentence out
+// would keep passing while the wording it copied changed underneath, and the
+// classification it is exercising is a lookup FROM that wording.
+func SentenceForClass(class string) string {
+	for _, known := range vocabulary {
+		if known.class == class {
+			return known.sentence
+		}
+	}
+	return ""
+}

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -129,6 +129,10 @@ type Snapshot struct {
 	// which is a legitimate fleet rather than a failed read — Stats returns
 	// the error for that.
 	Units []SweepUnit
+	// Failures is the failing rows grouped by kind and by the sentence they
+	// recorded — the input the exposition classifies. Empty is a fleet with
+	// nothing failing, which is the healthy case and not a failed read.
+	Failures []FailureCount
 }
 
 // Stats reads the live job table for the metric surface.
@@ -157,7 +161,11 @@ func Stats(ctx context.Context, pool *pgxpool.Pool) (Snapshot, error) {
 	if err != nil {
 		return Snapshot{}, err
 	}
-	return Snapshot{Rows: rows, Sweeps: sweeps, Units: units}, nil
+	failures, err := statsByFailure(ctx, pool)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{Rows: rows, Sweeps: sweeps, Units: units, Failures: failures}, nil
 }
 
 // subWorkspaceFanOuts answers the fan-out child kinds whose declared unit is

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -155,7 +155,7 @@ copy reported a truthful-looking zero. That stays true — the worker never
 re-serves a job-table gauge, and `--observe-addr` below is about the process,
 not the fleet.
 
-**`/metrics` — is a queue growing?** Nine gauge families over the job table:
+**`/metrics` — is a queue growing?** Ten gauge families over the job table:
 
 | Family | Labels | Meaning |
 |---|---|---|
@@ -168,8 +168,16 @@ not the fleet.
 | `margince_sweep_workspaces_failed` | `sweep` | those whose MOST RECENT child is discarded or cancelled |
 | `margince_sweep_units` | `sweep`, `unit` | the same reading one grain down, for the dispatchers that fan out per **connection** or per **build**: units with a surviving child |
 | `margince_sweep_units_failed` | `sweep`, `unit` | those whose MOST RECENT child is discarded or cancelled |
+| `margince_job_failures` | `kind`, `class` | failing work (retryable or discarded) by WHAT went wrong — the same class the failure list shows. `unclassified` is a failure whose recorded text nothing recognises, which is what an outage nobody has enumerated looks like. Cancelled work is not here: a deliberate stop is not an outage |
 
-The last two exist because the workspace pair counts each workspace once, and
+`margince_job_failures` is the one that makes an outage alertable rather than
+only readable. Without a class the only signal a monitor sees is the discarded
+count rising, and that rises identically for a provider outage, a revoked
+credential and a bug — three situations wanting three different responses. Its
+cardinality is bounded by the vocabularies: every class the core declares, plus
+each composed unit's own, plus the reserved one, for each failing kind.
+
+The sweep pairs exist because the workspace pair counts each workspace once, and
 four dispatchers fan out below that grain. They report **only** the kinds whose
 declared `fan_out_unit` is finer than a workspace — for the other twenty the
 unit *is* the workspace, so the two pairs would carry the same numbers.


### PR DESCRIPTION
Closes #1752.

## The signal an operator could not build on

The only alertable thing a monitor saw was **the discarded count going up**, and that rises identically for a provider outage, a revoked credential and a bug. Three situations wanting three different responses, one number — so a connector unreachable all night stayed visible only to somebody who opened the Maintenance screen and read it.

`margince_job_failures{kind,class}` publishes the class.

## Three properties worth naming

**It is the same class the screen shows.** Resolved through `jobs.VettedFailure` from the row's kind and its stored sentence, not from a second table here. Two classifiers over one vocabulary is two answers to one question, and the one an alert fired on would be the one nobody was reading.

**An unclassified failure still counts.** A failure in a shape nobody enumerated is exactly the one an outage arrives in; dropping it would make that outage invisible to the alert as well as to the screen — the surface going quiet in the one case it exists for. `unclassified` is reserved rather than derived, so no unit can declare a class that silently merges with it, and it costs one series.

**The series bound is stated and checked**, which nothing was doing for this exposition: at most `(core classes + every composed unit's own + one reserved) × the failing kinds`. Both halves grow when somebody adds a unit, and the exposition values a cardinality that is *knowable* rather than small — so `TestTheFailureSeriesBoundIsWhatTheVocabulariesAllow` turns a tenth unit from a surprise into a number a reviewer sees. It also asserts the bound is not vacuous.

## Two deliberate departures from the ruling's wording

**A gauge, not a counter.** Every family in this exposition is derived from the live job table, so the value *falls* when rows are retried or cleaned. `# TYPE counter` over a value that decreases tells every `rate()` downstream to read the decrease as a counter reset and invent a spike. The alert is `margince_job_failures > 0` either way; the wrong type would break the arithmetic around it. `writeFamilyHeader` writes `gauge` for the whole exposition, so this also keeps one type across it.

**`retryable` as well as `discarded`, and `cancelled` not at all.** A connector unreachable all night spends the night *retrying* — an alert that waited for every attempt to be spent would fire the morning after the outage it was meant to catch. A cancellation is somebody's own decision, already counted apart by `margince_job_cancelled`, and folding it in would reintroduce exactly the confusion this metric ends.

## Read

Its own grouped scan, not a count over the failure list: that list is capped at the newest few hundred rows for a screen, so a metric read off it would under-report precisely when a fleet is failing most — the one time it is being watched.

## Tests

- the class published is the screen's own, taken from the vocabulary rather than typed out (a literal would keep passing while the sentence it copied changed);
- an unrecognised sentence **and** a row with no recorded cause both count, on the reserved class;
- two sentences of one class are one series, summed — otherwise the class label means nothing;
- the series bound holds and is exercised across the whole core vocabulary.

Mutation-checked: routing the unclassified bucket to a real class fails its case.

## Checks

`make check-backend` green, `make craft-static` 0/0/0, `make test-it DIR=backend/internal/platform/jobs` green. The `/metrics` table in `docs/reference/configuration.md` gains the family and the reasoning.

## Related

#1751 adds an authored technical sentence to a failure — the *readable* half to this *alertable* one, sharing the class vocabulary. Worth taking in that order, as its ruling says.