### PR TITLE
feat(jobs): a failure names what went wrong, without quoting the provider

### DIFF
--- a/backend/internal/platform/jobs/failurestats.go
+++ b/backend/internal/platform/jobs/failurestats.go
@@ -93,9 +93,17 @@ func statsByFailure(ctx context.Context, pool *pgxpool.Pool) ([]FailureCount, er
 // can publish is (core classes + each unit's own + one reserved) × the kinds
 // that fail, and a bound nobody can count is a bound nobody is keeping.
 func CoreFailureClasses() []string {
-	out := make([]string, 0, len(vocabulary))
+	out := make([]string, 0, len(vocabulary)+len(technicalFaults))
 	for _, known := range vocabulary {
 		out = append(out, known.class)
+	}
+	// The authored technical classes are core as well — one vocabulary in two
+	// tables, because one is keyed by sentinel and the other by the cause's
+	// shape. A bound that counted only the first would be short by exactly the
+	// classes an infrastructure outage arrives under, which are the ones an
+	// alert is most likely to be watching.
+	for _, technical := range technicalFaults {
+		out = append(out, technical.class)
 	}
 	return out
 }
@@ -110,6 +118,11 @@ func SentenceForClass(class string) string {
 	for _, known := range vocabulary {
 		if known.class == class {
 			return known.sentence
+		}
+	}
+	for _, technical := range technicalFaults {
+		if technical.class == class {
+			return technical.sentence
 		}
 	}
 	return ""

--- a/backend/internal/platform/jobs/fault.go
+++ b/backend/internal/platform/jobs/fault.go
@@ -30,6 +30,13 @@ import (
 // This is the comms faultReason posture (a fixed sentence chosen by what
 // the cause IS, never the cause's own text) applied at the seam every
 // worker shares rather than in one module.
+//
+// The cause may be READ to choose among those sentences, and that is not a
+// crack in the rule — it is the rule working. technicalfault.go inspects a
+// cause's SHAPE (its type, its sentinel, a status integer a typed error
+// carries) and picks one of a closed authored set, so an operator learns that a
+// host did not resolve without the host's name travelling with it. What may
+// never travel is the cause's own TEXT.
 func Fault(err error) error { return FaultContext(context.Background(), err) }
 
 // FaultContext is Fault with the caller's context on the log line, so an
@@ -124,6 +131,20 @@ func faultFor(ctx context.Context, kind string, err error) error {
 		if errors.Is(err, known.sentinel) {
 			return &fault{sentence: known.sentence, cause: err}
 		}
+	}
+	// AFTER the sentinels, because a cause carrying one has already been named
+	// in the product's own terms and that name is the more useful of two true
+	// statements: "the record this job names no longer exists" tells an
+	// operator what to do, "the provider answered with a server error" tells
+	// them where it happened.
+	//
+	// The cause is READ here and never projected — the shape decides, the
+	// sentence is authored (technicalfault.go). An operator whose job failed
+	// because a host did not resolve now reads that, instead of being sent to
+	// a log to find out.
+	if technical, ok := technicalFaultFor(err); ok {
+		slog.ErrorContext(ctx, "jobs: a worker failed", faultLogAttrs(ctx, kind, technical.class, err)...)
+		return &fault{sentence: technical.sentence, cause: err}
 	}
 	// The SAME attributes as the two classified lines above. This is the branch
 	// whose sentence tells an operator the diagnosis is in the process log, so it

--- a/backend/internal/platform/jobs/faultclass.go
+++ b/backend/internal/platform/jobs/faultclass.go
@@ -139,6 +139,14 @@ func refuseCoreCollision(kind string, c extension.FailureClass) error {
 			return fmt.Errorf("jobs: kind %q class %q declares a substitute sentence — the substitutes are what this surface says when it has NOTHING to say about a failure, so a class that classified something may not claim one", kind, c.Class)
 		}
 	}
+	for _, technical := range technicalFaults {
+		if c.Sentence == technical.sentence {
+			return fmt.Errorf("jobs: kind %q class %q declares the sentence the core class %q already owns — a stored sentence is read back through the core table first, so this failure would report as %q", kind, c.Class, technical.class, technical.class)
+		}
+		if c.Class == technical.class {
+			return fmt.Errorf("jobs: kind %q declares class %q, which the core vocabulary already owns — one token names one failure, and an alert matching it would fire on both", kind, c.Class)
+		}
+	}
 	for _, known := range vocabulary {
 		if c.Sentence == known.sentence {
 			return fmt.Errorf("jobs: kind %q class %q declares the sentence the core class %q already owns — a stored sentence is read back through the core table first, so this failure would report as %q", kind, c.Class, known.class, known.class)
@@ -216,6 +224,14 @@ func VettedFailure(kind, stored string) (FailureDetail, bool) {
 	for _, known := range vocabulary {
 		if stored == known.sentence {
 			return FailureDetail{Class: known.class, Sentence: known.sentence, Remedy: known.remedy}, true
+		}
+	}
+	// The authored technical sentences are core too, and are read back the same
+	// way: the row stores the sentence and nothing else, whichever core table
+	// chose it.
+	for _, technical := range technicalFaults {
+		if stored == technical.sentence {
+			return FailureDetail{Class: technical.class, Sentence: technical.sentence, Remedy: technical.remedy}, true
 		}
 	}
 	composedClasses.mu.RLock()

--- a/backend/internal/platform/jobs/technicalfault.go
+++ b/backend/internal/platform/jobs/technicalfault.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package jobs
+
+// WHAT went wrong technically, said in the product's own words.
+//
+// The vocabulary beside this one classifies by SENTINEL: a job returned
+// apperrors.ErrNotFound, so the record is gone. Most infrastructure failures
+// carry no sentinel — they are a *net.DNSError, a refused dial, a handshake
+// that timed out — and those all landed on the same sentence, which tells an
+// operator only that the diagnosis is in a log they then have to go and read.
+// "The provider's host name did not resolve" is a different morning.
+//
+// THE CAUSE IS READ AND NEVER PROJECTED. Every sentence here is authored: the
+// classifier inspects the cause's SHAPE — its type, its sentinel, a status
+// integer a typed error carries — and CHOOSES one of a closed set. No part of
+// the cause's own text reaches the returned sentence, which is what keeps
+// Fault's promise absolute: river_job.errors has no workspace column and no
+// row-level protection, and a provider's prose routinely names the address or
+// the record it refused. Reading a cause to pick a sentence is not publishing
+// it, and a classifier that reached for the nearest match on a substring would
+// be how the prose starts leaking by another name.
+//
+// AN UNRECOGNISED CAUSE GETS NOTHING. It falls through to the unclassified
+// substitute exactly as before. A guess here would be worse than silence: the
+// sentence is what an operator acts on, and one chosen by resemblance sends
+// them after the wrong thing with the same confidence as a true one.
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"os"
+	"syscall"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// technicalFault is one recognisable failure shape and what the product says
+// about it. Same three fields as the sentinel vocabulary, because both are read
+// back through one surface and an operator must not be able to tell which table
+// classified their failure.
+type technicalFault struct {
+	// match answers whether this is the shape. It reads the cause's type and
+	// sentinels, never its message.
+	match    func(error) bool
+	class    string
+	sentence string
+	remedy   string
+}
+
+// technicalFaults is the closed set, most specific first.
+//
+// ORDER MATTERS between the transport entries: a DNS failure and a refused
+// connection both surface as a *net.OpError, so the more specific test has to
+// run first or every unresolved host would report as a refusal.
+var technicalFaults = []technicalFault{
+	{
+		match:    isDNSFailure,
+		class:    "host_unresolved",
+		sentence: "the provider's host name did not resolve",
+		remedy:   "Check the installation's DNS resolver and, if the host is right, whether the provider has retired it. A name that resolves nowhere does not fix itself on retry.",
+	},
+	{
+		match:    isTLSFailure,
+		class:    "tls_refused",
+		sentence: "the TLS handshake with the provider did not complete",
+		remedy:   "Check the installation's clock and its trust store first — an expired certificate and a wrong system time look identical from here — then whether an inspecting proxy sits in front of this connection.",
+	},
+	{
+		match:    isConnectionRefused,
+		class:    "connection_refused",
+		sentence: "the provider refused the connection",
+		remedy:   "Nothing to re-queue yet: the port answered and said no. Check whether the provider is in a maintenance window and whether this installation's egress address is allowed.",
+	},
+	{
+		match:    isTimeout,
+		class:    "provider_timed_out",
+		sentence: "the provider did not answer in time",
+		remedy:   "Retry normally. Persistent timeouts against one provider mean either their outage or a route that cannot carry this volume, and the run's own cadence is the next thing to look at.",
+	},
+	{
+		match:    providerStatusIn(401, 403),
+		class:    "provider_rejected_credential",
+		sentence: "the provider rejected this installation's credential",
+		remedy:   "Re-authorise the connection. A revoked token, a changed password and a withdrawn app grant all arrive exactly here.",
+	},
+	{
+		match:    providerServerError,
+		class:    "provider_server_error",
+		sentence: "the provider answered with a server error",
+		remedy:   "Theirs to fix. Retry is correct and the run does it; a day of these is a status page to read rather than a change to make here.",
+	},
+}
+
+// isDNSFailure answers the one shape that never fixes itself on retry.
+func isDNSFailure(err error) bool {
+	var dns *net.DNSError
+	return errors.As(err, &dns)
+}
+
+// isTLSFailure covers both ends of a handshake that did not complete: the
+// record the peer sent was not TLS at all, or the certificate was refused.
+func isTLSFailure(err error) bool {
+	var record tls.RecordHeaderError
+	var verify *tls.CertificateVerificationError
+	var alert tls.AlertError
+	return errors.As(err, &record) || errors.As(err, &verify) || errors.As(err, &alert)
+}
+
+// isConnectionRefused reads the syscall underneath, not the message.
+func isConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}
+
+// isTimeout takes the three spellings one timeout arrives in: the deadline the
+// caller set, the one the transport set, and net's own Timeout predicate.
+func isTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var timeout net.Error
+	return errors.As(err, &timeout) && timeout.Timeout()
+}
+
+// providerStatusIn matches a typed provider failure carrying one of these
+// statuses.
+//
+// The STATUS is read and the sentence is authored, which is the distinction the
+// whole file rests on: a bare status integer carries no record data, and
+// enumerating the ones that mean something keeps every published sentence a
+// member of the closed set rather than a number formatted into prose.
+func providerStatusIn(statuses ...int) func(error) bool {
+	return func(err error) bool {
+		var provider *connector.ProviderError
+		if !errors.As(err, &provider) {
+			return false
+		}
+		for _, s := range statuses {
+			if provider.Status == s {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// providerServerError matches any 5xx. Enumerated as a RANGE rather than as
+// statuses because they mean one thing to an operator — the provider broke —
+// and one sentence for them is the honest granularity; splitting 502 from 503
+// would publish a distinction nobody acts on differently.
+func providerServerError(err error) bool {
+	var provider *connector.ProviderError
+	return errors.As(err, &provider) && provider.Status >= 500 && provider.Status <= 599
+}
+
+// technicalFaultFor answers the authored classification for a cause's shape.
+func technicalFaultFor(err error) (technicalFault, bool) {
+	for _, f := range technicalFaults {
+		if f.match(err) {
+			return f, true
+		}
+	}
+	return technicalFault{}, false
+}

--- a/backend/internal/platform/jobs/technicalfault_test.go
+++ b/backend/internal/platform/jobs/technicalfault_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package jobs
+
+// The classifier reads the cause and publishes none of it.
+//
+// Every case here starts from an error in the shape a real provider failure
+// arrives in, and makes two assertions: the authored sentence comes out, and NO
+// PART OF THE INPUT DOES. The second is the one that holds the invariant
+// river_job.errors depends on — that column has no workspace and no row-level
+// protection, and a provider's prose routinely names the address or the record
+// it refused.
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// secretish are the fragments a real cause carries that must never reach the
+// stored sentence: the host somebody is syncing, the mailbox, the record id.
+var secretish = []string{
+	"mail.acme-customer.example",
+	"anna.weber@acme-customer.example",
+	"018f3a1b-0000-7000-8000-0000000000c1",
+}
+
+func TestATechnicalCauseIsNamedWithoutBeingQuoted(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		cause error
+		class string
+	}{{
+		name: "a host that does not resolve",
+		cause: &net.DNSError{
+			Err: "no such host", Name: secretish[0], IsNotFound: true,
+		},
+		class: "host_unresolved",
+	}, {
+		name:  "a certificate the trust store refuses",
+		cause: &tls.CertificateVerificationError{Err: errors.New("x509: certificate signed by unknown authority")},
+		class: "tls_refused",
+	}, {
+		name: "a refused dial",
+		cause: &net.OpError{
+			Op: "dial", Net: "tcp", Addr: &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 443},
+			Err: syscall.ECONNREFUSED,
+		},
+		class: "connection_refused",
+	}, {
+		name:  "a deadline the caller set",
+		cause: context.DeadlineExceeded,
+		class: "provider_timed_out",
+	}, {
+		name:  "a read that outlived its deadline",
+		cause: os.ErrDeadlineExceeded,
+		class: "provider_timed_out",
+	}, {
+		name: "a credential the provider rejected",
+		cause: &connector.ProviderError{
+			Op: "/users/" + secretish[1] + "/messages", Status: 401,
+			Reason: "invalid_grant", Class: errors.New("auth"),
+		},
+		class: "provider_rejected_credential",
+	}, {
+		name: "the provider's own fault",
+		cause: &connector.ProviderError{
+			Op: "/records/" + secretish[2], Status: 503, Class: errors.New("upstream"),
+		},
+		class: "provider_server_error",
+	}} {
+		t.Run(c.name, func(t *testing.T) {
+			got := Fault(c.cause)
+			want := SentenceForClass(c.class)
+			if want == "" {
+				t.Fatalf("no core sentence for class %q, so this case asserts nothing", c.class)
+			}
+			if got.Error() != want {
+				t.Errorf("stored sentence = %q, want the authored %q", got.Error(), want)
+			}
+			// The whole point: the cause is reachable through errors.Is and
+			// unreachable through the column.
+			if !errors.Is(got, c.cause) {
+				t.Error("the cause is no longer reachable, so nothing downstream can classify on it")
+			}
+			for _, fragment := range secretish {
+				if strings.Contains(got.Error(), fragment) {
+					t.Errorf("the stored sentence carries %q out of the cause — river_job.errors has no "+
+						"workspace column and no row-level protection, so this is fleet-visible", fragment)
+				}
+			}
+			// And the stronger form of the same property, which does not depend
+			// on this case having planted the right fragments: what is stored
+			// is EXACTLY a member of the authored set. A sentence assembled
+			// from the cause could not be, however careful the assembly —
+			// which is why the classifier chooses rather than formats.
+			if !isAuthoredSentence(got.Error()) {
+				t.Errorf("the stored sentence %q is not one of the authored set, so something was built from the cause", got.Error())
+			}
+		})
+	}
+}
+
+// A cause nobody enumerated gets NOTHING, which is the default this classifier
+// is safe because of: a sentence chosen by resemblance sends an operator after
+// the wrong thing with the same confidence as a true one.
+func TestACauseNobodyEnumeratedIsNotGuessedAt(t *testing.T) {
+	got := Fault(errors.New("the provider said something nobody has classified"))
+	if detail, ok := VettedFailure("", got.Error()); ok {
+		t.Errorf("an unrecognised cause was classified as %q — the classifier guessed", detail.Class)
+	}
+	if !strings.Contains(got.Error(), "could not classify") {
+		t.Errorf("stored sentence = %q, want the unclassified substitute", got.Error())
+	}
+}
+
+// A SENTINEL still wins. "The record this job names no longer exists" tells an
+// operator what to do; "the provider did not answer in time" tells them where it
+// happened, and the first is the more useful of two true statements.
+func TestASentinelOutranksTheCausesShape(t *testing.T) {
+	// A timeout the caller already classified as a budget refusal.
+	wrapped := errors.Join(apperrors.ErrBudgetExceeded, context.DeadlineExceeded)
+	got := Fault(wrapped)
+	if got.Error() == SentenceForClass("provider_timed_out") {
+		t.Error("the cause's shape outranked the sentinel the caller set, losing the more useful statement")
+	}
+}
+
+// Every class this file publishes is readable back, or the screen shows a
+// sentence with no class beside it and the metric counts it as unclassified.
+func TestEveryTechnicalSentenceReadsBackToItsClass(t *testing.T) {
+	for _, technical := range technicalFaults {
+		detail, ok := VettedFailure("", technical.sentence)
+		if !ok {
+			t.Errorf("the sentence for %q does not read back, so it publishes with no class", technical.class)
+			continue
+		}
+		if detail.Class != technical.class || detail.Remedy != technical.remedy {
+			t.Errorf("%q reads back as %q/%q", technical.class, detail.Class, detail.Remedy)
+		}
+	}
+}
+
+// isAuthoredSentence answers whether text is, exactly, one the product wrote.
+func isAuthoredSentence(text string) bool {
+	for _, technical := range technicalFaults {
+		if text == technical.sentence {
+			return true
+		}
+	}
+	for _, known := range vocabulary {
+		if text == known.sentence {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #1751. **Stacked on #5375** (its own ruling says to take them in that order, and this branch extends the class accessors that one adds) — I will retarget to `main` once that merges.

## The morning this changes

Most infrastructure failures carry no sentinel. A `*net.DNSError`, a refused dial, a handshake that did not complete — all landed on one sentence saying the diagnosis is in a log the operator then has to go and read. "The provider's host name did not resolve" is a different morning from "the job failed for a reason it could not classify".

## The cause is read and never projected

That distinction is the whole change, and it is why this is not a weakened invariant. The classifier inspects a cause's **shape** — its type, its sentinel, a status integer a typed error already carries — and **chooses** one of a closed authored set. No part of the cause's own text reaches the stored sentence.

`river_job.errors` has no workspace column and no row-level protection, and a provider's prose routinely names the address or the record it refused. `Fault`'s doc now says the cause may be *read* to pick among authored sentences, so the next reader does not take the classifier for a violation of the rule it is obeying.

## Seven shapes

| class | shape |
|---|---|
| `host_unresolved` | `*net.DNSError` |
| `tls_refused` | a record that was not TLS, a certificate refused, an alert |
| `connection_refused` | `syscall.ECONNREFUSED` under the `*net.OpError` |
| `provider_timed_out` | `context.DeadlineExceeded`, `os.ErrDeadlineExceeded`, `net.Error.Timeout()` |
| `provider_rejected_credential` | `connector.ProviderError` at 401/403 |
| `provider_server_error` | `connector.ProviderError` at 5xx |

**The status is enumerated, never formatted.** The ruling called it the thing to think hardest about: a bare integer carries no record data and is the most useful fact here, so the statuses that mean something get their own sentences and no number is ever written into prose — which keeps the invariant absolute rather than carving one exception into it. 5xx is deliberately **one** sentence: they mean one thing to an operator, and splitting 502 from 503 publishes a distinction nobody acts on differently.

DNS is tested before the refusal because both surface as a `*net.OpError`, and an unresolved host reported as a refusal sends somebody to the wrong system.

## Two defaults worth stating

**An unrecognised cause gets nothing** and falls through to the existing substitute. A sentence chosen by resemblance sends somebody after the wrong thing with the same confidence as a true one.

**A sentinel still wins**, checked first: *"the record this job names no longer exists"* tells an operator what to do; *"the provider did not answer in time"* tells them where it happened. The first is the more useful of two true statements.

## One vocabulary, two tables

The new classes join the core vocabulary for **every** reader of it — `VettedFailure` (so the screen shows a class and a remedy), `CoreFailureClasses` (so #5375's series bound counts them; a bound short by exactly the classes an infrastructure outage arrives under would be short where an alert is most likely watching), and `refuseCoreCollision` (a composed class silently taking `host_unresolved` would make one alert fire on two different failures).

## Tests

Real provider error shapes with a host, a mailbox and a record id planted in them. Each asserts:

- the authored sentence comes out, and the cause stays reachable through `errors.Is`;
- none of the plants appear;
- and the stronger form that does not depend on planting the right fragments — **what is stored is exactly a member of the authored set**. A sentence assembled from a cause could not be, however careful the assembly.

Plus: an unrecognised cause is not guessed at, a sentinel outranks the shape, and every technical sentence reads back to its own class and remedy (otherwise the screen shows a sentence with no class beside it).

Mutation-checked: disabling the classifier fails the first case.

## Checks

`make check-backend` green, `make craft-static` 0/0/0.