### PR TITLE
fix(ci): pull MinIO from quay, which still serves the digest we pin

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -212,7 +212,13 @@ services:
   # not-yet-ready backend with a bounded connect retry and creates the bucket,
   # so readiness is the store's job, not compose's.
   minio:
-    image: minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+    # FROM QUAY, NOT DOCKER HUB. The same manifest — the digest below is
+    # unchanged and pins the identical image — but `minio/minio` on Docker Hub
+    # now answers an anonymous pull with "denied: requested access to the
+    # resource is denied", so every CI job that starts this cluster failed at
+    # `db-up` before running a test. Quay is MinIO's own registry and serves
+    # this digest without credentials.
+    image: quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin


### PR DESCRIPTION
Docker Hub started refusing anonymous pulls of `minio/minio`, so every CI job that starts the test cluster now dies at `db-up` before running a test:

```
minio Error pull access denied for minio/minio, repository does not exist
or may require 'docker login': denied: requested access to the resource is denied
make[1]: *** [Makefile:714: db-up] Error 1
```

**Tests this claim covers:** everything behind `make db-up` — `integration / integration (isolation + erasure + HTTP e2e)`, and `check-ext-migrations`, which starts the cluster whenever an enabled unit declares `migrations/`.

**Not a version bump.** The digest is unchanged, so this is the same image byte for byte. Verified against both registries:

| registry | `docker manifest inspect …@sha256:14cea493…` |
| --- | --- |
| `minio/minio` (Docker Hub) | `denied: requested access to the resource is denied` / `unauthorized: authentication required` |
| `quay.io/minio/minio` | returns the manifest list |

`docker compose pull minio` then succeeds against quay.

**Why not the alternatives.** Authenticating to Docker Hub needs a secret this repository does not have. Pinning a different image would change what the tests run against, which is the one thing a fix for a registry outage must not do.

Found while [#5326](https://github.com/margince/margince/pull/5326) was blocked on it; it is not caused by that change and affects every branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development environment’s storage service image source while retaining the existing version pin.
  - Local development setups can now retrieve the service image more reliably when Docker Hub access is unavailable.
  - No user-facing product functionality or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->