### PR TITLE
A held message carries the route back to its review

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -33614,6 +33614,21 @@ components:
             `missed_window` — it came due while nothing was running and is now too late to be the
             message that was written. `timer_exhausted` — the job that wakes it ran out of
             attempts. `send_refused` — a gate refused for another reason at fire.
+        review_id:
+          type: [string, 'null']
+          format: uuid
+          description: |
+            The review this message's refusal opened, when one stands. Null on every message
+            nobody refused, and on a held row whose review has since been answered.
+
+            WHY IT IS ON THE ROW. A refusal answers `422 send_needs_review` carrying the review,
+            and that answer reaches the rep once — at the moment they pressed send. Navigate
+            away and the held message is a row explaining why it stopped with no way back to the
+            work that would unstop it. The id is what lets a held row open its own review.
+
+            It is a POINTER, never permission: reading the review is gated on its own terms
+            (initiator, assignee, or the `communication_exception` grant), so a caller holding
+            this id still gets 404 if the review is not theirs to see.
         version: { type: integer, format: int64 }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }

--- a/backend/internal/compose/integration/scheduledreviewlink_integration_test.go
+++ b/backend/internal/compose/integration/scheduledreviewlink_integration_test.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A held message carries the route back to the review that would unstop it.
+//
+// A refusal answers 422 with the review it opened, and that answer reaches the
+// rep exactly once: at the moment they pressed send. Navigate away, and the
+// scheduled list shows a held row that explains why the message stopped with no
+// way to reach the work that would let it go.
+//
+// So the row carries the id. It is a POINTER and never permission — reading the
+// review is gated on its own terms, and a caller handed an id for somebody
+// else's review is still refused when they open it.
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// scheduledRow is the shape these assertions read off the wire.
+type scheduledRow struct {
+	ID         string  `json:"id"`
+	Status     string  `json:"status"`
+	HeldReason *string `json:"held_reason"`
+	ReviewID   *string `json:"review_id"`
+}
+
+// scheduledList reads the caller's own scheduled messages.
+func scheduledList(t *testing.T, c *consentEnv) []scheduledRow {
+	t.Helper()
+	var out []scheduledRow
+	if status := c.Call(t, "GET", "/v1/scheduled-sends", nil, nil, &out); status != http.StatusOK {
+		t.Fatalf("listing scheduled messages → %d", status)
+	}
+	return out
+}
+
+// A HELD MESSAGE NAMES ITS REVIEW.
+func TestAHeldMessageCarriesTheRouteToItsReview(t *testing.T) {
+	c := setupConsent(t)
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send with no grant → %d, want 409", status)
+	}
+	var review string
+	if err := c.Owner.QueryRow(context.Background(),
+		`SELECT id::text FROM communication_review WHERE resolved_at IS NULL`).Scan(&review); err != nil {
+		t.Fatalf("reading the review: %v", err)
+	}
+
+	rows := scheduledList(t, c)
+	if len(rows) != 1 {
+		t.Fatalf("%d scheduled row(s), want the one held message", len(rows))
+	}
+	if rows[0].Status != "held" {
+		t.Fatalf("the row reads %q, want held", rows[0].Status)
+	}
+	if rows[0].ReviewID == nil {
+		t.Fatal("the held row names no review, so a rep looking at their scheduled list can see " +
+			"that the message stopped and has no way to reach the work that would unstop it")
+	}
+	if *rows[0].ReviewID != review {
+		t.Errorf("the row names review %q, want %q", *rows[0].ReviewID, review)
+	}
+
+	// THE DETAIL READ AGREES WITH THE LIST. A row that named its review in one
+	// and not the other would leave a screen working from whichever it happened
+	// to fetch.
+	var detail scheduledRow
+	if status := c.Call(t, "GET", "/v1/scheduled-sends/"+rows[0].ID, nil, nil, &detail); status != http.StatusOK {
+		t.Fatalf("reading the held message → %d", status)
+	}
+	if detail.ReviewID == nil || *detail.ReviewID != review {
+		t.Errorf("the detail read names %v, want %q", detail.ReviewID, review)
+	}
+}
+
+// A MESSAGE NOBODY REFUSED NAMES NO REVIEW, EVEN BESIDE ONE THAT DOES.
+//
+// The two messages sit in one list: a refused one holding a live review, and an
+// ordinary one holding nothing. What this pins is that the two rows get
+// DIFFERENT answers — a lookup keyed on anything coarser than the message
+// itself would put the first one's review on the second, sending a rep to work
+// about a message they did not click.
+//
+// It does NOT pin the held-status filter in stampReviews; the test below that
+// does is TestARescheduledMessageNamesNoReview.
+func TestAnOrdinaryScheduledMessageNamesNoReview(t *testing.T) {
+	c := setupConsent(t)
+
+	// First the refusal, so a live review exists to be mis-stamped.
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send with no grant → %d, want 409", status)
+	}
+
+	// Then an ordinary message the engine allows, scheduled rather than sent.
+	if status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", AnyMap{
+		"subject": "Re: Inbound question", "body": "answer",
+		"to":              []string{"subject@consent.test"},
+		"consent_purpose": "business_correspondence",
+		"scheduled_at":    time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339),
+		"scheduled_tz":    "UTC",
+	}, nil, nil); status >= 400 {
+		t.Fatalf("scheduling an ordinary message → %d", status)
+	}
+
+	rows := scheduledList(t, c)
+	if len(rows) != 2 {
+		t.Fatalf("%d scheduled row(s), want the held one and the ordinary one", len(rows))
+	}
+	var held, ordinary *scheduledRow
+	for i := range rows {
+		if rows[i].Status == "held" {
+			held = &rows[i]
+		} else {
+			ordinary = &rows[i]
+		}
+	}
+	if held == nil || ordinary == nil {
+		t.Fatalf("want one held row and one ordinary row, got %+v", rows)
+	}
+	// The held one carries its review, so this test is really about two
+	// different answers rather than about an installation that stamps nothing.
+	if held.ReviewID == nil {
+		t.Fatal("the held row names no review, so there is nothing that could be mis-stamped " +
+			"and this test proves nothing")
+	}
+	if ordinary.ReviewID != nil {
+		t.Errorf("the ordinary message names review %q — following it would send the rep to work "+
+			"about the OTHER message", *ordinary.ReviewID)
+	}
+}
+
+// AN ANSWERED REVIEW STOPS BEING NAMED WHILE THE MESSAGE IS STILL HELD.
+//
+// The lookup reads live reviews only, and this is what proves that rather than
+// proving the status filter beside it. A rep DECLINES the routed decision: the
+// review returns to them, is then cancelled, and the message stays held the
+// whole time — so a row still naming the closed review would be offering a
+// route to work somebody has already finished.
+func TestAMessageWhoseReviewIsOverNamesItNoMore(t *testing.T) {
+	c := setupConsent(t)
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send with no grant → %d, want 409", status)
+	}
+	before := scheduledList(t, c)
+	if len(before) != 1 || before[0].ReviewID == nil {
+		t.Fatalf("no held row naming a review to begin with: %+v", before)
+	}
+
+	// The review is closed WITHOUT the message moving: written directly,
+	// because every door that closes a review also settles the message, and
+	// what this test needs is the two apart.
+	if _, err := c.Owner.Exec(context.Background(),
+		`UPDATE communication_review SET state = 'cancelled', resolved_at = now()
+		  WHERE id = $1`, *before[0].ReviewID); err != nil {
+		t.Fatalf("closing the review: %v", err)
+	}
+
+	after := scheduledList(t, c)
+	if len(after) != 1 {
+		t.Fatalf("%d scheduled row(s) after, want the same one message", len(after))
+	}
+	if after[0].Status != "held" {
+		t.Fatalf("the message reads %q, want held — this test is about a held row whose review "+
+			"is over, and a moved message would pass it for the wrong reason", after[0].Status)
+	}
+	if after[0].ReviewID != nil {
+		t.Errorf("the held message still names review %q after it was closed — a rep following "+
+			"it reaches work somebody has already finished", *after[0].ReviewID)
+	}
+}
+
+// A RESCHEDULED MESSAGE NAMES NO REVIEW, THOUGH ITS REVIEW IS STILL LIVE.
+//
+// This is the case that makes the held-status filter in stampReviews decide the
+// answer rather than merely narrow the read, and it took a review round to
+// find: rescheduling a held message moves it back to 'scheduled' and
+// deliberately LEAVES ITS REVIEW LIVE, because the message is still going out
+// and its decision is still outstanding (RescheduleInTx).
+//
+// So the lookup would happily answer for that row. Without the filter, a
+// message the rep has already dealt with would carry a route to a refusal taken
+// at a moment that has passed — and the rep would be sent to work about a
+// message they have already moved.
+func TestARescheduledMessageNamesNoReview(t *testing.T) {
+	c := setupConsent(t)
+
+	if status, _ := c.send(t, "marketing_email"); status != http.StatusConflict {
+		t.Fatalf("marketing send with no grant → %d, want 409", status)
+	}
+	held := scheduledList(t, c)
+	if len(held) != 1 || held[0].ReviewID == nil {
+		t.Fatalf("no held row naming a review to begin with: %+v", held)
+	}
+	review := *held[0].ReviewID
+
+	var current struct {
+		Version int64 `json:"version"`
+	}
+	if status := c.Call(t, "GET", "/v1/scheduled-sends/"+held[0].ID, nil, nil, &current); status != http.StatusOK {
+		t.Fatalf("reading the held message → %d", status)
+	}
+	if status := c.Call(t, "PATCH", "/v1/scheduled-sends/"+held[0].ID, AnyMap{
+		"scheduled_at": time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339),
+		"scheduled_tz": "UTC",
+	}, map[string]string{"If-Match": strconv.FormatInt(current.Version, 10)}, nil); status >= 400 {
+		t.Fatalf("moving the held message → %d", status)
+	}
+
+	// The review really is still live, which is what makes this test about the
+	// filter rather than about a review that closed itself.
+	var resolved *string
+	if err := c.Owner.QueryRow(context.Background(),
+		`SELECT resolved_at::text FROM communication_review WHERE id = $1`, review).Scan(&resolved); err != nil {
+		t.Fatalf("reading the review: %v", err)
+	}
+	if resolved != nil {
+		t.Fatalf("the review closed when the message moved, so the filter is not what this test " +
+			"is exercising")
+	}
+
+	after := scheduledList(t, c)
+	if len(after) != 1 {
+		t.Fatalf("%d scheduled row(s), want the one moved message", len(after))
+	}
+	if after[0].Status == "held" {
+		t.Fatalf("the message still reads held, so it did not move")
+	}
+	if after[0].ReviewID != nil {
+		t.Errorf("the moved message names review %q — the rep already dealt with this one, and "+
+			"following it reaches a refusal taken at a moment that has passed", *after[0].ReviewID)
+	}
+}

--- a/backend/internal/compose/reviewdecision.go
+++ b/backend/internal/compose/reviewdecision.go
@@ -330,3 +330,20 @@ func reviewClosureFor(outcome activities.ReviewOutcome) (consent.ReviewClosure, 
 	}
 	return consent.ReviewClosure{}, false
 }
+
+// reviewLookup answers which review stands over a held message, so a scheduled
+// row can offer a route to the work that would unstop it.
+//
+// A seam rather than a direct call because activities may not import consent.
+// It carries the pool rather than a store because the read is one statement and
+// needs nothing else.
+type reviewLookup struct {
+	pool *pgxpool.Pool
+}
+
+// LiveReviewsForIntents implements activities.ReviewLookup.
+func (l reviewLookup) LiveReviewsForIntents(
+	ctx context.Context, intents []ids.UUID,
+) (map[ids.UUID]ids.UUID, error) {
+	return consent.NewStore(InstallationDB(l.pool)).LiveReviewsForIntents(ctx, intents)
+}

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -166,6 +166,10 @@ func (s *Server) applySendPath(pool *pgxpool.Pool) {
 		// has to retract the card it was handed to, or somebody is still being
 		// asked to send a message that is cancelled, moved or already gone.
 		WithReviewCloser(reviewCloser{router: retractionRouter(pool)}).
+		// The other half of the same seam: closing a review is what a settled
+		// message does, and FINDING one is what a held message needs so a rep
+		// can reach the work that would unstop it.
+		WithReviewLookup(reviewLookup{pool: pool}).
 		// Wired unconditionally, like the unsubscribe linker below: it needs
 		// nothing but the caller's transaction, so a deployment cannot forget
 		// it and leave an account-started send unable to resolve anyone.
@@ -320,6 +324,10 @@ func sendStore(pool *pgxpool.Pool, send SendPath) *activities.Store {
 		// has to retract the card it was handed to, or somebody is still being
 		// asked to send a message that is cancelled, moved or already gone.
 		WithReviewCloser(reviewCloser{router: retractionRouter(pool)}).
+		// The other half of the same seam: closing a review is what a settled
+		// message does, and FINDING one is what a held message needs so a rep
+		// can reach the work that would unstop it.
+		WithReviewLookup(reviewLookup{pool: pool}).
 		WithDraftOutcome(send.DraftOutcome)
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -33241,8 +33241,21 @@ type ScheduledSend struct {
 	Links *[]ActivityLinkInput `json:"links,omitempty"`
 
 	// MarketingPurpose For a marketing send, the consent purpose key it claimed, frozen with the message.
-	MarketingPurpose *string   `json:"marketing_purpose,omitempty"`
-	ScheduledAt      time.Time `json:"scheduled_at"`
+	MarketingPurpose *string `json:"marketing_purpose,omitempty"`
+
+	// ReviewId The review this message's refusal opened, when one stands. Null on every message
+	// nobody refused, and on a held row whose review has since been answered.
+	//
+	// WHY IT IS ON THE ROW. A refusal answers `422 send_needs_review` carrying the review,
+	// and that answer reaches the rep once — at the moment they pressed send. Navigate
+	// away and the held message is a row explaining why it stopped with no way back to the
+	// work that would unstop it. The id is what lets a held row open its own review.
+	//
+	// It is a POINTER, never permission: reading the review is gated on its own terms
+	// (initiator, assignee, or the `communication_exception` grant), so a caller holding
+	// this id still gets 404 if the review is not theirs to see.
+	ReviewId    *openapi_types.UUID `json:"review_id,omitempty"`
+	ScheduledAt time.Time           `json:"scheduled_at"`
 
 	// ScheduledTz The IANA zone the human picked the moment in, kept so it re-renders as meant.
 	ScheduledTz string `json:"scheduled_tz"`

--- a/backend/internal/modules/activities/handlers_scheduledsend.go
+++ b/backend/internal/modules/activities/handlers_scheduledsend.go
@@ -31,6 +31,13 @@ func (h Handlers) WithReviewCloser(closer ReviewCloser) Handlers {
 	return h
 }
 
+// WithReviewLookup returns handlers whose store can answer which review stands
+// over a held message, so a scheduled row carries a route to it.
+func (h Handlers) WithReviewLookup(lookup ReviewLookup) Handlers {
+	h.store = h.store.WithReviewLookup(lookup)
+	return h
+}
+
 // WithHeldNotifier returns handlers whose store raises the inbox card when a
 // message is stopped. The notifier lives on the STORE because that is where a
 // hold is written, and the handlers carry their own store instance.
@@ -119,6 +126,13 @@ func scheduledSendResponse(row ScheduledSend) crmcontracts.ScheduledSend {
 		Version:   row.Version,
 		CreatedAt: row.CreatedAt,
 		UpdatedAt: row.UpdatedAt,
+	}
+	// The route back to the work that would unstop a held message. Omitted
+	// rather than sent as a zero uuid when no review stands over it: a caller
+	// reading an id of nobody would follow it and be told it does not exist.
+	if !row.ReviewID.IsZero() {
+		review := openapi_types.UUID(row.ReviewID)
+		out.ReviewId = &review
 	}
 	if cc := emailList(row.Cc); len(cc) > 0 {
 		out.Cc = &cc

--- a/backend/internal/modules/activities/reviewlookup.go
+++ b/backend/internal/modules/activities/reviewlookup.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// The seams a refused message crosses to reach its review.
+//
+// A refusal freezes a message into a held row and consent opens a review for
+// it. Two questions cross back the other way: which review stands over this
+// message, and — when the message settles — how to end it. Both live here
+// because this module may not import consent, so compose binds them (ADR-0054).
+//
+// ReviewCloser is in scheduledsend.go beside the hold it answers. This file
+// holds the READ, which is the half a surface needs: a rep looking at their
+// scheduled list sees a message that stopped, and without the id on the row
+// there is nothing on it that leads to the work that would unstop it.
+
+import (
+	"context"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// ReviewLookup answers which review, if any, stands over each of these held
+// messages.
+//
+// WHY A SEAM. The review lives in consent and this module may not import a
+// sibling, so compose binds it — the same shape ReviewCloser above has, and for
+// the same reason.
+//
+// BATCHED, taking every id a list read returned rather than one at a time. A
+// per-row call would put one query behind every message in a rep's scheduled
+// list, and the list is exactly where this is read.
+//
+// A POINTER, NOT PERMISSION. What comes back is an id; reading the review
+// itself is gated on its own terms, so a caller who is handed one here can
+// still be refused when they open it.
+//
+// Nil is a composition with no review surface, and a row then carries no review
+// id — which reads correctly as "no review stands over this", the same answer
+// every unrefused message gives.
+type ReviewLookup interface {
+	LiveReviewsForIntents(ctx context.Context, intents []ids.UUID) (map[ids.UUID]ids.UUID, error)
+}
+
+// WithReviewLookup wires the consent-side read a held row uses to find the work
+// that would unstop it.
+func (s *Store) WithReviewLookup(lookup ReviewLookup) *Store {
+	clone := *s
+	clone.reviewLookup = lookup
+	return &clone
+}

--- a/backend/internal/modules/activities/scheduledsend.go
+++ b/backend/internal/modules/activities/scheduledsend.go
@@ -167,6 +167,11 @@ type ScheduledSend struct {
 	ScheduledBy ids.UUID
 	ActivityID  ids.UUID
 	HeldReason  string
+	// ReviewID is the review standing over this message's refusal, when one
+	// does. Zero on every message nobody refused — and on a held row whose
+	// review has since been answered, which is a row a rep can only cancel or
+	// reschedule now.
+	ReviewID ids.UUID
 	// Links are the records an account-started message files itself under,
 	// frozen at composition. Empty on a reply, whose records come from its
 	// anchor; the ones a reply adds beyond those travel in also_links and are

--- a/backend/internal/modules/activities/scheduledsendstore.go
+++ b/backend/internal/modules/activities/scheduledsendstore.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/jackc/pgx/v5"
 
@@ -90,7 +91,70 @@ func (s *Store) ListScheduledSends(ctx context.Context, status string) ([]Schedu
 		}
 		return nil
 	})
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	s.stampReviews(ctx, out)
+	return out, nil
+}
+
+// stampReviews fills in the review standing over each held message.
+//
+// AFTER the rows are read rather than joined into the query, because the review
+// table is consent's and this module may not reach into it. The seam takes
+// every id at once, so a list of thirty messages costs one read.
+//
+// A LOOKUP FAILURE IS NOT A LIST FAILURE, which is why this returns nothing
+// rather than an error. The rows are what the rep asked for and they are
+// already correct; a review id is a route to FURTHER work, and failing the
+// whole page because a link on it could not be resolved would take away
+// something usable to protect something optional.
+//
+// Unstamped rows read as "no review stands over this" — the honest answer when
+// we could not find out, and the same one every unrefused message gives.
+func (s *Store) stampReviews(ctx context.Context, rows []ScheduledSend) {
+	if s.reviewLookup == nil || len(rows) == 0 {
+		return
+	}
+	// ONLY THE HELD ONES, and this decides the answer rather than merely
+	// narrowing the read.
+	//
+	// A RESCHEDULED MESSAGE IS THE CASE THAT MAKES IT SO. RescheduleInTx moves
+	// a held row back to 'scheduled' and deliberately LEAVES ITS REVIEW LIVE —
+	// the message is still going out and its decision is still outstanding, and
+	// the fire path that carries it opens no review of its own. So the lookup
+	// would happily answer for that row, and without this filter a message the
+	// rep has already dealt with would carry a route to a refusal about a
+	// moment that has passed.
+	//
+	// It narrows the read too: a list of thirty scheduled messages does not
+	// send thirty ids to answer about the two that stopped.
+	intents := make([]ids.UUID, 0, len(rows))
+	for _, row := range rows {
+		if row.Status == ScheduledStatusHeld {
+			intents = append(intents, row.ID)
+		}
+	}
+	if len(intents) == 0 {
+		return
+	}
+	reviews, err := s.reviewLookup.LiveReviewsForIntents(ctx, intents)
+	if err != nil {
+		// Swallowed for the caller, which is why this returns nothing at all —
+		// and LOGGED, because the two are different decisions. A page that
+		// silently loses its links every time is indistinguishable from one
+		// where no message was refused, so a lost grant or a dead pool would
+		// look like ordinary quiet until somebody asked why nobody could reach
+		// their reviews.
+		slog.WarnContext(ctx, "held messages listed without the reviews standing over them",
+			"err", err, "messages", len(intents))
+		return
+	}
+	for i := range rows {
+		if id, ok := reviews[rows[i].ID]; ok {
+			rows[i].ReviewID = id
+		}
+	}
 }
 
 // GetScheduledSend reads one of the caller's scheduled messages.
@@ -103,7 +167,12 @@ func (s *Store) GetScheduledSend(ctx context.Context, id ids.UUID) (ScheduledSen
 		out, err = readScheduledSendTx(ctx, tx, id)
 		return err
 	})
-	return out, err
+	if err != nil {
+		return ScheduledSend{}, err
+	}
+	one := []ScheduledSend{out}
+	s.stampReviews(ctx, one)
+	return one[0], nil
 }
 
 // readScheduledSendTx is the detail read inside a caller's transaction.

--- a/backend/internal/modules/activities/store.go
+++ b/backend/internal/modules/activities/store.go
@@ -94,6 +94,9 @@ type Store struct {
 	// Injected because consent is a sibling; nil on a composition with no
 	// review surface, and a cancel then proceeds as it always did.
 	reviewCloser ReviewCloser
+	// reviewLookup answers which review stands over a held message, so a row
+	// can offer a route to the work that would unstop it.
+	reviewLookup ReviewLookup
 	// clock reads the current instant. Injected so the scheduling suites can
 	// pin a due moment and a missed window without sleeping (P3).
 	clock func() time.Time

--- a/backend/internal/modules/consent/reviewroute.go
+++ b/backend/internal/modules/consent/reviewroute.go
@@ -358,3 +358,69 @@ func (s *Store) AwaitingDecision(ctx context.Context, limit int) ([]Review, int,
 // is worked from the end that has been waiting longest rather than from
 // whichever rows the planner happened to reach.
 const maxAwaitingDecision = 100
+
+// LiveReviewsForIntents answers which review, if any, stands over each of these
+// held messages. It implements activities.ReviewLookup; compose binds it.
+//
+// GATED ON READING THE MESSAGE, and SCOPED TO THE CALLER'S OWN REVIEWS.
+//
+// The grant is activity:read, the same check the scheduled-send list makes
+// before it has any ids to ask about. Gating on the REVIEW's own grant would
+// refuse the rep whose message it is — they may not direct a send, and this is
+// their own held message they are looking at.
+//
+// THE SCOPE IS THE HALF THAT MATTERS, and it took a review round to add. The
+// caller supplies the ids, and this is an exported store method — so an
+// argument resting on what today's call sites happen to pass is an argument
+// about them rather than about this function, and the next caller inherits
+// none of it. Without the predicate below, anybody holding activity:read could
+// pass somebody else's message id and learn that their correspondence carries
+// an outstanding refusal, a fact ReviewForReader hides with a 404.
+//
+// ON initiated_by, which is the rep who pressed send and therefore the rep the
+// held message belongs to. Consent cannot read scheduled_send to check
+// ownership directly — that is activities' table — and it does not need to:
+// the review records who was refused, and that is the same person.
+//
+// ONE READ FOR EVERY ID, because the surface that needs this is a list.
+func (s *Store) LiveReviewsForIntents(
+	ctx context.Context, intents []ids.UUID,
+) (map[ids.UUID]ids.UUID, error) {
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	// A principal with no seat — a system worker, a connector — initiated no
+	// review, so the predicate below would match nothing. Answering empty says
+	// that plainly rather than sending a zero uuid into the query.
+	seat := initiatingSeat(ctx)
+	out := make(map[ids.UUID]ids.UUID, len(intents))
+	if len(intents) == 0 || seat.IsZero() {
+		// An empty map rather than a nil one: the answer is "no review stands
+		// over any of these", which every caller reads the same way.
+		return out, nil
+	}
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT delivery_intent_id, id
+			  FROM communication_review
+			 WHERE delivery_intent_id = ANY($1::uuid[])
+			   AND resolved_at IS NULL
+			   AND initiated_by = $2`, intents, seat)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var intent, review ids.UUID
+			if err := rows.Scan(&intent, &review); err != nil {
+				return err
+			}
+			out[intent] = review
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("consent: finding the reviews standing over these messages: %w", err)
+	}
+	return out, nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24435,6 +24435,21 @@ export interface components {
              * @enum {string|null}
              */
             held_reason?: "consent_withdrawn" | "sender_inactive" | "missed_window" | "timer_exhausted" | "send_refused" | null;
+            /**
+             * Format: uuid
+             * @description The review this message's refusal opened, when one stands. Null on every message
+             *     nobody refused, and on a held row whose review has since been answered.
+             *
+             *     WHY IT IS ON THE ROW. A refusal answers `422 send_needs_review` carrying the review,
+             *     and that answer reaches the rep once — at the moment they pressed send. Navigate
+             *     away and the held message is a row explaining why it stopped with no way back to the
+             *     work that would unstop it. The id is what lets a held row open its own review.
+             *
+             *     It is a POINTER, never permission: reading the review is gated on its own terms
+             *     (initiator, assignee, or the `communication_exception` grant), so a caller holding
+             *     this id still gets 404 if the review is not theirs to see.
+             */
+            review_id?: string | null;
             /** Format: int64 */
             version: number;
             /** Format: date-time */


### PR DESCRIPTION
A refusal freezes the message into a held `scheduled_send` and opens a `communication_review` for it. The refusal answers `422` with that review's id, and that answer reaches the rep exactly once, at the moment they pressed send.

Navigate away and the scheduled list shows a row explaining why the message stopped, with nothing on it that leads to the work that would let it go. The rep's remaining moves are to move the message or give up on it, neither of which is the one they want.

So the row carries the id. It is a pointer and never permission: reading the review still goes through the scoped reader, which refuses a stranger with 404.

## How it crosses

The activities module may not import consent, so the lookup seam is declared in activities and compose binds it. It is the other half of the seam the review closer already had. Batched, so one read answers a whole list.

Only held rows are asked about, and that decides the answer rather than merely narrowing the read. A rescheduled message moves back to `scheduled` and deliberately keeps its live review, so without the filter a message the rep has already dealt with would carry a route to a refusal taken at a moment that has passed.

## Scoped to the caller's own reviews

The lookup takes `activity:read`, the grant that lets somebody look at the message, rather than the review's own grant which would refuse the rep whose message it is. It also filters on the review's initiator. Without that, anybody holding `activity:read` could pass somebody else's message id and learn their correspondence carries an outstanding refusal.

A lookup failure does not fail the page. The rows are correct and a review id is a route to further work. It is logged, because a page that silently loses its links is otherwise indistinguishable from one where nothing was refused.

## Review

One Codex round, which corrected my own documented reasoning. I had claimed the held-status filter was only an optimisation, because removing it left my tests green. The real reason that mutation survived was a missing test: a rescheduled message keeps its live review, so the filter genuinely decides the answer. That case is now covered and the mutation fails.

Codex also found that scoping the lookup on "the only caller passes safe rows" is a property of today's call site rather than of the function. The repo's own uniqueness-claim gate then caught the same sentence in my comment.

Every behaviour is pinned by a test that fails without it.

`make check-backend` green, plus the activities and consent module lanes and the full compose integration lane.

## Not in this slice

The button. No review route exists in the frontend yet, so it would point nowhere. It lands with B6b's review drawer, which consumes this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a review id to held scheduled-send rows so a rep can reach the review that stopped a message. Previously the refusal's answer arrived once at send time, and the scheduled list gave no way back to the review.

- The id is a pointer, never permission: reading the review stays gated, and a stranger still gets 404.
- The lookup is batched and scoped to the caller's own reviews, and only held rows are asked, so a rescheduled message that keeps its live review is not stamped.
- `activities` may not import `consent`, so compose wires the new `ReviewLookup` seam beside the existing closer.
- A lookup failure leaves rows unstamped and logs instead of failing the list.
- The frontend button that consumes this field lands in a later slice.

<sup>Written for commit 9178fe3f1a29324defe0f5f96423bd093489961f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

