### PR TITLE
A renamed column reaches the trigger bodies before the rows

### DIFF
--- a/backend/internal/platform/dbmigrate/dbmigrate.go
+++ b/backend/internal/platform/dbmigrate/dbmigrate.go
@@ -427,8 +427,14 @@ func assertLedgerMatches(namespace string, done map[string]appliedRow, m Migrati
 // own answer.
 func assertContentMatches(namespace string, done map[string]appliedRow, m Migration) error {
 	recorded, ok := done[m.Version]
-	if !ok || recorded.digest == nil || *recorded.digest == Digest(m) {
+	current := Digest(m)
+	if !ok || recorded.digest == nil || *recorded.digest == current {
 		return nil
+	}
+	for _, eq := range equivalentContent[namespace][m.Version] {
+		if *recorded.digest == eq.applied && current == eq.source {
+			return nil
+		}
 	}
 	return fmt.Errorf(
 		"pgmigrate: %s %s_%s: applied content does not match the source — this database ran a "+

--- a/backend/internal/platform/dbmigrate/dbmigrate_test.go
+++ b/backend/internal/platform/dbmigrate/dbmigrate_test.go
@@ -281,6 +281,15 @@ func TestSupersededContentIsAdmittedAndNothingElseIs(t *testing.T) {
 // must equal what the file hashes to today, and its applied half must differ
 // from that. A stale source half silently stops excusing anything, which is the
 // failure nobody would notice until a deployed database refused to migrate.
+//
+// The APPLIED half cannot be checked from this tree, and nothing here pretends
+// to. It names bytes that no longer exist in the working tree — that is what
+// makes it the applied half — so what it describes survives in version control
+// and in the ledgers of the databases it names. A wrong one fails safe: it
+// matches no ledger, those databases keep getting the ordinary refusal, and no
+// unchecked content is ever let through, because a typo does not find a second
+// preimage of a SHA-256. Verify an applied digest when you ADD an entry, against
+// the content as committed; this test cannot do it for you later.
 func TestEveryEquivalenceMatchesTheMigrationThatShips(t *testing.T) {
 	t.Parallel()
 	for namespace, versions := range equivalentContent {

--- a/backend/internal/platform/dbmigrate/dbmigrate_test.go
+++ b/backend/internal/platform/dbmigrate/dbmigrate_test.go
@@ -4,6 +4,8 @@
 package dbmigrate
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -228,6 +230,107 @@ func TestARevertOfAnUnverifiableRowIsAdmitted(t *testing.T) {
 			"the same as mismatched, and treating it as one strands every database that migrated "+
 			"before the column existed", err)
 	}
+}
+
+// A database that applied content named in supersededDigests reached the schema
+// the current source builds, so it migrates on rather than stranding.
+//
+// The refusal case is what gives this one teeth: an unrelated mismatch on the
+// SAME version must still be refused, or the entry would read as "stop checking
+// this migration" rather than "this one earlier byte sequence is equivalent".
+func TestSupersededContentIsAdmittedAndNothingElseIs(t *testing.T) {
+	t.Parallel()
+	const version = "1789122755"
+	m := Migration{
+		Version: version,
+		Name:    "the_record_type_is_called_company",
+		UpSQL:   readMigration(t, version+"_the_record_type_is_called_company.up.sql"),
+		DownSQL: readMigration(t, version+"_the_record_type_is_called_company.down.sql"),
+	}
+
+	// The digest the broken content recorded on every database that applied it.
+	admitted := equivalentContent["core"][version][0].applied
+	if err := assertContentMatches("core", map[string]appliedRow{version: {name: m.Name, digest: &admitted}}, m); err != nil {
+		t.Errorf("a database holding applied-but-equivalent content refused: %v — it reached the "+
+			"schema this source builds and has nowhere else to go", err)
+	}
+
+	// Some OTHER applied content on the same version is still a mismatch.
+	stranger := "bb" + strings.Repeat("0", 62)
+	if err := assertContentMatches("core", map[string]appliedRow{version: {name: m.Name, digest: &stranger}}, m); err == nil {
+		t.Error("applied content that is not the recorded one was admitted — an entry excuses one " +
+			"known byte sequence, not every database on this version")
+	}
+
+	// And the entry must expire when the SOURCE changes again. Without this the
+	// first excused edit would excuse every later one nobody checked.
+	edited := m
+	edited.UpSQL += "\n-- a further edit, which is a new claim\n"
+	if err := assertContentMatches("core", map[string]appliedRow{version: {name: m.Name, digest: &admitted}}, edited); err == nil {
+		t.Error("a FURTHER edit to this migration was admitted because the database held the " +
+			"equivalent content — an entry names one source, not permission to keep editing")
+	}
+
+	// The allowance is per namespace, so custom's same version is unaffected.
+	if err := assertContentMatches("custom", map[string]appliedRow{version: {name: m.Name, digest: &admitted}}, m); err == nil {
+		t.Error("a core equivalence admitted the same version in the custom namespace")
+	}
+}
+
+// Every entry must describe the migrations that actually ship: its source half
+// must equal what the file hashes to today, and its applied half must differ
+// from that. A stale source half silently stops excusing anything, which is the
+// failure nobody would notice until a deployed database refused to migrate.
+func TestEveryEquivalenceMatchesTheMigrationThatShips(t *testing.T) {
+	t.Parallel()
+	for namespace, versions := range equivalentContent {
+		shipped := map[string]Migration{}
+		for _, m := range loadNamespaceMigrations(t, namespace) {
+			shipped[m.Version] = m
+		}
+		for version, entries := range versions {
+			m, ok := shipped[version]
+			if !ok {
+				t.Errorf("%s %s: no such migration ships; the entry names nothing", namespace, version)
+				continue
+			}
+			if len(entries) == 0 {
+				t.Errorf("%s %s: an empty list excuses nothing; remove the entry", namespace, version)
+			}
+			for _, eq := range entries {
+				if eq.source != Digest(m) {
+					t.Errorf("%s %s: the entry's source digest is %s but the migration now hashes to "+
+						"%s — the file changed again, so this equivalence describes content that no "+
+						"longer ships and admits nobody", namespace, version, eq.source, Digest(m))
+				}
+				if eq.applied == eq.source {
+					t.Errorf("%s %s: applied and source digests are equal, so the entry excuses "+
+						"nothing the plain comparison did not already admit", namespace, version)
+				}
+			}
+		}
+	}
+}
+
+// loadNamespaceMigrations reads one namespace's migrations off disk, so the test
+// above compares against what ships rather than a copy of it.
+func loadNamespaceMigrations(t *testing.T, namespace string) []Migration {
+	t.Helper()
+	root := filepath.Join("..", "..", "..", "migrations")
+	migrations, err := Load(os.DirFS(root), namespace)
+	if err != nil {
+		t.Fatalf("loading the %s migrations: %v", namespace, err)
+	}
+	return migrations
+}
+
+func readMigration(t *testing.T, name string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("..", "..", "..", "migrations", "core", name))
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	return string(body)
 }
 
 // A version this database never applied has no content to disagree about.

--- a/backend/internal/platform/dbmigrate/equivalence.go
+++ b/backend/internal/platform/dbmigrate/equivalence.go
@@ -18,17 +18,24 @@ package dbmigrate
 // editing. Every entry asserts that two exact byte sequences build the same
 // schema, and belongs here only once that has been checked by comparing the
 // schemas they produce. Nothing is added here to make an edit convenient.
+//
+// An entry admits the version on the way DOWN as well as up, so the two byte
+// sequences must also ROLL BACK compatibly — the down half that ships will run
+// against a database whose up half was the other sequence. The entry below
+// satisfies that the simplest way there is: only the up file was edited, so the
+// down halves are byte-identical. An entry whose down half differs needs that
+// checked separately, and equal up-schemas do not imply it.
 var equivalentContent = map[string]map[string][]equivalence{
 	"core": {
-		// 1789122755 renamed the organization record type to company. It rewrote
-		// stored row values BEFORE the PL/pgSQL function bodies naming the
-		// renamed columns, so on a database holding rows the first UPDATE fired
-		// a trigger whose body still read OLD.organization_id and the migration
-		// aborted. On an empty schema no trigger fires, so that content applied
-		// cleanly and recorded the applied digest below. Moving the function
-		// bodies ahead of the updates changed their order and nothing else: the
-		// two files build schemas that differ in no catalog object, compared as
-		// pg_dump -s of two databases migrated from them.
+		// 1789122755 is the migration that renamed the company record type's
+		// columns. It rewrote stored row values BEFORE the PL/pgSQL function
+		// bodies naming the renamed columns, so on a database holding rows the
+		// first UPDATE fired a trigger whose body still spelled the pre-rename
+		// column and the migration aborted. On an empty schema no trigger fires,
+		// so that content applied cleanly and recorded the applied digest below.
+		// Moving the function bodies ahead of the updates changed their order and
+		// nothing else: the two files build schemas that differ in no catalog
+		// object, compared as pg_dump -s of two databases migrated from them.
 		"1789122755": {{
 			applied: "1c6205d459b647ad8c3ae1cbac41ec19ad12d48e8186b2be2abdf8d68a59ed79",
 			source:  "c3f55e24d2d4bb724f53d125e27b4d0a2410033015fd08dfd9b0a92e52898785",

--- a/backend/internal/platform/dbmigrate/equivalence.go
+++ b/backend/internal/platform/dbmigrate/equivalence.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package dbmigrate
+
+// equivalentContent names, per namespace and version, a pair of digests that
+// build the SAME schema: the content a database may already hold, and the exact
+// source content it is equivalent to. A database holding the applied half is
+// admitted while the source still hashes to the current half.
+//
+// BOTH halves are named on purpose. Keyed on the applied digest alone, an entry
+// would admit whatever the source said next — the first edit would be excused,
+// and so would every later one nobody checked. Naming the current half makes an
+// entry expire the moment the file changes again: the next edit is a new claim,
+// and it stops migrations until somebody checks it and records the new pair.
+//
+// This is an enumerated list of specific past content, not a rule that forgives
+// editing. Every entry asserts that two exact byte sequences build the same
+// schema, and belongs here only once that has been checked by comparing the
+// schemas they produce. Nothing is added here to make an edit convenient.
+var equivalentContent = map[string]map[string][]equivalence{
+	"core": {
+		// 1789122755 renamed the organization record type to company. It rewrote
+		// stored row values BEFORE the PL/pgSQL function bodies naming the
+		// renamed columns, so on a database holding rows the first UPDATE fired
+		// a trigger whose body still read OLD.organization_id and the migration
+		// aborted. On an empty schema no trigger fires, so that content applied
+		// cleanly and recorded the applied digest below. Moving the function
+		// bodies ahead of the updates changed their order and nothing else: the
+		// two files build schemas that differ in no catalog object, compared as
+		// pg_dump -s of two databases migrated from them.
+		"1789122755": {{
+			applied: "1c6205d459b647ad8c3ae1cbac41ec19ad12d48e8186b2be2abdf8d68a59ed79",
+			source:  "c3f55e24d2d4bb724f53d125e27b4d0a2410033015fd08dfd9b0a92e52898785",
+		}},
+	},
+}
+
+// equivalence is one checked claim that two byte sequences build one schema.
+type equivalence struct {
+	applied string // what the database recorded
+	source  string // what the source must still hash to for that to hold
+}

--- a/backend/migrations/core/1789122755_the_record_type_is_called_company.up.sql
+++ b/backend/migrations/core/1789122755_the_record_type_is_called_company.up.sql
@@ -280,130 +280,15 @@ ALTER FUNCTION organization_no_ancestor_cycle() RENAME TO company_no_ancestor_cy
 ALTER FUNCTION organization_refuse_anchor_retirement() RENAME TO company_refuse_anchor_retirement;
 
 
--- activity_link.entity_type
-ALTER TABLE activity_link DROP CONSTRAINT activity_link_entity_type_check;
-ALTER TABLE activity_link DROP CONSTRAINT activity_link_shape;
-UPDATE activity_link SET entity_type = 'company' WHERE entity_type = 'organization';
-ALTER TABLE activity_link ADD CONSTRAINT activity_link_entity_type_check
-  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'project'));
-ALTER TABLE activity_link ADD CONSTRAINT activity_link_shape
-  CHECK (((entity_type = 'person') AND (person_id IS NOT NULL) AND (company_id IS NULL) AND (deal_id IS NULL) AND (lead_id IS NULL) AND (project_id IS NULL)) OR ((entity_type = 'company') AND (company_id IS NOT NULL) AND (person_id IS NULL) AND (deal_id IS NULL) AND (lead_id IS NULL) AND (project_id IS NULL)) OR ((entity_type = 'deal') AND (deal_id IS NOT NULL) AND (person_id IS NULL) AND (company_id IS NULL) AND (lead_id IS NULL) AND (project_id IS NULL)) OR ((entity_type = 'lead') AND (lead_id IS NOT NULL) AND (person_id IS NULL) AND (company_id IS NULL) AND (deal_id IS NULL) AND (project_id IS NULL)) OR ((entity_type = 'project') AND (project_id IS NOT NULL) AND (person_id IS NULL) AND (company_id IS NULL) AND (deal_id IS NULL) AND (lead_id IS NULL)));
-
--- ai_feedback.subject_type
-ALTER TABLE ai_feedback DROP CONSTRAINT ai_feedback_subject_type_check;
-UPDATE ai_feedback SET subject_type = 'company' WHERE subject_type = 'organization';
-ALTER TABLE ai_feedback ADD CONSTRAINT ai_feedback_subject_type_check
-  CHECK (subject_type IN ('company', 'person', 'deal', 'lead'));
-
--- attachment.entity_type
-ALTER TABLE attachment DROP CONSTRAINT attachment_entity_type_check;
-UPDATE attachment SET entity_type = 'company' WHERE entity_type = 'organization';
-ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check
-  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
-
--- capture_backfill_creation.kind
-ALTER TABLE capture_backfill_creation DROP CONSTRAINT capture_backfill_creation_kind;
-UPDATE capture_backfill_creation SET kind = 'company_queued' WHERE kind = 'organization_queued';
-ALTER TABLE capture_backfill_creation ADD CONSTRAINT capture_backfill_creation_kind
-  CHECK (kind IN ('person', 'company_queued'));
-
--- capture_pending_counterparty.kind
-ALTER TABLE capture_pending_counterparty DROP CONSTRAINT capture_pending_counterparty_kind_check;
-UPDATE capture_pending_counterparty SET kind = 'company_sender' WHERE kind = 'organization_sender';
-ALTER TABLE capture_pending_counterparty ADD CONSTRAINT capture_pending_counterparty_kind_check
-  CHECK ((kind IS NULL) OR kind IN ('person', 'role_mailbox', 'company_sender', 'newsletter', 'transactional', 'spam', 'personal', 'advisor'));
-
--- custom_field.object
-ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
-UPDATE custom_field SET object = 'company' WHERE object = 'organization';
-ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check
-  CHECK (object IN ('person', 'company', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
-
--- dedupe_candidate.entity_type
-ALTER TABLE dedupe_candidate DROP CONSTRAINT dedupe_candidate_entity_type_check;
-ALTER TABLE dedupe_candidate DROP CONSTRAINT dedupe_candidate_shape;
-UPDATE dedupe_candidate SET entity_type = 'company' WHERE entity_type = 'organization';
-ALTER TABLE dedupe_candidate ADD CONSTRAINT dedupe_candidate_entity_type_check
-  CHECK (entity_type IN ('person', 'company', 'lead'));
-ALTER TABLE dedupe_candidate ADD CONSTRAINT dedupe_candidate_shape
-  CHECK (((entity_type = 'person') AND (left_person_id IS NOT NULL) AND (right_person_id IS NOT NULL) AND (left_company_id IS NULL) AND (right_company_id IS NULL) AND (left_lead_id IS NULL) AND (right_lead_id IS NULL)) OR ((entity_type = 'company') AND (left_company_id IS NOT NULL) AND (right_company_id IS NOT NULL) AND (left_person_id IS NULL) AND (right_person_id IS NULL) AND (left_lead_id IS NULL) AND (right_lead_id IS NULL)) OR ((entity_type = 'lead') AND (left_lead_id IS NOT NULL) AND (right_lead_id IS NOT NULL) AND (left_person_id IS NULL) AND (right_person_id IS NULL) AND (left_company_id IS NULL) AND (right_company_id IS NULL)));
-
--- embedding.entity_type
-ALTER TABLE embedding DROP CONSTRAINT embedding_entity_type_check;
-UPDATE embedding SET entity_type = 'company' WHERE entity_type = 'organization';
-ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check
-  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
-
--- field_provenance.object_type
-ALTER TABLE field_provenance DROP CONSTRAINT field_provenance_object_type_check;
-UPDATE field_provenance SET object_type = 'company' WHERE object_type = 'organization';
-ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check
-  CHECK (object_type IN ('person', 'company', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
-
--- list.entity_type
-ALTER TABLE list DROP CONSTRAINT list_entity_type_check;
-UPDATE list SET entity_type = 'company' WHERE entity_type = 'organization';
-ALTER TABLE list ADD CONSTRAINT list_entity_type_check
-  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'project'));
-
--- list_member.entity_type
-ALTER TABLE list_member DROP CONSTRAINT list_member_entity_type_check;
-UPDATE list_member SET entity_type = 'company' WHERE entity_type = 'organization';
-ALTER TABLE list_member ADD CONSTRAINT list_member_entity_type_check
-  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'project'));
-
--- person_profile_field.field
-ALTER TABLE person_profile_field DROP CONSTRAINT person_profile_field_field_check;
-UPDATE person_profile_field SET field = 'company_name' WHERE field = 'org_name';
-ALTER TABLE person_profile_field ADD CONSTRAINT person_profile_field_field_check
-  CHECK (field IN ('title', 'phone', 'role', 'linkedin', 'company_name', 'address', 'website'));
-
--- record_grant.record_type
-ALTER TABLE record_grant DROP CONSTRAINT record_grant_record_type_check;
-UPDATE record_grant SET record_type = 'company' WHERE record_type = 'organization';
-ALTER TABLE record_grant ADD CONSTRAINT record_grant_record_type_check
-  CHECK (record_type IN ('person', 'company', 'deal', 'lead', 'project'));
-
--- saved_view.resource
-ALTER TABLE saved_view DROP CONSTRAINT saved_view_resource_check;
-UPDATE saved_view SET resource = 'companies' WHERE resource = 'organizations';
-ALTER TABLE saved_view ADD CONSTRAINT saved_view_resource_check
-  CHECK (resource IN ('people', 'companies', 'deals', 'activities', 'leads', 'partners', 'projects'));
-
--- signal.entity_type
-ALTER TABLE signal DROP CONSTRAINT signal_entity_type_check;
-UPDATE signal SET entity_type = 'company' WHERE entity_type = 'organization';
-ALTER TABLE signal ADD CONSTRAINT signal_entity_type_check
-  CHECK ((entity_type IS NULL) OR entity_type IN ('deal', 'company', 'person', 'project'));
-
--- site_read.target_kind
-ALTER TABLE site_read DROP CONSTRAINT site_read_target_kind_check;
-ALTER TABLE site_read DROP CONSTRAINT site_read_target_shape;
-UPDATE site_read SET target_kind = 'company' WHERE target_kind = 'organization';
-ALTER TABLE site_read ADD CONSTRAINT site_read_target_kind_check
-  CHECK (target_kind IN ('onboarding', 'company', 'domain_triage'));
-ALTER TABLE site_read ADD CONSTRAINT site_read_target_shape
-  CHECK (((target_kind = 'onboarding') AND ((company_id IS NULL) OR ((company_id IS NOT NULL) AND (confirmed_at IS NOT NULL)))) OR ((target_kind = 'company') AND (company_id IS NOT NULL)) OR ((target_kind = 'domain_triage') AND ((company_id IS NULL) OR ((company_id IS NOT NULL) AND (confirmed_at IS NOT NULL)))));
-
--- taggable.entity_type
-ALTER TABLE taggable DROP CONSTRAINT taggable_entity_type_check;
-UPDATE taggable SET entity_type = 'company' WHERE entity_type = 'organization';
-ALTER TABLE taggable ADD CONSTRAINT taggable_entity_type_check
-  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'project'));
-
--- user_record_view.entity_type
-ALTER TABLE user_record_view DROP CONSTRAINT user_record_view_entity_type_check;
-UPDATE user_record_view SET entity_type = 'company' WHERE entity_type = 'organization';
-ALTER TABLE user_record_view ADD CONSTRAINT user_record_view_entity_type_check
-  CHECK (entity_type IN ('company', 'person'));
-
--- weekly_plan_commitment.linked_record_type
-ALTER TABLE weekly_plan_commitment DROP CONSTRAINT weekly_plan_commitment_link_type_check;
-UPDATE weekly_plan_commitment SET linked_record_type = 'company' WHERE linked_record_type = 'organization';
-ALTER TABLE weekly_plan_commitment ADD CONSTRAINT weekly_plan_commitment_link_type_check
-  CHECK ((linked_record_type IS NULL) OR linked_record_type IN ('deal', 'lead', 'person', 'company', 'project'));
-
--- 8. the function bodies, which name the tables and columns above
+-- 7. the function bodies, which name the tables and columns above.
+--
+-- BEFORE the data updates below, not after. A rename moves a column, but a
+-- PL/pgSQL body is stored as text and keeps whatever it said: after section 2
+-- renamed activity_link.organization_id, trg_activity_link_last_activity still
+-- read OLD.organization_id. The first UPDATE in section 9 fires that trigger,
+-- so with the bodies rewritten later the migration failed with
+-- 'record "old" has no field "organization_id"' -- but only on a database
+-- holding rows, because an empty UPDATE never fires a trigger.
 
 CREATE OR REPLACE FUNCTION activity_link_refuses_a_company_meeting()
 RETURNS trigger
@@ -612,7 +497,7 @@ BEGIN
 END;
 $$;
 
--- 9. the functions that take arguments.
+-- 8. the functions that take arguments.
 --
 -- CREATE OR REPLACE cannot rename a function, an argument or a RETURNS
 -- TABLE column, so these are dropped and rewritten rather than replaced.
@@ -809,6 +694,132 @@ $fn$;;
 GRANT EXECUTE ON FUNCTION company_open_pipeline_rollup(date) TO margince_app;
 COMMENT ON FUNCTION company_open_pipeline_rollup(date) IS
   'Open pipeline per company in the installation base currency, as of the date the CALLER names. Open deals hold no frozen rate — that happens on close — so each foreign-currency deal converts at the latest fx_rate on or before as_of, across both currencies'' minor-unit scales (currency_minor_digits). The date is a parameter rather than CURRENT_DATE because two readers of one response must not select two different rates: the caller binds it from the same clock every other derived figure reads. A deal with no usable rate, or whose converted amount does not fit a bigint, contributes nothing and is still counted in open_deal_count, so a partial sum is detectable rather than silently short. The total itself answers NULL when it does not fit either.';
+
+-- 9. where the word is a stored VALUE, once every function that
+-- reads these tables spells the new column names.
+
+-- activity_link.entity_type
+ALTER TABLE activity_link DROP CONSTRAINT activity_link_entity_type_check;
+ALTER TABLE activity_link DROP CONSTRAINT activity_link_shape;
+UPDATE activity_link SET entity_type = 'company' WHERE entity_type = 'organization';
+ALTER TABLE activity_link ADD CONSTRAINT activity_link_entity_type_check
+  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'project'));
+ALTER TABLE activity_link ADD CONSTRAINT activity_link_shape
+  CHECK (((entity_type = 'person') AND (person_id IS NOT NULL) AND (company_id IS NULL) AND (deal_id IS NULL) AND (lead_id IS NULL) AND (project_id IS NULL)) OR ((entity_type = 'company') AND (company_id IS NOT NULL) AND (person_id IS NULL) AND (deal_id IS NULL) AND (lead_id IS NULL) AND (project_id IS NULL)) OR ((entity_type = 'deal') AND (deal_id IS NOT NULL) AND (person_id IS NULL) AND (company_id IS NULL) AND (lead_id IS NULL) AND (project_id IS NULL)) OR ((entity_type = 'lead') AND (lead_id IS NOT NULL) AND (person_id IS NULL) AND (company_id IS NULL) AND (deal_id IS NULL) AND (project_id IS NULL)) OR ((entity_type = 'project') AND (project_id IS NOT NULL) AND (person_id IS NULL) AND (company_id IS NULL) AND (deal_id IS NULL) AND (lead_id IS NULL)));
+
+-- ai_feedback.subject_type
+ALTER TABLE ai_feedback DROP CONSTRAINT ai_feedback_subject_type_check;
+UPDATE ai_feedback SET subject_type = 'company' WHERE subject_type = 'organization';
+ALTER TABLE ai_feedback ADD CONSTRAINT ai_feedback_subject_type_check
+  CHECK (subject_type IN ('company', 'person', 'deal', 'lead'));
+
+-- attachment.entity_type
+ALTER TABLE attachment DROP CONSTRAINT attachment_entity_type_check;
+UPDATE attachment SET entity_type = 'company' WHERE entity_type = 'organization';
+ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check
+  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+
+-- capture_backfill_creation.kind
+ALTER TABLE capture_backfill_creation DROP CONSTRAINT capture_backfill_creation_kind;
+UPDATE capture_backfill_creation SET kind = 'company_queued' WHERE kind = 'organization_queued';
+ALTER TABLE capture_backfill_creation ADD CONSTRAINT capture_backfill_creation_kind
+  CHECK (kind IN ('person', 'company_queued'));
+
+-- capture_pending_counterparty.kind
+ALTER TABLE capture_pending_counterparty DROP CONSTRAINT capture_pending_counterparty_kind_check;
+UPDATE capture_pending_counterparty SET kind = 'company_sender' WHERE kind = 'organization_sender';
+ALTER TABLE capture_pending_counterparty ADD CONSTRAINT capture_pending_counterparty_kind_check
+  CHECK ((kind IS NULL) OR kind IN ('person', 'role_mailbox', 'company_sender', 'newsletter', 'transactional', 'spam', 'personal', 'advisor'));
+
+-- custom_field.object
+ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
+UPDATE custom_field SET object = 'company' WHERE object = 'organization';
+ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check
+  CHECK (object IN ('person', 'company', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+
+-- dedupe_candidate.entity_type
+ALTER TABLE dedupe_candidate DROP CONSTRAINT dedupe_candidate_entity_type_check;
+ALTER TABLE dedupe_candidate DROP CONSTRAINT dedupe_candidate_shape;
+UPDATE dedupe_candidate SET entity_type = 'company' WHERE entity_type = 'organization';
+ALTER TABLE dedupe_candidate ADD CONSTRAINT dedupe_candidate_entity_type_check
+  CHECK (entity_type IN ('person', 'company', 'lead'));
+ALTER TABLE dedupe_candidate ADD CONSTRAINT dedupe_candidate_shape
+  CHECK (((entity_type = 'person') AND (left_person_id IS NOT NULL) AND (right_person_id IS NOT NULL) AND (left_company_id IS NULL) AND (right_company_id IS NULL) AND (left_lead_id IS NULL) AND (right_lead_id IS NULL)) OR ((entity_type = 'company') AND (left_company_id IS NOT NULL) AND (right_company_id IS NOT NULL) AND (left_person_id IS NULL) AND (right_person_id IS NULL) AND (left_lead_id IS NULL) AND (right_lead_id IS NULL)) OR ((entity_type = 'lead') AND (left_lead_id IS NOT NULL) AND (right_lead_id IS NOT NULL) AND (left_person_id IS NULL) AND (right_person_id IS NULL) AND (left_company_id IS NULL) AND (right_company_id IS NULL)));
+
+-- embedding.entity_type
+ALTER TABLE embedding DROP CONSTRAINT embedding_entity_type_check;
+UPDATE embedding SET entity_type = 'company' WHERE entity_type = 'organization';
+ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check
+  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+
+-- field_provenance.object_type
+ALTER TABLE field_provenance DROP CONSTRAINT field_provenance_object_type_check;
+UPDATE field_provenance SET object_type = 'company' WHERE object_type = 'organization';
+ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check
+  CHECK (object_type IN ('person', 'company', 'deal', 'lead', 'activity', 'project', 'relationship', 'partner'));
+
+-- list.entity_type
+ALTER TABLE list DROP CONSTRAINT list_entity_type_check;
+UPDATE list SET entity_type = 'company' WHERE entity_type = 'organization';
+ALTER TABLE list ADD CONSTRAINT list_entity_type_check
+  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'project'));
+
+-- list_member.entity_type
+ALTER TABLE list_member DROP CONSTRAINT list_member_entity_type_check;
+UPDATE list_member SET entity_type = 'company' WHERE entity_type = 'organization';
+ALTER TABLE list_member ADD CONSTRAINT list_member_entity_type_check
+  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'project'));
+
+-- person_profile_field.field
+ALTER TABLE person_profile_field DROP CONSTRAINT person_profile_field_field_check;
+UPDATE person_profile_field SET field = 'company_name' WHERE field = 'org_name';
+ALTER TABLE person_profile_field ADD CONSTRAINT person_profile_field_field_check
+  CHECK (field IN ('title', 'phone', 'role', 'linkedin', 'company_name', 'address', 'website'));
+
+-- record_grant.record_type
+ALTER TABLE record_grant DROP CONSTRAINT record_grant_record_type_check;
+UPDATE record_grant SET record_type = 'company' WHERE record_type = 'organization';
+ALTER TABLE record_grant ADD CONSTRAINT record_grant_record_type_check
+  CHECK (record_type IN ('person', 'company', 'deal', 'lead', 'project'));
+
+-- saved_view.resource
+ALTER TABLE saved_view DROP CONSTRAINT saved_view_resource_check;
+UPDATE saved_view SET resource = 'companies' WHERE resource = 'organizations';
+ALTER TABLE saved_view ADD CONSTRAINT saved_view_resource_check
+  CHECK (resource IN ('people', 'companies', 'deals', 'activities', 'leads', 'partners', 'projects'));
+
+-- signal.entity_type
+ALTER TABLE signal DROP CONSTRAINT signal_entity_type_check;
+UPDATE signal SET entity_type = 'company' WHERE entity_type = 'organization';
+ALTER TABLE signal ADD CONSTRAINT signal_entity_type_check
+  CHECK ((entity_type IS NULL) OR entity_type IN ('deal', 'company', 'person', 'project'));
+
+-- site_read.target_kind
+ALTER TABLE site_read DROP CONSTRAINT site_read_target_kind_check;
+ALTER TABLE site_read DROP CONSTRAINT site_read_target_shape;
+UPDATE site_read SET target_kind = 'company' WHERE target_kind = 'organization';
+ALTER TABLE site_read ADD CONSTRAINT site_read_target_kind_check
+  CHECK (target_kind IN ('onboarding', 'company', 'domain_triage'));
+ALTER TABLE site_read ADD CONSTRAINT site_read_target_shape
+  CHECK (((target_kind = 'onboarding') AND ((company_id IS NULL) OR ((company_id IS NOT NULL) AND (confirmed_at IS NOT NULL)))) OR ((target_kind = 'company') AND (company_id IS NOT NULL)) OR ((target_kind = 'domain_triage') AND ((company_id IS NULL) OR ((company_id IS NOT NULL) AND (confirmed_at IS NOT NULL)))));
+
+-- taggable.entity_type
+ALTER TABLE taggable DROP CONSTRAINT taggable_entity_type_check;
+UPDATE taggable SET entity_type = 'company' WHERE entity_type = 'organization';
+ALTER TABLE taggable ADD CONSTRAINT taggable_entity_type_check
+  CHECK (entity_type IN ('person', 'company', 'deal', 'lead', 'project'));
+
+-- user_record_view.entity_type
+ALTER TABLE user_record_view DROP CONSTRAINT user_record_view_entity_type_check;
+UPDATE user_record_view SET entity_type = 'company' WHERE entity_type = 'organization';
+ALTER TABLE user_record_view ADD CONSTRAINT user_record_view_entity_type_check
+  CHECK (entity_type IN ('company', 'person'));
+
+-- weekly_plan_commitment.linked_record_type
+ALTER TABLE weekly_plan_commitment DROP CONSTRAINT weekly_plan_commitment_link_type_check;
+UPDATE weekly_plan_commitment SET linked_record_type = 'company' WHERE linked_record_type = 'organization';
+ALTER TABLE weekly_plan_commitment ADD CONSTRAINT weekly_plan_commitment_link_type_check
+  CHECK ((linked_record_type IS NULL) OR linked_record_type IN ('deal', 'lead', 'person', 'company', 'project'));
 
 -- 10. where the word is a VALUE or a sentence rather than a name.
 --


### PR DESCRIPTION
`make dev` fails on any database that holds rows. Migration `1789122755_the_record_type_is_called_company.up.sql` aborts with:

```
ERROR: record "old" has no field "organization_id" (SQLSTATE 42703)
CONTEXT: SQL statement "SELECT refresh_last_activity_for_link(OLD.person_id, OLD.deal_id, OLD.organization_id)"
PL/pgSQL function trg_activity_link_last_activity() line 4 at PERFORM
```

## The defect

The migration renamed `activity_link.organization_id` to `company_id` in section 2, rewrote stored row values in section 7, then rewrote the PL/pgSQL function bodies in section 8.

A rename moves a column. It does not rewrite a function body, which Postgres stores as text. So by section 7 the trigger function `trg_activity_link_last_activity` still read `OLD.organization_id`, and the first `UPDATE` fired it.

Three bodies carried stale text: `trg_activity_link_last_activity`, `trg_deal_last_activity`, `trg_relationship_last_activity`. The triggers themselves were never the problem, because Postgres tracks a `WHEN` clause by attribute number.

## Why CI is green

CI migrates a fresh empty schema. An `UPDATE` matching zero rows fires no trigger, so the stale body is never parsed. A dev database with rows hits it immediately.

## Commit 1: the reorder

The function bodies, and the argument-taking functions they call, move ahead of the data updates. Sections are renumbered to read in order, and the new section 7 says why it must come first.

Content is unchanged. Sorting the file before and after the move gives byte-identical output, so only ordering changed.

## Commit 2: the databases that already applied the broken content

Editing a shipped migration is normally refused for good reason, and the runner enforces it: `assertContentMatches` hashes every migration and stops the run when the ledger's recorded digest no longer matches the source. That check runs before the apply loop, so no later migration can repair it.

The first commit on its own would therefore strand every database that already applied the old content. That case is real rather than theoretical: the broken content only fails where rows exist to fire the trigger, so on an empty schema it applies cleanly. CI and every fresh install are exactly that. Running the real migrate binary against an empty database confirms it records digest `1c6205d4`.

`equivalentContent` admits that one recorded digest, and only while the source still hashes to the content it was checked against. Both halves are named deliberately: keyed on the applied digest alone, an entry admits whatever the source says next, so the first edit is excused and so is every later one nobody checked. That weaker version was written, found to admit an unrelated edit, and replaced. A test holds the case.

The equivalence claim itself was checked rather than asserted. Two databases migrated from the two file versions produce `pg_dump -s` output differing only in pg_dump's own restrict nonce.

## Verification

| check | result |
| --- | --- |
| full migration against a 313-row database | exit 0, zero errors |
| `make migrate` applied for real | 7 migrations, schema at head |
| database holding the superseded content | migrates forward, no error |
| a further unrelated edit to that migration | still refused, original error |
| `make test-integration` | 6115 tests, 0 skips |
| `make check-backend`, `make craft-static`, `make rls-store-path` | pass |

Both repaired triggers were exercised against real rows after migrating.

**Tests this claim covers:** local `make dev` / `make migrate` against any database holding `activity_link` rows. CI is unaffected, since the empty-schema path never reproduced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database migration handling so installations with previously applied, schema-equivalent migration content can continue upgrading safely.
  - Unrelated or modified migration content continues to be rejected to prevent inconsistent database states.

- **Database Updates**
  - Updated the core schema migration to rename “organization” terminology to “company,” including related values, fields, and database functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->