### PR TITLE
fix(testdb): a seeded reference table is preserved by the reset, and a gate says so

### DIFF
--- a/backend/internal/platform/testdb/reset.go
+++ b/backend/internal/platform/testdb/reset.go
@@ -126,7 +126,7 @@ const resetTables = `
 // it, so the corpus lives here beside the reset that owns it.
 const PreservedReferenceTables = `('activity_kind', 'channel_provider', 'lead_source', ` +
 	`'lead_disqualify_reason', 'sdr_handoff_reason', 'field_mask', 'overlay_mode', ` +
-	`'currency_minor_digits')`
+	`'currency_minor_digits', 'deal_acquisition_source')`
 
 // reclaimSlack is how much a table may grow past its empty size before a reset
 // TRUNCATEs it instead of DELETEing it. Growth, not absolute size, is the

--- a/backend/internal/platform/testdb/reset_integration_test.go
+++ b/backend/internal/platform/testdb/reset_integration_test.go
@@ -528,3 +528,40 @@ func TestResetEmptiesAnExtensionTable(t *testing.T) {
 		t.Errorf("Reset left %d row(s) in ext.ext_resetprobe_note — an extension's rows would bleed into every later test in this process", remaining)
 	}
 }
+
+// A table the MIGRATIONS seed belongs in PreservedReferenceTables, and this is
+// what says so without anybody remembering to.
+//
+// The two lists this package keeps are both hand-written, and a reference table
+// added to the schema has to be added to them by whoever added it. That is the
+// step #5338 missed: `deal_acquisition_source` shipped seeded and unlisted, the
+// reset scope therefore still covered it, and schemaEmpty — which asks the same
+// fragment — found rows in a freshly cloned schema and refused to vouch for it.
+// The cost was not only the red: reusableClone answers on that verdict, so the
+// integration lane stopped reusing clones and rebuilt the schema for every
+// package instead.
+//
+// DERIVED, not restated. A database that has only just been migrated holds
+// exactly the rows the migrations put there, so the tables holding rows ARE the
+// boot-seeded ones — no second list to keep in step, and a new seeded table
+// fails here the day it lands rather than the day somebody reads a lane log.
+//
+// One direction only. A listed table that is empty is not a finding: a
+// reference catalog seeded later by the application, or one whose rows a
+// migration has since removed, is still a table the reset must leave alone.
+func TestEverySeededReferenceTableIsPreservedByTheReset(t *testing.T) {
+	ctx := context.Background()
+	owner := ownerConn(t)
+
+	// Every table the reset would empty — PreservedReferenceTables already
+	// removed — that nonetheless holds rows on a schema nothing has written to.
+	seededButUnlisted := nonEmptyTables(ctx, t, owner)
+	if len(seededButUnlisted) == 0 {
+		return
+	}
+	t.Errorf("the migrations seed %v, and the reset's scope still covers them. "+
+		"A seeded catalog inside the reset scope is emptied by a reset and, before that, "+
+		"makes schemaEmpty refuse to vouch for a freshly migrated clone — which turns off "+
+		"clone reuse for the whole integration lane. Add them to PreservedReferenceTables.",
+		seededButUnlisted)
+}


### PR DESCRIPTION
Claiming this red so nobody duplicates the diagnosis.

**Test taken:** `TestACloneCarryingARowRuleIsNeverReused` in `backend/internal/platform/testdb`.

**Reproduced on clean `origin/main`**, with no other change in the tree:

```
headprobe_integration_test.go:476: with the row rule gone the same clone was still
refused (err=<nil>): 1 table(s) already hold rows (public.deal_acquisition_source)
```

**Cause.** [#5338](https://github.com/margince/margince/pull/5338) adds `deal_acquisition_source` and seeds it in the migration with eight `system` rows — an ordinary reference catalog. `schemaEmpty` in `headprobe.go` asserts a freshly-cloned schema holds **no rows in any table**, so a seeded catalog now reads as contamination. Nothing is wrong with the migration; the probe's assumption is what stopped being true.

**Second consequence, worth more than the red.** `schemaEmpty` is what decides reuse-or-rebuild for the integration lane. It now answers "not empty" on every clone, so the lane logs

```
testdb: rebuilding the schema rather than reusing the clone — 1 table(s) already hold rows
```

and every integration package rebuilds the schema instead of reusing a clone. That is a repo-wide slowdown, not just a red test — and it is a plausible cause of the `exit code 143` runner kills that have been hitting integration shards today.

**The design question a fix has to answer.** The probe is guarding against *leftover test data* in a reused clone. Seeded reference rows are identical in the template and in every clone, so they cannot misreport a reset — but "no rows anywhere" cannot tell the two apart. The honest check is "does this clone differ from the pristine template it came from", which needs a baseline the probe does not currently have. Narrowing the test assertion alone would clear the red while leaving the rebuild-every-time regression in place, so I did not want to do that quietly.

Found while [#5326](https://github.com/margince/margince/pull/5326) was blocked on it. Not caused by that change — every branch inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database resets now preserve seeded acquisition-source reference data, keeping it available after test database resets.

* **Tests**
  * Added coverage to verify that all seeded reference tables are preserved during resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->