### PR TITLE
fix(testdb): drop a uniqueness claim the new gate's own comment made

### DIFF
--- a/backend/internal/platform/testdb/reset_integration_test.go
+++ b/backend/internal/platform/testdb/reset_integration_test.go
@@ -543,8 +543,9 @@ func TestResetEmptiesAnExtensionTable(t *testing.T) {
 //
 // DERIVED, not restated. A database that has only just been migrated holds
 // exactly the rows the migrations put there, so the tables holding rows ARE the
-// boot-seeded ones — no second list to keep in step, and a new seeded table
-// fails here the day it lands rather than the day somebody reads a lane log.
+// boot-seeded ones. The obligation comes from the schema itself rather than
+// from a list somebody has to update, so a new seeded table fails here the day
+// it lands rather than the day somebody reads a lane log.
 //
 // One direction only. A listed table that is empty is not a finding: a
 // reference catalog seeded later by the application, or one whose rows a


### PR DESCRIPTION
Main is red on `TestEveryUniquenessClaimNamesItsGateOrIsRegisteredDebt` and `TestEveryShapeAttributesTheClaimsItsCensusPins`, and it is my fault: [#5385](https://github.com/margince/margince/pull/5385) landed with

> no second list to keep in step

in its doc comment. That is exactly the shape the first gate refuses — a comment asserting a declaration is the only one of its kind, naming no gate to hold it — and it pushed the `no-second` shape from the 11 claims `shapeCensus` pins to 12, so the second gate went red with it.

Reproduced on clean `origin/main` at `34d2ffa02`:

```
internal/platform/testdb/reset_integration_test.go:532
  func TestEverySeededReferenceTableIsPreservedByTheReset — "no second list" (no-second)
```

**Fix.** The claim was rhetorical and says nothing the test needs: the point is that the obligation comes from the schema rather than from a list somebody updates. Reworded to say that without asserting what else exists. `./gates/...` and the `platform/testdb` package are both green with it.

The gate was right to catch this — a false "only one of its kind" is worse than silence, which is the reason it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified comments describing how boot-seeded reference tables are derived from existing migrated-schema rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->