### PR TITLE
A scanner fetching a confirm link is not a person opening it

### DIFF
--- a/backend/internal/compose/integration/linktruth_integration_test.go
+++ b/backend/internal/compose/integration/linktruth_integration_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What a confirm link's row says happened, and whether it is true.
+//
+// opened_at is evidence: the middle of the ask-to-click chain a controller
+// produces to show a consent was freely given — the mail went out, the person
+// opened it, the answer landed.
+//
+// It was stamped by every GET, and most GETs of a link in a mail are machines.
+// Mail security products fetch every link before delivering the message, and
+// each of those wrote a line saying a named data subject opened their consent
+// link.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// linkRow is what the token row records about being fetched.
+type linkRow struct {
+	opened       *string
+	firstFetched *string
+	fetchCount   int
+}
+
+func readLinkRow(t *testing.T, c *consentEnv) linkRow {
+	t.Helper()
+	var row linkRow
+	if err := c.Owner.QueryRow(context.Background(), `
+		SELECT opened_at::text, first_fetched_at::text, fetch_count
+		  FROM confirm_token ORDER BY issued_at DESC LIMIT 1`).
+		Scan(&row.opened, &row.firstFetched, &row.fetchCount); err != nil {
+		t.Fatalf("reading the link row: %v", err)
+	}
+	return row
+}
+
+// askForALink has the workspace mail a confirm link and returns its token.
+func askForALink(t *testing.T, c *consentEnv) string {
+	t.Helper()
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/confirm-request",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("ask the workspace to mail the confirm link → %d", status)
+	}
+	return confirmLinkToken(t, c.AppEnv)
+}
+
+// A SCANNER FETCHING THE LINK IS NOT THE SUBJECT OPENING IT.
+//
+// Mail security products fetch every link in a message before delivering it.
+// Each of those used to write a line saying a named data subject opened their
+// consent link — frequently at a moment they were asleep, and always in the
+// direction that flatters the controller.
+func TestAScannerFetchingTheLinkIsNotAnOpening(t *testing.T) {
+	c := setupConsent(t)
+	token := askForALink(t, c)
+
+	if status := publicCall(t, c.AppEnv, "GET", "/v1/public/confirm/"+token, nil,
+		map[string]string{"Sec-Purpose": "prefetch"}, nil); status != http.StatusOK {
+		t.Fatalf("the scanner's fetch → %d, want 200 — the page still has to serve", status)
+	}
+
+	row := readLinkRow(t, c)
+	if row.opened != nil {
+		t.Error("a prefetch was recorded as the subject opening their consent link, which puts " +
+			"a moment that did not happen into the evidence for their grant")
+	}
+	// THE FETCH IS STILL RECORDED, which is the other half: a link that is
+	// fetched and never answered says something operationally, and dropping the
+	// fact entirely would trade one untruth for a blind spot.
+	if row.firstFetched == nil {
+		t.Error("the fetch went unrecorded entirely, so nothing distinguishes a link nobody " +
+			"received from one nobody answered")
+	}
+	if row.fetchCount != 1 {
+		t.Errorf("fetch_count reads %d, want 1", row.fetchCount)
+	}
+}
+
+// A PERSON OPENING THE PAGE STILL RECORDS AN OPENING.
+//
+// Without this, the test above would pass against an implementation that
+// stopped writing opened_at altogether — which would lose the middle of the
+// chain rather than making it truthful.
+func TestSomebodyOpeningTheLinkIsRecordedAsOne(t *testing.T) {
+	c := setupConsent(t)
+	token := askForALink(t, c)
+
+	if status := publicCall(t, c.AppEnv, "GET", "/v1/public/confirm/"+token, nil,
+		map[string]string{"Sec-Fetch-Mode": "navigate", "Sec-Fetch-Dest": "document"},
+		nil); status != http.StatusOK {
+		t.Fatalf("the subject opening their link → %d, want 200", status)
+	}
+
+	row := readLinkRow(t, c)
+	if row.opened == nil {
+		t.Error("somebody navigated to their own confirm page and it was not recorded as an " +
+			"opening, so the ask-to-click chain has no middle")
+	}
+	if row.firstFetched == nil {
+		t.Error("the fetch was not recorded")
+	}
+}
+
+// A SECOND FETCH COUNTS AND DOES NOT MOVE THE FIRST.
+func TestRepeatedFetchesCountWithoutRewritingTheFirst(t *testing.T) {
+	c := setupConsent(t)
+	token := askForALink(t, c)
+
+	scanner := map[string]string{"Sec-Purpose": "prefetch"}
+	for range 3 {
+		if status := publicCall(t, c.AppEnv, "GET", "/v1/public/confirm/"+token, nil,
+			scanner, nil); status != http.StatusOK {
+			t.Fatalf("fetching the link → %d", status)
+		}
+	}
+
+	row := readLinkRow(t, c)
+	// THE FIRST FETCH IS NOT MOVED by the ones after it. A column that took the
+	// latest fetch would say the link was first seen at whatever moment the
+	// most recent scanner happened to run, which is a different fact wearing
+	// the same name.
+	if row.firstFetched == nil {
+		t.Fatal("no first fetch was recorded")
+	}
+	first := *row.firstFetched
+	if status := publicCall(t, c.AppEnv, "GET", "/v1/public/confirm/"+token, nil,
+		scanner, nil); status != http.StatusOK {
+		t.Fatalf("a fourth fetch → %d", status)
+	}
+	if again := readLinkRow(t, c); again.firstFetched == nil || *again.firstFetched != first {
+		t.Errorf("first_fetched_at moved from %q to %v on a later fetch", first, again.firstFetched)
+	}
+	row = readLinkRow(t, c)
+	if row.fetchCount != 4 {
+		t.Errorf("fetch_count reads %d after four fetches, want 4 — a link fetched many times "+
+			"in seconds was not read that many times by a human, and the count is what says so",
+			row.fetchCount)
+	}
+	if row.opened != nil {
+		t.Error("three machine fetches produced an opening")
+	}
+}

--- a/backend/internal/modules/consent/confirmflow_integration_test.go
+++ b/backend/internal/modules/consent/confirmflow_integration_test.go
@@ -225,13 +225,13 @@ func TestASpentLinkOpensNothing(t *testing.T) {
 	seedMarketingPurpose(t, e)
 	link := issueLink(t, e)
 
-	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token); err != nil {
+	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token, FetchByAPerson); err != nil {
 		t.Fatalf("resolve a live link: %v", err)
 	}
 	if _, err := e.store.SubmitConfirmation(e.ctx, link.Token, ConfirmSubmission{}); err != nil {
 		t.Fatalf("submit: %v", err)
 	}
-	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token, FetchByAPerson); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("resolve a spent link: %v, want not-found", err)
 	}
 }
@@ -357,7 +357,7 @@ func TestARefusedAnswerLeavesNoStagedCorrections(t *testing.T) {
 	}
 	// And the link is unspent, so the person can answer again rather than
 	// having burned their one chance on a server-side fault.
-	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token); err != nil {
+	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token, FetchByAPerson); err != nil {
 		t.Errorf("the link was spent by a refused submit: %v", err)
 	}
 }
@@ -375,7 +375,7 @@ func TestAnUnofferedFieldIsRefusedWithoutSpendingTheLink(t *testing.T) {
 	if !errors.As(err, &invalid) {
 		t.Fatalf("err = %v, want a validation error on the field", err)
 	}
-	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token); err != nil {
+	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token, FetchByAPerson); err != nil {
 		t.Errorf("a refused submit spent the link: %v", err)
 	}
 }
@@ -387,10 +387,10 @@ func TestAFreshLinkRetiresTheOneBeforeIt(t *testing.T) {
 	first := issueLink(t, e)
 	second := issueLink(t, e)
 
-	if _, err := e.store.ResolveConfirmToken(e.ctx, first.Token); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := e.store.ResolveConfirmToken(e.ctx, first.Token, FetchByAPerson); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("the superseded link still opens: %v", err)
 	}
-	if _, err := e.store.ResolveConfirmToken(e.ctx, second.Token); err != nil {
+	if _, err := e.store.ResolveConfirmToken(e.ctx, second.Token, FetchByAPerson); err != nil {
 		t.Errorf("the fresh link does not open: %v", err)
 	}
 }
@@ -451,7 +451,7 @@ func TestALinkHeldByAnArchivedSubjectReadsAsAbsent(t *testing.T) {
 	link := issueLink(t, e)
 	archiveConsentSubject(t, e.owner, "person", e.person.UUID)
 
-	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := e.store.ResolveConfirmToken(e.ctx, link.Token, FetchByAPerson); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("resolve: %v, want not-found — an archived subject's link reads as absent", err)
 	}
 	if _, err := e.store.SubmitConfirmation(e.ctx, link.Token, ConfirmSubmission{}); !errors.Is(err, apperrors.ErrNotFound) {

--- a/backend/internal/modules/consent/confirmmail_integration_test.go
+++ b/backend/internal/modules/consent/confirmmail_integration_test.go
@@ -256,7 +256,7 @@ func TestAMintedLinkOpensTheSubjectsOwnRecord(t *testing.T) {
 	}
 	token = strings.Fields(token)[0]
 
-	ref, err := e.store.ResolveConfirmToken(context.Background(), token)
+	ref, err := e.store.ResolveConfirmToken(context.Background(), token, FetchByAPerson)
 	if err != nil {
 		t.Fatalf("resolve the token that was actually sealed: %v", err)
 	}

--- a/backend/internal/modules/consent/confirmresolve.go
+++ b/backend/internal/modules/consent/confirmresolve.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Opening a confirm link, and recording what that actually was.
+//
+// The resolver lives here rather than beside the mint because what it writes is
+// the subject of linkfetch.go: a fetch is always recorded, an opening only when
+// the request presents as a person navigating to the page. Those two columns
+// are evidence, and keeping the rule and the write in sight of each other is
+// what stops the next author restoring the old one-line version.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// ResolveConfirmToken answers whose record a confirm link opens. Unknown,
+// expired, already-spent and belonging-to-an-archived-subject read as absent,
+// all four identically, so the surface never becomes an oracle for which it was.
+//
+// The liveness test is here rather than in the card read, so both verbs get it
+// from one statement. An ordinary archive does not delete these rows — only
+// Art. 17 erasure and the retention anonymizer do — so a rep archiving a contact
+// who holds a live link would otherwise leave the next click answering 500,
+// and a submit would burn the link before refusing.
+//
+// Resolution runs outside row-level security for the same reason the preference
+// resolver does: the surface it serves has no session, and the token IS the
+// authorization.
+//
+// IT RECORDS WHAT ACTUALLY HAPPENED, which is two different facts. Every
+// resolution counts a fetch (first_fetched_at, fetch_count); only one the
+// request itself presents as a person navigating to the page stamps opened_at.
+//
+// That column is evidence — the middle of the ask-to-click chain a later reader
+// follows from the row, with a named data subject as its subject — and it used
+// to be written by every GET. Most GETs of a link in a mail are not people:
+// scanners, proxies and preview generators fetch them before the recipient sees
+// the message, and each one wrote a line saying somebody opened their consent
+// link. See linkfetch.go for what the request is asked and why the doubt falls
+// towards recording a person.
+func (s *Store) ResolveConfirmToken(
+	ctx context.Context, token string, by FetchKind,
+) (ConfirmRef, error) {
+	var ref ConfirmRef
+	// The kind is read HERE and not only at the spend, because the read is a
+	// disclosure of its own: a consent link's page must show the subscription
+	// question and not the person's record card. Gating the write and leaving
+	// the read open would hand whoever holds a consent link everything the
+	// record page shows, which is wider than the mail that carried it.
+	var purposeID *ids.PurposeID
+	err := database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
+		err := tx.QueryRow(ctx, `
+			UPDATE confirm_token ct
+			   SET first_fetched_at = coalesce(ct.first_fetched_at, $2),
+			       fetch_count = ct.fetch_count + 1,
+			       opened_at = CASE WHEN $3 THEN coalesce(ct.opened_at, $2) ELSE ct.opened_at END
+			WHERE ct.token_hash = $1 AND ct.consumed_at IS NULL AND ct.expires_at > $2
+			  AND EXISTS (SELECT 1 FROM person p
+			               WHERE p.id = ct.person_id AND p.archived_at IS NULL)
+			RETURNING ct.person_id, ct.id, ct.delivered_to, ct.kind, ct.purpose_id`,
+			hashPublicToken(token), s.now().UTC(), by == FetchByAPerson).Scan(
+			&ref.PersonID, &ref.TokenID, &ref.DeliveredTo, &ref.Kind, &purposeID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		if purposeID != nil {
+			ref.PurposeID = *purposeID
+		}
+		return err
+	})
+	if err != nil {
+		return ConfirmRef{}, err
+	}
+	return ref, nil
+}

--- a/backend/internal/modules/consent/confirmtoken.go
+++ b/backend/internal/modules/consent/confirmtoken.go
@@ -30,7 +30,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
-	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
@@ -318,54 +317,6 @@ func (s *Store) issueLink(ctx context.Context, personID ids.PersonID, kind strin
 		return IssuedConfirm{}, err
 	}
 	return out, nil
-}
-
-// ResolveConfirmToken answers whose record a confirm link opens. Unknown,
-// expired, already-spent and belonging-to-an-archived-subject read as absent,
-// all four identically, so the surface never becomes an oracle for which it was.
-//
-// The liveness test is here rather than in the card read, so both verbs get it
-// from one statement. An ordinary archive does not delete these rows — only
-// Art. 17 erasure and the retention anonymizer do — so a rep archiving a contact
-// who holds a live link would otherwise leave the next click answering 500,
-// and a submit would burn the link before refusing.
-//
-// Resolution runs outside row-level security for the same reason the preference
-// resolver does: the surface it serves has no session, and the token IS the
-// authorization.
-//
-// It stamps opened_at on first resolution, which is the ask-to-click chain a
-// later reader follows from the token row: the mail went out at issued_at, the
-// person opened it at opened_at, and the answer landed at consumed_at.
-func (s *Store) ResolveConfirmToken(ctx context.Context, token string) (ConfirmRef, error) {
-	var ref ConfirmRef
-	// The kind is read HERE and not only at the spend, because the read is a
-	// disclosure of its own: a consent link's page must show the subscription
-	// question and not the person's record card. Gating the write and leaving
-	// the read open would hand whoever holds a consent link everything the
-	// record page shows, which is wider than the mail that carried it.
-	var purposeID *ids.PurposeID
-	err := database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
-		err := tx.QueryRow(ctx, `
-			UPDATE confirm_token ct SET opened_at = coalesce(ct.opened_at, $2)
-			WHERE ct.token_hash = $1 AND ct.consumed_at IS NULL AND ct.expires_at > $2
-			  AND EXISTS (SELECT 1 FROM person p
-			               WHERE p.id = ct.person_id AND p.archived_at IS NULL)
-			RETURNING ct.person_id, ct.id, ct.delivered_to, ct.kind, ct.purpose_id`,
-			hashPublicToken(token), s.now().UTC()).Scan(
-			&ref.PersonID, &ref.TokenID, &ref.DeliveredTo, &ref.Kind, &purposeID)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return apperrors.ErrNotFound
-		}
-		if purposeID != nil {
-			ref.PurposeID = *purposeID
-		}
-		return err
-	})
-	if err != nil {
-		return ConfirmRef{}, err
-	}
-	return ref, nil
 }
 
 // subjectOfConfirmTokenTx names whose link this is, without taking a row lock.

--- a/backend/internal/modules/consent/handlers_confirm.go
+++ b/backend/internal/modules/consent/handlers_confirm.go
@@ -17,10 +17,18 @@ import (
 )
 
 // GetConfirmDetails implements (GET /public/confirm/{token}): one contact's own
-// view of what is held about them. Resolving stamps the link as opened, which is
-// the middle of the ask-to-click chain the proof row later refers to.
+// view of what is held about them.
+//
+// Resolving records a FETCH always and an OPENING only when the request does
+// not announce itself as a machine. The opening is the middle of the
+// ask-to-click chain the proof row later refers to, and a scanner prefetching
+// the link must not write it — see linkfetch.go.
+//
+// The request is read HERE because this is where one exists. The store is given
+// the answer rather than the headers, so the rule lives in one place and every
+// other surface that ever resolves a token has to state which it is.
 func (h Handlers) GetConfirmDetails(w http.ResponseWriter, r *http.Request, token string) {
-	ref, err := h.store.ResolveConfirmToken(r.Context(), token)
+	ref, err := h.store.ResolveConfirmToken(r.Context(), token, WhatFetchedThis(r))
 	if err != nil {
 		writeConsentErr(w, r, err)
 		return

--- a/backend/internal/modules/consent/linkfetch.go
+++ b/backend/internal/modules/consent/linkfetch.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Telling a machine fetching a link from a person opening it.
+//
+// confirm_token.opened_at is evidence. A grant's demonstrability rests partly
+// on the ask-to-click chain a later reader follows from the row: the mail went
+// out at issued_at, the person opened it at opened_at, the answer landed at
+// consumed_at. That sentence has a named data subject as its subject.
+//
+// Every GET of the confirm page used to stamp it, and most GETs of a link in a
+// mail are not people. Mail security products fetch every link before
+// delivering the message; so do link expanders, preview generators, corporate
+// proxies and the recipient's own mail client generating a thumbnail. Each of
+// those wrote a line saying somebody opened their consent link, frequently at a
+// moment they were asleep.
+//
+// AN INVENTED OPENING IS NOT A COSMETIC TELEMETRY ERROR. It is a false line in
+// the record a controller would produce to show a consent was freely given, and
+// it is false in the direction that flatters the controller — which is the
+// direction an auditor reads hardest.
+//
+// WHAT THIS CANNOT DO, stated plainly because the limit is the interesting
+// part. There is no way to prove a human is at the keyboard from one HTTP
+// request, and this does not pretend to.
+//
+// It catches the scanners that ANNOUNCE themselves — every browser-initiated
+// prefetch, prerender and preview, which is what mail clients and link
+// expanders trigger. It catches NONE of the plain HTTP clients that send no
+// Fetch Metadata at all, and a great many security scanners are exactly that.
+// So this narrows the defect rather than closing it, and a later change that
+// wants to close it needs a different signal than a request header.
+//
+// A REQUEST THAT SAYS NOTHING IS COUNTED AS A PERSON, which is the deliberate
+// direction: over-recording a fetch as an opening is the defect being fixed,
+// and a fix that swung far enough to suppress real openings would replace one
+// untruth with another.
+//
+// ONE CASE FALLS THE OTHER WAY AND IS LEFT THERE. A browser that prerenders
+// the page and then activates it for a subject who really does read it makes
+// only the prerender request — the activation reuses what was fetched — so the
+// opening goes unrecorded. That is under-recording, which leaves opened_at
+// saying less than the truth rather than more, and a row that stays NULL
+// claims nothing about anybody. Recording it would need a signal from the page
+// after activation, which is a frontend change and its own decision.
+//
+// WHAT IT MUST NOT TEST is how the request was initiated. The confirm page is
+// an SPA: the subject's browser navigates to the page, and the PAGE then calls
+// this endpoint with fetch(), which carries Sec-Fetch-Mode: cors and
+// Sec-Fetch-Dest: empty. Judging those would classify every genuine opening as
+// a machine — the defect this exists to fix, inverted and applied to everybody.
+
+import "net/http"
+
+// FetchKind says what retrieved a link, as far as the request admits.
+type FetchKind int
+
+const (
+	// FetchByAPerson is a request that presents as a human navigating to the
+	// page: a top-level document navigation, or a request that says nothing
+	// either way. The second half is the lenient direction — see the file
+	// comment.
+	FetchByAPerson FetchKind = iota
+	// FetchByAMachine is a request that SAYS it is not a person opening the
+	// page: a prefetch, a preview, a subresource load, a non-navigation.
+	FetchByAMachine
+)
+
+// The Fetch Metadata headers a browser sends on its own, which a page cannot
+// forge and which are exactly the ones a scanner's HTTP client either omits or
+// fills in honestly.
+const (
+	headerSecPurpose = "Sec-Purpose"
+	headerPurpose    = "Purpose"
+	headerXPurpose   = "X-Purpose"
+	headerXMoz       = "X-Moz"
+)
+
+// WhatFetchedThis reads a request and answers whether it may be recorded as a
+// person opening the page.
+//
+// THE DECISION IS ONE-SIDED. Every arm below turns a person into a machine, and
+// none turns a machine into a person: an empty request stays FetchByAPerson.
+// The failure this exists to end is recording openings nobody made, so the
+// question asked is "does this request DENY being a person opening the page",
+// not "does it prove it is one" — which no request can.
+func WhatFetchedThis(r *http.Request) FetchKind {
+	// A PREFETCH SAYS SO. The Sec-Purpose header is set by the browser, not by
+	// the page, precisely so a server can decline to treat a speculative load
+	// as a visit. The two older spellings are Chrome's and Firefox's, still
+	// sent by versions in the field.
+	for _, header := range []string{headerSecPurpose, headerPurpose, headerXPurpose} {
+		if r.Header.Get(header) != "" {
+			return FetchByAMachine
+		}
+	}
+	// Firefox's own link prefetch, which predates the standard header.
+	if r.Header.Get(headerXMoz) != "" {
+		return FetchByAMachine
+	}
+	// SEC-FETCH-MODE AND SEC-FETCH-DEST ARE DELIBERATELY NOT TESTED. See the
+	// file comment: this endpoint is called by the confirm page's own fetch(),
+	// so a genuine opening arrives as cors/empty and judging those would
+	// suppress every one of them.
+	return FetchByAPerson
+}

--- a/backend/internal/modules/consent/linkfetch_test.go
+++ b/backend/internal/modules/consent/linkfetch_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What the request admits about who sent it.
+//
+// The rule is one-sided on purpose: every arm turns a person into a machine and
+// none turns a machine into a person, because the defect being fixed is
+// recording openings nobody made. These cases pin both halves of that — the
+// requests that must be refused an opening, and the ones that must still get
+// one.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestARequestThatSaysItIsNotAPersonDoesNotOpenTheLink(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+	}{
+		{
+			// The standard header, set by the browser and not by the page,
+			// which exists so a server can decline to treat a speculative load
+			// as a visit.
+			name:    "a browser prefetching the link",
+			headers: map[string]string{"Sec-Purpose": "prefetch"},
+		},
+		{
+			name:    "Chrome's older spelling",
+			headers: map[string]string{"Purpose": "prefetch"},
+		},
+		{
+			name:    "the X- spelling still in the field",
+			headers: map[string]string{"X-Purpose": "preview"},
+		},
+		{
+			name:    "Firefox's own link prefetch",
+			headers: map[string]string{"X-Moz": "prefetch"},
+		},
+		{
+			name: "a navigation that is nonetheless a prefetch",
+			headers: map[string]string{
+				"Sec-Fetch-Mode": "navigate",
+				"Sec-Fetch-Dest": "document",
+				"Sec-Purpose":    "prefetch;prerender",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "/v1/public/confirm/cfm_x", nil)
+			for k, v := range tc.headers {
+				r.Header.Set(k, v)
+			}
+			if got := WhatFetchedThis(r); got != FetchByAMachine {
+				t.Errorf("%s was recorded as a person opening their consent link, which writes a "+
+					"line of evidence about a moment that did not happen", tc.name)
+			}
+		})
+	}
+}
+
+func TestARequestThatPresentsAsAPersonOpensTheLink(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+	}{
+		{
+			// What a browser sends when somebody clicks the link in their mail.
+			name: "somebody navigating to the page",
+			headers: map[string]string{
+				"Sec-Fetch-Mode": "navigate",
+				"Sec-Fetch-Dest": "document",
+			},
+		},
+		{
+			// THE LENIENT DIRECTION, and it is deliberate. An older browser or
+			// a proxy that strips headers sends nothing, and refusing to record
+			// their opening would swing the defect the other way — a real
+			// person's click going unrecorded because of their network.
+			name:    "a request that says nothing either way",
+			headers: nil,
+		},
+		{
+			// THE CASE THAT MATTERS MOST, and the one that nearly shipped
+			// backwards. The confirm page is an SPA: the subject navigates to
+			// it, and the PAGE calls this endpoint with fetch(), which carries
+			// cors/empty. Judging those would have classified every genuine
+			// opening as a machine.
+			name: "the confirm page's own call on the subject's behalf",
+			headers: map[string]string{
+				"Sec-Fetch-Mode": "cors",
+				"Sec-Fetch-Dest": "empty",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "/v1/public/confirm/cfm_x", nil)
+			for k, v := range tc.headers {
+				r.Header.Set(k, v)
+			}
+			if got := WhatFetchedThis(r); got != FetchByAPerson {
+				t.Errorf("%s was refused an opening, so a real click goes unrecorded and the "+
+					"ask-to-click chain loses its middle", tc.name)
+			}
+		})
+	}
+}

--- a/backend/migrations/core/1789160000_a_scanner_fetching_a_link_is_not_a_person_opening_it.down.sql
+++ b/backend/migrations/core/1789160000_a_scanner_fetching_a_link_is_not_a_person_opening_it.down.sql
@@ -1,0 +1,16 @@
+-- Dropping the fetch columns, and putting back what the up migration moved.
+--
+-- The up migration cleared opened_at on rows whose value it could not
+-- attribute, moving it to first_fetched_at. Coming back down, first_fetched_at
+-- is about to disappear — so a row that was cleared would lose the moment
+-- entirely, which is worse than the ambiguity the up migration resolved. The
+-- value returns to where it was, meaning exactly what it meant before.
+SET LOCAL lock_timeout = '3s';
+
+UPDATE confirm_token
+   SET opened_at = first_fetched_at
+ WHERE opened_at IS NULL AND first_fetched_at IS NOT NULL;
+
+ALTER TABLE confirm_token
+    DROP COLUMN IF EXISTS first_fetched_at,
+    DROP COLUMN IF EXISTS fetch_count;

--- a/backend/migrations/core/1789160000_a_scanner_fetching_a_link_is_not_a_person_opening_it.up.sql
+++ b/backend/migrations/core/1789160000_a_scanner_fetching_a_link_is_not_a_person_opening_it.up.sql
@@ -1,0 +1,88 @@
+-- A machine fetching a link is not a person opening it.
+--
+-- confirm_token.opened_at is stamped by the RESOLVER, which every GET of the
+-- confirm page runs. The column's own comment calls it "when the page was first
+-- opened with this token, so the ask-to-click chain is readable from the row" —
+-- and that chain is evidence. A grant's demonstrability rests partly on it: the
+-- mail went out at issued_at, the person opened it at opened_at, the answer
+-- landed at consumed_at.
+--
+-- Nothing in that sequence distinguishes a person from a machine. Mail security
+-- products fetch every link in a message before delivering it; so do link
+-- expanders, preview generators and corporate proxies. Each of those stamps
+-- opened_at, and the row then says a named data subject opened their link at a
+-- moment they were very probably asleep.
+--
+-- THE HARM IS THAT IT IS EVIDENCE. An invented opening is not a cosmetic
+-- telemetry error: it is a false line in the record a controller would produce
+-- to show a consent was freely given. Worse, it is systematically false in the
+-- direction that flatters the controller, which is the direction an auditor
+-- looks at hardest.
+--
+-- So the fetch and the opening become two facts.
+--
+--   first_fetched_at  — when anything first retrieved this link, machine or
+--                       person. Operationally useful (a link that is fetched
+--                       and never answered says something) and claims nothing
+--                       about who.
+--   fetch_count       — how many times. A link fetched eleven times in two
+--                       seconds was not read eleven times by a human.
+--
+-- opened_at STAYS, with its meaning narrowed to what it always claimed: a
+-- person opened this. Nothing in this migration writes it; the writer that does
+-- is the one that can tell the difference, and it lands with this change.
+--
+-- EXISTING VALUES MOVE RATHER THAN BEING COPIED, and that is the whole
+-- question this migration had to answer.
+--
+-- An opened_at already on a row was written under the old rule, so it may be a
+-- scanner's. Copying it into first_fetched_at is right whichever it was:
+-- something fetched the link at that moment. LEAVING it in opened_at as well
+-- is not, because opened_at now means "a person opened this" — and the subject
+-- access export reads exactly that column to tell a subject their link was
+-- "opened and not answered" (privacy/sarconsentlinks.go). That is a statement
+-- about their own conduct, in their own data export, and for a pre-upgrade row
+-- we cannot stand behind it.
+--
+-- So the value goes where it is true and is cleared where it is not. What is
+-- lost is a timestamp we could not attribute; what is kept is every one of
+-- those moments, under a column that claims only what we know.
+
+-- THE LOCK IS HELD THROUGH THE BACKFILL, and lock_timeout does not change
+-- that: it bounds the WAIT and never the HOLD, so every reader and writer of
+-- confirm_token blocks for as long as the UPDATE below takes
+-- (docs/how-to/apply-migrations.md §5).
+--
+-- ACCEPTED HERE ON THE SIZE OF THIS TABLE RATHER THAN WAVED AWAY. A confirm
+-- token is minted when somebody asks one contact to confirm their details, so
+-- the row count tracks deliberate operator actions rather than traffic, and
+-- the UPDATE touches only the rows that were ever fetched
+-- (WHERE opened_at IS NOT NULL). What blocks is the confirm-link path alone —
+-- minting, resolving and submitting — for the length of one indexed update.
+--
+-- The documented alternative is to land the column, backfill from application
+-- code, then validate. That is the right shape for a table with millions of
+-- rows and the wrong one here: it would leave the ambiguous opened_at values
+-- standing in the subject access export for however long the backfill took to
+-- be written and run, which is the defect this migration exists to end.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE confirm_token
+    ADD COLUMN first_fetched_at timestamptz,
+    ADD COLUMN fetch_count integer NOT NULL DEFAULT 0;
+
+-- Every existing opened_at was a fetch, whatever else it may have been — and
+-- only a fetch is what we can say.
+UPDATE confirm_token
+   SET first_fetched_at = opened_at,
+       fetch_count = 1,
+       opened_at = NULL
+ WHERE opened_at IS NOT NULL;
+
+COMMENT ON COLUMN confirm_token.first_fetched_at IS
+    'When anything first retrieved this link — a person, a scanner, a proxy. Claims nothing about who.';
+COMMENT ON COLUMN confirm_token.fetch_count IS
+    'How many times this link has been retrieved. A link fetched many times in seconds was not read that many times by a human.';
+COMMENT ON COLUMN confirm_token.opened_at IS
+    'When a PERSON first opened this page, which is evidence and so is written only where a machine fetch can be told apart from a human one. A scanner prefetching the link leaves first_fetched_at and not this.';
+

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2319,6 +2319,8 @@ public.confirm_token.confirm_token_purpose_is_consents CHECK (((kind = 'consent_
 public.confirm_token.consumed_at timestamp with time zone gen=- def=-
 public.confirm_token.delivered_to text NOT NULL gen=- def=-
 public.confirm_token.expires_at timestamp with time zone NOT NULL gen=- def=-
+public.confirm_token.fetch_count integer NOT NULL gen=- def=0
+public.confirm_token.first_fetched_at timestamp with time zone gen=- def=-
 public.confirm_token.id uuid NOT NULL gen=- def=uuidv7()
 public.confirm_token.issued_at timestamp with time zone NOT NULL gen=- def=now()
 public.confirm_token.kind text NOT NULL gen=- def='record_confirmation'::text


### PR DESCRIPTION
`confirm_token.opened_at` is evidence. It is the middle of the ask-to-click chain a controller produces to show a consent was freely given: the mail went out, the person opened it, the answer landed. That sentence has a named data subject as its subject.

Every GET of the confirm page stamped it, and most GETs of a link in a mail are not people. Mail security products fetch every link before delivering the message; so do link expanders, preview generators and corporate proxies. Each of those wrote a line saying somebody opened their consent link, frequently at a moment they were asleep.

It reaches the subject too. The access export reads that column to tell them their link was "opened and not answered".

## What this does

The fetch and the opening become two facts. `first_fetched_at` and `fetch_count` count every retrieval and claim nothing about who. `opened_at` keeps its meaning and is written only when the request does not announce itself as a machine.

Existing values move rather than being copied. A value written under the old rule may be a scanner's, and leaving it in a column that now means "a person opened this" would keep telling subjects something about their own conduct we cannot stand behind. The down migration puts it back.

## What it does not do, stated in the code

It catches the scanners that announce themselves through the Fetch Metadata headers a browser sets. It catches none of the plain HTTP clients that send nothing, and many scanners are exactly that. This narrows the defect rather than closing it.

It must not judge `Sec-Fetch-Mode` or `Sec-Fetch-Dest`. The confirm page is a single-page app: the subject navigates to the page, and the page then calls this endpoint with `fetch()`, which carries cors and empty. Judging those would classify every genuine opening as a machine, which is this defect inverted and applied to everybody. A test pins that case by name.

One case falls the other way and is left there. A browser that prerenders the page and then activates it makes only the prerender request, so a real opening goes unrecorded. That is under-recording, and a row that stays null claims nothing about anybody.

## The migration's lock

The backfill holds the ALTER's lock, which `lock_timeout` does not change. Accepted on this table's size rather than waved away: a confirm token is minted when an operator asks one contact to confirm their details, so the row count tracks deliberate actions, and the update touches only rows that were ever fetched. The reasoning is written into the migration.

## Cut from this slice

Server-bound wording, which the plan pairs with this. It would have bound the invitation email's body, but the subject answers a different question rendered from a frontend string that exists nowhere server-side. The proof would have named a different proposition than the one accepted, which is worse than the client's sentence rather than better. Publishing that question server-side is its own slice.

## Review

Two Codex rounds. The first caught that the classifier would have inverted the feature for every real user. The second found the subject access export was where the old ambiguous timestamps did their harm.

`make check-backend` green, plus the consent, privacy and full compose integration lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops scanner fetches of confirm links from being recorded as the recipient opening them. Every retrieval now writes `first_fetched_at` and bumps `fetch_count`; `opened_at` is stamped only when the request does not present itself as a machine.

**Migration**
- Moves existing `opened_at` values to `first_fetched_at` and clears `opened_at`, since a pre-upgrade value may be a scanner's.
- The backfill runs under the ALTER's lock; accepted on this table's size.

**Classification**
- Prefetch and purpose headers classify a request as a machine; requests that say nothing count as people, keeping real openings recorded.
- `Sec-Fetch-Mode`/`Sec-Fetch-Dest` are not judged, because the single-page confirm page itself calls the endpoint with `fetch()`, which carries cors/empty.
- Prerendered pages that activate under-record, leaving `opened_at` null rather than claiming a person.

<sup>Written for commit f237ac01d97c8e9b67c5d601efb6cbe6ffe2c48a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

