### PR TITLE
A grant names the question it answered

### DIFF
--- a/backend/gates/marketingquestion_test.go
+++ b/backend/gates/marketingquestion_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind claim H2
+
+package gates
+
+// The question a grant is bound to is the question the screen asks.
+//
+// A subscription consent's proof now names a published row: the subject is
+// recorded as having agreed to the wording this installation published, in the
+// language their link was minted in. That claim is only true while the
+// published wording and the wording on the screen are the same sentence.
+//
+// They live in two catalogs — backend/internal/platform/mailcopy for the
+// published one, frontend/src/i18n for the rendered one — and nothing in either
+// build makes them agree. Edit the screen's string alone and every grant after
+// it records somebody agreeing to a sentence they were not shown, which is the
+// defect the binding exists to end, arriving from the other side.
+//
+// WHEN THE QUESTION CHANGES: edit both catalogs, and bump
+// marketingQuestionVersion in consent/marketingquestion.go. The bump is what
+// tells a reader the proposition moved; the old version stays published for the
+// grants that named it.
+//
+// THE PROPER FIX, when somebody has the appetite, is for the page to RENDER the
+// published wording rather than its own copy — one source, nothing to drift.
+// This gate is what makes the two-catalog arrangement survivable until then.
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Where each catalog keeps the question.
+const (
+	serverCopyFile   = "internal/platform/mailcopy/catalog.go"
+	frontendCopyRoot = "../frontend/src/i18n/"
+)
+
+// theQuestionsSharedFields are the screen's keys and the server fields that
+// must say the same thing, in the order the published body joins them.
+var theQuestionsSharedFields = []struct {
+	screenKey   string
+	serverField string
+}{
+	{"confirm.marketing.ask", "ConfirmMarketingAsk"},
+	{"confirm.marketing.yes", "ConfirmMarketingYes"},
+	{"confirm.marketing.no", "ConfirmMarketingNo"},
+	// The dedicated subscription link's page asks a different question, and a
+	// grant through that door binds it. It drifts the same way.
+	{"confirm.subscription.ask", "ConfirmSubscriptionAsk"},
+	{"confirm.subscription.confirm", "ConfirmSubscriptionConfirm"},
+}
+
+// theQuestionsLanguages maps each frontend catalog onto the position its
+// translation occupies in the server's three-argument line() call.
+var theQuestionsLanguages = []struct {
+	file     string
+	position int
+}{
+	{"en.ts", 0},
+	{"de.ts", 1},
+	{"vi.ts", 2},
+}
+
+func TestThePublishedQuestionIsTheOneTheScreenAsks(t *testing.T) {
+	t.Parallel()
+
+	server, err := os.ReadFile(serverCopyFile)
+	if err != nil {
+		t.Fatalf("reading the published copy: %v", err)
+	}
+	for _, field := range theQuestionsSharedFields {
+		published := publishedRenderings(t, string(server), field.serverField)
+		for _, language := range theQuestionsLanguages {
+			shown := screenRendering(t, language.file, field.screenKey)
+			want := published[language.position]
+			if shown != want {
+				t.Errorf("%s in %s disagrees with %s in %s:\n"+
+					"  screen:    %q\n"+
+					"  published: %q\n"+
+					"A grant records the published sentence as what the subject agreed to, so a "+
+					"screen showing a different one records an agreement to words nobody saw.",
+					field.screenKey, language.file, field.serverField, serverCopyFile, shown, want)
+			}
+		}
+	}
+}
+
+// publishedRenderings pulls one field's three translations out of its line()
+// call. Read from source rather than by importing the package, because a gate
+// that linked the catalog would be satisfied by a build that compiles.
+func publishedRenderings(t *testing.T, source, field string) [3]string {
+	t.Helper()
+	call := regexp.MustCompile(
+		`return &c\.` + regexp.QuoteMeta(field) + ` \}\,\s*((?:\s*"(?:[^"\\]|\\.)*",?\n?)+)\)`)
+	match := call.FindStringSubmatch(source)
+	if match == nil {
+		t.Fatalf("no line() call for %s in %s: this gate is not reading what it thinks it is",
+			field, serverCopyFile)
+	}
+	literals := regexp.MustCompile(`"((?:[^"\\]|\\.)*)"`).FindAllStringSubmatch(match[1], -1)
+	if len(literals) != 3 {
+		t.Fatalf("%s has %d rendering(s), want the three languages", field, len(literals))
+	}
+	var out [3]string
+	for i, literal := range literals {
+		out[i] = unquoted(t, literal[1])
+	}
+	return out
+}
+
+// screenRendering pulls one key's value out of a frontend catalog.
+func screenRendering(t *testing.T, file, key string) string {
+	t.Helper()
+	raw, err := os.ReadFile(frontendCopyRoot + file)
+	if err != nil {
+		t.Fatalf("reading %s: %v", file, err)
+	}
+	// The value may sit on the same line as the key or wrap onto the next, and
+	// a long one is split across several adjacent literals.
+	entry := regexp.MustCompile(
+		regexp.QuoteMeta(`"`+key+`":`) + `\s*((?:"(?:[^"\\]|\\.)*"\s*\+?\s*)+)`)
+	// EVERY definition, not the first. A key defined twice is legal
+	// TypeScript and the LAST one wins at runtime, so a gate reading the first
+	// would compare a sentence the screen does not show — which is how a
+	// second, disagreeing definition would have slipped past this check.
+	matches := entry.FindAllStringSubmatch(string(raw), -1)
+	if len(matches) == 0 {
+		t.Fatalf("%s is not in %s: the screen no longer asks the question this gate compares",
+			key, file)
+	}
+	if len(matches) > 1 {
+		t.Errorf("%s is defined %d times in %s. The last wins at runtime, so the others are "+
+			"dead and one of them is what this gate would otherwise have compared.",
+			key, len(matches), file)
+	}
+	var built strings.Builder
+	for _, literal := range regexp.MustCompile(`"((?:[^"\\]|\\.)*)"`).
+		FindAllStringSubmatch(matches[len(matches)-1][1], -1) {
+		built.WriteString(unquoted(t, literal[1]))
+	}
+	return built.String()
+}
+
+// unquoted turns one source literal's body into the string it denotes. Both
+// catalogs write Go-style escapes — the frontend's are \uXXXX sequences the
+// formatter produced — so one unquoter serves both.
+func unquoted(t *testing.T, body string) string {
+	t.Helper()
+	out, err := strconv.Unquote(`"` + body + `"`)
+	if err != nil {
+		t.Fatalf("reading the literal %q: %v", body, err)
+	}
+	return out
+}

--- a/backend/internal/compose/consentwording.go
+++ b/backend/internal/compose/consentwording.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Publishing the wording this installation stands behind.
+//
+// Two callers and two reasons. Workspace seeding publishes so the very first
+// grant has a row to name; every boot republishes so an UPGRADED installation
+// — which skips seeding entirely, because its workspace already exists — is not
+// left pinning versions nothing has published.
+//
+// Both are safe to repeat: PublishTextVersionTx is idempotent on
+// key + version + locale, and refuses when the same version's words have
+// changed. So a boot that finds the wording edited without a version bump fails
+// loudly here rather than quietly serving one thing while past proofs name
+// another.
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// publishConsentWording republishes every wording this build ships, on each
+// boot. See the call site for why it cannot live in workspace seeding alone.
+//
+// UNDER A SYSTEM PRINCIPAL, which is not decoration: publishing a wording
+// writes an audit row, and storekit refuses one with no actor bound to the
+// context. Boot starts from context.Background(), so passing it straight
+// through made the publish fail — on exactly the upgraded installations this
+// exists for, where the rows really are missing, and the API then exits on
+// every restart. A fresh installation hid it, because seeding supplies an
+// actor and publishes everything before this runs.
+//
+// The same shape workspace seeding uses (identity's bootstrap): a system
+// principal and a fresh correlation id, because boot IS the originating
+// operation here and the audit rows want something to trace to.
+func publishConsentWording(ctx context.Context, pool *pgxpool.Pool, wsID ids.UUID) error {
+	bootCtx := principal.WithActor(principal.WithWorkspaceID(ctx, wsID), principal.Principal{
+		Type: principal.PrincipalSystem, ID: systemActor,
+	})
+	bootCtx = principal.WithCorrelationID(bootCtx, ids.NewV7())
+	return InstallationDB(pool).Tx(bootCtx, func(tx pgx.Tx) error {
+		now := time.Now()
+		if err := consent.PublishControllerTemplatesTx(bootCtx, tx, now); err != nil {
+			return err
+		}
+		return consent.PublishMarketingQuestionTx(bootCtx, tx, now)
+	})
+}
+
+// seedConsentText publishes the installation's own wording beside the purpose
+// catalog and the retention defaults, in the same transaction.
+//
+// Here rather than at a later door because a proof row may name a version from
+// the first grant onwards: wording published after the fact would leave the
+// earliest proofs pointing at nothing, and those are exactly the rows nobody
+// can reconstruct later.
+func seedConsentText(ctx context.Context, tx pgx.Tx) error {
+	now := time.Now()
+	if err := consent.PublishControllerTemplatesTx(ctx, tx, now); err != nil {
+		return err
+	}
+	// The question the confirm PAGE asks, which is what a subscription consent
+	// is actually given to. Published here beside the mail wording and for the
+	// same reason this whole function runs at boot: a grant names the row, so
+	// the row has to exist before the first grant can.
+	if err := consent.PublishMarketingQuestionTx(ctx, tx, now); err != nil {
+		return err
+	}
+	return consent.SeedDefaultRetentionTx(ctx, tx)
+}

--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -95,6 +95,23 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 	} else {
 		log.Info("installation bound to existing company", "workspace_id", wsID.String())
 	}
+	// THE PUBLISHED WORDING, ON EVERY BOOT and not only on the one that creates
+	// the workspace.
+	//
+	// seedConsentText runs inside workspace seeding, which an EXISTING
+	// installation skips entirely — so an upgrade would add the columns that
+	// pin which wording a link asks, start pinning them, and never publish the
+	// rows they point at. Every grant after that upgrade would name a version
+	// nothing had published, which is the fallback path and exactly the silence
+	// this change exists to end.
+	//
+	// Safe to repeat: PublishTextVersionTx is idempotent on key+version+locale
+	// and REFUSES when the same version's words have changed, so a boot that
+	// finds the wording edited without a version bump fails loudly here rather
+	// than quietly serving one thing and having past proofs name another.
+	if err := publishConsentWording(ctx, pool, wsID.UUID); err != nil {
+		return err
+	}
 	// `setting` is not tenant-scoped, so a bootstrap over a database that still
 	// holds a previous installation's rows creates a new workspace beside them
 	// and keeps the OLD identity. The values in margince.yaml are then read,
@@ -335,20 +352,6 @@ func seedConsent(ctx context.Context, tx pgx.Tx, configured []deployconfig.Conse
 		return err
 	}
 	return seedConsentText(ctx, tx)
-}
-
-// seedConsentText publishes the installation's own wording beside the purpose
-// catalog and the retention defaults, in the same transaction.
-//
-// Here rather than at a later door because a proof row may name a version from
-// the first grant onwards: wording published after the fact would leave the
-// earliest proofs pointing at nothing, and those are exactly the rows nobody
-// can reconstruct later.
-func seedConsentText(ctx context.Context, tx pgx.Tx) error {
-	if err := consent.PublishControllerTemplatesTx(ctx, tx, time.Now()); err != nil {
-		return err
-	}
-	return consent.SeedDefaultRetentionTx(ctx, tx)
 }
 
 // seedRetentionPosture turns the retain-only posture on when the deployment asked

--- a/backend/internal/compose/integration/boundquestion_integration_test.go
+++ b/backend/internal/compose/integration/boundquestion_integration_test.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What a subscription consent's proof says the subject agreed to.
+//
+// consent_event.policy_text is that sentence, and on both confirm-link doors it
+// came from the SUBMISSION BODY — whatever the subject's own browser said it
+// had shown them. So the evidence a controller produces to show consent was
+// freely given quoted a string the client chose, and a client that chose a
+// different one would be believed. Meanwhile consent_text_version_id had sat
+// unwritten since the migration that added it.
+//
+// AN EARLIER ATTEMPT BOUND THE WRONG SENTENCE and was reverted: it named the
+// invitation mail's body, which says confirming turns a request into a
+// permission. The PAGE asks something else — news roughly once a month — and
+// that is what a subject answers. A proof naming the first would be published,
+// checkable, server-controlled, and about the wrong proposition.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// grantedProof is what one proof row records about the wording.
+type grantedProof struct {
+	versionID *string
+	text      string
+	version   *string
+}
+
+func readGrantedProof(t *testing.T, c *consentEnv, source string) grantedProof {
+	t.Helper()
+	var out grantedProof
+	if err := c.Owner.QueryRow(context.Background(), `
+		SELECT consent_text_version_id::text, policy_text, policy_version
+		  FROM consent_event
+		 WHERE source = $1
+		 ORDER BY captured_at DESC LIMIT 1`, source).
+		Scan(&out.versionID, &out.text, &out.version); err != nil {
+		t.Fatalf("reading the proof: %v", err)
+	}
+	return out
+}
+
+// mintAConfirmLink has the workspace mail a record-confirmation link.
+func mintAConfirmLink(t *testing.T, c *consentEnv) string {
+	t.Helper()
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/confirm-request",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("ask the workspace to mail the confirm link → %d", status)
+	}
+	return confirmLinkToken(t, c.AppEnv)
+}
+
+// THE PROOF NAMES THE PUBLISHED QUESTION, NOT THE CLIENT'S SENTENCE.
+func TestAGrantNamesThePublishedQuestionItAnswered(t *testing.T) {
+	c := setupConsent(t)
+	token := mintAConfirmLink(t, c)
+
+	// The client sends something else entirely. Before this change it would
+	// have been recorded verbatim as what the subject agreed to.
+	var receipt crmcontracts.ConfirmSubmissionReceipt
+	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/confirm/"+token, AnyMap{
+		"marketing_choice":  "granted",
+		"marketing_wording": "I agree to absolutely anything whatsoever.",
+	}, nil, &receipt); s != http.StatusOK {
+		t.Fatalf("the subject spends their own link → %d, want 200", s)
+	}
+
+	proof := readGrantedProof(t, c, "confirm_details")
+	if proof.versionID == nil {
+		t.Fatal("the grant names no published question, so its proof still rests on a sentence " +
+			"that arrived in the same request as the answer it is meant to evidence")
+	}
+	if strings.Contains(proof.text, "absolutely anything whatsoever") {
+		t.Error("the proof quotes the CLIENT's sentence — a client that chose a different one " +
+			"would be believed")
+	}
+
+	// IT NAMES A ROW THAT EXISTS AND SAYS THE SAME THING, so a reader following
+	// the id is not given a second, disagreeing answer to what was agreed.
+	var body, key string
+	if err := c.Owner.QueryRow(context.Background(),
+		`SELECT body, key FROM consent_text_version WHERE id = $1 AND published_at IS NOT NULL`,
+		*proof.versionID).Scan(&body, &key); err != nil {
+		t.Fatalf("the proof names a wording that is not published: %v", err)
+	}
+	if key != "marketing_question" {
+		t.Errorf("the proof names the %q wording — a subscription consent is given to the "+
+			"question on the page, not to the mail that carried the link", key)
+	}
+	if proof.text != body {
+		t.Errorf("policy_text and the row it names disagree:\n  proof: %q\n  row:   %q",
+			proof.text, body)
+	}
+	// THE ANSWERS ARE IN IT. What somebody agreed to is the question and the
+	// option they picked together; a version pinning only the question would
+	// let the labels change under it.
+	if !strings.Contains(body, "keep me posted") {
+		t.Errorf("the published question does not carry the answers the subject chose between: %q",
+			body)
+	}
+}
+
+// THE DEDICATED CONSENT LINK BINDS TOO.
+//
+// Two doors write a grant from a confirm link, and this is the one most
+// double-opt-in consents actually arrive through. Fixing only the other would
+// have left the defect standing where it matters most.
+func TestADedicatedConsentLinkBindsTheQuestionToo(t *testing.T) {
+	c := setupConsent(t)
+
+	// A double-opt-in link is minted for one purpose and asks only about that.
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in",
+		AnyMap{"purpose_id": c.purposes["marketing_email"]}, nil, nil); status >= 400 {
+		t.Fatalf("minting the double-opt-in link → %d", status)
+	}
+	token := confirmLinkToken(t, c.AppEnv)
+
+	var receipt crmcontracts.ConfirmSubmissionReceipt
+	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/confirm/"+token, AnyMap{
+		"marketing_choice":  "granted",
+		"marketing_wording": "whatever the client says",
+	}, nil, &receipt); s != http.StatusOK {
+		t.Fatalf("spending the consent link → %d, want 200", s)
+	}
+
+	proof := readGrantedProof(t, c, "consent_link")
+	if proof.versionID == nil {
+		t.Fatal("a dedicated consent link's grant names no published question, so the door most " +
+			"double-opt-in consents come through still records the client's sentence")
+	}
+
+	// AND IT NAMES THE RIGHT ONE, which asserting a non-null id does not show.
+	// This page asks a different question from the record-confirmation page: it
+	// names the purpose the link was minted for rather than describing a
+	// frequency. Binding the other door's sentence would be published,
+	// checkable, server-controlled — and about a proposition nobody was asked,
+	// which is the defect an earlier attempt shipped and had to revert.
+	var key, body string
+	if err := c.Owner.QueryRow(context.Background(),
+		`SELECT key, body FROM consent_text_version WHERE id = $1`, *proof.versionID).
+		Scan(&key, &body); err != nil {
+		t.Fatalf("reading the bound question: %v", err)
+	}
+	if key != "subscription_question" {
+		t.Errorf("the subscription page's grant names the %q wording — the subject was asked to "+
+			"confirm a named purpose, not the generic monthly-news question", key)
+	}
+	if !strings.Contains(body, "{purpose}") {
+		t.Errorf("the published question does not carry the placeholder the page fills: %q", body)
+	}
+
+	// AND THE PROOF NAMES THE PURPOSE, not the placeholder. The published row
+	// keeps {purpose} — one row serves every purpose — but what the subject
+	// read had their subscription's own name in it, and the export hands them
+	// policy_text with the purpose's KEY beside it rather than its label. A
+	// hole in the sentence is a hole nobody can fill.
+	if strings.Contains(proof.text, "{purpose}") {
+		t.Errorf("the proof records a sentence with a hole in it: %q", proof.text)
+	}
+	var label string
+	if err := c.Owner.QueryRow(context.Background(),
+		`SELECT label FROM consent_purpose WHERE key = 'marketing_email'`).Scan(&label); err != nil {
+		t.Fatalf("reading the purpose label: %v", err)
+	}
+	if !strings.Contains(proof.text, label) {
+		t.Errorf("the proof does not name what the subject subscribed to:\n  proof: %q\n  want it to contain: %q",
+			proof.text, label)
+	}
+}
+
+// A LINK THAT PINNED NOTHING KEEPS THE EVIDENCE IT HAD.
+//
+// Links minted before the question was pinned name no version and no locale.
+// Refusing those grants would be punishing subjects for our own missing
+// bookkeeping, so they record the client's sentence exactly as before — and
+// name no published row, which says plainly that nothing was checked.
+func TestALinkThatPinnedNoQuestionStillRecordsTheGrant(t *testing.T) {
+	c := setupConsent(t)
+	token := mintAConfirmLink(t, c)
+
+	// Unpin it, as a link minted before this change would be.
+	if _, err := c.Owner.Exec(context.Background(),
+		`UPDATE confirm_token SET question_locale = NULL, question_version = NULL`); err != nil {
+		t.Fatalf("unpinning the link: %v", err)
+	}
+
+	var receipt crmcontracts.ConfirmSubmissionReceipt
+	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/confirm/"+token, AnyMap{
+		"marketing_choice":  "granted",
+		"marketing_wording": "Yes, send me occasional product news.",
+	}, nil, &receipt); s != http.StatusOK {
+		t.Fatalf("the subject's consent was refused over our own bookkeeping → %d", s)
+	}
+
+	proof := readGrantedProof(t, c, "confirm_details")
+	if proof.versionID != nil {
+		t.Errorf("an unpinned link named published wording %q — we cannot say which of three "+
+			"rows the subject read, and guessing is what this whole change exists to stop",
+			*proof.versionID)
+	}
+	if proof.text != "Yes, send me occasional product news." {
+		t.Errorf("the fallback did not record what the client sent: %q", proof.text)
+	}
+}

--- a/backend/internal/modules/consent/boundquestion.go
+++ b/backend/internal/modules/consent/boundquestion.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What a proof row records as the thing the subject agreed to.
+//
+// Both confirm-link doors used to write in.MarketingWording — the sentence that
+// arrived in the same request as the answer it is meant to evidence. This
+// resolves the published question the link pinned instead, so the proof names a
+// row the controller published and a reader can check it against.
+//
+// WHAT THE PIN DOES NOT SETTLE, stated because the limits are real and a reader
+// should not take this for more than it is.
+//
+// The page renders its own copy of the question from the frontend catalog
+// rather than fetching the published row. Two consequences follow, and both are
+// bounded rather than closed:
+//
+//   - The page picks its language from the reader's browser, while the pin
+//     records the language the MAIL went out in. A link mailed in English and
+//     opened in a German browser records the English wording as what was seen.
+//   - The pin names the version live when the link was minted. A frontend
+//     redeploy between minting and clicking changes what the page shows while
+//     the proof still names what was pinned.
+//
+// Both are narrower than what they replace: an unpinned, unpublished,
+// client-supplied string that could say anything. The cross-catalog gate
+// (gates/marketingquestion_test.go) keeps the two copies of the wording in step
+// so the second case needs a deliberate edit to arise, and closing either
+// properly means the page rendering the published row — one source, nothing to
+// drift.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// GrantWording is what one proof row says about what was agreed.
+type GrantWording struct {
+	// Text is the sentence recorded on the proof.
+	Text string
+	// Version names which published version it is, nil when nothing was bound
+	// and the engine's own default applies.
+	Version *string
+	// VersionID is the published row, zero when nothing was bound.
+	VersionID ids.UUID
+}
+
+// wordingForGrantTx decides what a grant through a confirm link records.
+//
+// ONE HELPER FOR BOTH DOORS. A record-confirmation link and a dedicated consent
+// link each wrote whatever sentence arrived in the submission, and fixing one
+// would have left the other — the one most double-opt-in grants come through —
+// exactly as it was.
+func (s *Store) wordingForGrantTx(
+	ctx context.Context, tx pgx.Tx, ref ConfirmRef, submitted string,
+) (GrantWording, error) {
+	bound, found, err := publishedQuestionForLinkTx(ctx, tx, ref)
+	if err != nil {
+		return GrantWording{}, err
+	}
+	if !found {
+		// The client's sentence, which is what this door recorded before and is
+		// the honest evidence for a link that cannot name a published row.
+		return GrantWording{Text: submitted}, nil
+	}
+	// THE PURPOSE GOES INTO THE RECORDED SENTENCE, not into the published row.
+	//
+	// The subscription question carries a {purpose} placeholder, and the page
+	// fills it with the purpose's own label before the subject reads it. The
+	// PUBLISHED row keeps the placeholder — publishing one row per purpose
+	// would make a version mean something different for each — but the PROOF
+	// records what was actually on the screen.
+	//
+	// Without this the subject's own data export hands them "Confirm that you
+	// want to receive {purpose}.", a sentence with a hole in it, and the export
+	// carries the purpose's KEY rather than its label, so nothing in front of
+	// them fills it.
+	text, err := substitutePurposeTx(ctx, tx, bound.Text, ref.PurposeID)
+	if err != nil {
+		return GrantWording{}, err
+	}
+	version := bound.Version
+	return GrantWording{Text: text, Version: &version, VersionID: bound.VersionID}, nil
+}
+
+// substitutePurposeTx fills the {purpose} placeholder with the label the page
+// showed, leaving any other text untouched.
+//
+// A MISSING LABEL LEAVES THE PLACEHOLDER rather than failing the grant. A
+// purpose archived between the mail and the click has no label to read, and
+// refusing somebody's consent because we can no longer name what they
+// subscribed to would be the wrong way round — the proof still carries
+// purpose_id, which is what identifies it.
+func substitutePurposeTx(
+	ctx context.Context, tx pgx.Tx, text string, purposeID ids.PurposeID,
+) (string, error) {
+	if !strings.Contains(text, purposePlaceholder) || purposeID.IsZero() {
+		return text, nil
+	}
+	var label string
+	err := tx.QueryRow(ctx,
+		`SELECT label FROM consent_purpose WHERE id = $1`, purposeID).Scan(&label)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return text, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("consent: naming the purpose this question asked about: %w", err)
+	}
+	return strings.ReplaceAll(text, purposePlaceholder, label), nil
+}
+
+// purposePlaceholder is what the published subscription question holds where
+// the purpose's own name goes. One spelling, shared with the catalog that
+// writes it and the screen that fills it.
+const purposePlaceholder = "{purpose}"
+
+// boundQuestion is a published question a grant can point at.
+type boundQuestion struct {
+	VersionID ids.UUID
+	Text      string
+	Version   string
+}
+
+// publishedQuestionForLinkTx resolves the question this link pinned.
+//
+// NOT FOUND IS NOT AN ERROR, and it covers one expected case and one that is
+// not. A link minted before the question was pinned names nothing, and there is
+// no honest way to say which of three published rows somebody read — those
+// grants keep the weaker evidence they already had, because refusing somebody's
+// consent over our own missing bookkeeping would be the wrong way round.
+//
+// A link that DOES name a version and locale with nothing published for them is
+// the other case: this installation asked a question it never published, or
+// publishing has not run. The grant still stands — the subject clicked a real
+// link and answered a real question — but it is logged rather than folded in
+// with the expected case.
+func publishedQuestionForLinkTx(
+	ctx context.Context, tx pgx.Tx, ref ConfirmRef,
+) (boundQuestion, bool, error) {
+	if ref.QuestionKey == "" || ref.QuestionLocale == "" || ref.QuestionVersion == 0 {
+		return boundQuestion{}, false, nil
+	}
+	version := fmt.Sprintf("v%d", ref.QuestionVersion)
+	var out boundQuestion
+	err := tx.QueryRow(ctx, `
+		SELECT id, body, version
+		  FROM consent_text_version
+		 WHERE key = $1 AND version = $2 AND locale = $3 AND published_at IS NOT NULL`,
+		ref.QuestionKey, version, ref.QuestionLocale).
+		Scan(&out.VersionID, &out.Text, &out.Version)
+	if errors.Is(err, pgx.ErrNoRows) {
+		slog.WarnContext(ctx, "a confirm link pinned a question this installation has not published",
+			"key", ref.QuestionKey, "version", version, "locale", ref.QuestionLocale)
+		return boundQuestion{}, false, nil
+	}
+	if err != nil {
+		return boundQuestion{}, false, fmt.Errorf(
+			"consent: reading the question this link asked: %w", err)
+	}
+	return out, true, nil
+}

--- a/backend/internal/modules/consent/confirmsubmit.go
+++ b/backend/internal/modules/consent/confirmsubmit.go
@@ -156,13 +156,22 @@ func (s *Store) recordMarketingAnswerTx(ctx context.Context, tx pgx.Tx, ref Conf
 	if err != nil {
 		return err
 	}
+	// THE QUESTION THE SUBJECT ANSWERED, where the link pinned one. See
+	// boundquestion.go: in.MarketingWording is what the client said it had
+	// shown, and a client that said something else would be believed.
+	wording, err := s.wordingForGrantTx(ctx, tx, ref, in.MarketingWording)
+	if err != nil {
+		return err
+	}
 	source := "confirm_details"
 	input := RecordInput{
-		PersonID:   ref.PersonID,
-		PurposeID:  purposeID,
-		NewState:   in.MarketingChoice,
-		Source:     &source,
-		PolicyText: &in.MarketingWording,
+		PersonID:      ref.PersonID,
+		PurposeID:     purposeID,
+		NewState:      in.MarketingChoice,
+		Source:        &source,
+		PolicyText:    &wording.Text,
+		PolicyVersion: wording.Version,
+		TextVersionID: wording.VersionID,
 		// Earned, not asserted: this is set only after spendConfirmTokenTx
 		// consumed the link that proves the mailbox.
 		MailboxProof: MailboxProvenByConfirmLink,
@@ -268,13 +277,23 @@ func validateConfirmSubmission(in ConfirmSubmission) error {
 // name its own purpose would let whoever holds one link grant any purpose,
 // which is the operator-completable round trip this whole change removed.
 func (s *Store) recordLinkedPurposeTx(ctx context.Context, tx pgx.Tx, ref ConfirmRef, in ConfirmSubmission) error {
+	// THE SAME BINDING THE OTHER DOOR TAKES. A dedicated consent link is the
+	// path most double-opt-in grants actually arrive through, so leaving it on
+	// the client's sentence would have fixed the defect for the door fewer
+	// people use.
+	wording, err := s.wordingForGrantTx(ctx, tx, ref, in.MarketingWording)
+	if err != nil {
+		return err
+	}
 	source := "consent_link"
 	input := RecordInput{
-		PersonID:   ref.PersonID,
-		PurposeID:  ref.PurposeID,
-		NewState:   in.MarketingChoice,
-		Source:     &source,
-		PolicyText: &in.MarketingWording,
+		PersonID:      ref.PersonID,
+		PurposeID:     ref.PurposeID,
+		NewState:      in.MarketingChoice,
+		Source:        &source,
+		PolicyText:    &wording.Text,
+		PolicyVersion: wording.Version,
+		TextVersionID: wording.VersionID,
 		// Earned, not asserted: set only after spendConfirmTokenTx consumed the
 		// link that proves the mailbox. This is what satisfies a double-opt-in
 		// purpose, and the only thing that does.

--- a/backend/internal/modules/consent/confirmtoken.go
+++ b/backend/internal/modules/consent/confirmtoken.go
@@ -94,6 +94,14 @@ type ConfirmRef struct {
 	// also edit the record would be a wider capability than the mail described.
 	Kind      string
 	PurposeID ids.PurposeID
+	// QuestionLocale and QuestionVersion name the published subscription
+	// question this link will ask, pinned when it was minted. They are what
+	// lets a grant point at the row the subject actually read rather than at
+	// whatever is deployed when they click. Empty and zero on a link minted
+	// before they were recorded.
+	QuestionKey     string
+	QuestionLocale  string
+	QuestionVersion int
 }
 
 // IssueConfirmToken mints the single-use link for one person and returns the
@@ -255,13 +263,27 @@ func (s *Store) issueLink(ctx context.Context, personID ids.PersonID, kind strin
 		}
 		// A confirm_token row is a security artifact, not a kernel entity, so
 		// the row id stays untyped — as consent_doi_token's does.
+		// THE QUESTION THIS LINK WILL ASK, pinned now rather than read back when
+		// the subject answers. The page renders in the installation's mail
+		// language, and both that and the question's version can change between
+		// the mail going out and the click coming back — so a grant resolving
+		// either at proof time would name wording the subject never saw.
+		//
+		// The language is resolved through the same call that renders the mail
+		// below, so the row and the page cannot disagree about which one.
+		questionLocale := s.mailLanguage(ctx, tx)
+		// WHICH question, decided from the link kind so the pin and the page
+		// cannot disagree about what the subject will be asked.
+		questionKey := QuestionKeyForLink(kind)
 		var tokenRowID ids.UUID
 		if err := tx.QueryRow(ctx, `
-			INSERT INTO confirm_token (person_id, token_hash, delivered_to, issued_at, expires_at, kind, purpose_id)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			INSERT INTO confirm_token (person_id, token_hash, delivered_to, issued_at, expires_at, kind, purpose_id,
+			                           question_key, question_locale, question_version)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 			RETURNING id`,
 			personID, hashPublicToken(token), deliveredTo, issued, expires,
-			kind, nullablePurpose(purposeID)).Scan(&tokenRowID); err != nil {
+			kind, nullablePurpose(purposeID),
+			questionKey, questionLocale, marketingQuestionVersion).Scan(&tokenRowID); err != nil {
 			return err
 		}
 		// The address is audited because it is the evidence: a later reader
@@ -357,19 +379,34 @@ func (s *Store) subjectOfConfirmTokenTx(ctx context.Context, tx pgx.Tx, token st
 func (s *Store) spendConfirmTokenTx(ctx context.Context, tx pgx.Tx, token string) (ConfirmRef, error) {
 	var ref ConfirmRef
 	var purposeID *ids.PurposeID
+	// The published question this link pinned, which the grant names.
+	var questionKey *string
+	var questionLocale *string
+	var questionVersion *int
 	err := tx.QueryRow(ctx, `
 		UPDATE confirm_token ct SET consumed_at = $2
 		WHERE ct.token_hash = $1 AND ct.consumed_at IS NULL AND ct.expires_at > $2
 		  AND EXISTS (SELECT 1 FROM person p
 		               WHERE p.id = ct.person_id AND p.archived_at IS NULL)
-		RETURNING ct.person_id, ct.id, ct.delivered_to, ct.kind, ct.purpose_id`,
+		RETURNING ct.person_id, ct.id, ct.delivered_to, ct.kind, ct.purpose_id,
+		          ct.question_key, ct.question_locale, ct.question_version`,
 		hashPublicToken(token), s.now().UTC()).Scan(
-		&ref.PersonID, &ref.TokenID, &ref.DeliveredTo, &ref.Kind, &purposeID)
+		&ref.PersonID, &ref.TokenID, &ref.DeliveredTo, &ref.Kind, &purposeID,
+		&questionKey, &questionLocale, &questionVersion)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ConfirmRef{}, fmt.Errorf("confirm token: %w", apperrors.ErrNotFound)
 	}
 	if purposeID != nil {
 		ref.PurposeID = *purposeID
+	}
+	if questionKey != nil {
+		ref.QuestionKey = *questionKey
+	}
+	if questionLocale != nil {
+		ref.QuestionLocale = *questionLocale
+	}
+	if questionVersion != nil {
+		ref.QuestionVersion = *questionVersion
 	}
 	return ref, err
 }

--- a/backend/internal/modules/consent/consentproof.go
+++ b/backend/internal/modules/consent/consentproof.go
@@ -118,12 +118,16 @@ func upsertConsentWithProof(ctx context.Context, tx pgx.Tx, in RecordInput, sub 
 	// which takes its input by value: a default written there never reaches the
 	// INSERT, and the CHECK would refuse every row that door writes.
 	text, version := wordingFor(ConsentState(in.NewState), in.PolicyText, in.PolicyVersion)
+	// The published row this rests on, where the door knew which one. Written
+	// BESIDE policy_text rather than instead of it: the text stays readable
+	// without a join, and the id is what a reader checks it against.
 	_, err := tx.Exec(ctx, `
 		INSERT INTO consent_event (`+sub.column+`, purpose_id, new_state, lawful_basis, source,
 		                           policy_text, policy_version, double_opt_in_confirmed_at, captured_at, captured_by,
-		                           issuance_trigger)
-		VALUES ($1, $2, $3, $4, coalesce($5, 'api'), $6, $7, $8, $9, $10, $11)`,
+		                           issuance_trigger, consent_text_version_id)
+		VALUES ($1, $2, $3, $4, coalesce($5, 'api'), $6, $7, $8, $9, $10, $11, $12)`,
 		sub.id, in.PurposeID, in.NewState, in.LawfulBasis, in.Source,
-		text, version, doiConfirmedAt, capturedAt, actorID, trigger)
+		text, version, doiConfirmedAt, capturedAt, actorID, trigger,
+		zeroUUIDAsNull(in.TextVersionID))
 	return err
 }

--- a/backend/internal/modules/consent/marketingquestion.go
+++ b/backend/internal/modules/consent/marketingquestion.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The question a subscription consent is given TO.
+//
+// A consent granted through a confirm link recorded policy_text from the
+// SUBMISSION BODY — whatever the subject's browser said it had shown them. So
+// the proof a controller produces to show consent was freely given quoted a
+// sentence the client chose, and a client that chose a different one would be
+// believed. Meanwhile consent_event.consent_text_version_id has sat unwritten
+// since migration 1788669014.
+//
+// WHY BINDING THE MAIL'S WORDING IS NOT THE FIX, which is what an earlier
+// attempt did and had to be reverted. The mail says "confirming below turns
+// that into a permission we will act on". The PAGE asks something else: "news
+// from time to time, roughly once a month". A subject agrees to the second. A
+// proof naming the first would be checkable, published, server-controlled — and
+// about the wrong proposition, which is worse than an unchecked quote of the
+// right one.
+//
+// So the page's own question is published here, in the same three languages and
+// through the same text-version machinery, and that is what a grant names.
+//
+// THE ANSWERS TRAVEL WITH IT. What somebody agreed to is the question and the
+// option they picked together: "roughly once a month" answered with "no thanks"
+// is not a consent, and a version pinning only the question would let the
+// labels change under it. One published body carries all three.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
+)
+
+// TemplateMarketingQuestion is the published key for the subscription question.
+//
+// A TEMPLATE KEY OF ITS OWN, not a field on the confirm-mail templates, because
+// the two change for different reasons and a shared version would tie them
+// together: rewording the mail's invitation would invalidate every grant's
+// pinned question, and rewording the question would claim the mail changed.
+const TemplateMarketingQuestion = "marketing_question"
+
+// TemplateSubscriptionQuestion is the dedicated subscription link's question,
+// which names the purpose rather than describing a frequency.
+//
+// A SECOND KEY, because they are two different propositions and a subject
+// answers exactly one. Binding either door to the other's sentence would record
+// an agreement to something nobody was asked — which is the defect this whole
+// change exists to end, and the one an earlier attempt shipped.
+const TemplateSubscriptionQuestion = "subscription_question"
+
+// marketingQuestionVersion is bumped when the question or either answer
+// changes. A version that moved for any other reason would tell a reader the
+// proposition changed when it did not.
+//
+// Held by: TestThePublishedQuestionIsTheOneTheScreenAsks
+// (backend/gates/marketingquestion_test.go), which compares this catalog
+// against the frontend's own strings.
+const marketingQuestionVersion = 1
+
+// QuestionKeyForLink names which published question a link will ask.
+//
+// The two confirm links show different pages. A record-confirmation link shows
+// the generic marketing question with its yes/no; a consent link shows the
+// named-purpose subscription question with one affirmative button.
+//
+// The key is decided at MINT, from the link kind, which is the same fact the
+// page branches on when it chooses which body to render — so the two agree
+// about WHICH question is asked. They can still disagree about its exact words
+// and language; see boundquestion.go for what the pin does and does not
+// settle.
+func QuestionKeyForLink(kind string) string {
+	if kind == LinkConsentConfirmation {
+		return TemplateSubscriptionQuestion
+	}
+	return TemplateMarketingQuestion
+}
+
+// RenderQuestion resolves one published question into the body a proof row
+// points at.
+//
+// THE PURPOSE IS NOT SUBSTITUTED HERE. The subscription question carries a
+// {purpose} placeholder, and the published row keeps it: what is published is
+// the installation's wording, and the purpose a given link named is already on
+// the proof row beside it. Substituting would publish one row per purpose and
+// make the version mean something different for each.
+func RenderQuestion(key, language string) string {
+	words := mailcopy.For(language)
+	if key == TemplateSubscriptionQuestion {
+		return strings.Join([]string{
+			words.ConfirmSubscriptionAsk,
+			words.ConfirmSubscriptionConfirm,
+		}, "\n")
+	}
+	return RenderMarketingQuestion(language)
+}
+
+// RenderMarketingQuestion resolves the question and its two answers into the
+// one body a proof row points at.
+//
+// ONE BODY RATHER THAN THREE COLUMNS, because what is being pinned is a whole
+// proposition. A reader following consent_text_version_id wants to see what the
+// subject was asked and what they could say, in the order they saw it.
+func RenderMarketingQuestion(language string) string {
+	words := mailcopy.For(language)
+	return strings.Join([]string{
+		words.ConfirmMarketingAsk,
+		words.ConfirmMarketingYes,
+		words.ConfirmMarketingNo,
+	}, "\n")
+}
+
+// PublishMarketingQuestionTx publishes the question in every language this
+// build speaks, beside the controller templates and for the same reason: the
+// installation's language can change after a link was sent, so a wording
+// published only for the current setting would disappear from a later boot and
+// the proof would name a row nobody could read.
+func PublishMarketingQuestionTx(ctx context.Context, tx pgx.Tx, now time.Time) error {
+	for _, key := range []string{TemplateMarketingQuestion, TemplateSubscriptionQuestion} {
+		for _, language := range mailcopy.Languages() {
+			if _, err := PublishTextVersionTx(ctx, tx, TextVersion{
+				Key:         key,
+				Version:     fmt.Sprintf("v%d", marketingQuestionVersion),
+				Locale:      string(language),
+				Body:        RenderQuestion(key, string(language)),
+				PublishedAt: now,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -278,6 +278,16 @@ type RecordInput struct {
 	// demonstrability). Nil keeps the API-surface defaults.
 	PolicyText    *string
 	PolicyVersion *string
+	// TextVersionID names the PUBLISHED wording this grant rests on, where the
+	// door knows which one the subject read. It is what makes the proof
+	// checkable: a reader follows it to the row the controller published rather
+	// than trusting policy_text, which on a public door arrived in the same
+	// request as the answer it evidences.
+	//
+	// Zero on every door that cannot say — a link minted before the question
+	// was pinned, an API caller stating their own wording — and those rows keep
+	// the weaker evidence they always had.
+	TextVersionID ids.UUID
 	// NeverOverrideExisting is the anonymous-capture rule: a public
 	// surface asserting "granted" must not flip a decision already on
 	// record — above all a WITHDRAWAL, which an attacker knowing only an

--- a/backend/internal/platform/mailcopy/catalog.go
+++ b/backend/internal/platform/mailcopy/catalog.go
@@ -264,6 +264,33 @@ func morningLines(line writeLine) {
 // speak to a stranger the installation holds a record about, and about their
 // own rights.
 func confirmLines(line writeLine) {
+	// THE QUESTION THE PAGE ASKS, which is what a consent is given TO. Its
+	// translations are the ones the confirm screen shipped, moved here so the
+	// proof can name a published row rather than quoting whatever arrived with
+	// the answer.
+	line(func(c *Copy) *string { return &c.ConfirmMarketingAsk },
+		"News from time to time, roughly once a month. You decide, and I will hold to it.",
+		"Neuigkeiten ab und zu, etwa einmal im Monat. Sie entscheiden, ich halte mich daran.",
+		"Tin tức thỉnh thoảng, khoảng mỗi tháng một lần. Bạn quyết định, và tôi sẽ tuân theo.")
+	line(func(c *Copy) *string { return &c.ConfirmMarketingYes },
+		"Yes, keep me posted",
+		"Ja, halten Sie mich auf dem Laufenden",
+		"Có, hãy gửi tin cho tôi")
+	line(func(c *Copy) *string { return &c.ConfirmMarketingNo },
+		"No thanks, just keep my details correct",
+		"Nein danke, nur meine Daten korrekt halten",
+		"Không, chỉ cần giữ thông tin của tôi chính xác")
+	// THE DEDICATED SUBSCRIPTION LINK'S OWN QUESTION, which names the purpose
+	// rather than describing a frequency. A grant through that door binds this;
+	// one through the record-confirmation door binds the pair above.
+	line(func(c *Copy) *string { return &c.ConfirmSubscriptionAsk },
+		"Confirm that you want to receive {purpose}.",
+		"Bestätigen Sie, dass Sie {purpose} erhalten möchten.",
+		"Xác nhận rằng bạn muốn nhận {purpose}.")
+	line(func(c *Copy) *string { return &c.ConfirmSubscriptionConfirm },
+		"Yes, subscribe me",
+		"Ja, ich möchte das Abo",
+		"Có, đăng ký cho tôi")
 	line(func(c *Copy) *string { return &c.ConfirmRecordSubject },
 		"Your details, and whether we may stay in touch",
 		"Ihre Daten, und ob wir in Kontakt bleiben dürfen",

--- a/backend/internal/platform/mailcopy/mailcopy.go
+++ b/backend/internal/platform/mailcopy/mailcopy.go
@@ -193,6 +193,33 @@ type Copy struct {
 	ConfirmRecordBody     string
 	ConfirmConsentSubject string
 	ConfirmConsentBody    string
+	// ConfirmMarketingAsk is the QUESTION ON THE PAGE, not in the mail — the
+	// sentence beside the yes/no a subject actually answers.
+	//
+	// It lives in this catalog rather than in the frontend's because it is the
+	// proposition a consent is given to, and a proof row that quoted a string
+	// the client sent would be evidence the client wrote. Published through the
+	// same text-version machinery as the mail wording, so the grant can name
+	// the row the controller published.
+	//
+	// ConfirmMarketingYes and ConfirmMarketingNo are the two answers, here for
+	// the same reason: what a subject chose is part of what they were asked.
+	ConfirmMarketingAsk string
+	ConfirmMarketingYes string
+	ConfirmMarketingNo  string
+	// ConfirmSubscriptionAsk is the OTHER question, and the two are not
+	// interchangeable. A record-confirmation link asks the generic marketing
+	// question above; a dedicated subscription link names the purpose it was
+	// minted for — "confirm that you want to receive {purpose}" — which is a
+	// narrower and more specific proposition.
+	//
+	// Binding either door to the other's sentence would record somebody
+	// agreeing to something they were not asked, which is the defect the whole
+	// published-question change exists to end.
+	//
+	// {purpose} is substituted with the purpose's own label at render time.
+	ConfirmSubscriptionAsk     string
+	ConfirmSubscriptionConfirm string
 	// ConfirmPersonal says the link is the reader's alone. ConfirmExpiry is
 	// APPENDED to it when the link has a date, with the date as %s.
 	//

--- a/backend/migrations/core/1789170000_a_grant_names_the_question_it_answered.down.sql
+++ b/backend/migrations/core/1789170000_a_grant_names_the_question_it_answered.down.sql
@@ -1,0 +1,10 @@
+-- Dropping the pinned question. The proof rows that named one keep their
+-- policy_text, which is what they had before and what they fall back to: only
+-- the pointer goes, and consent_text_version_id is nullable, so a row that
+-- named a version simply stops naming one.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE confirm_token
+    DROP COLUMN IF EXISTS question_key,
+    DROP COLUMN IF EXISTS question_locale,
+    DROP COLUMN IF EXISTS question_version;

--- a/backend/migrations/core/1789170000_a_grant_names_the_question_it_answered.up.sql
+++ b/backend/migrations/core/1789170000_a_grant_names_the_question_it_answered.up.sql
@@ -1,0 +1,51 @@
+-- A grant names the question it answered.
+--
+-- consent_event.policy_text is the sentence a proof row quotes as what the
+-- subject agreed to, and on the confirm-link door it came from the SUBMISSION
+-- BODY — whatever the subject's own browser said it had shown them. The
+-- evidence a controller produces to show consent was freely given therefore
+-- quotes a string the client chose, and a client that chose a different one
+-- would be believed. consent_event.consent_text_version_id has existed since
+-- 1788669014 with nothing writing it.
+--
+-- The question is now published server-side (consent/marketingquestion.go), in
+-- every language this build speaks. Binding it means knowing WHICH published
+-- row the subject read, and a published wording is identified by key, version
+-- AND locale.
+--
+-- BOTH GO ON THE TOKEN, because the token is what the subject comes back
+-- holding: the submit has it in hand and no delivery row, and reaching through
+-- comms_outbound would make the proof depend on a row the erasure engine is
+-- entitled to scrub.
+--
+-- THE VERSION IS PINNED AT MINT, not read from the running build when the link
+-- is answered. A link mailed under v1 and clicked after a v2 deploy would
+-- otherwise record the subject agreeing to wording they were never shown —
+-- which is the same defect as quoting the client, arriving from the other side.
+--
+-- NULLABLE, and existing rows stay NULL. A link minted before this was recorded
+-- was answered against a question we did not pin, and choosing one now — the
+-- current version, say — would state as fact something we would be guessing, in
+-- the evidence column this exists to make honest. NULL says we do not know, and
+-- the writer treats it that way: those grants keep exactly the weaker evidence
+-- they already had.
+
+SET LOCAL lock_timeout = '3s';
+
+-- AND WHICH QUESTION, because the two links show different pages. A
+-- record-confirmation link asks the generic marketing question with a yes/no; a
+-- dedicated consent link names the purpose it was minted for. A subject answers
+-- exactly one, and binding either door to the other's sentence would record an
+-- agreement to something nobody was asked.
+ALTER TABLE confirm_token
+    ADD COLUMN question_key text,
+    ADD COLUMN question_locale text,
+    ADD COLUMN question_version integer;
+
+COMMENT ON COLUMN confirm_token.question_key IS
+    'Which published question the confirm page will ask — the generic marketing one, or the dedicated subscription one that names its purpose. NULL on links minted before this was recorded.';
+
+COMMENT ON COLUMN confirm_token.question_locale IS
+    'The language the confirm page will ask its subscription question in, recorded when the link is minted so a grant can name the published wording the subject actually read. NULL on links minted before this was recorded.';
+COMMENT ON COLUMN confirm_token.question_version IS
+    'The version of that question, pinned at mint so a link answered after a redeploy names what the subject saw rather than what is deployed when they click. NULL on links minted before this was recorded.';

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2327,6 +2327,9 @@ public.confirm_token.kind text NOT NULL gen=- def='record_confirmation'::text
 public.confirm_token.opened_at timestamp with time zone gen=- def=-
 public.confirm_token.person_id uuid NOT NULL gen=- def=-
 public.confirm_token.purpose_id uuid gen=- def=-
+public.confirm_token.question_key text gen=- def=-
+public.confirm_token.question_locale text gen=- def=-
+public.confirm_token.question_version integer gen=- def=-
 public.confirm_token.token_hash text NOT NULL gen=- def=-
 public.confirm_token_hash_key CREATE UNIQUE INDEX confirm_token_hash_key ON public.confirm_token USING btree (token_hash)
 public.confirm_token_live_by_kind CREATE INDEX confirm_token_live_by_kind ON public.confirm_token USING btree (person_id, kind, purpose_id) WHERE (consumed_at IS NULL)

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -391,7 +391,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `waiveronoffender_test.go` | H2 | A waiver must be asked about an offender, never about a candidate. |
 | `workflowhandler_test.go` | H2 | The workflow.Handler read/write contract as a fitness function (ports/workflow.Handler): Match is a pure predicate and Plan computes the typed Effect WITHOUT applying it — "this is what makes dry-run and diff preview possible". |
 
-## Claim (13)
+## Claim (14)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -400,6 +400,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `elapsedonespelling_test.go` | H1 | "How many days of silence" is spelled once. |
 | `employmentcurrency_test.go` | H1 | employment.IsCurrentSQL calls itself "the ONE spelling of 'this job is still theirs', and the only definition of a current employment in this product". |
 | `livemember_test.go` | H1 | "Someone who still works here" is `status = 'active' AND archived\_at IS NULL` on app\_user, and TWO functions in two different packages each called themselves the ONE spelling of it while the tree held about twenty copies. |
+| `marketingquestion_test.go` | H2 | The question a grant is bound to is the question the screen asks. |
 | `meetingoverspelling_test.go` | H2 | "This meeting is over" is spelled twice, and the two must say the same thing. |
 | `noisejudgedspelling_test.go` | H2 | "An already-settled answer disowns this contact" is spelled once. |
 | `onedraftwriter_test.go` | H1 | One writer produces every grounded draft, or the surfaces drift. |


### PR DESCRIPTION
`consent_event.policy_text` is the sentence a proof row quotes as what the subject agreed to. On both confirm-link doors it came from the submission body, meaning whatever the subject's own browser said it had shown them. The evidence a controller produces to show consent was freely given therefore quoted a string the client chose, and a client that chose a different one would be believed.

`consent_event.consent_text_version_id` has existed since an earlier migration with nothing writing it.

## Why binding the mail was not the fix

An earlier attempt bound the invitation email's body and was reverted. The mail says confirming turns a request into a permission. The page asks something else, and the subject agrees to that. A proof naming the mail would be published, checkable and server-controlled, and about the wrong proposition, which is worse than an unchecked quote of the right one.

So the page's own question moved server-side, into the three-language catalog beside the mail wording, and is published as its own text-version key.

## Two pages, two questions

A record-confirmation link asks about frequency with a yes/no. A dedicated subscription link names the purpose it was minted for and offers one affirmative button. These are different propositions and a subject answers exactly one, so there are two published keys and the link kind decides which is pinned.

Binding either door to the other's sentence is the same defect as quoting the client. The first review round caught me doing exactly that on the subscription door, and the test I had written asserted only that a version id existed, so it passed.

The key, locale and version are pinned at mint, so a link mailed under one version and clicked after a redeploy names what the subject saw.

The published subscription question keeps its `{purpose}` placeholder, because one row serves every purpose. The proof records the sentence with the purpose's own label substituted in, because the subject's export carries the purpose key rather than its label, and a hole in the sentence is a hole nobody can fill.

## What the pin does not settle, written in the code

The page still renders its own copy rather than fetching the published row. It picks its language from the browser while the pin records the mail's, and a frontend redeploy between minting and clicking changes what is shown. Both are narrower than the client-supplied string they replace, and a new gate keeps the two catalogs in step so the second needs a deliberate edit to arise.

## Publishing on every boot

An upgraded installation skips workspace seeding entirely, so it would have pinned versions nothing had published. Publishing now runs on every start. It is idempotent, and refuses when a version's words changed without a version bump, so an unversioned edit fails the boot rather than quietly serving one thing while past proofs name another.

## Review

Two Codex rounds. The first found I had repeated the reverted mistake on the subscription door. The second found my every-boot publish broke boot on exactly the installations it was for: publishing writes an audit row, and boot had no actor bound, so the API would exit on every restart. A fresh install hid it because seeding publishes first.

The repo's own uniqueness-claim gate then caught a comment of mine claiming the pin and the page "cannot disagree", which the review had just shown was not true.

Every behaviour is pinned by a test that fails without it.

`make check-backend` green, plus the consent, privacy and full compose integration lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consent proofs no longer quote the client's sentence. Both confirm-link doors recorded `consent_event.policy_text` from the submission body — whatever the subject's browser said it had shown — so the evidence named a string the client chose; now the question the page asks is published server-side, pinned to the link at mint, and the proof names that published row.

**Pinning behavior**

- Two doors ask different questions (generic marketing yes/no vs. purpose-named subscription), so there are two published keys, chosen by link kind.
- Key, locale, and version are pinned at mint; the subscription proof substitutes `{purpose}` with the purpose's label while the published row keeps it.
- Publishing now runs on every boot because upgraded installations skip workspace seeding; it refuses unversioned wording edits and binds a system principal for its audit row.
- Links minted before the pin keep the fallback: the client's sentence, with no version id.
- A new gate (`marketingquestion_test.go`) compares the published wording against the frontend's screen strings so the two cannot drift.

<sup>Written for commit e16842ef38ff7ceda890afecabda7a621aa2150a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized marketing and subscription consent questions with distinct confirmation wording.
  - Consent links now preserve the exact question language and version shown to recipients.
  - Consent records now reference the published wording used, including the applicable purpose label.
  - Published consent wording is refreshed automatically during application startup.
- **Bug Fixes**
  - Consent records no longer rely solely on client-provided wording when a published version is available.
  - Older links without published question metadata continue to record their provided wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->