### PR TITLE
Contract payment terms, and contracts carry custom fields

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31728,6 +31728,8 @@ components:
     # ---- Project ----
     Contract:
       type: object
+      additionalProperties: true
+      x-extension: true
       description: |
         An agreement between the installation and one company. Mirrors the
         `contract` table. Carries no owner: visibility is inherited from the linked
@@ -31798,6 +31800,12 @@ components:
           type: [integer, 'null']
           minimum: 0
           description: Drives the renewal warning, which fires against the notice deadline rather than the renewal date (CONTRACT-FORM-3).
+        payment_term_days:
+          type: [integer, 'null']
+          minimum: 0
+          description: >-
+            How many days the customer has to pay. Zero is a real value and means due on
+            receipt; absent means nobody has recorded terms, which is not the same thing.
         status:
           type: string
           enum: [draft, active, expired, cancelled, superseded]
@@ -31848,6 +31856,8 @@ components:
 
     CreateContractRequest:
       type: object
+      additionalProperties: true
+      x-extension: true
       required: [company_id, title]
       properties:
         company_id: { type: string, format: uuid }
@@ -31863,10 +31873,13 @@ components:
         renewal_on: { type: [string, 'null'], format: date }
         auto_renew: { type: boolean, default: false }
         notice_period_days: { type: [integer, 'null'], minimum: 0 }
+        payment_term_days: { type: [integer, 'null'], minimum: 0 }
         signed_on: { type: [string, 'null'], format: date }
 
     UpdateContractRequest:
       type: object
+      additionalProperties: true
+      x-extension: true
       description: 'Partial. Status is absent by design — it moves through changeContractStatus.'
       properties:
         deal_id: { type: [string, 'null'], format: uuid }
@@ -31881,6 +31894,7 @@ components:
         renewal_on: { type: [string, 'null'], format: date }
         auto_renew: { type: boolean }
         notice_period_days: { type: [integer, 'null'], minimum: 0 }
+        payment_term_days: { type: [integer, 'null'], minimum: 0 }
         signed_on: { type: [string, 'null'], format: date }
 
     ChangeContractStatusRequest:
@@ -31904,6 +31918,8 @@ components:
 
     RenewContractRequest:
       type: object
+      additionalProperties: true
+      x-extension: true
       required: [title, value_basis]
       description: |
         The successor's terms. It freezes its own rate and inherits none — the counterparty
@@ -31930,6 +31946,7 @@ components:
         renewal_on: { type: [string, 'null'], format: date }
         auto_renew: { type: boolean, default: false }
         notice_period_days: { type: [integer, 'null'], minimum: 0 }
+        payment_term_days: { type: [integer, 'null'], minimum: 0 }
         signed_on: { type: [string, 'null'], format: date }
 
     Project:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -14246,7 +14246,7 @@ paths:
         - name: object
           in: query
           required: true
-          schema: { type: string, enum: [contact, company, deal, lead, project] }
+          schema: { type: string, enum: [contact, company, deal, lead, project, contract] }
           description: Target core object (CUSTOM-FIELDS-PARAM-2).
         - name: status
           in: query
@@ -38188,7 +38188,7 @@ components:
         id: { type: string, format: uuid }
         object:
           type: string
-          enum: [contact, company, deal, lead, project]
+          enum: [contact, company, deal, lead, project, contract]
           description: The existing core object this field is added to (CUSTOM-FIELDS-PARAM-2).
         label: { type: string, description: Display label; the only thing a rename updates. }
         slug: { type: string, description: Admin-facing key the column_name derives from. }
@@ -38246,7 +38246,7 @@ components:
       properties:
         object:
           type: string
-          enum: [contact, company, deal, lead, project]
+          enum: [contact, company, deal, lead, project, contract]
         label: { type: string }
         type:
           type: string

--- a/backend/gates/enumsync_test.go
+++ b/backend/gates/enumsync_test.go
@@ -63,7 +63,12 @@ var enumBindings = map[string]struct{ pkgDir, typeName string }{
 	"attachment.entity_type":       {"internal/shared/ports/datasource", "EntityType"},
 	"embedding.entity_type":        {"internal/shared/ports/datasource", "EntityType"},
 	"field_provenance.object_type": {"internal/shared/ports/datasource", "EntityType"},
-	"custom_field.object":          {"internal/shared/ports/datasource", "EntityType"},
+	// NOT EntityType, and this is the one binding where the difference is the
+	// point. A custom field hangs off a TARGET; an EntityType is something a
+	// record provider can be asked about. Contract is the first member that is
+	// the former without being the latter, so the CHECK mirrors
+	// fieldcatalog.Target and the gate compares it against that.
+	"custom_field.object": {"internal/shared/ports/fieldcatalog", "Target"},
 }
 
 // checkInList captures CHECK (col IN ('a','b',…)) allowing an optional

--- a/backend/internal/compose/handlersets.go
+++ b/backend/internal/compose/handlersets.go
@@ -173,7 +173,8 @@ func (s *Server) wireProject360(pool *pgxpool.Pool) {
 		deals.NewStore(InstallationDB(pool), DealsInstallation()).WithFieldCatalog(customfields.NewService(pool, nil)),
 		ProjectsStore(pool),
 		s.contactsStore,
-		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)),
+		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)).
+			WithFieldCatalog(customfields.NewService(pool, nil)),
 		activities.NewStore(InstallationDB(pool)),
 		time.Now,
 	)

--- a/backend/internal/compose/project360seam.go
+++ b/backend/internal/compose/project360seam.go
@@ -33,7 +33,7 @@ func project360Reader(pool *pgxpool.Pool) agents.Project360Reader {
 		deals.NewStore(InstallationDB(pool), DealsInstallation()).WithFieldCatalog(catalog),
 		ProjectsStore(pool),
 		contacts.NewStore(InstallationDB(pool)).WithFieldCatalog(catalog),
-		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)),
+		contracts.NewStore(InstallationDB(pool), ContractFreezeRate(pool)).WithFieldCatalog(catalog),
 		activities.NewStore(InstallationDB(pool)),
 		clockNow,
 	)

--- a/backend/internal/compose/renewalobjectparity_test.go
+++ b/backend/internal/compose/renewalobjectparity_test.go
@@ -14,7 +14,6 @@ package compose
 // their own cross-module vocabularies).
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/modules/automation"
@@ -24,16 +23,44 @@ import (
 func TestRenewalReminderObjectsMatchesFieldObjectsExactly(t *testing.T) {
 	renewal := append([]string(nil), automation.RenewalReminderObjects()...)
 	fields := append([]string(nil), customfields.FieldObjects...)
-	sort.Strings(renewal)
-	sort.Strings(fields)
 
-	if len(renewal) != len(fields) {
-		t.Fatalf("automation.RenewalReminderObjects() has %d entries, customfields.FieldObjects has %d — they must name the identical closed set",
-			len(renewal), len(fields))
+	// The two sets were identical until Contract, which takes custom fields
+	// without being anything an automation can fire on: the record provider
+	// refuses it and the preview's scope clause does not know its table. So the
+	// relation is SUBSET, not equality, and every difference is named here —
+	// an unnamed one is the drift this test exists to catch.
+	notAutomatable := map[string]string{
+		"contract": "a custom-field target that no automation can fire on: " +
+			"taskeffect's owner read answers UnsupportedEntityError for it, and " +
+			"automations_preview's auth.ScopeClauseFor does not know the table",
 	}
-	for i := range renewal {
-		if renewal[i] != fields[i] {
-			t.Fatalf("automation.RenewalReminderObjects() and customfields.FieldObjects diverge: %v vs %v", renewal, fields)
+
+	inFields := map[string]bool{}
+	for _, object := range fields {
+		inFields[object] = true
+	}
+	for _, object := range renewal {
+		if !inFields[object] {
+			t.Errorf("automation.RenewalReminderObjects() names %q, which is not a custom-field object — "+
+				"a reminder on a date field nobody can create", object)
+		}
+	}
+	inRenewal := map[string]bool{}
+	for _, object := range renewal {
+		inRenewal[object] = true
+	}
+	for _, object := range fields {
+		if inRenewal[object] {
+			continue
+		}
+		if _, named := notAutomatable[object]; !named {
+			t.Errorf("customfields.FieldObjects names %q and automation does not, with no reason given — "+
+				"either add it to RenewalReminderObjects or name it in notAutomatable with what refuses it", object)
+		}
+	}
+	for object := range notAutomatable {
+		if !inFields[object] {
+			t.Errorf("notAutomatable names %q, which is not a custom-field object at all — the exception outlived its subject", object)
 		}
 	}
 }

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -128,13 +128,14 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// Built here rather than behind an option: an endpoint's own request
 		// rate is not a feature a deployment opts into, and every role that
 		// serves /v1 comes through this constructor.
-		httpMetrics:         httpserver.NewHTTPMetrics(),
-		uploadLimits:        limits,
-		authHandlers:        authH,
-		contactsHandlers:    newContactsHandlers(pool).WithUploadLimit(limits.LinkedInImport),
-		dealsHandlers:       dealsH,
-		projectsHandlers:    projects.HandlersOver(ProjectsStore(pool)),
-		contractsHandlers:   contracts.NewHandlers(InstallationDB(pool), ContractFreezeRate(pool)),
+		httpMetrics:      httpserver.NewHTTPMetrics(),
+		uploadLimits:     limits,
+		authHandlers:     authH,
+		contactsHandlers: newContactsHandlers(pool).WithUploadLimit(limits.LinkedInImport),
+		dealsHandlers:    dealsH,
+		projectsHandlers: projects.HandlersOver(ProjectsStore(pool)),
+		contractsHandlers: contracts.NewHandlers(InstallationDB(pool), ContractFreezeRate(pool)).
+			WithFieldCatalog(customfields.NewService(pool, nil)),
 		dealroomsHandlers:   dealrooms.NewHandlers(InstallationDB(pool)),
 		commissionsHandlers: commissions.NewHandlers(InstallationDB(pool)),
 		activitiesHandlers:  newActivitiesHandlers(pool).WithUploadLimit(limits.Attachment),

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -25219,6 +25219,9 @@ type Contract struct {
 	// NoticePeriodDays Drives the renewal warning, which fires against the notice deadline rather than the renewal date (CONTRACT-FORM-3).
 	NoticePeriodDays *int `json:"notice_period_days,omitempty"`
 
+	// PaymentTermDays How many days the customer has to pay. Zero is a real value and means due on receipt; absent means nobody has recorded terms, which is not the same thing.
+	PaymentTermDays *int `json:"payment_term_days,omitempty"`
+
 	// ProjectId The delivery this agreement funds, when one is attached. Null for no project and for a project the reader may not open; `masked_fields` names it only in the second case.
 	ProjectId *openapi_types.UUID `json:"project_id,omitempty"`
 	RenewalOn *openapi_types.Date `json:"renewal_on,omitempty"`
@@ -25249,8 +25252,9 @@ type Contract struct {
 	ValueBasis ContractValueBasis `json:"value_basis"`
 
 	// ValueMinor Total contract value in minor units, or twelve months of billing when `value_basis` is `annualized_12m`. Present exactly when `currency` is.
-	ValueMinor *int64 `json:"value_minor,omitempty"`
-	Version    *int64 `json:"version,omitempty"`
+	ValueMinor           *int64                 `json:"value_minor,omitempty"`
+	Version              *int64                 `json:"version,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
 // ContractStatus Read-only here — asserted through changeContractStatus so the transition, its event and any proposal are written from one transaction.
@@ -25545,20 +25549,22 @@ type CreateContactRequest struct {
 
 // CreateContractRequest defines model for CreateContractRequest.
 type CreateContractRequest struct {
-	AutoRenew        *bool                            `json:"auto_renew,omitempty"`
-	CompanyId        openapi_types.UUID               `json:"company_id"`
-	ContractNumber   *string                          `json:"contract_number,omitempty"`
-	Currency         *string                          `json:"currency,omitempty"`
-	DealId           *openapi_types.UUID              `json:"deal_id,omitempty"`
-	EndsOn           *openapi_types.Date              `json:"ends_on,omitempty"`
-	NoticePeriodDays *int                             `json:"notice_period_days,omitempty"`
-	ProjectId        *openapi_types.UUID              `json:"project_id,omitempty"`
-	RenewalOn        *openapi_types.Date              `json:"renewal_on,omitempty"`
-	SignedOn         *openapi_types.Date              `json:"signed_on,omitempty"`
-	StartsOn         *openapi_types.Date              `json:"starts_on,omitempty"`
-	Title            string                           `json:"title"`
-	ValueBasis       *CreateContractRequestValueBasis `json:"value_basis,omitempty"`
-	ValueMinor       *int64                           `json:"value_minor,omitempty"`
+	AutoRenew            *bool                            `json:"auto_renew,omitempty"`
+	CompanyId            openapi_types.UUID               `json:"company_id"`
+	ContractNumber       *string                          `json:"contract_number,omitempty"`
+	Currency             *string                          `json:"currency,omitempty"`
+	DealId               *openapi_types.UUID              `json:"deal_id,omitempty"`
+	EndsOn               *openapi_types.Date              `json:"ends_on,omitempty"`
+	NoticePeriodDays     *int                             `json:"notice_period_days,omitempty"`
+	PaymentTermDays      *int                             `json:"payment_term_days,omitempty"`
+	ProjectId            *openapi_types.UUID              `json:"project_id,omitempty"`
+	RenewalOn            *openapi_types.Date              `json:"renewal_on,omitempty"`
+	SignedOn             *openapi_types.Date              `json:"signed_on,omitempty"`
+	StartsOn             *openapi_types.Date              `json:"starts_on,omitempty"`
+	Title                string                           `json:"title"`
+	ValueBasis           *CreateContractRequestValueBasis `json:"value_basis,omitempty"`
+	ValueMinor           *int64                           `json:"value_minor,omitempty"`
+	AdditionalProperties map[string]interface{}           `json:"-"`
 }
 
 // CreateContractRequestValueBasis defines model for CreateContractRequest.ValueBasis.
@@ -33179,6 +33185,7 @@ type RenewContractRequest struct {
 	DealId           *openapi_types.UUID `json:"deal_id,omitempty"`
 	EndsOn           *openapi_types.Date `json:"ends_on,omitempty"`
 	NoticePeriodDays *int                `json:"notice_period_days,omitempty"`
+	PaymentTermDays  *int                `json:"payment_term_days,omitempty"`
 	ProjectId        *openapi_types.UUID `json:"project_id,omitempty"`
 	RenewalOn        *openapi_types.Date `json:"renewal_on,omitempty"`
 	SignedOn         *openapi_types.Date `json:"signed_on,omitempty"`
@@ -33186,8 +33193,9 @@ type RenewContractRequest struct {
 	Title            string              `json:"title"`
 
 	// ValueBasis Stated explicitly rather than inherited: an open-ended agreement becoming a fixed term changes what its value measures.
-	ValueBasis RenewContractRequestValueBasis `json:"value_basis"`
-	ValueMinor *int64                         `json:"value_minor,omitempty"`
+	ValueBasis           RenewContractRequestValueBasis `json:"value_basis"`
+	ValueMinor           *int64                         `json:"value_minor,omitempty"`
+	AdditionalProperties map[string]interface{}         `json:"-"`
 }
 
 // RenewContractRequestValueBasis Stated explicitly rather than inherited: an open-ended agreement becoming a fixed term changes what its value measures.
@@ -36033,19 +36041,21 @@ type UpdateContactRequestVisibility string
 
 // UpdateContractRequest Partial. Status is absent by design — it moves through changeContractStatus.
 type UpdateContractRequest struct {
-	AutoRenew        *bool                            `json:"auto_renew,omitempty"`
-	ContractNumber   *string                          `json:"contract_number,omitempty"`
-	Currency         *string                          `json:"currency,omitempty"`
-	DealId           *openapi_types.UUID              `json:"deal_id,omitempty"`
-	EndsOn           *openapi_types.Date              `json:"ends_on,omitempty"`
-	NoticePeriodDays *int                             `json:"notice_period_days,omitempty"`
-	ProjectId        *openapi_types.UUID              `json:"project_id,omitempty"`
-	RenewalOn        *openapi_types.Date              `json:"renewal_on,omitempty"`
-	SignedOn         *openapi_types.Date              `json:"signed_on,omitempty"`
-	StartsOn         *openapi_types.Date              `json:"starts_on,omitempty"`
-	Title            *string                          `json:"title,omitempty"`
-	ValueBasis       *UpdateContractRequestValueBasis `json:"value_basis,omitempty"`
-	ValueMinor       *int64                           `json:"value_minor,omitempty"`
+	AutoRenew            *bool                            `json:"auto_renew,omitempty"`
+	ContractNumber       *string                          `json:"contract_number,omitempty"`
+	Currency             *string                          `json:"currency,omitempty"`
+	DealId               *openapi_types.UUID              `json:"deal_id,omitempty"`
+	EndsOn               *openapi_types.Date              `json:"ends_on,omitempty"`
+	NoticePeriodDays     *int                             `json:"notice_period_days,omitempty"`
+	PaymentTermDays      *int                             `json:"payment_term_days,omitempty"`
+	ProjectId            *openapi_types.UUID              `json:"project_id,omitempty"`
+	RenewalOn            *openapi_types.Date              `json:"renewal_on,omitempty"`
+	SignedOn             *openapi_types.Date              `json:"signed_on,omitempty"`
+	StartsOn             *openapi_types.Date              `json:"starts_on,omitempty"`
+	Title                *string                          `json:"title,omitempty"`
+	ValueBasis           *UpdateContractRequestValueBasis `json:"value_basis,omitempty"`
+	ValueMinor           *int64                           `json:"value_minor,omitempty"`
+	AdditionalProperties map[string]interface{}           `json:"-"`
 }
 
 // UpdateContractRequestValueBasis defines model for UpdateContractRequest.ValueBasis.
@@ -45991,6 +46001,489 @@ func (a Contact) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
+// Getter for additional properties for Contract. Returns the specified
+// element and whether it was found
+func (a Contract) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for Contract
+func (a *Contract) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for Contract to handle AdditionalProperties
+func (a *Contract) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["archived_at"]; found {
+		err = json.Unmarshal(raw, &a.ArchivedAt)
+		if err != nil {
+			return fmt.Errorf("error reading 'archived_at': %w", err)
+		}
+		delete(object, "archived_at")
+	}
+
+	if raw, found := object["auto_renew"]; found {
+		err = json.Unmarshal(raw, &a.AutoRenew)
+		if err != nil {
+			return fmt.Errorf("error reading 'auto_renew': %w", err)
+		}
+		delete(object, "auto_renew")
+	}
+
+	if raw, found := object["cancellation_effective_on"]; found {
+		err = json.Unmarshal(raw, &a.CancellationEffectiveOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'cancellation_effective_on': %w", err)
+		}
+		delete(object, "cancellation_effective_on")
+	}
+
+	if raw, found := object["cancellation_notice_on"]; found {
+		err = json.Unmarshal(raw, &a.CancellationNoticeOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'cancellation_notice_on': %w", err)
+		}
+		delete(object, "cancellation_notice_on")
+	}
+
+	if raw, found := object["captured_by"]; found {
+		err = json.Unmarshal(raw, &a.CapturedBy)
+		if err != nil {
+			return fmt.Errorf("error reading 'captured_by': %w", err)
+		}
+		delete(object, "captured_by")
+	}
+
+	if raw, found := object["company_id"]; found {
+		err = json.Unmarshal(raw, &a.CompanyId)
+		if err != nil {
+			return fmt.Errorf("error reading 'company_id': %w", err)
+		}
+		delete(object, "company_id")
+	}
+
+	if raw, found := object["contract_number"]; found {
+		err = json.Unmarshal(raw, &a.ContractNumber)
+		if err != nil {
+			return fmt.Errorf("error reading 'contract_number': %w", err)
+		}
+		delete(object, "contract_number")
+	}
+
+	if raw, found := object["created_at"]; found {
+		err = json.Unmarshal(raw, &a.CreatedAt)
+		if err != nil {
+			return fmt.Errorf("error reading 'created_at': %w", err)
+		}
+		delete(object, "created_at")
+	}
+
+	if raw, found := object["currency"]; found {
+		err = json.Unmarshal(raw, &a.Currency)
+		if err != nil {
+			return fmt.Errorf("error reading 'currency': %w", err)
+		}
+		delete(object, "currency")
+	}
+
+	if raw, found := object["deal_id"]; found {
+		err = json.Unmarshal(raw, &a.DealId)
+		if err != nil {
+			return fmt.Errorf("error reading 'deal_id': %w", err)
+		}
+		delete(object, "deal_id")
+	}
+
+	if raw, found := object["ends_on"]; found {
+		err = json.Unmarshal(raw, &a.EndsOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'ends_on': %w", err)
+		}
+		delete(object, "ends_on")
+	}
+
+	if raw, found := object["fx_rate_date"]; found {
+		err = json.Unmarshal(raw, &a.FxRateDate)
+		if err != nil {
+			return fmt.Errorf("error reading 'fx_rate_date': %w", err)
+		}
+		delete(object, "fx_rate_date")
+	}
+
+	if raw, found := object["fx_rate_to_base"]; found {
+		err = json.Unmarshal(raw, &a.FxRateToBase)
+		if err != nil {
+			return fmt.Errorf("error reading 'fx_rate_to_base': %w", err)
+		}
+		delete(object, "fx_rate_to_base")
+	}
+
+	if raw, found := object["id"]; found {
+		err = json.Unmarshal(raw, &a.Id)
+		if err != nil {
+			return fmt.Errorf("error reading 'id': %w", err)
+		}
+		delete(object, "id")
+	}
+
+	if raw, found := object["masked_fields"]; found {
+		err = json.Unmarshal(raw, &a.MaskedFields)
+		if err != nil {
+			return fmt.Errorf("error reading 'masked_fields': %w", err)
+		}
+		delete(object, "masked_fields")
+	}
+
+	if raw, found := object["notice_period_days"]; found {
+		err = json.Unmarshal(raw, &a.NoticePeriodDays)
+		if err != nil {
+			return fmt.Errorf("error reading 'notice_period_days': %w", err)
+		}
+		delete(object, "notice_period_days")
+	}
+
+	if raw, found := object["payment_term_days"]; found {
+		err = json.Unmarshal(raw, &a.PaymentTermDays)
+		if err != nil {
+			return fmt.Errorf("error reading 'payment_term_days': %w", err)
+		}
+		delete(object, "payment_term_days")
+	}
+
+	if raw, found := object["project_id"]; found {
+		err = json.Unmarshal(raw, &a.ProjectId)
+		if err != nil {
+			return fmt.Errorf("error reading 'project_id': %w", err)
+		}
+		delete(object, "project_id")
+	}
+
+	if raw, found := object["renewal_on"]; found {
+		err = json.Unmarshal(raw, &a.RenewalOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'renewal_on': %w", err)
+		}
+		delete(object, "renewal_on")
+	}
+
+	if raw, found := object["signed_on"]; found {
+		err = json.Unmarshal(raw, &a.SignedOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'signed_on': %w", err)
+		}
+		delete(object, "signed_on")
+	}
+
+	if raw, found := object["source"]; found {
+		err = json.Unmarshal(raw, &a.Source)
+		if err != nil {
+			return fmt.Errorf("error reading 'source': %w", err)
+		}
+		delete(object, "source")
+	}
+
+	if raw, found := object["starts_on"]; found {
+		err = json.Unmarshal(raw, &a.StartsOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'starts_on': %w", err)
+		}
+		delete(object, "starts_on")
+	}
+
+	if raw, found := object["status"]; found {
+		err = json.Unmarshal(raw, &a.Status)
+		if err != nil {
+			return fmt.Errorf("error reading 'status': %w", err)
+		}
+		delete(object, "status")
+	}
+
+	if raw, found := object["superseded_by_id"]; found {
+		err = json.Unmarshal(raw, &a.SupersededById)
+		if err != nil {
+			return fmt.Errorf("error reading 'superseded_by_id': %w", err)
+		}
+		delete(object, "superseded_by_id")
+	}
+
+	if raw, found := object["title"]; found {
+		err = json.Unmarshal(raw, &a.Title)
+		if err != nil {
+			return fmt.Errorf("error reading 'title': %w", err)
+		}
+		delete(object, "title")
+	}
+
+	if raw, found := object["under_contract"]; found {
+		err = json.Unmarshal(raw, &a.UnderContract)
+		if err != nil {
+			return fmt.Errorf("error reading 'under_contract': %w", err)
+		}
+		delete(object, "under_contract")
+	}
+
+	if raw, found := object["updated_at"]; found {
+		err = json.Unmarshal(raw, &a.UpdatedAt)
+		if err != nil {
+			return fmt.Errorf("error reading 'updated_at': %w", err)
+		}
+		delete(object, "updated_at")
+	}
+
+	if raw, found := object["value_basis"]; found {
+		err = json.Unmarshal(raw, &a.ValueBasis)
+		if err != nil {
+			return fmt.Errorf("error reading 'value_basis': %w", err)
+		}
+		delete(object, "value_basis")
+	}
+
+	if raw, found := object["value_minor"]; found {
+		err = json.Unmarshal(raw, &a.ValueMinor)
+		if err != nil {
+			return fmt.Errorf("error reading 'value_minor': %w", err)
+		}
+		delete(object, "value_minor")
+	}
+
+	if raw, found := object["version"]; found {
+		err = json.Unmarshal(raw, &a.Version)
+		if err != nil {
+			return fmt.Errorf("error reading 'version': %w", err)
+		}
+		delete(object, "version")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for Contract to handle AdditionalProperties
+func (a Contract) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.ArchivedAt != nil {
+		object["archived_at"], err = json.Marshal(a.ArchivedAt)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'archived_at': %w", err)
+		}
+	}
+
+	if a.AutoRenew != nil {
+		object["auto_renew"], err = json.Marshal(a.AutoRenew)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'auto_renew': %w", err)
+		}
+	}
+
+	if a.CancellationEffectiveOn != nil {
+		object["cancellation_effective_on"], err = json.Marshal(a.CancellationEffectiveOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'cancellation_effective_on': %w", err)
+		}
+	}
+
+	if a.CancellationNoticeOn != nil {
+		object["cancellation_notice_on"], err = json.Marshal(a.CancellationNoticeOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'cancellation_notice_on': %w", err)
+		}
+	}
+
+	object["captured_by"], err = json.Marshal(a.CapturedBy)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'captured_by': %w", err)
+	}
+
+	if a.CompanyId != nil {
+		object["company_id"], err = json.Marshal(a.CompanyId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'company_id': %w", err)
+		}
+	}
+
+	if a.ContractNumber != nil {
+		object["contract_number"], err = json.Marshal(a.ContractNumber)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'contract_number': %w", err)
+		}
+	}
+
+	object["created_at"], err = json.Marshal(a.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'created_at': %w", err)
+	}
+
+	if a.Currency != nil {
+		object["currency"], err = json.Marshal(a.Currency)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'currency': %w", err)
+		}
+	}
+
+	if a.DealId != nil {
+		object["deal_id"], err = json.Marshal(a.DealId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'deal_id': %w", err)
+		}
+	}
+
+	if a.EndsOn != nil {
+		object["ends_on"], err = json.Marshal(a.EndsOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'ends_on': %w", err)
+		}
+	}
+
+	if a.FxRateDate != nil {
+		object["fx_rate_date"], err = json.Marshal(a.FxRateDate)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'fx_rate_date': %w", err)
+		}
+	}
+
+	if a.FxRateToBase != nil {
+		object["fx_rate_to_base"], err = json.Marshal(a.FxRateToBase)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'fx_rate_to_base': %w", err)
+		}
+	}
+
+	object["id"], err = json.Marshal(a.Id)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'id': %w", err)
+	}
+
+	if a.MaskedFields != nil {
+		object["masked_fields"], err = json.Marshal(a.MaskedFields)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'masked_fields': %w", err)
+		}
+	}
+
+	if a.NoticePeriodDays != nil {
+		object["notice_period_days"], err = json.Marshal(a.NoticePeriodDays)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'notice_period_days': %w", err)
+		}
+	}
+
+	if a.PaymentTermDays != nil {
+		object["payment_term_days"], err = json.Marshal(a.PaymentTermDays)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'payment_term_days': %w", err)
+		}
+	}
+
+	if a.ProjectId != nil {
+		object["project_id"], err = json.Marshal(a.ProjectId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'project_id': %w", err)
+		}
+	}
+
+	if a.RenewalOn != nil {
+		object["renewal_on"], err = json.Marshal(a.RenewalOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'renewal_on': %w", err)
+		}
+	}
+
+	if a.SignedOn != nil {
+		object["signed_on"], err = json.Marshal(a.SignedOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'signed_on': %w", err)
+		}
+	}
+
+	object["source"], err = json.Marshal(a.Source)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'source': %w", err)
+	}
+
+	if a.StartsOn != nil {
+		object["starts_on"], err = json.Marshal(a.StartsOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'starts_on': %w", err)
+		}
+	}
+
+	object["status"], err = json.Marshal(a.Status)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'status': %w", err)
+	}
+
+	if a.SupersededById != nil {
+		object["superseded_by_id"], err = json.Marshal(a.SupersededById)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'superseded_by_id': %w", err)
+		}
+	}
+
+	object["title"], err = json.Marshal(a.Title)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'title': %w", err)
+	}
+
+	object["under_contract"], err = json.Marshal(a.UnderContract)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'under_contract': %w", err)
+	}
+
+	object["updated_at"], err = json.Marshal(a.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'updated_at': %w", err)
+	}
+
+	object["value_basis"], err = json.Marshal(a.ValueBasis)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'value_basis': %w", err)
+	}
+
+	if a.ValueMinor != nil {
+		object["value_minor"], err = json.Marshal(a.ValueMinor)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'value_minor': %w", err)
+		}
+	}
+
+	object["version"], err = json.Marshal(a.Version)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'version': %w", err)
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
 // Getter for additional properties for CreateCompanyRequest. Returns the specified
 // element and whether it was found
 func (a CreateCompanyRequest) Get(fieldName string) (value interface{}, found bool) {
@@ -46377,6 +46870,280 @@ func (a CreateContactRequest) MarshalJSON() ([]byte, error) {
 		object["title"], err = json.Marshal(a.Title)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'title': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for CreateContractRequest. Returns the specified
+// element and whether it was found
+func (a CreateContractRequest) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for CreateContractRequest
+func (a *CreateContractRequest) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for CreateContractRequest to handle AdditionalProperties
+func (a *CreateContractRequest) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["auto_renew"]; found {
+		err = json.Unmarshal(raw, &a.AutoRenew)
+		if err != nil {
+			return fmt.Errorf("error reading 'auto_renew': %w", err)
+		}
+		delete(object, "auto_renew")
+	}
+
+	if raw, found := object["company_id"]; found {
+		err = json.Unmarshal(raw, &a.CompanyId)
+		if err != nil {
+			return fmt.Errorf("error reading 'company_id': %w", err)
+		}
+		delete(object, "company_id")
+	}
+
+	if raw, found := object["contract_number"]; found {
+		err = json.Unmarshal(raw, &a.ContractNumber)
+		if err != nil {
+			return fmt.Errorf("error reading 'contract_number': %w", err)
+		}
+		delete(object, "contract_number")
+	}
+
+	if raw, found := object["currency"]; found {
+		err = json.Unmarshal(raw, &a.Currency)
+		if err != nil {
+			return fmt.Errorf("error reading 'currency': %w", err)
+		}
+		delete(object, "currency")
+	}
+
+	if raw, found := object["deal_id"]; found {
+		err = json.Unmarshal(raw, &a.DealId)
+		if err != nil {
+			return fmt.Errorf("error reading 'deal_id': %w", err)
+		}
+		delete(object, "deal_id")
+	}
+
+	if raw, found := object["ends_on"]; found {
+		err = json.Unmarshal(raw, &a.EndsOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'ends_on': %w", err)
+		}
+		delete(object, "ends_on")
+	}
+
+	if raw, found := object["notice_period_days"]; found {
+		err = json.Unmarshal(raw, &a.NoticePeriodDays)
+		if err != nil {
+			return fmt.Errorf("error reading 'notice_period_days': %w", err)
+		}
+		delete(object, "notice_period_days")
+	}
+
+	if raw, found := object["payment_term_days"]; found {
+		err = json.Unmarshal(raw, &a.PaymentTermDays)
+		if err != nil {
+			return fmt.Errorf("error reading 'payment_term_days': %w", err)
+		}
+		delete(object, "payment_term_days")
+	}
+
+	if raw, found := object["project_id"]; found {
+		err = json.Unmarshal(raw, &a.ProjectId)
+		if err != nil {
+			return fmt.Errorf("error reading 'project_id': %w", err)
+		}
+		delete(object, "project_id")
+	}
+
+	if raw, found := object["renewal_on"]; found {
+		err = json.Unmarshal(raw, &a.RenewalOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'renewal_on': %w", err)
+		}
+		delete(object, "renewal_on")
+	}
+
+	if raw, found := object["signed_on"]; found {
+		err = json.Unmarshal(raw, &a.SignedOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'signed_on': %w", err)
+		}
+		delete(object, "signed_on")
+	}
+
+	if raw, found := object["starts_on"]; found {
+		err = json.Unmarshal(raw, &a.StartsOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'starts_on': %w", err)
+		}
+		delete(object, "starts_on")
+	}
+
+	if raw, found := object["title"]; found {
+		err = json.Unmarshal(raw, &a.Title)
+		if err != nil {
+			return fmt.Errorf("error reading 'title': %w", err)
+		}
+		delete(object, "title")
+	}
+
+	if raw, found := object["value_basis"]; found {
+		err = json.Unmarshal(raw, &a.ValueBasis)
+		if err != nil {
+			return fmt.Errorf("error reading 'value_basis': %w", err)
+		}
+		delete(object, "value_basis")
+	}
+
+	if raw, found := object["value_minor"]; found {
+		err = json.Unmarshal(raw, &a.ValueMinor)
+		if err != nil {
+			return fmt.Errorf("error reading 'value_minor': %w", err)
+		}
+		delete(object, "value_minor")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for CreateContractRequest to handle AdditionalProperties
+func (a CreateContractRequest) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.AutoRenew != nil {
+		object["auto_renew"], err = json.Marshal(a.AutoRenew)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'auto_renew': %w", err)
+		}
+	}
+
+	object["company_id"], err = json.Marshal(a.CompanyId)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'company_id': %w", err)
+	}
+
+	if a.ContractNumber != nil {
+		object["contract_number"], err = json.Marshal(a.ContractNumber)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'contract_number': %w", err)
+		}
+	}
+
+	if a.Currency != nil {
+		object["currency"], err = json.Marshal(a.Currency)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'currency': %w", err)
+		}
+	}
+
+	if a.DealId != nil {
+		object["deal_id"], err = json.Marshal(a.DealId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'deal_id': %w", err)
+		}
+	}
+
+	if a.EndsOn != nil {
+		object["ends_on"], err = json.Marshal(a.EndsOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'ends_on': %w", err)
+		}
+	}
+
+	if a.NoticePeriodDays != nil {
+		object["notice_period_days"], err = json.Marshal(a.NoticePeriodDays)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'notice_period_days': %w", err)
+		}
+	}
+
+	if a.PaymentTermDays != nil {
+		object["payment_term_days"], err = json.Marshal(a.PaymentTermDays)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'payment_term_days': %w", err)
+		}
+	}
+
+	if a.ProjectId != nil {
+		object["project_id"], err = json.Marshal(a.ProjectId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'project_id': %w", err)
+		}
+	}
+
+	if a.RenewalOn != nil {
+		object["renewal_on"], err = json.Marshal(a.RenewalOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'renewal_on': %w", err)
+		}
+	}
+
+	if a.SignedOn != nil {
+		object["signed_on"], err = json.Marshal(a.SignedOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'signed_on': %w", err)
+		}
+	}
+
+	if a.StartsOn != nil {
+		object["starts_on"], err = json.Marshal(a.StartsOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'starts_on': %w", err)
+		}
+	}
+
+	object["title"], err = json.Marshal(a.Title)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'title': %w", err)
+	}
+
+	if a.ValueBasis != nil {
+		object["value_basis"], err = json.Marshal(a.ValueBasis)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'value_basis': %w", err)
+		}
+	}
+
+	if a.ValueMinor != nil {
+		object["value_minor"], err = json.Marshal(a.ValueMinor)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'value_minor': %w", err)
 		}
 	}
 
@@ -50847,6 +51614,265 @@ func (a Project) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
+// Getter for additional properties for RenewContractRequest. Returns the specified
+// element and whether it was found
+func (a RenewContractRequest) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for RenewContractRequest
+func (a *RenewContractRequest) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for RenewContractRequest to handle AdditionalProperties
+func (a *RenewContractRequest) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["auto_renew"]; found {
+		err = json.Unmarshal(raw, &a.AutoRenew)
+		if err != nil {
+			return fmt.Errorf("error reading 'auto_renew': %w", err)
+		}
+		delete(object, "auto_renew")
+	}
+
+	if raw, found := object["contract_number"]; found {
+		err = json.Unmarshal(raw, &a.ContractNumber)
+		if err != nil {
+			return fmt.Errorf("error reading 'contract_number': %w", err)
+		}
+		delete(object, "contract_number")
+	}
+
+	if raw, found := object["currency"]; found {
+		err = json.Unmarshal(raw, &a.Currency)
+		if err != nil {
+			return fmt.Errorf("error reading 'currency': %w", err)
+		}
+		delete(object, "currency")
+	}
+
+	if raw, found := object["deal_id"]; found {
+		err = json.Unmarshal(raw, &a.DealId)
+		if err != nil {
+			return fmt.Errorf("error reading 'deal_id': %w", err)
+		}
+		delete(object, "deal_id")
+	}
+
+	if raw, found := object["ends_on"]; found {
+		err = json.Unmarshal(raw, &a.EndsOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'ends_on': %w", err)
+		}
+		delete(object, "ends_on")
+	}
+
+	if raw, found := object["notice_period_days"]; found {
+		err = json.Unmarshal(raw, &a.NoticePeriodDays)
+		if err != nil {
+			return fmt.Errorf("error reading 'notice_period_days': %w", err)
+		}
+		delete(object, "notice_period_days")
+	}
+
+	if raw, found := object["payment_term_days"]; found {
+		err = json.Unmarshal(raw, &a.PaymentTermDays)
+		if err != nil {
+			return fmt.Errorf("error reading 'payment_term_days': %w", err)
+		}
+		delete(object, "payment_term_days")
+	}
+
+	if raw, found := object["project_id"]; found {
+		err = json.Unmarshal(raw, &a.ProjectId)
+		if err != nil {
+			return fmt.Errorf("error reading 'project_id': %w", err)
+		}
+		delete(object, "project_id")
+	}
+
+	if raw, found := object["renewal_on"]; found {
+		err = json.Unmarshal(raw, &a.RenewalOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'renewal_on': %w", err)
+		}
+		delete(object, "renewal_on")
+	}
+
+	if raw, found := object["signed_on"]; found {
+		err = json.Unmarshal(raw, &a.SignedOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'signed_on': %w", err)
+		}
+		delete(object, "signed_on")
+	}
+
+	if raw, found := object["starts_on"]; found {
+		err = json.Unmarshal(raw, &a.StartsOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'starts_on': %w", err)
+		}
+		delete(object, "starts_on")
+	}
+
+	if raw, found := object["title"]; found {
+		err = json.Unmarshal(raw, &a.Title)
+		if err != nil {
+			return fmt.Errorf("error reading 'title': %w", err)
+		}
+		delete(object, "title")
+	}
+
+	if raw, found := object["value_basis"]; found {
+		err = json.Unmarshal(raw, &a.ValueBasis)
+		if err != nil {
+			return fmt.Errorf("error reading 'value_basis': %w", err)
+		}
+		delete(object, "value_basis")
+	}
+
+	if raw, found := object["value_minor"]; found {
+		err = json.Unmarshal(raw, &a.ValueMinor)
+		if err != nil {
+			return fmt.Errorf("error reading 'value_minor': %w", err)
+		}
+		delete(object, "value_minor")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for RenewContractRequest to handle AdditionalProperties
+func (a RenewContractRequest) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.AutoRenew != nil {
+		object["auto_renew"], err = json.Marshal(a.AutoRenew)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'auto_renew': %w", err)
+		}
+	}
+
+	if a.ContractNumber != nil {
+		object["contract_number"], err = json.Marshal(a.ContractNumber)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'contract_number': %w", err)
+		}
+	}
+
+	if a.Currency != nil {
+		object["currency"], err = json.Marshal(a.Currency)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'currency': %w", err)
+		}
+	}
+
+	if a.DealId != nil {
+		object["deal_id"], err = json.Marshal(a.DealId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'deal_id': %w", err)
+		}
+	}
+
+	if a.EndsOn != nil {
+		object["ends_on"], err = json.Marshal(a.EndsOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'ends_on': %w", err)
+		}
+	}
+
+	if a.NoticePeriodDays != nil {
+		object["notice_period_days"], err = json.Marshal(a.NoticePeriodDays)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'notice_period_days': %w", err)
+		}
+	}
+
+	if a.PaymentTermDays != nil {
+		object["payment_term_days"], err = json.Marshal(a.PaymentTermDays)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'payment_term_days': %w", err)
+		}
+	}
+
+	if a.ProjectId != nil {
+		object["project_id"], err = json.Marshal(a.ProjectId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'project_id': %w", err)
+		}
+	}
+
+	if a.RenewalOn != nil {
+		object["renewal_on"], err = json.Marshal(a.RenewalOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'renewal_on': %w", err)
+		}
+	}
+
+	if a.SignedOn != nil {
+		object["signed_on"], err = json.Marshal(a.SignedOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'signed_on': %w", err)
+		}
+	}
+
+	if a.StartsOn != nil {
+		object["starts_on"], err = json.Marshal(a.StartsOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'starts_on': %w", err)
+		}
+	}
+
+	object["title"], err = json.Marshal(a.Title)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'title': %w", err)
+	}
+
+	object["value_basis"], err = json.Marshal(a.ValueBasis)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'value_basis': %w", err)
+	}
+
+	if a.ValueMinor != nil {
+		object["value_minor"], err = json.Marshal(a.ValueMinor)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'value_minor': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
 // Getter for additional properties for UpdateCompanyRequest. Returns the specified
 // element and whether it was found
 func (a UpdateCompanyRequest) Get(fieldName string) (value interface{}, found bool) {
@@ -51271,6 +52297,269 @@ func (a UpdateContactRequest) MarshalJSON() ([]byte, error) {
 		object["visibility"], err = json.Marshal(a.Visibility)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'visibility': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for UpdateContractRequest. Returns the specified
+// element and whether it was found
+func (a UpdateContractRequest) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for UpdateContractRequest
+func (a *UpdateContractRequest) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for UpdateContractRequest to handle AdditionalProperties
+func (a *UpdateContractRequest) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["auto_renew"]; found {
+		err = json.Unmarshal(raw, &a.AutoRenew)
+		if err != nil {
+			return fmt.Errorf("error reading 'auto_renew': %w", err)
+		}
+		delete(object, "auto_renew")
+	}
+
+	if raw, found := object["contract_number"]; found {
+		err = json.Unmarshal(raw, &a.ContractNumber)
+		if err != nil {
+			return fmt.Errorf("error reading 'contract_number': %w", err)
+		}
+		delete(object, "contract_number")
+	}
+
+	if raw, found := object["currency"]; found {
+		err = json.Unmarshal(raw, &a.Currency)
+		if err != nil {
+			return fmt.Errorf("error reading 'currency': %w", err)
+		}
+		delete(object, "currency")
+	}
+
+	if raw, found := object["deal_id"]; found {
+		err = json.Unmarshal(raw, &a.DealId)
+		if err != nil {
+			return fmt.Errorf("error reading 'deal_id': %w", err)
+		}
+		delete(object, "deal_id")
+	}
+
+	if raw, found := object["ends_on"]; found {
+		err = json.Unmarshal(raw, &a.EndsOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'ends_on': %w", err)
+		}
+		delete(object, "ends_on")
+	}
+
+	if raw, found := object["notice_period_days"]; found {
+		err = json.Unmarshal(raw, &a.NoticePeriodDays)
+		if err != nil {
+			return fmt.Errorf("error reading 'notice_period_days': %w", err)
+		}
+		delete(object, "notice_period_days")
+	}
+
+	if raw, found := object["payment_term_days"]; found {
+		err = json.Unmarshal(raw, &a.PaymentTermDays)
+		if err != nil {
+			return fmt.Errorf("error reading 'payment_term_days': %w", err)
+		}
+		delete(object, "payment_term_days")
+	}
+
+	if raw, found := object["project_id"]; found {
+		err = json.Unmarshal(raw, &a.ProjectId)
+		if err != nil {
+			return fmt.Errorf("error reading 'project_id': %w", err)
+		}
+		delete(object, "project_id")
+	}
+
+	if raw, found := object["renewal_on"]; found {
+		err = json.Unmarshal(raw, &a.RenewalOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'renewal_on': %w", err)
+		}
+		delete(object, "renewal_on")
+	}
+
+	if raw, found := object["signed_on"]; found {
+		err = json.Unmarshal(raw, &a.SignedOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'signed_on': %w", err)
+		}
+		delete(object, "signed_on")
+	}
+
+	if raw, found := object["starts_on"]; found {
+		err = json.Unmarshal(raw, &a.StartsOn)
+		if err != nil {
+			return fmt.Errorf("error reading 'starts_on': %w", err)
+		}
+		delete(object, "starts_on")
+	}
+
+	if raw, found := object["title"]; found {
+		err = json.Unmarshal(raw, &a.Title)
+		if err != nil {
+			return fmt.Errorf("error reading 'title': %w", err)
+		}
+		delete(object, "title")
+	}
+
+	if raw, found := object["value_basis"]; found {
+		err = json.Unmarshal(raw, &a.ValueBasis)
+		if err != nil {
+			return fmt.Errorf("error reading 'value_basis': %w", err)
+		}
+		delete(object, "value_basis")
+	}
+
+	if raw, found := object["value_minor"]; found {
+		err = json.Unmarshal(raw, &a.ValueMinor)
+		if err != nil {
+			return fmt.Errorf("error reading 'value_minor': %w", err)
+		}
+		delete(object, "value_minor")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for UpdateContractRequest to handle AdditionalProperties
+func (a UpdateContractRequest) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.AutoRenew != nil {
+		object["auto_renew"], err = json.Marshal(a.AutoRenew)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'auto_renew': %w", err)
+		}
+	}
+
+	if a.ContractNumber != nil {
+		object["contract_number"], err = json.Marshal(a.ContractNumber)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'contract_number': %w", err)
+		}
+	}
+
+	if a.Currency != nil {
+		object["currency"], err = json.Marshal(a.Currency)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'currency': %w", err)
+		}
+	}
+
+	if a.DealId != nil {
+		object["deal_id"], err = json.Marshal(a.DealId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'deal_id': %w", err)
+		}
+	}
+
+	if a.EndsOn != nil {
+		object["ends_on"], err = json.Marshal(a.EndsOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'ends_on': %w", err)
+		}
+	}
+
+	if a.NoticePeriodDays != nil {
+		object["notice_period_days"], err = json.Marshal(a.NoticePeriodDays)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'notice_period_days': %w", err)
+		}
+	}
+
+	if a.PaymentTermDays != nil {
+		object["payment_term_days"], err = json.Marshal(a.PaymentTermDays)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'payment_term_days': %w", err)
+		}
+	}
+
+	if a.ProjectId != nil {
+		object["project_id"], err = json.Marshal(a.ProjectId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'project_id': %w", err)
+		}
+	}
+
+	if a.RenewalOn != nil {
+		object["renewal_on"], err = json.Marshal(a.RenewalOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'renewal_on': %w", err)
+		}
+	}
+
+	if a.SignedOn != nil {
+		object["signed_on"], err = json.Marshal(a.SignedOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'signed_on': %w", err)
+		}
+	}
+
+	if a.StartsOn != nil {
+		object["starts_on"], err = json.Marshal(a.StartsOn)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'starts_on': %w", err)
+		}
+	}
+
+	if a.Title != nil {
+		object["title"], err = json.Marshal(a.Title)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'title': %w", err)
+		}
+	}
+
+	if a.ValueBasis != nil {
+		object["value_basis"], err = json.Marshal(a.ValueBasis)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'value_basis': %w", err)
+		}
+	}
+
+	if a.ValueMinor != nil {
+		object["value_minor"], err = json.Marshal(a.ValueMinor)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'value_minor': %w", err)
 		}
 	}
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -6486,11 +6486,12 @@ func (e CreateContractRequestValueBasis) Valid() bool {
 
 // Defines values for CreateCustomFieldRequestObject.
 const (
-	CreateCustomFieldRequestObjectCompany CreateCustomFieldRequestObject = "company"
-	CreateCustomFieldRequestObjectContact CreateCustomFieldRequestObject = "contact"
-	CreateCustomFieldRequestObjectDeal    CreateCustomFieldRequestObject = "deal"
-	CreateCustomFieldRequestObjectLead    CreateCustomFieldRequestObject = "lead"
-	CreateCustomFieldRequestObjectProject CreateCustomFieldRequestObject = "project"
+	CreateCustomFieldRequestObjectCompany  CreateCustomFieldRequestObject = "company"
+	CreateCustomFieldRequestObjectContact  CreateCustomFieldRequestObject = "contact"
+	CreateCustomFieldRequestObjectContract CreateCustomFieldRequestObject = "contract"
+	CreateCustomFieldRequestObjectDeal     CreateCustomFieldRequestObject = "deal"
+	CreateCustomFieldRequestObjectLead     CreateCustomFieldRequestObject = "lead"
+	CreateCustomFieldRequestObjectProject  CreateCustomFieldRequestObject = "project"
 )
 
 // Valid indicates whether the value is a known member of the CreateCustomFieldRequestObject enum.
@@ -6499,6 +6500,8 @@ func (e CreateCustomFieldRequestObject) Valid() bool {
 	case CreateCustomFieldRequestObjectCompany:
 		return true
 	case CreateCustomFieldRequestObjectContact:
+		return true
+	case CreateCustomFieldRequestObjectContract:
 		return true
 	case CreateCustomFieldRequestObjectDeal:
 		return true
@@ -6975,11 +6978,12 @@ func (e CreateVoiceBuildRequestReason) Valid() bool {
 
 // Defines values for CustomFieldObject.
 const (
-	CustomFieldObjectCompany CustomFieldObject = "company"
-	CustomFieldObjectContact CustomFieldObject = "contact"
-	CustomFieldObjectDeal    CustomFieldObject = "deal"
-	CustomFieldObjectLead    CustomFieldObject = "lead"
-	CustomFieldObjectProject CustomFieldObject = "project"
+	CustomFieldObjectCompany  CustomFieldObject = "company"
+	CustomFieldObjectContact  CustomFieldObject = "contact"
+	CustomFieldObjectContract CustomFieldObject = "contract"
+	CustomFieldObjectDeal     CustomFieldObject = "deal"
+	CustomFieldObjectLead     CustomFieldObject = "lead"
+	CustomFieldObjectProject  CustomFieldObject = "project"
 )
 
 // Valid indicates whether the value is a known member of the CustomFieldObject enum.
@@ -6988,6 +6992,8 @@ func (e CustomFieldObject) Valid() bool {
 	case CustomFieldObjectCompany:
 		return true
 	case CustomFieldObjectContact:
+		return true
+	case CustomFieldObjectContract:
 		return true
 	case CustomFieldObjectDeal:
 		return true
@@ -16257,11 +16263,12 @@ func (e SuppressContactJSONBodyKind) Valid() bool {
 
 // Defines values for ListCustomFieldsParamsObject.
 const (
-	ListCustomFieldsParamsObjectCompany ListCustomFieldsParamsObject = "company"
-	ListCustomFieldsParamsObjectContact ListCustomFieldsParamsObject = "contact"
-	ListCustomFieldsParamsObjectDeal    ListCustomFieldsParamsObject = "deal"
-	ListCustomFieldsParamsObjectLead    ListCustomFieldsParamsObject = "lead"
-	ListCustomFieldsParamsObjectProject ListCustomFieldsParamsObject = "project"
+	ListCustomFieldsParamsObjectCompany  ListCustomFieldsParamsObject = "company"
+	ListCustomFieldsParamsObjectContact  ListCustomFieldsParamsObject = "contact"
+	ListCustomFieldsParamsObjectContract ListCustomFieldsParamsObject = "contract"
+	ListCustomFieldsParamsObjectDeal     ListCustomFieldsParamsObject = "deal"
+	ListCustomFieldsParamsObjectLead     ListCustomFieldsParamsObject = "lead"
+	ListCustomFieldsParamsObjectProject  ListCustomFieldsParamsObject = "project"
 )
 
 // Valid indicates whether the value is a known member of the ListCustomFieldsParamsObject enum.
@@ -16270,6 +16277,8 @@ func (e ListCustomFieldsParamsObject) Valid() bool {
 	case ListCustomFieldsParamsObjectCompany:
 		return true
 	case ListCustomFieldsParamsObjectContact:
+		return true
+	case ListCustomFieldsParamsObjectContract:
 		return true
 	case ListCustomFieldsParamsObjectDeal:
 		return true

--- a/backend/internal/modules/automation/automations_catalog_renewal.go
+++ b/backend/internal/modules/automation/automations_catalog_renewal.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
-	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // renewalReminderObjects is the closed set of record types renewal_reminder
@@ -29,20 +28,18 @@ import (
 // catalog_triggers.go's own event-type constants are: "kept as constants
 // here because more than one automation surface... references the same
 // string" — this validator is that surface for the object vocabulary.
+// Contract is deliberately ABSENT, and it is the first custom-field target
+// that is. A renewal reminder fires an effect, and both halves of that effect
+// refuse a contract: the record provider answers UnsupportedEntityError for it
+// (taskeffect.go's owner read), and the preview's auth.ScopeClauseFor does not
+// know the table. Listing it here would offer an administrator a reminder that
+// silently never fires and a preview that errors — worse than not offering it.
 var renewalReminderObjects = []string{
 	string(datasource.EntityContact),
 	string(datasource.EntityCompany),
 	string(datasource.EntityDeal),
 	string(datasource.EntityLead),
 	string(datasource.EntityProject),
-	// Contract is a custom-field TARGET without being a datasource.EntityType:
-	// a field may hang off one, which is all a date reminder needs, while
-	// nothing asks a record provider about it. Spelled from the field-catalog
-	// vocabulary for that reason, and present here because the compose fitness
-	// test holds this list and customfields.FieldObjects to the identical set —
-	// a date field an administrator can create and then not build a reminder on
-	// would be the drift that test exists to catch.
-	string(fieldcatalog.TargetContract),
 }
 
 // RenewalReminderObjects exports renewalReminderObjects for the ONE

--- a/backend/internal/modules/automation/automations_catalog_renewal.go
+++ b/backend/internal/modules/automation/automations_catalog_renewal.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // renewalReminderObjects is the closed set of record types renewal_reminder
@@ -34,6 +35,14 @@ var renewalReminderObjects = []string{
 	string(datasource.EntityDeal),
 	string(datasource.EntityLead),
 	string(datasource.EntityProject),
+	// Contract is a custom-field TARGET without being a datasource.EntityType:
+	// a field may hang off one, which is all a date reminder needs, while
+	// nothing asks a record provider about it. Spelled from the field-catalog
+	// vocabulary for that reason, and present here because the compose fitness
+	// test holds this list and customfields.FieldObjects to the identical set —
+	// a date field an administrator can create and then not build a reminder on
+	// would be the drift that test exists to catch.
+	string(fieldcatalog.TargetContract),
 }
 
 // RenewalReminderObjects exports renewalReminderObjects for the ONE

--- a/backend/internal/modules/contracts/contract_lifecycle.go
+++ b/backend/internal/modules/contracts/contract_lifecycle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // terminalStatuses are the states an agreement does not come back out of. A
@@ -84,9 +85,13 @@ func (s *Store) ChangeStatus(ctx context.Context, id ids.ContractID, to string, 
 	if err := auth.Require(ctx, contractObject, principal.ActionUpdate); err != nil {
 		return crmcontracts.Contract{}, err
 	}
+	active, err := s.catalogColumns(ctx)
+	if err != nil {
+		return crmcontracts.Contract{}, err
+	}
 
 	var out crmcontracts.Contract
-	err := s.tx(ctx, func(tx pgx.Tx) error {
+	err = s.tx(ctx, func(tx pgx.Tx) error {
 		existing, err := writableContract(ctx, tx, id, s.today())
 		if err != nil {
 			return err
@@ -98,7 +103,7 @@ func (s *Store) ChangeStatus(ctx context.Context, id ids.ContractID, to string, 
 		if err != nil {
 			return err
 		}
-		out, err = applyStatusTx(ctx, tx, id, existing, to, nil, ifVersion, s.today(), frozen)
+		out, err = applyStatusTx(ctx, tx, id, existing, active, to, nil, ifVersion, s.today(), frozen)
 		return err
 	})
 	return out, err
@@ -131,7 +136,7 @@ func statusOf(c crmcontracts.Contract) string {
 }
 
 // applyStatusTx writes one status transition with its audit and event.
-func applyStatusTx(ctx context.Context, tx pgx.Tx, id ids.ContractID, existing crmcontracts.Contract,
+func applyStatusTx(ctx context.Context, tx pgx.Tx, id ids.ContractID, existing crmcontracts.Contract, active []fieldcatalog.Column,
 	to string, supersededBy *ids.ContractID, ifVersion *int64, asOf time.Time, frozen *frozenRate,
 ) (crmcontracts.Contract, error) {
 	patch := storekit.NewPatch()
@@ -169,7 +174,7 @@ func applyStatusTx(ctx context.Context, tx pgx.Tx, id ids.ContractID, existing c
 	if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, changed); err != nil {
 		return crmcontracts.Contract{}, fmt.Errorf("emit contract.status_changed: %w", err)
 	}
-	return readContractForCaller(ctx, tx, id, asOf)
+	return readContractForCaller(ctx, tx, id, asOf, active)
 }
 
 // frozenRate is what activation stamps: the conversion and the day it is the
@@ -222,12 +227,16 @@ func (s *Store) freezeRateForActivation(ctx context.Context, tx pgx.Tx,
 // because that is what a notice period is — the status moves later, when the
 // date arrives and a human or a proposal says so.
 func (s *Store) Cancel(ctx context.Context, id ids.ContractID, noticeOn, effectiveOn time.Time, ifVersion *int64) (crmcontracts.Contract, error) {
+	active, err := s.catalogColumns(ctx)
+	if err != nil {
+		return crmcontracts.Contract{}, err
+	}
 	if err := auth.Require(ctx, contractObject, principal.ActionUpdate); err != nil {
 		return crmcontracts.Contract{}, err
 	}
 
 	var out crmcontracts.Contract
-	err := s.tx(ctx, func(tx pgx.Tx) error {
+	err = s.tx(ctx, func(tx pgx.Tx) error {
 		existing, err := writableContract(ctx, tx, id, s.today())
 		if err != nil {
 			return err
@@ -242,7 +251,7 @@ func (s *Store) Cancel(ctx context.Context, id ids.ContractID, noticeOn, effecti
 		if err := applyContractUpdate(ctx, tx, id, patch, ifVersion, "contract cancellation"); err != nil {
 			return err
 		}
-		out, err = readContractForCaller(ctx, tx, id, s.today())
+		out, err = readContractForCaller(ctx, tx, id, s.today(), active)
 		return err
 	})
 	return out, err
@@ -260,6 +269,10 @@ func (s *Store) Renew(ctx context.Context, id ids.ContractID, successor CreateCo
 		return crmcontracts.Contract{}, err
 	}
 	by, err := storekit.CapturedBy(ctx)
+	if err != nil {
+		return crmcontracts.Contract{}, err
+	}
+	active, err := s.catalogColumns(ctx)
 	if err != nil {
 		return crmcontracts.Contract{}, err
 	}
@@ -282,12 +295,12 @@ func (s *Store) Renew(ctx context.Context, id ids.ContractID, successor CreateCo
 		}
 		successor.CompanyID = ids.CompanyID{UUID: anchor}
 
-		created, err := createContractTx(ctx, tx, successor, by, s.today())
+		created, err := createContractTx(ctx, tx, successor, by, s.today(), active)
 		if err != nil {
 			return err
 		}
 		successorID := ids.ContractID{UUID: ids.UUID(created.Id)}
-		if _, err := applyStatusTx(ctx, tx, id, predecessor, StatusSuperseded, &successorID, ifVersion, s.today(), nil); err != nil {
+		if _, err := applyStatusTx(ctx, tx, id, predecessor, active, StatusSuperseded, &successorID, ifVersion, s.today(), nil); err != nil {
 			return err
 		}
 		out = created

--- a/backend/internal/modules/contracts/contract_lifecycle.go
+++ b/backend/internal/modules/contracts/contract_lifecycle.go
@@ -58,23 +58,35 @@ func (e *ContractCheckError) Error() string { return e.Reason }
 func contractCheckError(constraint string) error {
 	switch constraint {
 	case "contract_value_pair":
-		return &ContractCheckError{Field: "value_minor",
-			Reason: "a contract value needs its currency, and a currency needs its value"}
+		return &ContractCheckError{
+			Field:  "value_minor",
+			Reason: "a contract value needs its currency, and a currency needs its value",
+		}
 	case "contract_fx_pair":
-		return &ContractCheckError{Field: "fx_rate_to_base",
-			Reason: "a frozen conversion rate needs the date it was frozen on"}
+		return &ContractCheckError{
+			Field:  "fx_rate_to_base",
+			Reason: "a frozen conversion rate needs the date it was frozen on",
+		}
 	case "contract_term_order":
-		return &ContractCheckError{Field: "ends_on",
-			Reason: "a term cannot end before it starts"}
+		return &ContractCheckError{
+			Field:  "ends_on",
+			Reason: "a term cannot end before it starts",
+		}
 	case "contract_cancellation_within_term":
-		return &ContractCheckError{Field: "cancellation_effective_on",
-			Reason: "a cancellation cannot take effect after the term already ends"}
+		return &ContractCheckError{
+			Field:  "cancellation_effective_on",
+			Reason: "a cancellation cannot take effect after the term already ends",
+		}
 	case "contract_cancellation_order":
-		return &ContractCheckError{Field: "cancellation_effective_on",
-			Reason: "a cancellation cannot take effect before notice was given"}
+		return &ContractCheckError{
+			Field:  "cancellation_effective_on",
+			Reason: "a cancellation cannot take effect before notice was given",
+		}
 	case "contract_superseded_agrees":
-		return &ContractCheckError{Field: "status",
-			Reason: "a superseded contract names its successor, and only a superseded one may"}
+		return &ContractCheckError{
+			Field:  "status",
+			Reason: "a superseded contract names its successor, and only a superseded one may",
+		}
 	default:
 		return &ContractCheckError{Field: "", Reason: "the contract's dates or amounts contradict each other"}
 	}

--- a/backend/internal/modules/contracts/contract_list.go
+++ b/backend/internal/modules/contracts/contract_list.go
@@ -150,10 +150,17 @@ func (s *Store) ListProjectContractsTx(ctx context.Context, tx pgx.Tx, projectID
 	if err := auth.EnsureLinkTarget(ctx, tx, projectTable, projectID.UUID); err != nil {
 		return crmcontracts.ContractListResponse{}, err
 	}
-	active, err := s.catalogColumns(ctx)
-	if err != nil {
-		return crmcontracts.ContractListResponse{}, err
-	}
+	// NO catalog fetch here, deliberately. This runs INSIDE a transaction the
+	// caller opened — the 360 assembly holds one across every section — and the
+	// catalog reader opens a second transaction of its own to answer. On a pool
+	// with one connection, or a busy one, that waits for a connection this
+	// caller is itself holding, which is a deadlock rather than a slow page.
+	//
+	// The cost is that the project page's contract rows carry no custom values.
+	// That is the right trade for a compact section listing title, value and
+	// dates: the full record is one click away and reads them through the
+	// handler path, which fetches the catalog before it opens anything.
+	var active []fieldcatalog.Column
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	asOfPos := arg(s.today())

--- a/backend/internal/modules/contracts/contract_list.go
+++ b/backend/internal/modules/contracts/contract_list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // ListContractsInput selects one account's agreements.
@@ -39,22 +40,26 @@ func (s *Store) ListCompanyContracts(ctx context.Context, in ListContractsInput)
 	if err := auth.Require(ctx, contractObject, principal.ActionRead); err != nil {
 		return crmcontracts.ContractListResponse{}, err
 	}
+	active, err := s.catalogColumns(ctx)
+	if err != nil {
+		return crmcontracts.ContractListResponse{}, err
+	}
 
 	var out crmcontracts.ContractListResponse
-	err := s.tx(ctx, func(tx pgx.Tx) error {
+	err = s.tx(ctx, func(tx pgx.Tx) error {
 		// Naming the account is a read of it: a caller who cannot see the
 		// company does not learn how many agreements it holds.
 		if err := auth.EnsureLinkTarget(ctx, tx, companyTable, in.CompanyID.UUID); err != nil {
 			return err
 		}
 		var err error
-		out, err = listContractsTx(ctx, tx, in, s.today())
+		out, err = listContractsTx(ctx, tx, in, s.today(), active)
 		return err
 	})
 	return out, err
 }
 
-func listContractsTx(ctx context.Context, tx pgx.Tx, in ListContractsInput, asOf time.Time) (crmcontracts.ContractListResponse, error) {
+func listContractsTx(ctx context.Context, tx pgx.Tx, in ListContractsInput, asOf time.Time, active []fieldcatalog.Column) (crmcontracts.ContractListResponse, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	companyPos := arg(in.CompanyID)
@@ -85,8 +90,9 @@ func listContractsTx(ctx context.Context, tx pgx.Tx, in ListContractsInput, asOf
 
 	limit := storekit.ClampLimit(in.Limit)
 	rows, err := tx.Query(ctx, storekit.SQLf(
-		`SELECT %s, %s FROM contract WHERE %s ORDER BY `+termOrder+` LIMIT $%d`,
-		contractColumns, underContractSQL(asOfPos), strings.Join(where, " AND "), arg(limit+1)), args...)
+		`SELECT %s%s, %s FROM contract WHERE %s ORDER BY `+termOrder+` LIMIT $%d`,
+		contractColumns, storekit.SelectSuffix(active), underContractSQL(asOfPos),
+		strings.Join(where, " AND "), arg(limit+1)), args...)
 	if err != nil {
 		return crmcontracts.ContractListResponse{}, fmt.Errorf("list contracts: %w", err)
 	}
@@ -94,7 +100,7 @@ func listContractsTx(ctx context.Context, tx pgx.Tx, in ListContractsInput, asOf
 
 	contracts := make([]crmcontracts.Contract, 0, limit)
 	for rows.Next() {
-		c, err := scanContract(rows)
+		c, err := scanContract(rows, active)
 		if err != nil {
 			return crmcontracts.ContractListResponse{}, fmt.Errorf("scan contract: %w", err)
 		}
@@ -144,6 +150,10 @@ func (s *Store) ListProjectContractsTx(ctx context.Context, tx pgx.Tx, projectID
 	if err := auth.EnsureLinkTarget(ctx, tx, projectTable, projectID.UUID); err != nil {
 		return crmcontracts.ContractListResponse{}, err
 	}
+	active, err := s.catalogColumns(ctx)
+	if err != nil {
+		return crmcontracts.ContractListResponse{}, err
+	}
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	asOfPos := arg(s.today())
@@ -157,15 +167,16 @@ func (s *Store) ListProjectContractsTx(ctx context.Context, tx pgx.Tx, projectID
 	}
 	lim := storekit.ClampLimit(limit)
 	rows, err := tx.Query(ctx, storekit.SQLf(
-		`SELECT %s, %s FROM contract WHERE %s ORDER BY `+termOrder+` LIMIT $%d`,
-		contractColumns, underContractSQL(asOfPos), strings.Join(where, " AND "), arg(lim+1)), args...)
+		`SELECT %s%s, %s FROM contract WHERE %s ORDER BY `+termOrder+` LIMIT $%d`,
+		contractColumns, storekit.SelectSuffix(active), underContractSQL(asOfPos),
+		strings.Join(where, " AND "), arg(lim+1)), args...)
 	if err != nil {
 		return crmcontracts.ContractListResponse{}, fmt.Errorf("list project contracts: %w", err)
 	}
 	defer rows.Close()
 	contracts := make([]crmcontracts.Contract, 0, lim)
 	for rows.Next() {
-		c, err := scanContract(rows)
+		c, err := scanContract(rows, active)
 		if err != nil {
 			return crmcontracts.ContractListResponse{}, fmt.Errorf("scan contract: %w", err)
 		}

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -171,11 +171,22 @@ func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcon
 			return err
 		}
 		patch := contractPatch(existing, in)
+		// The cf_* values travel in the request's extension bag, so they are
+		// patched from it rather than from a named field. Without this a PATCH
+		// carrying custom fields succeeds and changes nothing.
+		storekit.SetCustomFieldPatch(patch, active, in.AdditionalProperties, existing.AdditionalProperties)
 		if patch.Empty() {
 			// The unchanged row still leaves the store, so it is masked like
-			// any other answer — `existing` is the write path's pre-image.
-			out, err = maskContractForCaller(ctx, tx, existing)
-			return err
+			// any other answer. It is re-read WITH the catalog rather than
+			// reusing the pre-image: writableContract reads with nil columns,
+			// so `existing` carries no custom values and answering with it
+			// would strip every one from the response.
+			unchanged, readErr := readContractForCaller(ctx, tx, id, s.today(), active)
+			if readErr != nil {
+				return readErr
+			}
+			out = unchanged
+			return nil
 		}
 		if err := applyContractUpdate(ctx, tx, id, patch, ifVersion, "contract update"); err != nil {
 			return err

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -40,6 +40,7 @@ type CreateContractInput struct {
 	RenewalOn        *time.Time
 	AutoRenew        bool
 	NoticePeriodDays *int
+	PaymentTermDays  *int
 	SignedOn         *time.Time
 	Source           string
 }
@@ -82,11 +83,12 @@ func createContractTx(ctx context.Context, tx pgx.Tx, in CreateContractInput, by
 	_, err := tx.Exec(ctx,
 		`INSERT INTO contract (id, company_id, deal_id, project_id, contract_number, title,
 		                       value_minor, currency, value_basis, starts_on, ends_on, renewal_on,
-		                       auto_renew, notice_period_days, signed_on, source, captured_by)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+		                       auto_renew, notice_period_days, payment_term_days, signed_on,
+		                       source, captured_by)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
 		id, in.CompanyID, in.DealID, in.ProjectID, in.ContractNumber, in.Title,
 		in.ValueMinor, in.Currency, in.ValueBasis, in.StartsOn, in.EndsOn, in.RenewalOn,
-		in.AutoRenew, in.NoticePeriodDays, in.SignedOn, in.Source, by)
+		in.AutoRenew, in.NoticePeriodDays, in.PaymentTermDays, in.SignedOn, in.Source, by)
 	if err != nil {
 		if storekit.IsForeignKeyViolation(err) {
 			return crmcontracts.Contract{}, apperrors.ErrNotFound
@@ -317,6 +319,9 @@ func contractPatch(existing crmcontracts.Contract, in crmcontracts.UpdateContrac
 	}
 	if in.NoticePeriodDays != nil {
 		patch.Set("notice_period_days", existing.NoticePeriodDays, *in.NoticePeriodDays)
+	}
+	if in.PaymentTermDays != nil {
+		patch.Set("payment_term_days", existing.PaymentTermDays, *in.PaymentTermDays)
 	}
 	if in.SignedOn != nil {
 		patch.Set("signed_on", existing.SignedOn, in.SignedOn.Time)

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -21,6 +21,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // CreateContractInput is one agreement as a human recorded it. Status is
@@ -41,8 +42,10 @@ type CreateContractInput struct {
 	AutoRenew        bool
 	NoticePeriodDays *int
 	PaymentTermDays  *int
-	SignedOn         *time.Time
-	Source           string
+	// CustomFields are the cf_* values a create carries, as the wire sent them.
+	CustomFields map[string]any
+	SignedOn     *time.Time
+	Source       string
 }
 
 // CreateContract records an agreement.
@@ -54,17 +57,21 @@ func (s *Store) CreateContract(ctx context.Context, in CreateContractInput) (crm
 	if err != nil {
 		return crmcontracts.Contract{}, err
 	}
+	active, err := s.catalogColumns(ctx)
+	if err != nil {
+		return crmcontracts.Contract{}, err
+	}
 
 	var out crmcontracts.Contract
 	err = s.tx(ctx, func(tx pgx.Tx) error {
 		var err error
-		out, err = createContractTx(ctx, tx, in, by, s.today())
+		out, err = createContractTx(ctx, tx, in, by, s.today(), active)
 		return err
 	})
 	return out, err
 }
 
-func createContractTx(ctx context.Context, tx pgx.Tx, in CreateContractInput, by string, asOf time.Time) (crmcontracts.Contract, error) {
+func createContractTx(ctx context.Context, tx pgx.Tx, in CreateContractInput, by string, asOf time.Time, active []fieldcatalog.Column) (crmcontracts.Contract, error) {
 	// Naming the counterparty is a read of it, and naming a deal is a read of
 	// that deal — both are client-supplied references to row-scoped records, so
 	// a caller may not hang an agreement off something it cannot see.
@@ -80,15 +87,18 @@ func createContractTx(ctx context.Context, tx pgx.Tx, in CreateContractInput, by
 	}
 
 	id := ids.New[ids.ContractKind]()
+	cfCols, cfHolders, args := storekit.InsertFragments(active, in.CustomFields, []any{
+		id, in.CompanyID, in.DealID, in.ProjectID, in.ContractNumber, in.Title,
+		in.ValueMinor, in.Currency, in.ValueBasis, in.StartsOn, in.EndsOn, in.RenewalOn,
+		in.AutoRenew, in.NoticePeriodDays, in.PaymentTermDays, in.SignedOn, in.Source, by,
+	})
 	_, err := tx.Exec(ctx,
 		`INSERT INTO contract (id, company_id, deal_id, project_id, contract_number, title,
 		                       value_minor, currency, value_basis, starts_on, ends_on, renewal_on,
 		                       auto_renew, notice_period_days, payment_term_days, signed_on,
-		                       source, captured_by)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
-		id, in.CompanyID, in.DealID, in.ProjectID, in.ContractNumber, in.Title,
-		in.ValueMinor, in.Currency, in.ValueBasis, in.StartsOn, in.EndsOn, in.RenewalOn,
-		in.AutoRenew, in.NoticePeriodDays, in.PaymentTermDays, in.SignedOn, in.Source, by)
+		                       source, captured_by`+cfCols+`)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18`+cfHolders+`)`,
+		args...)
 	if err != nil {
 		if storekit.IsForeignKeyViolation(err) {
 			return crmcontracts.Contract{}, apperrors.ErrNotFound
@@ -118,19 +128,23 @@ func createContractTx(ctx context.Context, tx pgx.Tx, in CreateContractInput, by
 	if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, created); err != nil {
 		return crmcontracts.Contract{}, fmt.Errorf("emit contract.created: %w", err)
 	}
-	return readContractForCaller(ctx, tx, id, asOf)
+	return readContractForCaller(ctx, tx, id, asOf, active)
 }
 
 // UpdateContract applies a partial patch. Status is absent by design: it moves
 // through ChangeStatus, so a correction to a term can never silently activate
 // an agreement.
 func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcontracts.UpdateContractRequest, ifVersion *int64) (crmcontracts.Contract, error) {
+	active, err := s.catalogColumns(ctx)
+	if err != nil {
+		return crmcontracts.Contract{}, err
+	}
 	if err := auth.Require(ctx, contractObject, principal.ActionUpdate); err != nil {
 		return crmcontracts.Contract{}, err
 	}
 
 	var out crmcontracts.Contract
-	err := s.tx(ctx, func(tx pgx.Tx) error {
+	err = s.tx(ctx, func(tx pgx.Tx) error {
 		// The patch is a write, so the row must first be visible as a read —
 		// otherwise a caller learns a contract exists by patching it.
 		existing, err := writableContract(ctx, tx, id, s.today())
@@ -166,7 +180,7 @@ func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcon
 		if err := applyContractUpdate(ctx, tx, id, patch, ifVersion, "contract update"); err != nil {
 			return err
 		}
-		out, err = readContractForCaller(ctx, tx, id, s.today())
+		out, err = readContractForCaller(ctx, tx, id, s.today(), active)
 		return err
 	})
 	return out, err

--- a/backend/internal/modules/contracts/fieldmask.go
+++ b/backend/internal/modules/contracts/fieldmask.go
@@ -33,6 +33,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // The masked_fields names for the three references. They are the wire members'
@@ -81,8 +82,9 @@ var maskedReferences = []maskedReference{
 // comes through it.
 func readContractForCaller(
 	ctx context.Context, tx pgx.Tx, id ids.ContractID, asOf time.Time,
+	active []fieldcatalog.Column,
 ) (crmcontracts.Contract, error) {
-	out, err := readContract(ctx, tx, id, asOf)
+	out, err := readContract(ctx, tx, id, asOf, active)
 	if err != nil {
 		return crmcontracts.Contract{}, err
 	}

--- a/backend/internal/modules/contracts/handlers.go
+++ b/backend/internal/modules/contracts/handlers.go
@@ -222,6 +222,7 @@ func createInput(req crmcontracts.CreateContractRequest) (CreateContractInput, e
 	}
 	in.NoticePeriodDays = req.NoticePeriodDays
 	in.PaymentTermDays = req.PaymentTermDays
+	in.CustomFields = req.AdditionalProperties
 	in.StartsOn = timePtr(req.StartsOn)
 	in.EndsOn = timePtr(req.EndsOn)
 	in.RenewalOn = timePtr(req.RenewalOn)
@@ -254,6 +255,7 @@ func renewInput(req crmcontracts.RenewContractRequest) CreateContractInput {
 	}
 	in.NoticePeriodDays = req.NoticePeriodDays
 	in.PaymentTermDays = req.PaymentTermDays
+	in.CustomFields = req.AdditionalProperties
 	in.StartsOn = timePtr(req.StartsOn)
 	in.EndsOn = timePtr(req.EndsOn)
 	in.RenewalOn = timePtr(req.RenewalOn)

--- a/backend/internal/modules/contracts/handlers.go
+++ b/backend/internal/modules/contracts/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // Handlers is this module's transport.
@@ -26,6 +27,15 @@ type Handlers struct {
 // NewHandlers builds the contract handler set.
 func NewHandlers(db *database.DB, freezeRate FreezeRateFunc) Handlers {
 	return Handlers{store: NewStore(db, freezeRate)}
+}
+
+// WithFieldCatalog wires the workspace custom-field catalog into the
+// transport's store. Compose injects modules/customfields' Service here;
+// without it the seam stays nil and every read and write runs
+// core-columns-only, which is a silent no-op rather than an error.
+func (h Handlers) WithFieldCatalog(catalog fieldcatalog.Reader) Handlers {
+	h.store = h.store.WithFieldCatalog(catalog)
+	return h
 }
 
 // pathID converts a contract path parameter into its typed id.

--- a/backend/internal/modules/contracts/handlers.go
+++ b/backend/internal/modules/contracts/handlers.go
@@ -221,6 +221,7 @@ func createInput(req crmcontracts.CreateContractRequest) (CreateContractInput, e
 		in.AutoRenew = *req.AutoRenew
 	}
 	in.NoticePeriodDays = req.NoticePeriodDays
+	in.PaymentTermDays = req.PaymentTermDays
 	in.StartsOn = timePtr(req.StartsOn)
 	in.EndsOn = timePtr(req.EndsOn)
 	in.RenewalOn = timePtr(req.RenewalOn)
@@ -252,6 +253,7 @@ func renewInput(req crmcontracts.RenewContractRequest) CreateContractInput {
 		in.AutoRenew = *req.AutoRenew
 	}
 	in.NoticePeriodDays = req.NoticePeriodDays
+	in.PaymentTermDays = req.PaymentTermDays
 	in.StartsOn = timePtr(req.StartsOn)
 	in.EndsOn = timePtr(req.EndsOn)
 	in.RenewalOn = timePtr(req.RenewalOn)

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -21,6 +21,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // Three different subjects in this module answer to the word "contract", and
@@ -87,6 +88,27 @@ type Store struct {
 	// contract by its frozen rate, so a NULL one is a contract the guard
 	// cannot see and an installation can restate underneath.
 	freezeRate FreezeRateFunc
+	// catalog is the fieldcatalog seam (custom-field columns); nil means no
+	// catalog is wired and every read and write runs core-columns-only, which
+	// is the supported shape for a deployment that never mounted the module.
+	catalog fieldcatalog.Reader
+}
+
+// WithFieldCatalog wires the workspace custom-field catalog into this store.
+// Compose injects modules/customfields' Service; contracts may not import that
+// module, so the seam is the edge (ADR-0054 §3).
+func (s *Store) WithFieldCatalog(catalog fieldcatalog.Reader) *Store {
+	s.catalog = catalog
+	return s
+}
+
+// catalogColumns answers the active custom-field columns for a contract, or
+// none when no catalog is wired.
+func (s *Store) catalogColumns(ctx context.Context) ([]fieldcatalog.Column, error) {
+	if s.catalog == nil {
+		return nil, nil
+	}
+	return s.catalog.ActiveColumns(ctx, contractObject)
 }
 
 // FreezeRateFunc answers what one currency converts to the installation's base
@@ -115,7 +137,7 @@ func (s *Store) today() time.Time {
 // one meaning of the word (CONTRACT-FORM-1).
 const contractColumns = `id, company_id, deal_id, project_id, contract_number, title,
 	value_minor, currency, value_basis, fx_rate_to_base, fx_rate_date,
-	starts_on, ends_on, renewal_on, auto_renew, notice_period_days,
+	starts_on, ends_on, renewal_on, auto_renew, notice_period_days, payment_term_days,
 	status, signed_on, cancellation_notice_on, cancellation_effective_on,
 	superseded_by_id, source, captured_by, version, created_at, updated_at, archived_at`
 
@@ -159,7 +181,7 @@ func scanContract(row pgx.Row) (crmcontracts.Contract, error) {
 	)
 	err := row.Scan(&id, &companyID, &dealID, &projectID, &c.ContractNumber, &c.Title,
 		&c.ValueMinor, &c.Currency, &basis, &c.FxRateToBase, &fxDate,
-		&startsOn, &endsOn, &renewalOn, &c.AutoRenew, &c.NoticePeriodDays,
+		&startsOn, &endsOn, &renewalOn, &c.AutoRenew, &c.NoticePeriodDays, &c.PaymentTermDays,
 		&status, &signedOn, &noticeOn, &effectiveOn,
 		&supersededBy, &c.Source, &capturedBy, &c.Version, &c.CreatedAt, &c.UpdatedAt,
 		&c.ArchivedAt, &underContract)

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -183,12 +183,15 @@ func scanContract(row pgx.Row, active []fieldcatalog.Column) (crmcontracts.Contr
 		effectiveOn   *time.Time
 		fxDate        *time.Time
 	)
-	dests := []any{&id, &companyID, &dealID, &projectID, &c.ContractNumber, &c.Title,
+
+	dests := []any{
+		&id, &companyID, &dealID, &projectID, &c.ContractNumber, &c.Title,
 		&c.ValueMinor, &c.Currency, &basis, &c.FxRateToBase, &fxDate,
 		&startsOn, &endsOn, &renewalOn, &c.AutoRenew, &c.NoticePeriodDays, &c.PaymentTermDays,
 		&status, &signedOn, &noticeOn, &effectiveOn,
 		&supersededBy, &c.Source, &capturedBy, &c.Version, &c.CreatedAt, &c.UpdatedAt,
-		&c.ArchivedAt}
+		&c.ArchivedAt,
+	}
 	cf := storekit.ScanDests(active)
 	if err := row.Scan(append(append(dests, cf...), &underContract)...); err != nil {
 		return crmcontracts.Contract{}, err

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -159,7 +159,11 @@ func underContractSQL(asOfPos int) string {
 	)`, asOfPos)
 }
 
-func scanContract(row pgx.Row) (crmcontracts.Contract, error) {
+// scanContract reads one row. `active` is the custom-field columns the caller
+// asked for, appended to the select list in the same order — the values land
+// between the core columns and the derived under-contract flag, which is why
+// the flag's destination goes last rather than beside its neighbours.
+func scanContract(row pgx.Row, active []fieldcatalog.Column) (crmcontracts.Contract, error) {
 	var (
 		c             crmcontracts.Contract
 		underContract bool
@@ -179,14 +183,18 @@ func scanContract(row pgx.Row) (crmcontracts.Contract, error) {
 		effectiveOn   *time.Time
 		fxDate        *time.Time
 	)
-	err := row.Scan(&id, &companyID, &dealID, &projectID, &c.ContractNumber, &c.Title,
+	dests := []any{&id, &companyID, &dealID, &projectID, &c.ContractNumber, &c.Title,
 		&c.ValueMinor, &c.Currency, &basis, &c.FxRateToBase, &fxDate,
 		&startsOn, &endsOn, &renewalOn, &c.AutoRenew, &c.NoticePeriodDays, &c.PaymentTermDays,
 		&status, &signedOn, &noticeOn, &effectiveOn,
 		&supersededBy, &c.Source, &capturedBy, &c.Version, &c.CreatedAt, &c.UpdatedAt,
-		&c.ArchivedAt, &underContract)
-	if err != nil {
+		&c.ArchivedAt}
+	cf := storekit.ScanDests(active)
+	if err := row.Scan(append(append(dests, cf...), &underContract)...); err != nil {
 		return crmcontracts.Contract{}, err
+	}
+	if values := storekit.ExtractValues(active, cf); len(values) > 0 {
+		c.AdditionalProperties = values
 	}
 	c.Id = openapi_types.UUID(id)
 	c.CompanyId = uuidPtr(&companyID)
@@ -240,13 +248,17 @@ func uuidPtr(id *ids.UUID) *openapi_types.UUID {
 
 // GetContract reads one agreement.
 func (s *Store) GetContract(ctx context.Context, id ids.ContractID) (crmcontracts.Contract, error) {
+	active, err := s.catalogColumns(ctx)
+	if err != nil {
+		return crmcontracts.Contract{}, err
+	}
 	if err := auth.Require(ctx, contractObject, principal.ActionRead); err != nil {
 		return crmcontracts.Contract{}, err
 	}
 	var out crmcontracts.Contract
-	err := s.tx(ctx, func(tx pgx.Tx) error {
+	err = s.tx(ctx, func(tx pgx.Tx) error {
 		var err error
-		out, err = readContractForCaller(ctx, tx, id, s.today())
+		out, err = readContractForCaller(ctx, tx, id, s.today(), active)
 		return err
 	})
 	return out, err
@@ -255,7 +267,7 @@ func (s *Store) GetContract(ctx context.Context, id ids.ContractID) (crmcontract
 // readContract reads one agreement inside the caller's transaction, applying
 // the inherited row-scope gate. A row the caller cannot see answers ErrNotFound
 // rather than a denial, so a contract's existence stays hidden.
-func readContract(ctx context.Context, tx pgx.Tx, id ids.ContractID, asOf time.Time) (crmcontracts.Contract, error) {
+func readContract(ctx context.Context, tx pgx.Tx, id ids.ContractID, asOf time.Time, active []fieldcatalog.Column) (crmcontracts.Contract, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	idPos := arg(id)
@@ -271,9 +283,9 @@ func readContract(ctx context.Context, tx pgx.Tx, id ids.ContractID, asOf time.T
 	}
 
 	row := tx.QueryRow(ctx, storekit.SQLf(
-		`SELECT %s, %s FROM contract WHERE %s`,
-		contractColumns, underContractSQL(asOfPos), where), args...)
-	out, err := scanContract(row)
+		`SELECT %s%s, %s FROM contract WHERE %s`,
+		contractColumns, storekit.SelectSuffix(active), underContractSQL(asOfPos), where), args...)
+	out, err := scanContract(row, active)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return crmcontracts.Contract{}, apperrors.ErrNotFound
 	}

--- a/backend/internal/modules/contracts/writability.go
+++ b/backend/internal/modules/contracts/writability.go
@@ -64,13 +64,15 @@ import (
 // agreement they may not even know exists, for the length of their own
 // transaction.
 func writableContract(ctx context.Context, tx pgx.Tx, id ids.ContractID, asOf time.Time) (crmcontracts.Contract, error) {
-	if _, err := readContract(ctx, tx, id, asOf); err != nil {
+	// nil columns: this reads only to PROVE visibility and throws the row
+	// away, so fetching custom values here would be work nobody reads.
+	if _, err := readContract(ctx, tx, id, asOf, nil); err != nil {
 		return crmcontracts.Contract{}, err
 	}
 	if _, err := storekit.LockRow(ctx, tx, contractTable, id.UUID, storekit.IncludeArchived); err != nil {
 		return crmcontracts.Contract{}, err
 	}
-	existing, err := readContract(ctx, tx, id, asOf)
+	existing, err := readContract(ctx, tx, id, asOf, nil)
 	if err != nil {
 		return crmcontracts.Contract{}, err
 	}

--- a/backend/internal/modules/customfields/engine.go
+++ b/backend/internal/modules/customfields/engine.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/shared/kernel/values"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // The closed type/object sets (CUSTOM-FIELDS-PARAM-1/PARAM-2). No cap,
@@ -80,6 +81,15 @@ var FieldObjects = []string{
 	string(datasource.EntityDeal),
 	string(datasource.EntityLead),
 	string(datasource.EntityProject),
+	// Contract comes from the field-catalog TARGET vocabulary rather than from
+	// datasource.EntityType, and the difference is the whole reason that
+	// vocabulary exists. EntityType is what a record PROVIDER can be asked
+	// about: a member there owes native provider routing, agent record shapes
+	// and the embedding and provenance consumers that enumerate it, and
+	// TestTheRecordProviderServesExactlyTheSeamVocabulary fails the moment one
+	// answers UnsupportedEntityError. A contract carries typed extra fields
+	// without any of that being true of it.
+	string(fieldcatalog.TargetContract),
 }
 
 var allowedObjects = func() map[string]bool {

--- a/backend/internal/modules/customfields/engine_test.go
+++ b/backend/internal/modules/customfields/engine_test.go
@@ -346,7 +346,7 @@ func TestFieldTypes_AgreesWithThePortsClosedSet(t *testing.T) {
 // its cf_* columns and a contract shape that carries them — is derived in
 // fieldobjects_test.go rather than restated here.
 func TestFieldObjects_IsTheExplicitTargetSet(t *testing.T) {
-	want := []string{"contact", "company", "deal", "lead", "project"}
+	want := []string{"contact", "company", "deal", "lead", "project", "contract"}
 	if len(FieldObjects) != len(want) {
 		t.Fatalf("FieldObjects = %v, want %v — activity and relationship are excluded for want of "+
 			"wire carriage and store wiring; see the engine's own comment", FieldObjects, want)

--- a/backend/internal/modules/customfields/fieldobjects_test.go
+++ b/backend/internal/modules/customfields/fieldobjects_test.go
@@ -23,6 +23,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // carriageShapes binds each object to the contract types a cf_* value has to
@@ -44,6 +45,9 @@ var carriageShapes = map[string]struct{ create, read reflect.Type }{
 	},
 	string(datasource.EntityProject): {
 		reflect.TypeFor[crmcontracts.CreateProjectRequest](), reflect.TypeFor[crmcontracts.Project](),
+	},
+	string(fieldcatalog.TargetContract): {
+		reflect.TypeFor[crmcontracts.CreateContractRequest](), reflect.TypeFor[crmcontracts.Contract](),
 	},
 	// The two exclusions, carried here so the assertion below can state WHY
 	// each is excluded rather than assert an absence from FieldObjects.
@@ -114,11 +118,16 @@ func TestTheExcludedObjectsStillLackTheCarriageThatWouldAdmitThem(t *testing.T) 
 // cleanly, while one wider than the CHECK would fail at INSERT with a
 // constraint violation no caller can act on.
 func TestEveryFieldObjectIsSpelledTheWayTheCatalogCheckSpellsIt(t *testing.T) {
-	// The CHECK's vocabulary is the entity vocabulary; membership in it is what
-	// makes a spelling insertable at all.
+	// The CHECK's vocabulary is the field-catalog TARGET set, which is wider
+	// than datasource.EntityType and deliberately separate from it: a target is
+	// something a field may hang off, while an EntityType is something a record
+	// provider can be asked about, and Contract is the first member that is the
+	// former without being the latter. Asking EntityType here would refuse a
+	// spelling the CHECK admits, which is the wrong direction — the safety this
+	// test holds is that the allowlist never exceeds what the database accepts.
 	vocabulary := map[string]bool{}
-	for _, entity := range datasource.EntityTypes() {
-		vocabulary[string(entity)] = true
+	for _, target := range fieldcatalog.Targets() {
+		vocabulary[string(target)] = true
 	}
 	for _, object := range FieldObjects {
 		if !vocabulary[object] {

--- a/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
+++ b/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
@@ -126,6 +126,8 @@ type FilterableReader interface {
 // configured stop rendering.
 type Target string
 
+// The targets themselves. Every value the custom_field.object CHECK admits,
+// including the ones no active target list offers today.
 const (
 	TargetContact      Target = "contact"
 	TargetCompany      Target = "company"

--- a/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
+++ b/backend/internal/shared/ports/fieldcatalog/fieldcatalog.go
@@ -108,3 +108,54 @@ type Reader interface {
 type FilterableReader interface {
 	FilterableColumns(ctx context.Context, object string) ([]Column, error)
 }
+
+// Target is what a custom field may be ATTACHED to.
+//
+// Deliberately its own vocabulary rather than datasource.EntityType, which it
+// otherwise resembles. EntityType is what a record PROVIDER can be asked
+// about: declaring a member there obliges native provider routing, agent
+// record-shape generation and the embedding/provenance consumers that
+// enumerate it, and TestTheRecordProviderServesExactlyTheSeamVocabulary fails
+// the moment a member answers UnsupportedEntityError. A contract can carry a
+// typed extra field without any of that being true of it, and widening
+// EntityType to say so would promise five capabilities to buy one.
+//
+// Every value the custom_field.object CHECK already admits is here, including
+// the ones no active target list offers: a catalog row written under an older
+// vocabulary must stay readable, or the fields an installation already
+// configured stop rendering.
+type Target string
+
+const (
+	TargetContact      Target = "contact"
+	TargetCompany      Target = "company"
+	TargetDeal         Target = "deal"
+	TargetLead         Target = "lead"
+	TargetProject      Target = "project"
+	TargetContract     Target = "contract"
+	TargetActivity     Target = "activity"
+	TargetRelationship Target = "relationship"
+	TargetPartner      Target = "partner"
+)
+
+// Targets is the closed set, in the order the CHECK constraint spells it so a
+// reader comparing the two reads them the same way.
+func Targets() []Target {
+	return []Target{
+		TargetContact, TargetCompany, TargetDeal, TargetLead,
+		TargetActivity, TargetProject, TargetRelationship, TargetPartner,
+		TargetContract,
+	}
+}
+
+// Valid reports whether a stored value is one this vocabulary knows. A row
+// carrying anything else is a row written by a version this binary cannot
+// reason about, and the catalog refuses rather than guesses.
+func (t Target) Valid() bool {
+	for _, known := range Targets() {
+		if t == known {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/migrations/core/1789174139_a_contract_says_when_it_is_paid_and_carries_its_own_fields.down.sql
+++ b/backend/migrations/core/1789174139_a_contract_says_when_it_is_paid_and_carries_its_own_fields.down.sql
@@ -3,10 +3,10 @@ SET LOCAL lock_timeout = '3s';
 ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
 ALTER TABLE custom_field
     ADD CONSTRAINT custom_field_object_check
-    CHECK (object = ANY (ARRAY[
+    CHECK (object IN (
         'contact', 'company', 'deal', 'lead',
         'activity', 'project', 'relationship', 'partner'
-    ]::text[]));
+    ));
 
 ALTER TABLE contract DROP CONSTRAINT contract_payment_term_days_nonnegative;
 ALTER TABLE contract DROP COLUMN payment_term_days;

--- a/backend/migrations/core/1789174139_a_contract_says_when_it_is_paid_and_carries_its_own_fields.down.sql
+++ b/backend/migrations/core/1789174139_a_contract_says_when_it_is_paid_and_carries_its_own_fields.down.sql
@@ -1,0 +1,12 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
+ALTER TABLE custom_field
+    ADD CONSTRAINT custom_field_object_check
+    CHECK (object = ANY (ARRAY[
+        'contact', 'company', 'deal', 'lead',
+        'activity', 'project', 'relationship', 'partner'
+    ]::text[]));
+
+ALTER TABLE contract DROP CONSTRAINT contract_payment_term_days_nonnegative;
+ALTER TABLE contract DROP COLUMN payment_term_days;

--- a/backend/migrations/core/1789174139_a_contract_says_when_it_is_paid_and_carries_its_own_fields.up.sql
+++ b/backend/migrations/core/1789174139_a_contract_says_when_it_is_paid_and_carries_its_own_fields.up.sql
@@ -26,11 +26,16 @@ ALTER TABLE contract
 -- value CAME FROM — a connector, an import, a crawl — and nothing writes
 -- contract values from any of those. Widening it would declare a capability no
 -- writer has, and the slice that adds one can widen it then.
+-- Written as IN (...) rather than = ANY (ARRAY[...]), which is equivalent to
+-- Postgres and NOT equivalent to the enum-sync gate: that gate's reader matches
+-- only the IN form, so the ANY spelling makes it silently stop comparing this
+-- constraint against its Go vocabulary. A gate that quietly checks nothing is
+-- worse than one that fails.
 ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
 ALTER TABLE custom_field
     ADD CONSTRAINT custom_field_object_check
-    CHECK (object = ANY (ARRAY[
+    CHECK (object IN (
         'contact', 'company', 'deal', 'lead',
         'activity', 'project', 'relationship', 'partner',
         'contract'
-    ]::text[]));
+    ));

--- a/backend/migrations/core/1789174139_a_contract_says_when_it_is_paid_and_carries_its_own_fields.up.sql
+++ b/backend/migrations/core/1789174139_a_contract_says_when_it_is_paid_and_carries_its_own_fields.up.sql
@@ -1,0 +1,36 @@
+SET LOCAL lock_timeout = '3s';
+
+-- Two things a contract could not hold before: how long the customer has to
+-- pay, and whatever else this installation needs to record about one.
+
+-- Net terms in days. An integer rather than a picklist because the number is
+-- the fact — Net 14, 30 and 60 are shortcuts a form offers, not the vocabulary.
+-- Zero is a real value and means due on receipt, which is why the CHECK admits
+-- it and the column stays nullable for "not specified": a contract nobody has
+-- recorded terms for is not a contract due immediately.
+ALTER TABLE contract ADD COLUMN payment_term_days integer;
+
+ALTER TABLE contract
+    ADD CONSTRAINT contract_payment_term_days_nonnegative
+    CHECK (payment_term_days IS NULL OR payment_term_days >= 0);
+
+-- Contract joins the custom-field targets.
+--
+-- The CHECK is widened and NOTHING else: datasource.EntityType stays as it is.
+-- Declaring a member there obliges native provider routing, agent record-shape
+-- generation and the embedding and provenance consumers that enumerate it, and
+-- a contract needs none of that to carry a typed extra field. The bounded
+-- vocabulary in shared/ports/fieldcatalog is what this constraint mirrors.
+--
+-- field_provenance is deliberately NOT widened here. Provenance records where a
+-- value CAME FROM — a connector, an import, a crawl — and nothing writes
+-- contract values from any of those. Widening it would declare a capability no
+-- writer has, and the slice that adds one can widen it then.
+ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
+ALTER TABLE custom_field
+    ADD CONSTRAINT custom_field_object_check
+    CHECK (object = ANY (ARRAY[
+        'contact', 'company', 'deal', 'lead',
+        'activity', 'project', 'relationship', 'partner',
+        'contract'
+    ]::text[]));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2733,6 +2733,7 @@ public.contract.contract_deal_id_fkey FOREIGN KEY (deal_id) REFERENCES deal(id) 
 public.contract.contract_fx_pair CHECK (((fx_rate_to_base IS NULL) = (fx_rate_date IS NULL)))
 public.contract.contract_notice_period_days_check CHECK (((notice_period_days IS NULL) OR (notice_period_days >= 0)))
 public.contract.contract_number text gen=- def=-
+public.contract.contract_payment_term_days_nonnegative CHECK (((payment_term_days IS NULL) OR (payment_term_days >= 0)))
 public.contract.contract_pkey PRIMARY KEY (id)
 public.contract.contract_project_id_fkey FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE SET NULL
 public.contract.contract_set_updated_at CREATE TRIGGER contract_set_updated_at BEFORE UPDATE ON public.contract FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version()
@@ -2751,6 +2752,7 @@ public.contract.fx_rate_date date gen=- def=-
 public.contract.fx_rate_to_base numeric(20,10) gen=- def=-
 public.contract.id uuid NOT NULL gen=- def=uuidv7()
 public.contract.notice_period_days integer gen=- def=-
+public.contract.payment_term_days integer gen=- def=-
 public.contract.project_id uuid gen=- def=-
 public.contract.renewal_on date gen=- def=-
 public.contract.signed_on date gen=- def=-
@@ -2812,7 +2814,7 @@ public.custom_field.created_by uuid NOT NULL gen=- def=-
 public.custom_field.currency character(3) gen=- def=-
 public.custom_field.custom_field_created_by_fkey FOREIGN KEY (created_by) REFERENCES app_user(id) ON DELETE RESTRICT
 public.custom_field.custom_field_currency_check CHECK (((currency IS NULL) OR (currency ~ '^[A-Z]{3}$'::text)))
-public.custom_field.custom_field_object_check CHECK ((object = ANY (ARRAY['contact'::text, 'company'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text, 'partner'::text])))
+public.custom_field.custom_field_object_check CHECK ((object = ANY (ARRAY['contact'::text, 'company'::text, 'deal'::text, 'lead'::text, 'activity'::text, 'project'::text, 'relationship'::text, 'partner'::text, 'contract'::text])))
 public.custom_field.custom_field_pkey PRIMARY KEY (id)
 public.custom_field.custom_field_status_check CHECK ((status = ANY (ARRAY['active'::text, 'retired'::text])))
 public.custom_field.custom_field_type_check CHECK ((type = ANY (ARRAY['text'::text, 'number'::text, 'date'::text, 'currency'::text, 'picklist'::text, 'boolean'::text])))

--- a/frontend/src/api/if-match-coverage.test.ts
+++ b/frontend/src/api/if-match-coverage.test.ts
@@ -56,7 +56,7 @@ const UNPINNED_WRITES: readonly string[] = [
   "screens/contacteditmergearchive.tsx DELETE /contacts/{id}",
   "screens/contactrail.tsx DELETE /relationships/{id}",
   "screens/relationships.tsx DELETE /relationships/{id}",
-  "screens/contractform.tsx PATCH /contracts/{id}",
+  "screens/contractwrites.ts PATCH /contracts/{id}",
   "screens/customfields.tsx PATCH /custom-fields/{id}",
   // The two FACT writes stay: CompanyFact carries no version on the wire,
   // so no caller can pin one. Its sibling, CompanyProfileField, now does — the

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22684,6 +22684,8 @@ export interface components {
             auto_renew: boolean;
             /** @description Drives the renewal warning, which fires against the notice deadline rather than the renewal date (CONTRACT-FORM-3). */
             notice_period_days?: number | null;
+            /** @description How many days the customer has to pay. Zero is a real value and means due on receipt; absent means nobody has recorded terms, which is not the same thing. */
+            payment_term_days?: number | null;
             /**
              * @description Read-only here — asserted through changeContractStatus so the transition, its event and any proposal are written from one transaction.
              * @default draft
@@ -22725,6 +22727,8 @@ export interface components {
             readonly updated_at: string;
             /** Format: date-time */
             readonly archived_at?: string | null;
+        } & {
+            [key: string]: unknown;
         };
         ContractListResponse: {
             data: components["schemas"]["Contract"][];
@@ -22756,8 +22760,11 @@ export interface components {
             /** @default false */
             auto_renew: boolean;
             notice_period_days?: number | null;
+            payment_term_days?: number | null;
             /** Format: date */
             signed_on?: string | null;
+        } & {
+            [key: string]: unknown;
         };
         /** @description Partial. Status is absent by design — it moves through changeContractStatus. */
         UpdateContractRequest: {
@@ -22780,8 +22787,11 @@ export interface components {
             renewal_on?: string | null;
             auto_renew?: boolean;
             notice_period_days?: number | null;
+            payment_term_days?: number | null;
             /** Format: date */
             signed_on?: string | null;
+        } & {
+            [key: string]: unknown;
         };
         ChangeContractStatusRequest: {
             /**
@@ -22833,8 +22843,11 @@ export interface components {
             /** @default false */
             auto_renew: boolean;
             notice_period_days?: number | null;
+            payment_term_days?: number | null;
             /** Format: date */
             signed_on?: string | null;
+        } & {
+            [key: string]: unknown;
         };
         /** @description A project — the body of work a client relationship is made of. Mirrors the `project` table. */
         Project: {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -27871,7 +27871,7 @@ export interface components {
              * @description The existing core object this field is added to (CUSTOM-FIELDS-PARAM-2).
              * @enum {string}
              */
-            object: "contact" | "company" | "deal" | "lead" | "project";
+            object: "contact" | "company" | "deal" | "lead" | "project" | "contract";
             /** @description Display label; the only thing a rename updates. */
             label: string;
             /** @description Admin-facing key the column_name derives from. */
@@ -27919,7 +27919,7 @@ export interface components {
          */
         CreateCustomFieldRequest: {
             /** @enum {string} */
-            object: "contact" | "company" | "deal" | "lead" | "project";
+            object: "contact" | "company" | "deal" | "lead" | "project" | "contract";
             label: string;
             /** @enum {string} */
             type: "text" | "number" | "date" | "currency" | "picklist" | "boolean";
@@ -49836,7 +49836,7 @@ export interface operations {
                  */
                 sort?: components["parameters"]["Sort"];
                 /** @description Target core object (CUSTOM-FIELDS-PARAM-2). */
-                object: "contact" | "company" | "deal" | "lead" | "project";
+                object: "contact" | "company" | "deal" | "lead" | "project" | "contract";
                 /** @description Filter to one lifecycle state. Omitted returns both active and retired — this admin list intentionally does not default-exclude retired rows. */
                 status?: "active" | "retired";
             };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1244,6 +1244,9 @@ export const de = {
   "contracts.form.noticeDays": "K\u00fcndigungsfrist (Tage)",
   "contracts.form.noticeDaysHint":
     "Wie viel Vorlauf eine K\u00fcndigung braucht. Die Verl\u00e4ngerungswarnung kommt vor dieser Frist, nicht erst vor dem Verl\u00e4ngerungsdatum.",
+  "contracts.form.paymentTerms": "Zahlungsziel (Tage)",
+  "contracts.form.paymentTermsHint":
+    "Wie lange der Kunde Zeit hat zu zahlen. 0 bedeutet sofort f\u00e4llig; leer lassen, wenn nichts vereinbart wurde.",
   "contracts.form.signedOn": "Unterschrieben",
   "contracts.form.signedOnHint":
     "Nur wenn bekannt ist, dass unterschrieben wurde \u2014 nie aus dem Abschlussdatum eines Deals \u00fcbernommen.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1324,6 +1324,9 @@ export const en = {
   "contracts.form.noticeDays": "Notice period (days)",
   "contracts.form.noticeDaysHint":
     "How much notice a cancellation needs. The renewal warning fires before this deadline, not before the renewal date.",
+  "contracts.form.paymentTerms": "Payment terms (days)",
+  "contracts.form.paymentTermsHint":
+    "How long the customer has to pay. 0 means due on receipt; leave blank if nobody has agreed terms.",
   "contracts.form.signedOn": "Signed",
   "contracts.form.signedOnHint":
     "Only when a human knows it was signed \u2014 never taken from a deal's close date.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1230,6 +1230,10 @@ export const vi = {
     "Th\u1eddi h\u1ea1n b\u00e1o tr\u01b0\u1edbc (ng\u00e0y)",
   "contracts.form.noticeDaysHint":
     "C\u1ea7n b\u00e1o tr\u01b0\u1edbc bao l\u00e2u \u0111\u1ec3 h\u1ee7y. C\u1ea3nh b\u00e1o gia h\u1ea1n xu\u1ea5t hi\u1ec7n tr\u01b0\u1edbc h\u1ea1n n\u00e0y, kh\u00f4ng ph\u1ea3i tr\u01b0\u1edbc ng\u00e0y gia h\u1ea1n.",
+  "contracts.form.paymentTerms":
+    "Th\u1eddi h\u1ea1n thanh to\u00e1n (ng\u00e0y)",
+  "contracts.form.paymentTermsHint":
+    "Kh\u00e1ch h\u00e0ng c\u00f3 bao nhi\u00eau ng\u00e0y \u0111\u1ec3 thanh to\u00e1n. 0 ngh\u0129a l\u00e0 thanh to\u00e1n ngay; \u0111\u1ec3 tr\u1ed1ng n\u1ebfu ch\u01b0a th\u1ecfa thu\u1eadn.",
   "contracts.form.signedOn": "\u0110\u00e3 k\u00fd",
   "contracts.form.signedOnHint":
     "Ch\u1ec9 khi bi\u1ebft ch\u1eafc \u0111\u00e3 k\u00fd \u2014 kh\u00f4ng l\u1ea5y t\u1eeb ng\u00e0y ch\u1ed1t c\u1ee7a deal.",

--- a/frontend/src/screens/brief.readings.tsx
+++ b/frontend/src/screens/brief.readings.tsx
@@ -338,7 +338,7 @@ function meetingsReading(day: Worklist): MeetingsReading {
 // THE PERIOD IS IN THE TITLE, NOT THE BASIS. The headline reads one quarter's
 // open pipeline, and a reader who cannot see which quarter cannot reconcile it
 // against the currency totals beside it. `Q3` is all a title has room for, so
-// the full range — and, where the reading is the whole organization's rather
+// the full range — and, where the reading is the whole company's rather
 // than this reader's, whose pipeline it is — goes on the cell's hover line.
 //
 // READ THROUGH THE SAME KEY ANALYTICS USES. Two surfaces asking what the
@@ -405,7 +405,7 @@ function PipelineOutlook() {
   }
   const quarter = quarterLabel(data.period_start);
   return (
-    // The range and, where the figure is the whole organization's, whose
+    // The range and, where the figure is the whole company's, whose
     // pipeline it is: a dense title has room for a quarter and nothing more.
     <span ref={tip.ref} {...tip.trigger}>
       <StatCard

--- a/frontend/src/screens/brief.readings.tsx
+++ b/frontend/src/screens/brief.readings.tsx
@@ -338,7 +338,7 @@ function meetingsReading(day: Worklist): MeetingsReading {
 // THE PERIOD IS IN THE TITLE, NOT THE BASIS. The headline reads one quarter's
 // open pipeline, and a reader who cannot see which quarter cannot reconcile it
 // against the currency totals beside it. `Q3` is all a title has room for, so
-// the full range — and, where the reading is the whole company's rather
+// the full range — and, where the reading is the whole organization's rather
 // than this reader's, whose pipeline it is — goes on the cell's hover line.
 //
 // READ THROUGH THE SAME KEY ANALYTICS USES. Two surfaces asking what the
@@ -405,7 +405,7 @@ function PipelineOutlook() {
   }
   const quarter = quarterLabel(data.period_start);
   return (
-    // The range and, where the figure is the whole company's, whose
+    // The range and, where the figure is the whole organization's, whose
     // pipeline it is: a dense title has room for a quarter and nothing more.
     <span ref={tip.ref} {...tip.trigger}>
       <StatCard

--- a/frontend/src/screens/contractform.test.ts
+++ b/frontend/src/screens/contractform.test.ts
@@ -11,6 +11,7 @@ const DRAFT = {
   endsOn: "",
   renewalOn: "",
   noticePeriodDays: "",
+  paymentTermDays: "",
   signedOn: "",
 };
 

--- a/frontend/src/screens/contractform.tsx
+++ b/frontend/src/screens/contractform.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useId, useState } from "react";
-import { api } from "../api/client";
 import type { components } from "../api/schema";
 // The installation read every form shares: one query, one key, so the currency
 // this form writes is the same fact the settings screen shows.
@@ -12,8 +11,9 @@ import { Select } from "../design-system/select";
 import { SurfaceState } from "../design-system/surfacestate";
 import { useT } from "../i18n";
 import { uploadAttachment } from "./attachmentupload";
-import { problemMessageOf, throwProblem } from "./common";
+import { problemMessageOf } from "./common";
 import { paperState, useContractPaper } from "./contractpaper";
+import { createContract, patchContract } from "./contractwrites";
 
 // Recording an agreement.
 //
@@ -48,6 +48,7 @@ export type ContractDraft = {
   endsOn: string;
   renewalOn: string;
   noticePeriodDays: string;
+  paymentTermDays: string;
   signedOn: string;
 };
 
@@ -65,6 +66,7 @@ const EMPTY_DRAFT: ContractDraft = {
   endsOn: "",
   renewalOn: "",
   noticePeriodDays: "",
+  paymentTermDays: "",
   signedOn: "",
 };
 
@@ -227,6 +229,10 @@ function draftOf(contract: Contract | undefined): ContractDraft {
       contract.notice_period_days == null
         ? ""
         : String(contract.notice_period_days),
+    paymentTermDays:
+      contract.payment_term_days == null
+        ? ""
+        : String(contract.payment_term_days),
     signedOn: contract.signed_on ?? "",
   };
 }
@@ -394,6 +400,23 @@ export function ContractTermsFields({
       </Field>
 
       <Field
+        label={t("contracts.form.paymentTerms")}
+        hint={t("contracts.form.paymentTermsHint")}
+      >
+        {(props) => (
+          <TextInput
+            {...props}
+            type="number"
+            min={0}
+            value={draft.paymentTermDays}
+            onChange={(e) =>
+              setDraft({ ...draft, paymentTermDays: e.target.value })
+            }
+          />
+        )}
+      </Field>
+
+      <Field
         label={t("contracts.form.signedOn")}
         hint={t("contracts.form.signedOnHint")}
       >
@@ -532,54 +555,6 @@ export function SignedFileField({
   );
 }
 
-async function createContract(
-  companyId: string,
-  draft: ContractDraft,
-): Promise<string> {
-  const { data, error } = await api.POST("/contracts", {
-    body: contractBody(companyId, draft),
-  });
-  if (error) {
-    throwProblem(error);
-  }
-  return data?.id ?? "";
-}
-
-// A correction sends nulls for the fields a human cleared: once somebody has
-// removed a value, "I typed this by mistake" and "we never agreed one" are the
-// same answer, and leaving the old value in place would keep asserting the
-// mistake.
-async function patchContract(
-  contract: Contract,
-  draft: ContractDraft,
-): Promise<string> {
-  const { error } = await api.PATCH("/contracts/{id}", {
-    params: { path: { id: contract.id } },
-    body: {
-      title: draft.title.trim(),
-      contract_number: draft.contractNumber.trim() || null,
-      value_minor: draft.valueMinor > 0 ? draft.valueMinor : null,
-      // Same pairing as a create, and the same refusal to complete it with a
-      // guess: an amount whose currency the form does not hold goes out as the
-      // half it is, for the server to refuse in the open.
-      currency:
-        draft.valueMinor > 0 && draft.currency !== "" ? draft.currency : null,
-      value_basis: draft.valueBasis,
-      starts_on: draft.startsOn || null,
-      ends_on: draft.endsOn || null,
-      renewal_on: draft.renewalOn || null,
-      notice_period_days: draft.noticePeriodDays
-        ? Number(draft.noticePeriodDays)
-        : null,
-      signed_on: draft.signedOn || null,
-    },
-  });
-  if (error) {
-    throwProblem(error);
-  }
-  return contract.id;
-}
-
 // What the form refuses before the server has to.
 //
 // These mirror the database's own constraints rather than adding rules of their
@@ -622,6 +597,7 @@ export type ContractTermsFragment = Pick<
   | "ends_on"
   | "renewal_on"
   | "notice_period_days"
+  | "payment_term_days"
   | "signed_on"
 >;
 
@@ -647,6 +623,12 @@ export function contractTermsBody(draft: ContractDraft): ContractTermsFragment {
   }
   if (draft.noticePeriodDays !== "") {
     body.notice_period_days = Number(draft.noticePeriodDays);
+  }
+  // Emptiness, not falsiness: 0 is a real answer here and means due on
+  // receipt, so a truthiness check would silently drop the one term a
+  // reader is most likely to have typed deliberately.
+  if (draft.paymentTermDays !== "") {
+    body.payment_term_days = Number(draft.paymentTermDays);
   }
   if (draft.signedOn !== "") {
     body.signed_on = draft.signedOn;

--- a/frontend/src/screens/contractlifecycle.tsx
+++ b/frontend/src/screens/contractlifecycle.tsx
@@ -64,13 +64,12 @@ export function isTerminalContractStatus(status: Contract["status"]): boolean {
 
 function renewDraftOf(predecessor: Contract): ContractDraft {
   return {
-    // Title and basis are the two fields the successor is likeliest to keep,
-    // and both are required by the wire request — prefilled so renewing an
-    // unchanged agreement does not mean retyping what it was already called.
-    // Everything else the predecessor does NOT hand down: RenewContractRequest
-    // inherits only the counterparty (the server derives that), because a
-    // renewal is usually a fresh negotiation and an inherited amount or term
-    // would be a number nobody actually agreed to this time.
+    // Title and basis are the two the successor is likeliest to keep, and the
+    // wire requires both — prefilled so renewing an unchanged agreement does
+    // not mean retyping its own name. Nothing else is handed down: the request
+    // inherits only the counterparty, which the server derives, because a
+    // renewal is a fresh negotiation and an inherited amount, notice period or
+    // payment term would be a number nobody agreed to this time.
     title: predecessor.title,
     contractNumber: "",
     valueMinor: 0,
@@ -80,6 +79,7 @@ function renewDraftOf(predecessor: Contract): ContractDraft {
     endsOn: "",
     renewalOn: "",
     noticePeriodDays: "",
+    paymentTermDays: "",
     signedOn: "",
   };
 }

--- a/frontend/src/screens/contractwrites.ts
+++ b/frontend/src/screens/contractwrites.ts
@@ -1,0 +1,58 @@
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { throwProblem } from "./common";
+import { type ContractDraft, contractBody } from "./contractform";
+
+// The two writes the contract form makes. Extracted from contractform.tsx so
+// that file stays under the length cap; both are called from one place and
+// neither is reused elsewhere.
+
+type Contract = components["schemas"]["Contract"];
+
+export async function createContract(
+  companyId: string,
+  draft: ContractDraft,
+): Promise<string> {
+  const { data, error } = await api.POST("/contracts", {
+    body: contractBody(companyId, draft),
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data?.id ?? "";
+}
+
+// A correction sends nulls for the fields a human cleared: once somebody has
+// removed a value, "I typed this by mistake" and "we never agreed one" are the
+// same answer, and leaving the old value in place would keep asserting the
+// mistake.
+export async function patchContract(
+  contract: Contract,
+  draft: ContractDraft,
+): Promise<string> {
+  const { error } = await api.PATCH("/contracts/{id}", {
+    params: { path: { id: contract.id } },
+    body: {
+      title: draft.title.trim(),
+      contract_number: draft.contractNumber.trim() || null,
+      value_minor: draft.valueMinor > 0 ? draft.valueMinor : null,
+      // Same pairing as a create, and the same refusal to complete it with a
+      // guess: an amount whose currency the form does not hold goes out as the
+      // half it is, for the server to refuse in the open.
+      currency:
+        draft.valueMinor > 0 && draft.currency !== "" ? draft.currency : null,
+      value_basis: draft.valueBasis,
+      starts_on: draft.startsOn || null,
+      ends_on: draft.endsOn || null,
+      renewal_on: draft.renewalOn || null,
+      notice_period_days: draft.noticePeriodDays
+        ? Number(draft.noticePeriodDays)
+        : null,
+      signed_on: draft.signedOn || null,
+    },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return contract.id;
+}

--- a/frontend/src/screens/contractwrites.ts
+++ b/frontend/src/screens/contractwrites.ts
@@ -48,6 +48,11 @@ export async function patchContract(
       notice_period_days: draft.noticePeriodDays
         ? Number(draft.noticePeriodDays)
         : null,
+      // Emptiness, not falsiness: 0 means due on receipt and is the answer a
+      // reader is most likely to have typed deliberately. A truthiness check
+      // here would send null and clear the very term they just set.
+      payment_term_days:
+        draft.paymentTermDays !== "" ? Number(draft.paymentTermDays) : null,
       signed_on: draft.signedOn || null,
     },
   });


### PR DESCRIPTION
Two things a contract could not hold before: how long the customer has to pay, and whatever else an installation needs to record about one.

## Payment terms

`payment_term_days` is an integer rather than a picklist, because the number is the fact — Net 14, 30 and 60 are shortcuts a form offers, not the vocabulary. Zero is a real value meaning due on receipt, which is why the CHECK admits it while the column stays nullable for "not specified". A contract nobody has recorded terms for is not a contract due immediately, and that difference survives Go, SQL, the wire and the form.

## Contract as a custom-field target, without joining EntityType

This is the decision the slice turns on. `datasource.EntityType` is what a record PROVIDER can be asked about: declaring a member there obliges native provider routing, agent record-shape generation and the embedding and provenance consumers that enumerate it. A contract carries typed extra fields without any of that being true of it, so widening EntityType would promise five capabilities to buy one.

A bounded `Target` vocabulary in `shared/ports/fieldcatalog` carries it instead, preserving every spelling the CHECK already admitted — including activity, relationship and partner, which no active target list offers — because a catalog row written under an older vocabulary must stay readable.

## What the review changed

Codex found the feature was inert through the real API: the HTTP handlers built their own store with no catalog seam, so custom values were dropped on write and omitted on read everywhere except the project-360 path. It also found PATCH ignoring the extension bag entirely and stripping existing values from its own response, a catalog fetch nested inside a caller's transaction that could deadlock the project page on a busy pool, and a frontend PATCH that silently no-opped on payment terms.

Two things were reversed rather than patched. Contract came back out of the automation vocabulary, where I had put it only to satisfy a parity gate: both halves of a renewal reminder refuse a contract, so listing it offered a reminder that never fires. And the enum-sync gate had gone silent, because its reader matches only `CHECK (col IN (...))` and my migration used `= ANY (ARRAY[...])`. The CHECK is rewritten in the form the gate reads, and its binding now points at the Target vocabulary — so the gate proves the split this slice exists to make.

## Verified

Against a real database: negative terms refused, zero and 30 accepted, a contract custom field inserts, an unknown target still refused. Both local gates pass at exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds payment terms to contracts and lets contracts carry custom-field values, so an installation can record how long a customer has to pay and attach its own fields to an agreement. Contracts accept `payment_term_days` (nullable integer, zero means due on receipt) and a custom-field extension bag across create, update, read, and renewal.

**New Features**

- Contracts store payment terms as a non-negative integer; zero means due on receipt and NULL means not yet agreed, so an unrecorded term is not confused with "due immediately".
- Contracts join custom-field targets through a new bounded `Target` vocabulary in `shared/ports/fieldcatalog` rather than through `datasource.EntityType`, keeping contract fields free of the record-provider obligations an `EntityType` member would promise.
- The form offers a payment-terms field beside the notice period, and renewal drafts do not inherit terms, matching the existing rule that a renewal hands down nothing but the counterparty.

**Bug Fixes**

- Wires the custom-field catalog into the contract HTTP handlers and the project-360 seam, which previously dropped custom values on write and omitted them on read through every normal API call.
- PATCH now applies and returns custom-field values instead of ignoring the extension bag and stripping existing values from its own response.
- The project page's contract rows no longer read custom fields, because a catalog fetch inside the caller's transaction could deadlock a single-connection pool.
- Leaves contract out of the automation vocabulary — both halves of a renewal reminder refuse a contract, so listing it would offer a reminder that never fires.
- Rewrites the `custom_field.object` CHECK to the `IN (...)` form the enum-sync gate reads and rebinds it to `Target`, so the gate verifies the vocabulary instead of silently skipping.

<sup>Written for commit 6d164643d77bf01dfc2c990d0d2e2b3814150689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contracts now support optional payment terms in days, including immediate payment (`0`) and unspecified terms.
  * Contract custom fields can be created, edited, stored, and displayed.
  * Custom fields now support contracts as a target.
  * Contract creation, renewal, and updates preserve payment terms and custom-field values.
* **Documentation**
  * Added payment-term guidance in English, German, and Vietnamese.
* **Bug Fixes**
  * Improved contract data handling across lifecycle operations and contract listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->