### PR TITLE
fix(brief): call the record type a company in two comments

### DIFF
--- a/frontend/src/screens/brief.readings.tsx
+++ b/frontend/src/screens/brief.readings.tsx
@@ -338,7 +338,7 @@ function meetingsReading(day: Worklist): MeetingsReading {
 // THE PERIOD IS IN THE TITLE, NOT THE BASIS. The headline reads one quarter's
 // open pipeline, and a reader who cannot see which quarter cannot reconcile it
 // against the currency totals beside it. `Q3` is all a title has room for, so
-// the full range — and, where the reading is the whole organization's rather
+// the full range — and, where the reading is the whole company's rather
 // than this reader's, whose pipeline it is — goes on the cell's hover line.
 //
 // READ THROUGH THE SAME KEY ANALYTICS USES. Two surfaces asking what the
@@ -405,7 +405,7 @@ function PipelineOutlook() {
   }
   const quarter = quarterLabel(data.period_start);
   return (
-    // The range and, where the figure is the whole organization's, whose
+    // The range and, where the figure is the whole company's, whose
     // pipeline it is: a dense title has room for a quarter and nothing more.
     <span ref={tip.ref} {...tip.trigger}>
       <StatCard


### PR DESCRIPTION
Two comments in the pipeline reading said "organization" where the record type is called company. `TestTheRecordTypeIsCalledCompany` refuses the retired word in prose as well as in identifiers, so `main` has been red on `go test ./gates` since #5324.

They came in with #5324, where a rebase across the rename restored the older wording in blocks that had been moved to new files. Same mechanism as the nine `person` comments fixed inside that PR, one noun over.

## Why it reached main

The gate lives in the backend gate package, so it does not run in `make check-fe`. It is also not in `make check-gates`, which runs only nine named meta-gate tests — the Makefile comment above that target says so, and I verified it exits 0 with this red present. The lane that runs the whole package is `make check-go` / `make check-backend`, or directly `cd backend && go test ./gates/ -count=1`.

There are three vocabulary gates in total, and they do not overlap:

| Gate | Checks | Lane |
|---|---|---|
| `TestTheRecordIsCalledAContact` | comments and prose, `person` / `people` | backend |
| `TestTheRecordTypeIsCalledCompany` | comments and prose, `organization` | backend |
| `src/i18n/record-noun.test.ts` | user-facing catalog values | frontend |

## Verification

- `cd backend && go test ./gates/ -count=1` — the full package, green
- `src/i18n/record-noun.test.ts` — green
- `make check-fe` — green, 668 test files
- Swept every file #5324 touched for both retired words; the remaining hits are human-sense catalog values and the waiver file's own explanation, all waived by path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two comments in the brief pipeline reading that still said "organization" where the record type is called company. The gate that enforces this vocabulary only runs in the backend lane, so the stale wording reached `main` through the frontend flow.

<sup>Written for commit 1f7418ac1de288a162dd13d7ae5c506dd5a77bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

