### PR TITLE
Show what happened to a subscription choice the server could not apply

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6287,6 +6287,15 @@ export const de = {
     "Wir speichern den genauen Wortlaut, den du gesehen hast, und einen Zeitstempel als Nachweis — danach gilt er für jeden künftigen Versand.",
   "prefs.save": "Einstellungen speichern",
   "prefs.discard": "Verwerfen",
+  "prefs.cannotGrant":
+    "F\u00fcr diesen Datensatz k\u00f6nnen wir {purposes} nicht starten. Wenn das nicht stimmt, antworten Sie auf eine unserer E-Mails \u2014 ein Mensch sieht nach.",
+  "prefs.cannotGrantWhy": "F\u00fcr diesen Datensatz nicht aktivierbar.",
+  "prefs.choiceNotApplied":
+    "Eine Ihrer Auswahlen wurde nicht \u00fcbernommen. Oben sehen Sie Ihre aktuellen Einstellungen.",
+  "prefs.confirmationSent":
+    "Fast geschafft: Bitte pr\u00fcfen Sie Ihre E-Mails und best\u00e4tigen Sie {purposes} \u00fcber den Link. Bis dahin startet dieses Abo nicht.",
+  "prefs.confirmationUnavailable":
+    "Wir konnten die Best\u00e4tigungs-E-Mail f\u00fcr {purposes} nicht senden, daher wurde nichts gestartet. Bitte versuchen Sie es sp\u00e4ter erneut.",
   "prefs.partialSave":
     "Beim Speichern ist etwas schiefgelaufen. Einige deiner Entscheidungen wurden möglicherweise schon übernommen — wir haben deinen aktuellen Stand neu geladen, damit du genau siehst, wo du stehst.",
   "prefs.wording.business_correspondence":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6447,6 +6447,15 @@ export const en = {
     "We record the exact wording you saw and a timestamp as proof — then it applies to every future send.",
   "prefs.save": "Save preferences",
   "prefs.discard": "Discard",
+  "prefs.cannotGrant":
+    "We cannot start {purposes} on this record. If you think that is wrong, reply to any of our emails and we will look into it.",
+  "prefs.cannotGrantWhy": "This cannot be switched on for this record.",
+  "prefs.choiceNotApplied":
+    "One of your choices did not take effect. Your current settings are shown above.",
+  "prefs.confirmationSent":
+    "Almost there: check your email and click the link to confirm {purposes}. That subscription does not start until you do.",
+  "prefs.confirmationUnavailable":
+    "We could not send the confirmation email for {purposes}, so it has not started. Please try again later.",
   "prefs.partialSave":
     "Something went wrong part-way. Some of your choices may have been saved — we've reloaded your current settings so you can see exactly where you stand.",
   "prefs.wording.business_correspondence":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6212,6 +6212,16 @@ export const vi = {
     "Chúng tôi ghi lại đúng nội dung bạn đã đọc kèm dấu thời gian làm bằng chứng — rồi nó áp dụng cho mọi lần gửi về sau.",
   "prefs.save": "Lưu tuỳ chọn",
   "prefs.discard": "Bỏ thay đổi",
+  "prefs.cannotGrant":
+    "Ch\u00fang t\u00f4i kh\u00f4ng th\u1ec3 b\u1eaft \u0111\u1ea7u {purposes} cho h\u1ed3 s\u01a1 n\u00e0y. N\u1ebfu b\u1ea1n cho r\u1eb1ng \u0111i\u1ec1u n\u00e0y kh\u00f4ng \u0111\u00fang, h\u00e3y tr\u1ea3 l\u1eddi b\u1ea5t k\u1ef3 email n\u00e0o c\u1ee7a ch\u00fang t\u00f4i.",
+  "prefs.cannotGrantWhy":
+    "Kh\u00f4ng th\u1ec3 b\u1eadt cho h\u1ed3 s\u01a1 n\u00e0y.",
+  "prefs.choiceNotApplied":
+    "M\u1ed9t trong c\u00e1c l\u1ef1a ch\u1ecdn c\u1ee7a b\u1ea1n ch\u01b0a c\u00f3 hi\u1ec7u l\u1ef1c. C\u00e0i \u0111\u1eb7t hi\u1ec7n t\u1ea1i \u0111\u01b0\u1ee3c hi\u1ec3n th\u1ecb \u1edf tr\u00ean.",
+  "prefs.confirmationSent":
+    "S\u1eafp xong: Vui l\u00f2ng ki\u1ec3m tra email v\u00e0 nh\u1ea5p v\u00e0o li\u00ean k\u1ebft \u0111\u1ec3 x\u00e1c nh\u1eadn {purposes}. \u0110\u0103ng k\u00fd \u0111\u00f3 ch\u01b0a b\u1eaft \u0111\u1ea7u cho \u0111\u1ebfn khi b\u1ea1n l\u00e0m v\u1eady.",
+  "prefs.confirmationUnavailable":
+    "Ch\u00fang t\u00f4i kh\u00f4ng g\u1eedi \u0111\u01b0\u1ee3c email x\u00e1c nh\u1eadn cho {purposes}, n\u00ean n\u00f3 ch\u01b0a b\u1eaft \u0111\u1ea7u. Vui l\u00f2ng th\u1eed l\u1ea1i sau.",
   "prefs.partialSave":
     "Có gì đó hỏng giữa chừng. Một phần lựa chọn của bạn có thể đã được lưu — chúng tôi đã tải lại thiết lập hiện tại để bạn thấy đúng mình đang ở đâu.",
   "prefs.wording.business_correspondence":

--- a/frontend/src/screens/preferencerow.tsx
+++ b/frontend/src/screens/preferencerow.tsx
@@ -1,0 +1,119 @@
+import { Lock } from "lucide-react";
+
+import { Checkbox } from "../design-system/atoms";
+import type { useT } from "../i18n";
+import { labelOf, type PurposeView, stateLineKey } from "./preferences.logic";
+
+// One purpose, as a row the subject can stage a change on.
+//
+// Split from the page because the page is a query, a draft, a save and four
+// notices, and this is a control with its own rules about what it may offer.
+//
+export function PreferenceRow({
+  purpose,
+  on,
+  wording,
+  t,
+  onToggle,
+  disabled,
+  mayGrant,
+}: Readonly<{
+  purpose: PurposeView;
+  on: boolean;
+  wording: string;
+  t: ReturnType<typeof useT>;
+  onToggle: () => void;
+  // True while a write this row's toggle could race with is in flight — a
+  // locked purpose is already disabled for its own reason, so the two
+  // conditions just combine below rather than this prop overriding that one.
+  disabled: boolean;
+  // Whether this SUBJECT may take a grant at all — see grantRefused below.
+  //
+  // Named mayGrant rather than subjectMayGrant because the helper that
+  // computes it is called subjectMayGrant: an identically named prop resolves
+  // to the IMPORT when somebody forgets to destructure it, which typechecks
+  // cleanly and throws at render. That happened once already.
+  mayGrant: boolean;
+}>) {
+  // A double-opt-in purpose can now be turned ON here, and this row used to
+  // refuse it.
+  //
+  // The reason it refused was true when it was written: the write recorded a
+  // grant this page's reusable token could not evidence, the send gate refused
+  // that grant anyway, and a switch that always fails is worse than no switch.
+  // So the subject could turn a subscription off and never back on, and the
+  // mint guard refuses anybody doing it for them — a withdrawal was permanent.
+  //
+  // What the server does now is mail the confirmation link instead of writing
+  // a dead row, and answer `confirmation_sent`. The switch no longer always
+  // fails, so withholding it would be withholding the only route somebody has
+  // back to a subscription they once wanted.
+  //
+  // The row still SAYS what pressing it does, because the outcome is not the
+  // one a checkbox implies: nothing is subscribed until a link is clicked in
+  // another window.
+  const needsConfirmation = purpose.grant_needs_confirmation && !on;
+  // WHETHER THE SUBJECT MAY BE GRANTED ANYTHING AT ALL, which is a different
+  // question from whether this purpose needs a round trip.
+  //
+  // can_opt_in is `!locked && !grant_needs_confirmation && grantable`
+  // (preferenceview.go), and `grantable` is about the SUBJECT: an archived or
+  // Art. 17 anonymised record whose erasure destroyed the capability a fresh
+  // grant would re-open. The server refuses those with `cannot_grant` however
+  // the page asks.
+  //
+  // Reading can_opt_in directly would re-block every DOI row, because the flag
+  // is false for those too. So the subject-level half is recovered from the
+  // rows the round trip does NOT apply to: if not one of them may be granted,
+  // it is the subject rather than the purpose.
+  const grantRefused = !on && !mayGrant;
+  return (
+    <li className="pref-row">
+      <div className="pref-row-main">
+        <div className="pref-row-head">
+          {purpose.locked && <Lock className="pref-lock-icon" aria-hidden />}
+          <span className="pref-label">{labelOf(t, purpose)}</span>
+          {purpose.locked && (
+            <span className="pref-lock-badge">{t("prefs.alwaysOn")}</span>
+          )}
+        </div>
+        <p className="t-caption" data-testid={`wording-${purpose.key}`}>
+          {wording}
+        </p>
+        <p className="t-caption pref-state">{t(stateLineKey(purpose, on))}</p>
+        {purpose.locked && (
+          <p className="t-caption pref-locked-why">{t("prefs.lockedWhy")}</p>
+        )}
+        {grantRefused && (
+          <p className="t-caption pref-locked-why">
+            {t("prefs.cannotGrantWhy")}
+          </p>
+        )}
+        {needsConfirmation && !grantRefused && (
+          <p className="t-caption pref-locked-why">
+            {t("prefs.confirmationNeededWhy")}
+          </p>
+        )}
+      </div>
+      {/* A Checkbox, not a Switch, and the difference is not cosmetic: a
+          Switch IS the write, while a Checkbox states an intent something
+          later submits (design-system/README.md). This page stages every
+          change and commits them from the save bar below, so announcing
+          role="switch" would tell a screen-reader user their choice had
+          already taken effect when it has not. The visible label is
+          hidden because the row draws its own richer heading above. */}
+      <Checkbox
+        checked={on}
+        aria-label={labelOf(t, purpose)}
+        disabled={purpose.locked || grantRefused || disabled}
+        className="pref-check"
+        // Empty, because aria-label above already names the control: a
+        // second copy of the purpose name would put the same words on the
+        // page twice for a sighted reader and read them twice to everyone
+        // else.
+        label=""
+        onChange={onToggle}
+      />
+    </li>
+  );
+}

--- a/frontend/src/screens/preferences.logic.test.ts
+++ b/frontend/src/screens/preferences.logic.test.ts
@@ -61,8 +61,9 @@ const doiPurposes: PurposeView[] = [
     state: "withdrawn",
     locked: false,
     choice: "opted_out",
-    // A purpose needing a confirmation round-trip cannot be granted from
-    // here either, for the same reason a locked one cannot.
+    // can_opt_in is the SERVER's own field and stays as the server sends it.
+    // What changed is what the page does with a grant: it submits one, and the
+    // server answers by mailing a confirmation rather than refusing.
     can_opt_in: false,
     grant_needs_confirmation: true,
   },
@@ -173,11 +174,20 @@ describe("choice building", () => {
 });
 
 describe("a purpose needing a confirmation round-trip", () => {
-  // The defect this holds: the page offered the switch, the contact turned it
-  // on, and the save came back 422 with nothing recorded.
-  it("never submits a grant the server refuses", () => {
+  // THIS USED TO ASSERT THE OPPOSITE, and the reversal is the point.
+  //
+  // The grant was stripped here because the server refused it: submitting one
+  // came back 422 with nothing recorded, and it took the rest of the save with
+  // it. So a subscription could be turned off and never back on, and the mint
+  // guard refuses anybody doing it for the subject — a withdrawal was permanent.
+  //
+  // The server now mails a confirmation link instead of refusing. Stripping the
+  // choice here would mean the subject ticked the box, pressed save, and
+  // nothing happened at all — the same dead end, one layer up and without the
+  // honesty of the old blocked switch.
+  it("submits a grant so the server can mail its confirmation", () => {
     const draft = { doi_newsletter: true, doi_granted: true };
-    expect(dirtyKeys(doiPurposes, draft)).toEqual([]);
+    expect(dirtyKeys(doiPurposes, draft)).toEqual(["doi_newsletter"]);
   });
 
   // And the half that must keep working: an unsubscribe is honoured, so

--- a/frontend/src/screens/preferences.logic.ts
+++ b/frontend/src/screens/preferences.logic.ts
@@ -43,17 +43,18 @@ export function initialDraft(purposes: PurposeView[]): Draft {
 // toggle is disabled, so a draft that claims one moved is noise, never a pending
 // change.
 //
-// A double-opt-in purpose is excluded only in the GRANT direction, and for a
-// different reason: the server refuses that write too, but the withdrawal
-// beside it is honoured. Filtering the whole purpose would strip somebody's
-// unsubscribe; filtering neither would submit a choice that 422s and lose the
-// rest of the save with it.
+// A DOUBLE-OPT-IN GRANT IS NO LONGER EXCLUDED, and that exclusion is worth
+// remembering rather than just deleting. It was correct while the server
+// refused such a write: submitting one would 422 and lose the rest of the save
+// with it, so the grant was stripped and the withdrawal beside it kept.
+//
+// The server now takes that choice and mails a confirmation link instead of
+// refusing it. Stripping it here would mean the subject ticked the box, pressed
+// save, and nothing at all happened — the same dead end the old block was
+// built to be honest about, arriving one layer up.
 export function dirtyKeys(purposes: PurposeView[], draft: Draft): string[] {
   return purposes
     .filter((purpose) => !purpose.locked)
-    .filter(
-      (purpose) => !(purpose.grant_needs_confirmation && draft[purpose.key]),
-    )
     .filter((purpose) => draft[purpose.key] !== displayOn(purpose))
     .map((purpose) => purpose.key);
 }
@@ -142,4 +143,30 @@ export function rowIsOn(purpose: PurposeView, draft: Draft): boolean {
     return true;
   }
   return draft[purpose.key] ?? displayOn(purpose);
+}
+
+// subjectMayGrant answers whether this SUBJECT can be granted anything at all,
+// as opposed to whether a given purpose needs a confirmation round trip.
+//
+// The server sends one flag for both: can_opt_in is
+// `!locked && !grant_needs_confirmation && grantable` (preferenceview.go), and
+// only `grantable` is about the subject — an archived or Art. 17 anonymised
+// record whose erasure destroyed the capability a fresh grant would re-open.
+// The server refuses those with `cannot_grant` however the page asks.
+//
+// Recovered rather than asked for, because the wire carries no separate field:
+// among the purposes the round trip does NOT apply to, at least one offering
+// opt-in means the subject is eligible. None of them offering it means the
+// refusal is about the subject.
+//
+// NO SUCH PURPOSES AT ALL is read as eligible. An installation whose every
+// marketing purpose needs a round trip tells us nothing about the subject, and
+// blocking on no evidence would refuse a live contact their own subscription.
+export function subjectMayGrant(purposes: PurposeView[]): boolean {
+  const decidable = purposes.filter(
+    (purpose) => !purpose.locked && !purpose.grant_needs_confirmation,
+  );
+  return (
+    decidable.length === 0 || decidable.some((purpose) => purpose.can_opt_in)
+  );
 }

--- a/frontend/src/screens/preferences.test.tsx
+++ b/frontend/src/screens/preferences.test.tsx
@@ -75,6 +75,17 @@ const CENTER = {
       choice: "opted_out",
       can_opt_in: true,
     },
+    // A purpose the subject once had and took back, needing a confirmation
+    // round trip to have again. The row this page used to refuse to offer.
+    {
+      key: "doi_news",
+      label: "Research digest",
+      state: "withdrawn",
+      locked: false,
+      grant_needs_confirmation: true,
+      choice: "opted_out",
+      can_opt_in: false,
+    },
   ],
 };
 
@@ -456,5 +467,174 @@ describe("one-click unsubscribe (G-7)", () => {
 
     expect((await screen.findAllByRole("checkbox")).length).toBeGreaterThan(0);
     expect(screen.queryAllByRole("switch")).toHaveLength(0);
+  });
+
+  // THE ROW USED TO BE DISABLED, and that was right while the write always
+  // failed: the subject could turn a subscription off and never back on, and
+  // the mint guard refuses anybody doing it for them. A withdrawal was
+  // permanent, and a dead switch at least said so honestly.
+  //
+  // The server now mails a confirmation instead of refusing, so withholding
+  // the switch would withhold the only route back to a subscription somebody
+  // once wanted.
+  it("offers the switch for a purpose that needs a confirmation", async () => {
+    stubCenter();
+    render(<PreferenceCenterScreen token="tok-123" />);
+
+    expect(
+      await screen.findByRole("checkbox", { name: "Research digest" }),
+    ).toBeEnabled();
+  });
+
+  // AND SAYS WHAT PRESSING IT DOES, because the outcome is not the one a
+  // checkbox implies: nothing is subscribed until a link is clicked elsewhere.
+  it("still says a confirmation is needed", async () => {
+    stubCenter();
+    render(<PreferenceCenterScreen token="tok-123" />);
+
+    await screen.findByRole("checkbox", { name: "Research digest" });
+    expect(
+      screen.getByText(en["prefs.confirmationNeededWhy"]),
+    ).toBeInTheDocument();
+  });
+
+  // THE CHOICE REACHES THE SERVER. Stripped here, the subject would tick the
+  // box, press save, and nothing at all would happen — the same dead end the
+  // old blocked switch was built to be honest about, one layer up.
+  it("submits the grant so the server can mail its confirmation", async () => {
+    const sent: Sent[] = [];
+    stubCenter({}, sent);
+    render(<PreferenceCenterScreen token="tok-123" />);
+
+    await userEvent.click(
+      await screen.findByRole("checkbox", { name: "Research digest" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    const put = sent.find((r) => r.key === "PUT /public/preferences/tok-123");
+    if (!put)
+      throw new Error("nothing was PUT, so no choice reached the server");
+    const { choices } = put.body as { choices: { purpose_key: string }[] };
+    expect(choices.map((choice) => choice.purpose_key)).toContain("doi_news");
+  });
+
+  // AN INELIGIBLE SUBJECT IS REFUSED AT THE ROW, not silently at the server.
+  //
+  // can_opt_in conflates two things: whether a purpose needs a round trip, and
+  // whether this SUBJECT may take a grant at all — an archived or Art. 17
+  // anonymised record whose erasure destroyed the capability. Unblocking the
+  // DOI row meant no longer reading that flag directly, and without the
+  // subject-level half recovered separately the page would offer a checkbox
+  // the server refuses with `cannot_grant` and say nothing about it.
+  it("refuses the switch when the subject cannot be granted anything", async () => {
+    stubCenter({
+      "GET /public/preferences/tok-123": () =>
+        jsonResponse({
+          ...CENTER,
+          // Every decidable purpose closed to opt-in: the refusal is about the
+          // record, not about any one subscription.
+          purposes: CENTER.purposes.map((purpose) => ({
+            ...purpose,
+            can_opt_in: false,
+          })),
+        }),
+    });
+    render(<PreferenceCenterScreen token="tok-123" />);
+
+    expect(
+      await screen.findByRole("checkbox", { name: "Research digest" }),
+    ).toBeDisabled();
+    expect(
+      screen.getAllByText(en["prefs.cannotGrantWhy"]).length,
+    ).toBeGreaterThan(0);
+  });
+
+  // A RELAY FAULT IS NOT A REFUSAL, and the page must not report it as one —
+  // nor stay silent, which is what it did before: the tick simply vanished on
+  // the refetch with nothing said.
+  it("says the confirmation could not be sent rather than nothing", async () => {
+    stubCenter({
+      "PUT /public/preferences/tok-123": () =>
+        jsonResponse({
+          ...CENTER,
+          refused: [
+            { purpose_key: "doi_news", reason: "confirmation_unavailable" },
+          ],
+        }),
+    });
+    render(<PreferenceCenterScreen token="tok-123" />);
+
+    await userEvent.click(
+      await screen.findByRole("checkbox", { name: "Research digest" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(
+      await screen.findByText(/could not send the confirmation/i),
+    ).toBeInTheDocument();
+    // And NOT the success sentence: telling somebody to check their email for
+    // a message this installation could not send sends them looking for a
+    // fault on their own side.
+    expect(screen.queryByText(/check your email/i)).not.toBeInTheDocument();
+  });
+
+  // THE NOTICE DOES NOT OUTLIVE THE SAVE THAT PRODUCED IT. A later save with
+  // nothing pending would otherwise leave "check your email" standing about a
+  // choice the subject has since changed.
+  it("clears the pending notice on the next ordinary save", async () => {
+    let pending = true;
+    stubCenter({
+      "PUT /public/preferences/tok-123": () => {
+        const refused = pending
+          ? [{ purpose_key: "doi_news", reason: "confirmation_sent" }]
+          : [];
+        pending = false;
+        return jsonResponse({ ...CENTER, refused });
+      },
+    });
+    render(<PreferenceCenterScreen token="tok-123" />);
+
+    await userEvent.click(
+      await screen.findByRole("checkbox", { name: "Research digest" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    await screen.findByText(/check your email/i);
+
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: en["prefs.purpose.marketing_email"],
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText(/check your email/i)).not.toBeInTheDocument(),
+    );
+  });
+
+  // A PENDING SUBSCRIBE IS NOT A FAILURE AND NOT A PLAIN SUCCESS. The purpose
+  // rows come back unchanged — nothing is granted until the link is clicked —
+  // so a page that said nothing here would show the subject their tick
+  // vanishing with no explanation.
+  it("tells the subject a confirmation link is on its way", async () => {
+    stubCenter({
+      "PUT /public/preferences/tok-123": () =>
+        jsonResponse({
+          ...CENTER,
+          refused: [{ purpose_key: "doi_news", reason: "confirmation_sent" }],
+        }),
+    });
+    render(<PreferenceCenterScreen token="tok-123" />);
+
+    await userEvent.click(
+      await screen.findByRole("checkbox", { name: "Research digest" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    // It names WHICH subscription is waiting, in the notice itself: somebody
+    // who ticked two boxes needs to know which one is pending, and the rows
+    // cannot show it — nothing about them changed.
+    const notice = await screen.findByText(/check your email/i);
+    expect(notice).toHaveTextContent("Research digest");
   });
 });

--- a/frontend/src/screens/preferences.tsx
+++ b/frontend/src/screens/preferences.tsx
@@ -1,18 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Lock } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../api/client";
-import {
-  Button,
-  Card,
-  Checkbox,
-  EmptyState,
-  Skeleton,
-} from "../design-system/atoms";
+import { Button, Card, EmptyState, Skeleton } from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 import { problemMessageOf, throwProblem } from "./common";
+import { PreferenceRow } from "./preferencerow";
 import {
   type Draft,
   dirtyKeys,
@@ -20,9 +14,10 @@ import {
   labelOf,
   type PurposeView,
   rowIsOn,
-  stateLineKey,
+  subjectMayGrant,
   toChoices,
 } from "./preferences.logic";
+import { type ChoiceOutcome, PendingConfirmations } from "./preferencespending";
 import { PublicPage } from "./publicpage";
 import "./preferences.css";
 
@@ -111,6 +106,8 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
   });
 
   const purposes: PurposeView[] = center.data?.purposes ?? [];
+  // Whether this subject may take a grant at all — see subjectMayGrant.
+  const mayGrant = subjectMayGrant(purposes);
 
   // The wording rendered at each toggle IS the wording submitted for it —
   // one map, computed once per data load, read both for display and for the
@@ -129,6 +126,15 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
 
   const [draft, setDraft] = useState<Draft | null>(null);
   const [partialSave, setPartialSave] = useState(false);
+  // The purposes whose subscribe is waiting on a link the subject has still to
+  // click, from the save that asked for them. Held as names rather than a
+  // count: somebody who ticked two boxes needs to know which two are pending,
+  // and the page cannot derive it from the purpose rows because nothing about
+  // them changed — that is the whole point of the outcome.
+  // What the server said about the choices in the last save that did not
+  // simply take effect. Every one of them is a different sentence to the
+  // subject, and none of them is an error — see PendingConfirmations.
+  const [outcomes, setOutcomes] = useState<ChoiceOutcome[]>([]);
   // The one-click unsubscribe's own reply (G-7): the exact keys it just
   // withdrew, authoritative straight from the server — never re-derived by
   // guessing which purposes must have been granted before the call.
@@ -173,6 +179,18 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
       // prompted the save.
       queryClient.setQueryData(queryKey, data);
       setPartialSave(false);
+      // A SUBSCRIBE THAT NEEDS A ROUND TRIP IS NOT A FAILURE, and it is not a
+      // plain success either. The purpose rows come back unchanged — nothing is
+      // granted until the link is clicked — so a page that said nothing here
+      // would show the subject their tick vanishing with no explanation.
+      //
+      // It rides the `refused` list because that is the list the server uses
+      // for every outcome a choice did not simply take, and reading it as
+      // "these failed" is what this branch exists to prevent.
+      // ALWAYS REPLACED, never merged. A save that returns no pending outcome
+      // has none: leaving an earlier "check your email" on screen would tell
+      // the subject a link is coming for a choice they have since changed.
+      setOutcomes(data?.refused ?? []);
       // A granular save supersedes any pending one-click notice — the
       // subject just recorded their own explicit choice.
       setLastUnsubscribed(null);
@@ -184,6 +202,10 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
       // committed — re-read rather than let the local draft masquerade as
       // what actually applied.
       setPartialSave(true);
+      // A failed save says nothing about the last one's outcomes, and a
+      // "check your email" beside "something went wrong part-way" is two
+      // contradictory claims about the same press.
+      setOutcomes([]);
       queryClient.invalidateQueries({ queryKey });
     },
   });
@@ -211,6 +233,10 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
     },
     onSuccess: (data) => {
       setLastUnsubscribed(data.unsubscribed);
+      // The subject just stopped everything. A standing "check your email to
+      // confirm" would be telling them to finish subscribing to something they
+      // have this moment asked to be rid of.
+      setOutcomes([]);
       setUndoStaged(false);
       if (data.unsubscribed.length === 0) {
         return;
@@ -319,6 +345,7 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
             wording={wordingByKey[purpose.key]}
             t={t}
             disabled={writePending}
+            mayGrant={mayGrant}
             onToggle={() =>
               setDraft((prev) =>
                 prev ? { ...prev, [purpose.key]: !prev[purpose.key] } : prev,
@@ -364,6 +391,8 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
         </Card>
       )}
 
+      <PendingConfirmations outcomes={outcomes} purposes={purposes} />
+
       {dirty.length > 0 && (
         <div className="pref-save-bar">
           <p className="pref-not-saved">{t("prefs.notSaved")}</p>
@@ -400,75 +429,5 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
         </div>
       )}
     </PublicPage>
-  );
-}
-
-function PreferenceRow({
-  purpose,
-  on,
-  wording,
-  t,
-  onToggle,
-  disabled,
-}: Readonly<{
-  purpose: PurposeView;
-  on: boolean;
-  wording: string;
-  t: ReturnType<typeof useT>;
-  onToggle: () => void;
-  // True while a write this row's toggle could race with is in flight — a
-  // locked purpose is already disabled for its own reason, so the two
-  // conditions just combine below rather than this prop overriding that one.
-  disabled: boolean;
-}>) {
-  // A double-opt-in purpose can be turned OFF here but never ON: the write
-  // refuses the grant, because this page's token is reusable and long-lived,
-  // so it cannot evidence one deliberate choice the way a confirmation
-  // round-trip does. Offering a switch that always fails is worse than not
-  // offering it, so the grant is withheld while the withdrawal stays.
-  const grantBlocked = purpose.grant_needs_confirmation && !on;
-  return (
-    <li className="pref-row">
-      <div className="pref-row-main">
-        <div className="pref-row-head">
-          {purpose.locked && <Lock className="pref-lock-icon" aria-hidden />}
-          <span className="pref-label">{labelOf(t, purpose)}</span>
-          {purpose.locked && (
-            <span className="pref-lock-badge">{t("prefs.alwaysOn")}</span>
-          )}
-        </div>
-        <p className="t-caption" data-testid={`wording-${purpose.key}`}>
-          {wording}
-        </p>
-        <p className="t-caption pref-state">{t(stateLineKey(purpose, on))}</p>
-        {purpose.locked && (
-          <p className="t-caption pref-locked-why">{t("prefs.lockedWhy")}</p>
-        )}
-        {grantBlocked && (
-          <p className="t-caption pref-locked-why">
-            {t("prefs.confirmationNeededWhy")}
-          </p>
-        )}
-      </div>
-      {/* A Checkbox, not a Switch, and the difference is not cosmetic: a
-          Switch IS the write, while a Checkbox states an intent something
-          later submits (design-system/README.md). This page stages every
-          change and commits them from the save bar below, so announcing
-          role="switch" would tell a screen-reader user their choice had
-          already taken effect when it has not. The visible label is
-          hidden because the row draws its own richer heading above. */}
-      <Checkbox
-        checked={on}
-        aria-label={labelOf(t, purpose)}
-        disabled={purpose.locked || grantBlocked || disabled}
-        className="pref-check"
-        // Empty, because aria-label above already names the control: a
-        // second copy of the purpose name would put the same words on the
-        // page twice for a sighted reader and read them twice to everyone
-        // else.
-        label=""
-        onChange={onToggle}
-      />
-    </li>
   );
 }

--- a/frontend/src/screens/preferencespending.tsx
+++ b/frontend/src/screens/preferencespending.tsx
@@ -1,0 +1,85 @@
+import { Card } from "../design-system/atoms";
+import { useT } from "../i18n";
+import { labelOf, type PurposeView } from "./preferences.logic";
+
+/** One choice the server did not simply apply, and why. */
+export type ChoiceOutcome = Readonly<{
+  purpose_key: string;
+  reason: string;
+}>;
+
+/**
+ * What the page says about choices the server did not simply apply.
+ *
+ * They ride the server's `refused` list, and reading that list as "these
+ * failed" is the mistake this component exists to prevent. Only one of the
+ * three outcomes is a refusal the subject caused; the others are a round trip
+ * in progress and a fault on our side.
+ *
+ *   confirmation_sent        — the subscribe was taken and a link is on its
+ *                              way. The purpose rows come back UNCHANGED,
+ *                              because nothing is granted until that link is
+ *                              spent, so a page saying nothing here would show
+ *                              somebody their tick vanishing unexplained.
+ *   confirmation_unavailable — this installation cannot mail the confirmation.
+ *                              About US, so it must not be reported as their
+ *                              choice being declined.
+ *   cannot_grant             — the subject's own record cannot take a grant,
+ *                              which an erasure is the usual cause of.
+ *
+ * EACH KIND GETS ITS OWN SENTENCE, and an unknown one gets a plain line rather
+ * than silence: a code this build does not recognise still means the choice did
+ * not take, and showing nothing would leave the subject believing it did.
+ */
+export function PendingConfirmations({
+  outcomes,
+  purposes,
+}: Readonly<{
+  outcomes: readonly ChoiceOutcome[];
+  purposes: PurposeView[];
+}>) {
+  const t = useT();
+  if (outcomes.length === 0) return null;
+  const named = (reason: string) =>
+    outcomes
+      .filter((outcome) => outcome.reason === reason)
+      .map((outcome) => {
+        const purpose = purposes.find(
+          (candidate) => candidate.key === outcome.purpose_key,
+        );
+        // The key itself if the purpose is not in the view, which is a state
+        // the server should not produce — better a raw key than a sentence
+        // with a blank where a name belongs.
+        return purpose ? labelOf(t, purpose) : outcome.purpose_key;
+      });
+  const known = new Set([
+    "confirmation_sent",
+    "confirmation_unavailable",
+    "cannot_grant",
+  ]);
+  const unrecognised = outcomes.filter(
+    (outcome) => !known.has(outcome.reason),
+  ).length;
+
+  const sent = named("confirmation_sent");
+  const unavailable = named("confirmation_unavailable");
+  const refused = named("cannot_grant");
+  return (
+    <Card as="div" inset className="pref-partial-banner">
+      {sent.length > 0 && (
+        <p>{t("prefs.confirmationSent", { purposes: sent.join(", ") })}</p>
+      )}
+      {unavailable.length > 0 && (
+        <p>
+          {t("prefs.confirmationUnavailable", {
+            purposes: unavailable.join(", "),
+          })}
+        </p>
+      )}
+      {refused.length > 0 && (
+        <p>{t("prefs.cannotGrant", { purposes: refused.join(", ") })}</p>
+      )}
+      {unrecognised > 0 && <p>{t("prefs.choiceNotApplied")}</p>}
+    </Card>
+  );
+}


### PR DESCRIPTION
The preferences page now submits a double-opt-in grant instead of hiding it, and reports back what the server did with it.

## Why

`preferences.logic.ts` stripped every grant whose purpose carried `grant_needs_confirmation`, so pressing the toggle sent nothing and the row snapped back with no explanation. #5398 made the server mint a confirmation link for exactly that request, so the choice now has somewhere to go.

## What changed

- `preferences.logic.ts` — `dirtyKeys` no longer strips DOI grants. New `subjectMayGrant(purposes)` recovers the subject-level half of `can_opt_in` from the purpose rows; an empty set reads as eligible.
- `preferences.tsx` — holds the server's `refused` outcomes in state. Replaced on every save, cleared on save error and on unsubscribe-all.
- `preferencespending.tsx` (new) — renders four branches: `confirmation_sent`, `confirmation_unavailable`, `cannot_grant`, and an unrecognised-reason fallback.
- `preferencerow.tsx` (new) — the row extracted so `preferences.tsx` stays under the 500-line cap.
- Five new keys in `en.ts`, `de.ts`, `vi.ts`.

## One trap worth naming

`preferencerow.tsx`'s prop is `mayGrant`, not `subjectMayGrant`. A prop named after the imported helper shadows it, TypeScript resolves the undestructured name to the import, and the file typechecks clean while throwing at render.

## Gates

`make check-fe` green, `make fe-uat` green, 33 preference tests pass. `make check-backend` is red only on two pre-existing `TestTheRecordTypeIsCalledCompany` violations in `frontend/src/screens/brief.readings.tsx` (lines 341 and 408), introduced by #5324 and confirmed present on clean `origin/main` in a separate worktree. Not mine, not touched here.

Codex reviewed; three findings fixed and each fix mutation-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The preferences page now submits double-opt-in grants instead of dropping them, and reports what the server did with each choice.

Previously the save stripped every grant with `grant_needs_confirmation` and the toggle was disabled for those purposes, so subscribing sent nothing and the row snapped back with no explanation. The server now mails a confirmation link for that request (issue #5398), so the grant is sent and the page shows the outcome.

- New `PendingConfirmations` renders one sentence for each outcome: confirmation sent, email unavailable, subject cannot be granted, or an unrecognized-reason fallback.
- Outcomes are replaced on every save and cleared on save error and on unsubscribe-all.
- `subjectMayGrant` recovers subject-level eligibility from the purpose rows so the toggle is blocked only when the record cannot take any grant, not when a purpose needs a round trip.
- The row moved to `preferencerow.tsx`; its `mayGrant` prop avoids shadowing the imported helper.
- Five new i18n keys in `en`, `de`, and `vi`.

<sup>Written for commit 53020a006a404ce8e323194a0cdd37e4df10ab40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preference controls that clearly show locked, unavailable, and confirmation-required options.
  * Added pending confirmation notices for subscriptions, including confirmation sent, unavailable, or unable to grant outcomes.
  * Double-opt-in choices can now be submitted and processed through confirmation links.
  * Added German, English, and Vietnamese translations for preference and confirmation messages.

* **Bug Fixes**
  * Improved feedback when preference selections cannot be applied or confirmation delivery fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->