### PR TITLE
fix(brief): a reading is a floor only when its own lane was cut short

### DIFF
--- a/frontend/src/screens/brief.fixtures.ts
+++ b/frontend/src/screens/brief.fixtures.ts
@@ -779,3 +779,21 @@ export function boundedMeetings(
 ): WorklistCount {
   return { category: "meetings", considered, shown, more_available: true };
 }
+
+/** A decisions count read to the end. */
+export function wholeDecisions(n: number): WorklistCount {
+  return {
+    category: "decisions",
+    considered: n,
+    shown: n,
+    more_available: false,
+  };
+}
+
+/** A decisions count whose lane stopped at its bound. */
+export function boundedDecisions(
+  considered: number,
+  shown: number,
+): WorklistCount {
+  return { category: "decisions", considered, shown, more_available: true };
+}

--- a/frontend/src/screens/brief.parts.stories.tsx
+++ b/frontend/src/screens/brief.parts.stories.tsx
@@ -3,6 +3,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
+  boundedLeads,
   digest,
   NOT_FOUND,
   pipelineRows,
@@ -10,6 +11,7 @@ import {
   report,
   team,
   teamWeek,
+  wholeDecisions,
 } from "./brief.fixtures";
 import { BriefGlance } from "./brief.glance";
 import { PlanSection } from "./brief.plan";
@@ -265,13 +267,16 @@ export const Readings: Story = {
   render: part(<BriefReadingsStrip day={readingsDay()} />),
 };
 
-// A source ended short of its list, so every figure drawn from it is a floor.
-// It is a `+` ON the figures — `8+` — rather than the sentence that used to
-// stand under the row, and the cell's own hover line says why. Every figure the
-// flag covers wears the mark, which is the contract's own claim: it is set once
-// for the readings block, over four populations, so marking one slot would
-// invite the reading where the other three are exact. The pipeline slot is a
-// read of its own and stays unmarked.
+// A lane ended short of its list, so the figures drawn from THAT lane are
+// floors. It is a `+` ON the figures — `8+` — rather than the sentence that used
+// to stand under the row, and the cell's own hover line says why.
+//
+// The contrast is the point of this story: leads stopped at its bound and
+// decisions did not, so one wears the mark and the other stays exact. Marking
+// all of them was the old behaviour, and a `+` on the figures that are exact is
+// one a reader learns to discount. `urgent` spans every lane, so any bound
+// anywhere is its bound. The pipeline slot is a read of its own and stays
+// unmarked.
 //
 // The MEETINGS slot is the case to look at: this day has none, and a zero draws
 // a plain `0`. "0+" says "at least nothing", which is true of every number
@@ -281,9 +286,9 @@ export const ReadingsCapped: Story = {
   render: part(
     <BriefReadingsStrip
       day={readingsDay(
-        { buyer_replies: 100, prospecting: 8, more_available: true },
+        { buyer_replies: 100, prospecting: 8, review: 4, more_available: true },
         [],
-        [],
+        [boundedLeads(8, 8), wholeDecisions(4)],
         { urgent: 12 },
       )}
     />,
@@ -301,9 +306,12 @@ export const ReadingsOnAPhone: Story = {
   globals: { viewport: { value: "phone" } },
   render: part(
     <BriefReadingsStrip
-      day={readingsDay({ prospecting: 8, more_available: true }, [], [], {
-        urgent: 12,
-      })}
+      day={readingsDay(
+        { prospecting: 8, more_available: true },
+        [],
+        [boundedLeads(8, 8)],
+        { urgent: 12 },
+      )}
     />,
   ),
 };

--- a/frontend/src/screens/brief.readings.test.tsx
+++ b/frontend/src/screens/brief.readings.test.tsx
@@ -9,12 +9,15 @@ import { viewerZone } from "../format/timezone";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
 import {
+  boundedDecisions,
   boundedLeads,
   boundedMeetings,
   leadRow,
   meetingRow,
   readingsDay,
+  wholeDecisions,
   wholeLeads,
+  wholeMeetings,
 } from "./brief.fixtures";
 import { BriefReadingsStrip } from "./brief.readings";
 
@@ -45,7 +48,9 @@ function drawInZone(zone: string, ...args: Parameters<typeof readingsDay>) {
   );
 }
 
-function draw(...args: Parameters<typeof readingsDay>) {
+// The strip over a day built by hand, for the facts `readingsDay`'s parameters
+// do not reach — `sources_unavailable` among them.
+function drawDay(day: ReturnType<typeof readingsDay>) {
   // A QueryClient, because the pipeline reading is a read of its own: it is the
   // one figure on this plate that does not come from the worklist answer, and
   // it asks the same key Analytics asks.
@@ -55,10 +60,14 @@ function draw(...args: Parameters<typeof readingsDay>) {
   return render(
     <QueryClientProvider client={client}>
       <LocaleProvider initial="en">
-        <BriefReadingsStrip day={readingsDay(...args)} />
+        <BriefReadingsStrip day={day} />
       </LocaleProvider>
     </QueryClientProvider>,
   );
+}
+
+function draw(...args: Parameters<typeof readingsDay>) {
+  return drawDay(readingsDay(...args));
 }
 
 // Five READINGS, not five DOM children: a strip that wrapped its slots in a
@@ -400,24 +409,82 @@ describe("the brief readings strip", () => {
   // floor — a whole sentence of footnote under a plate whose argument is that
   // five readings are taken in at one glance. The fact belongs ON the figures.
   //
-  // Every figure the flag covers wears the mark, and that is the contract's own
-  // claim rather than a choice: `more_available` is set once for the readings
-  // block, over four populations, so attributing it to one slot would invite
-  // the reading where the other three are exact.
-  it("marks every figure it covers as a floor when a source was read to its limit", () => {
-    // Every worklist-derived figure non-zero, so the mark is asked of all four.
+  // A figure wears the mark when ITS OWN categories were cut short, not when
+  // some other lane was. A lane nobody could read at all is the exception and
+  // is covered further down: it marks the strip, because the source-to-category
+  // mapping that would narrow it lives on the server.
+  it("marks a figure whose own category was read to its limit", () => {
     draw(
       { more_available: true, prospecting: 2, review: 8 },
-      undefined,
-      undefined,
-      {
-        urgent: 4,
-      },
+      [],
+      [boundedDecisions(8, 8), wholeLeads(2), wholeMeetings(3)],
+      { urgent: 4 },
     );
 
-    // Four of the five: the pipeline slot is a read of its own and this flag
-    // says nothing about it.
-    expect(markedFigures()).toHaveLength(4);
+    // Decisions, plus the urgent slot — which spans every lane, so any bound
+    // anywhere makes it a floor. Leads and meetings were read whole and say so.
+    expect(markedFigures()).toEqual(expect.arrayContaining(["8+", "4+"]));
+    expect(markedFigures()).toHaveLength(2);
+  });
+
+  // THE CASE THIS EXISTS FOR. A calendar read whole used to show "3+" because
+  // an unrelated lane stopped at its bound, and a `+` on the figures that are
+  // exact is one a reader learns to discount.
+  it("leaves a whole-read figure exact when another lane was bounded", () => {
+    draw(
+      { more_available: true, prospecting: 2, review: 8 },
+      [],
+      [boundedDecisions(8, 8), wholeMeetings(3)],
+      { urgent: 0 },
+    );
+
+    expect(strippedFigures()).toContain("3");
+    expect(markedFigures()).not.toContain("3+");
+  });
+
+  // A lane that never ANSWERED is not a lane read to a bound, and the strip
+  // cannot tell which reading it would have fed: `sources_unavailable` names a
+  // source, and only the server maps a source to its lane. So it marks the
+  // whole strip rather than guessing, which over-marks instead of calling a
+  // figure exact over work nobody could see.
+  it("marks every figure when a source could not be read at all", () => {
+    const day = readingsDay(
+      { more_available: true, prospecting: 2, review: 8 },
+      [],
+      [wholeMeetings(3)],
+      { urgent: 4 },
+    );
+    day.sources_unavailable = [{ source: "calendar", reason: "failed" }];
+    drawDay(day);
+
+    // All three worklist slots, LEADS INCLUDED — a fallback wired to two of
+    // them would pass a test that only asked about two.
+    expect(markedFigures()).toContain("3+");
+    expect(markedFigures()).toContain("2+");
+    expect(markedFigures()).toContain("8+");
+  });
+
+  // Each lane keeps its own mark, asked one lane at a time. The tests above set
+  // the decisions lane bounded, so a `floorOf` wired to that lane alone would
+  // satisfy them while leaving leads and meetings permanently exact — the
+  // under-marking direction, and the one that fails silently.
+  it.each([
+    {
+      lane: "leads",
+      counts: [boundedLeads(2, 2), wholeMeetings(3), wholeDecisions(8)],
+      marked: "2+",
+    },
+    {
+      lane: "meetings",
+      counts: [wholeLeads(2), boundedMeetings(3, 3), wholeDecisions(8)],
+      marked: "3+",
+    },
+  ])("marks the $lane figure when only that lane was bounded", (each) => {
+    draw({ more_available: true, prospecting: 2, review: 8 }, [], each.counts, {
+      urgent: 0,
+    });
+
+    expect(markedFigures()).toEqual([each.marked]);
   });
 
   // A FLOOR OF NONE IS NOT A FLOOR. "0+" says "at least nothing", which is true
@@ -425,9 +492,16 @@ describe("the brief readings strip", () => {
   // a kind draws a plain zero, and the mark stays on the figures that count
   // something. It shipped as `0+` on a day with no meetings.
   it("leaves a zero unmarked even where the read was bounded", () => {
-    draw({ more_available: true, prospecting: 0, review: 8 }, [], [], {
-      urgent: 0,
-    });
+    // Both lanes bounded, so the zero and the eight are asked the same
+    // question and only the difference in their figures decides the mark.
+    draw(
+      { more_available: true, prospecting: 0, review: 8 },
+      [],
+      [boundedDecisions(8, 8), boundedLeads(0, 0)],
+      {
+        urgent: 0,
+      },
+    );
 
     const figures = strippedFigures();
     expect(figures).toContain("0");

--- a/frontend/src/screens/brief.readings.tsx
+++ b/frontend/src/screens/brief.readings.tsx
@@ -56,13 +56,41 @@ import type {
 // A BOUNDED READ IS A `+`, NOT A SENTENCE. The row used to carry a line saying
 // a source had been read to its limit, so every figure above it was a floor.
 // The fact belongs ON the figures: `8+` says it where the number is, and the
-// cell's hover line says why. `WorklistReadings.more_available` is ONE flag for
-// the whole readings block by contract — "set once for the strip rather than
-// per reading" — so it marks every figure it covers rather than being
-// attributed to whichever slot a reader happens to suspect.
+// cell's hover line says why.
+//
+// AND THE `+` GOES ON THE FIGURES IT IS TRUE OF. This file used to mark all
+// four from `WorklistReadings.more_available`, arguing that one flag is what
+// the contract states. That was right about the flag and wrong about the page:
+// it put a `+` on a calendar read whole because an unrelated lane stopped at
+// its bound, and a mark on the figures that are exact is one a reader learns
+// to discount. Placing it per slot is not guesswork — `counts` already carries
+// `more_available` PER CATEGORY, seeded from the bounded SOURCES through
+// `categoryOfSource` (reach.go), so each slot asks the lanes it is summed from.
 
 const MEETINGS = "meetings";
 const LEADS = "leads";
+const DECISIONS = "decisions";
+
+// Which categories came back at a bound, as the server marked them.
+//
+// An ABSENT category is not a bounded one. The server seeds `counts` from the
+// bounded sources BEFORE it walks the rows (reach.go), so a lane that stopped
+// early always leaves an entry even when the scope filter took every row it
+// found. A category with no entry at all therefore had no bound and no rows —
+// an honest nothing — and marking it would put a `+` on the zeros.
+//
+// A lane that could not be read AT ALL is a different fact and is not in
+// `counts`: it travels in `sources_unavailable`, and the strip-wide
+// `readings.more_available` already covers it.
+function boundedCategories(day: Worklist): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const count of day.counts) {
+    if (count.more_available) {
+      out.add(count.category);
+    }
+  }
+  return out;
+}
 
 // Open the worklist on the lane a reading counted.
 //
@@ -156,10 +184,29 @@ export function BriefReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
   const readings = day.readings;
   const meetings = meetingsReading(day);
   const soonest = soonestLeadDeadline(day);
-  // ONE flag for the four figures read off this answer, which is what the
-  // contract says it is. Splitting it per slot would attribute a bound to
-  // whichever reading looked likeliest, over populations that differ.
-  const floor = readings.more_available;
+  // Each figure carries its OWN categories' honesty, not the strip's.
+  //
+  // `readings.more_available` is one flag for the whole answer, and marking
+  // every slot from it said "3+" over a calendar that was read whole because an
+  // unrelated notice source stopped at its bound. A `+` a reader learns to
+  // discount is worse than none: it is on the exact figures that are exact.
+  //
+  // This is not the browser splitting one flag by guesswork. `counts` already
+  // carries `more_available` PER CATEGORY, seeded server-side from the bounded
+  // sources themselves (categoryOfSource, reach.go) so a bounded lane that left
+  // no surviving row still marks its category.
+  //
+  // A lane that never answered is the case this does NOT narrow. It travels in
+  // `sources_unavailable`, which names a SOURCE, and the source-to-category
+  // mapping is the server's (categoryOfSource) — re-deriving it here would be a
+  // second copy of it, drifting the first time a producer changes lane. So an
+  // unavailable lane keeps marking the whole strip through `unread`, which is
+  // the safe direction: it over-marks rather than calling a figure exact over
+  // work nobody could see.
+  const bounded = boundedCategories(day);
+  const unread = day.sources_unavailable.length > 0;
+  const floorOf = (category: string): boolean =>
+    unread || bounded.has(category);
   return (
     <section className="brief-readings" aria-label={t("brief.readings.label")}>
       <StatStrip testId="brief-readings">
@@ -170,7 +217,10 @@ export function BriefReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
           // the morning's first question is how many of those there are.
           count={day.summary.urgent}
           warn={day.summary.urgent > 0}
-          floor={floor}
+          // The one slot that genuinely spans the day: `urgent` is every row at
+          // the top two levels whatever lane raised it, so any bounded source
+          // anywhere makes it a floor. This is what `more_available` is for.
+          floor={readings.more_available}
           // The basis says what the figure was taken over, on every day. A zero
           // already reads as "none"; a line repeating that says the same thing
           // twice and drops the one fact it could add.
@@ -184,14 +234,14 @@ export function BriefReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
           // prepared is the one fact on this slot a reader must act on before
           // it begins. The count of meetings itself is neither good nor bad.
           warn={meetings.unready !== null && meetings.unready > 0}
-          floor={floor}
+          floor={floorOf(MEETINGS)}
           basis={meetingsDetail(meetings, locale, t, plural)}
           lane="meetings"
         />
         <LaneReading
           label={t("brief.readings.leads")}
           count={readings.prospecting}
-          floor={floor}
+          floor={floorOf(LEADS)}
           // The deadline is the fact that changes what a reader does before
           // lunch, and NULL rather than a guess where the page cannot honestly
           // compute one.
@@ -208,7 +258,7 @@ export function BriefReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
         <LaneReading
           label={t("brief.readings.decisions")}
           count={readings.review}
-          floor={floor}
+          floor={floorOf(DECISIONS)}
           basis={t("brief.readings.decisionsBasis")}
           lane="decisions"
         />


### PR DESCRIPTION
The Morning Brief's readings strip marked all four worklist figures as floors — rendering `3` as `3+` — from a single flag, `WorklistReadings.more_available`. So a calendar read whole showed `3+` because an unrelated lane stopped at its bound. A mark that lands on the figures that are exact is one a reader learns to discount, which spends the mark and buys nothing.

Each slot now asks the lanes it is summed from.

## Why this is not the browser guessing

`counts` already carries `more_available` **per category**, seeded server-side in `reach.go` from the bounded sources through `categoryOfSource` — before it walks the rows, so a bounded lane that left no surviving row still marks its own category. The page reads that instead of re-deriving anything.

Two cases stay strip-wide, both deliberately:

- **`urgent`** spans every lane, so any bound anywhere is genuinely its bound.
- **A source that never answered** appears in `sources_unavailable`, which names a *source*, not a category. The source-to-lane mapping is the server's; re-deriving it here would be a second copy that drifts the first time a producer changes lane. So an unavailable lane keeps marking the whole strip — over-marking rather than calling a figure exact over work nobody could see.

An absent category is **not** treated as bounded: the server always leaves an entry for a lane that stopped early, so no entry means no bound and no rows, and marking it would put a `+` on the zeros.

## The in-code argument this overturns

`brief.readings.tsx` carried a comment defending the blanket mark — one flag is what the contract states, and splitting it per slot would attribute a bound to whichever reading looked likeliest. That was right about the flag and wrong about the page. The comment is replaced rather than deleted, so the next reader sees the argument was answered.

## Verification

- `make check-fe` green, 668 test files
- `make craft-static` green
- Mutation-checked: reverting the per-lane logic fails 4 tests; wiring `floorOf` to one lane fails 4 tests — the under-marking direction, which is the one that fails silently
- Codex review addressed: added per-lane tests for leads and meetings, extended the unavailable-source test to cover leads, and fixed two Storybook stories that had silently stopped demonstrating their own capped state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Morning Brief readings strip so a figure shows "+" only when its own lane was cut short, instead of every figure wearing the mark from one strip-wide flag. A calendar read whole now says "3" even when an unrelated lane stops at its bound.

- `counts` already carries `more_available` per category, seeded server-side from the bounded sources, so each slot reads its own lanes instead of the page guessing.
- `urgent` and lanes no source could answer stay strip-wide on purpose: urgent spans every lane, and `sources_unavailable` names a source, which only the server can map to a lane.
- An absent category is not treated as bounded, since the server always leaves an entry for a lane that stopped early; marking it would put a "+" on the zeros.
- Tests cover per-lane marking, the unavailable-source case, and the silent under-marking direction.

<sup>Written for commit da51914bc05497d8a61f46b07145130c3849c020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Floor markers in the brief now accurately reflect whether more items are available for each category.
  * Exact readings remain unmarked when another category has additional items.
  * Unavailable sources continue to mark all readings, while zero-valued readings no longer display floor markers.
  * Urgent readings continue to use the overall availability state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->