### PR TITLE
fix(brief): the decisions reading claims a block only where there is one

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3003,8 +3003,9 @@ export const de = {
   "brief.readings.openDecisions": "Entscheidungen prüfen",
   "brief.readings.urgentBasis": "jemand wartet oder eine Zusage bricht",
   "brief.readings.decisions": "Offene Entscheidungen",
-  "brief.readings.decisionsBasis":
-    "jemand kommt erst weiter, wenn du antwortest",
+  "brief.readings.decisionsBasis": "wartet auf deine Antwort",
+  "brief.readings.decisionsBlocking_one": "1 hält Kundenarbeit auf",
+  "brief.readings.decisionsBlocking_other": "{count} halten Kundenarbeit auf",
   "brief.readings.pipeline": "Pipeline · {quarter}",
   "brief.readings.pipelinePlain": "Pipeline",
   "brief.readings.pipelineTipWorkspace": "{period} · gesamte Firma",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3113,7 +3113,13 @@ export const en = {
   "brief.readings.openDecisions": "Review decisions",
   "brief.readings.urgentBasis": "somebody waiting or a promise breaking",
   "brief.readings.decisions": "Decisions waiting",
-  "brief.readings.decisionsBasis": "somebody is blocked until you answer",
+  "brief.readings.decisionsBasis": "waiting on your answer",
+  // Only drawn where a decision on the page carries the server's own
+  // `work_blocked` consequence — a held SEND, not a duplicate pair. The basis
+  // above it claims nothing about who is waiting, because most decisions are
+  // contact hygiene and nobody is held up by one.
+  "brief.readings.decisionsBlocking_one": "1 holding up customer work",
+  "brief.readings.decisionsBlocking_other": "{count} holding up customer work",
   "brief.readings.pipeline": "Pipeline · {quarter}",
   // The same reading where the page cannot name a quarter: the read has not
   // landed, or its period start is not a month this calendar has.

--- a/frontend/src/i18n/record-noun.test.ts
+++ b/frontend/src/i18n/record-noun.test.ts
@@ -255,7 +255,6 @@ const HUMAN_SENSE_KEYS: Record<string, readonly string[]> = {
     "audit.unknownBuyer",
     "auth.unavailableBody",
     "blockedDomains.reasonHint",
-    "brief.readings.decisionsBasis",
     "brief.readings.urgentBasis",
     "captureExclusions.sub",
     "cf.col.addedBy",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2972,8 +2972,9 @@ export const vi = {
   "brief.readings.openDecisions": "Xem quyết định",
   "brief.readings.urgentBasis": "có người đang chờ hoặc một cam kết sắp lỡ",
   "brief.readings.decisions": "Quyết định đang chờ",
-  "brief.readings.decisionsBasis":
-    "có người phải chờ bạn trả lời mới đi tiếp được",
+  "brief.readings.decisionsBasis": "đang chờ bạn trả lời",
+  "brief.readings.decisionsBlocking_one": "1 đang chặn việc với khách",
+  "brief.readings.decisionsBlocking_other": "{count} đang chặn việc với khách",
   "brief.readings.pipeline": "Toàn cảnh pipeline · {quarter}",
   "brief.readings.pipelinePlain": "Toàn cảnh pipeline",
   "brief.readings.pipelineTipWorkspace": "{period} · toàn bộ tổ chức",

--- a/frontend/src/screens/brief.fixtures.ts
+++ b/frontend/src/screens/brief.fixtures.ts
@@ -780,6 +780,31 @@ export function boundedMeetings(
   return { category: "meetings", considered, shown, more_available: true };
 }
 
+/**
+ * A decision on the queue, and whether it actually holds customer work up.
+ *
+ * The split is the ranker's own: a decision about a SEND is blocking, and
+ * contact hygiene — a duplicate pair, a captured counterparty — is not
+ * (classifydecision.go). A fixture that made every decision blocking could not
+ * tell the strip's two basis lines apart.
+ */
+export function decisionRow(id: string, blocking: boolean): WorklistItem {
+  return {
+    id,
+    source: "approval",
+    // `kind` is what the server actually decides on: blocksCustomerWork reads
+    // it and treats an absent one as hygiene, so a fixture without it could
+    // not be the blocking row it claims to be.
+    kind: blocking ? "send_email" : "capture_counterparty",
+    level: blocking ? 5 : 6,
+    category: "decisions",
+    title: blocking ? "Send the renewal quote" : "Add someone from your mail",
+    because: [{ kind: blocking ? "blocks_customer_work" : "routine" }],
+    consequence: blocking ? "work_blocked" : "data_drifts",
+    actions: ["decide"],
+  };
+}
+
 /** A decisions count read to the end. */
 export function wholeDecisions(n: number): WorklistCount {
   return {

--- a/frontend/src/screens/brief.readings.honesty.ts
+++ b/frontend/src/screens/brief.readings.honesty.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Worklist } from "./worklist.queries";
+
+// What the readings strip is allowed to CLAIM, separated from how it draws.
+//
+// Both answers here are about honesty rather than layout: which figures are
+// floors, and how many decisions genuinely hold somebody up. They live beside
+// the strip rather than inside it because each is a question about the day's
+// data that a test can ask directly, without rendering five cards to find out.
+
+/** The lanes the strip's four worklist figures are summed from. */
+export const MEETINGS = "meetings";
+export const LEADS = "leads";
+export const DECISIONS = "decisions";
+
+// Which categories came back at a bound, as the server marked them.
+//
+// An ABSENT category is not a bounded one. The server seeds `counts` from the
+// bounded sources BEFORE it walks the rows (reach.go), so a lane that stopped
+// early always leaves an entry even when the scope filter took every row it
+// found. A category with no entry at all therefore had no bound and no rows —
+// an honest nothing — and marking it would put a `+` on the zeros.
+//
+// A lane that could not be read AT ALL is a different fact and is not in
+// `counts`: it travels in `sources_unavailable`, which names a SOURCE, and only
+// the server maps a source to its lane. The caller keeps that case strip-wide.
+export function boundedCategories(day: Worklist): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const count of day.counts) {
+    if (count.more_available) {
+      out.add(count.category);
+    }
+  }
+  return out;
+}
+
+// How many of the decisions genuinely hold somebody up, or null where the page
+// cannot honestly say.
+//
+// The strip used to claim "somebody is blocked until you answer" under every
+// pending decision, whatever kind. Most are not: the ranker puts a decision
+// about a SEND at the blocking level and contact hygiene — capturing a
+// counterparty, merging two records — a level below it, because a queue of
+// identical contact questions must never read as a customer waiting
+// (classifydecision.go). Claiming a person is held up by a duplicate pair is
+// the sentence that teaches a reader to discount the line.
+//
+// Counted off the rows' own `work_blocked` consequence, which is the server's
+// answer to the same question, so the strip cannot disagree with the row a
+// reader opens.
+//
+// NULL WHERE THE PAGE IS NOT THE WHOLE LANE, and this is the care the figure
+// needs. The count beside it is `readings.review`, taken over everything the
+// read weighed; this one can only be taken over the rows the page carries. On a
+// day whose decisions ran past page one those are different populations, and
+// pairing them prints "30 · 25 holding up customer work" when the true number
+// is higher — understating a block, silently, which is the one direction this
+// line must not fail in. So it is claimed ONLY where the page carries every
+// decision the read counted, the way the leads deadline and the meetings
+// readiness are.
+export function decisionsBlocking(day: Worklist): number | null {
+  const entry = day.counts.find((count) => count.category === DECISIONS);
+  if (entry === undefined) {
+    // No decision was read at all: nothing to be blocked by, and nothing
+    // missing either.
+    return 0;
+  }
+  if (entry.shown !== entry.considered || entry.more_available) {
+    return null;
+  }
+  return day.queue.filter(
+    (item) =>
+      item.category === DECISIONS && item.consequence === "work_blocked",
+  ).length;
+}

--- a/frontend/src/screens/brief.readings.test.tsx
+++ b/frontend/src/screens/brief.readings.test.tsx
@@ -12,6 +12,7 @@ import {
   boundedDecisions,
   boundedLeads,
   boundedMeetings,
+  decisionRow,
   leadRow,
   meetingRow,
   readingsDay,
@@ -725,6 +726,88 @@ describe("the pipeline period", () => {
     );
     expect(descriptions.every((text) => text.length > 0)).toBe(true);
     expect(new Set(descriptions).size).toBe(4);
+  });
+
+  // NOBODY IS BLOCKED BY A DUPLICATE PAIR. The strip said "somebody is blocked
+  // until you answer" under every pending decision, and most of them are
+  // contact hygiene the ranker deliberately puts BELOW a waiting customer. A
+  // line that claims a person is held up by a merge suggestion is the one a
+  // reader learns to discount.
+  it("claims nobody is blocked when no decision holds work up", () => {
+    draw(
+      { review: 2 },
+      [decisionRow("a1", false), decisionRow("a2", false)],
+      [wholeDecisions(2)],
+    );
+
+    expect(screen.getByText(en["brief.readings.decisionsBasis"])).toBeTruthy();
+    expect(screen.queryByText(/holding up customer work/)).toBeNull();
+  });
+
+  // And says so, with a count, where the server's own consequence says it is
+  // true. Counted off `work_blocked` rather than off the category, so the strip
+  // and the row a reader opens cannot disagree.
+  it("counts only the decisions that hold customer work up", () => {
+    draw(
+      { review: 3 },
+      [
+        decisionRow("a1", true),
+        decisionRow("a2", false),
+        decisionRow("a3", false),
+      ],
+      [wholeDecisions(3)],
+    );
+
+    expect(
+      screen.getByText(
+        en["brief.readings.decisionsBlocking_one"].replace("{count}", "1"),
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(en["brief.readings.decisionsBasis"])).toBeNull();
+  });
+
+  // The COUNT, not just its presence. One blocker proves nothing about
+  // counting: an implementation returning 1 whenever any blocker exists passes
+  // a single-blocker test, and prints "1 holding up customer work" over three.
+  it("says how many decisions hold customer work up", () => {
+    draw(
+      { review: 4 },
+      [
+        decisionRow("a1", true),
+        decisionRow("a2", true),
+        decisionRow("a3", true),
+        decisionRow("a4", false),
+      ],
+      [wholeDecisions(4)],
+    );
+
+    expect(
+      screen.getByText(
+        en["brief.readings.decisionsBlocking_other"].replace("{count}", "3"),
+      ),
+    ).toBeTruthy();
+  });
+
+  // AND NOT AT ALL WHERE THE PAGE IS NOT THE WHOLE LANE. The figure beside it
+  // is counted over everything the read weighed; this one can only see the
+  // rows the page carries. On a day whose decisions run past page one, pairing
+  // them understates a block — so the claim is withheld rather than guessed.
+  it("claims no blocking count when the page is not the whole lane", () => {
+    draw(
+      { review: 30 },
+      [decisionRow("a1", true)],
+      [
+        {
+          category: "decisions",
+          considered: 30,
+          shown: 1,
+          more_available: false,
+        },
+      ],
+    );
+
+    expect(screen.getByText(en["brief.readings.decisionsBasis"])).toBeTruthy();
+    expect(screen.queryByText(/holding up customer work/)).toBeNull();
   });
 
   // A NAMED DOOR HAS TO GO WHERE ITS NAME SAYS. Distinct names and distinct

--- a/frontend/src/screens/brief.readings.tsx
+++ b/frontend/src/screens/brief.readings.tsx
@@ -25,6 +25,13 @@ import {
 } from "../i18n";
 import { openAnalyticsSection } from "./analytics.address";
 import { useAnalyticsContext } from "./analytics.context";
+import {
+  boundedCategories,
+  DECISIONS,
+  decisionsBlocking,
+  LEADS,
+  MEETINGS,
+} from "./brief.readings.honesty";
 import { useForecastReadings } from "./forecast.queries";
 import { WORKLIST_FILTER_PARAM } from "./worklist";
 import { isUnprepared } from "./worklist.copy";
@@ -60,31 +67,6 @@ import type {
 // mark on the exact figures is one a reader learns to discount. Per slot is not
 // guesswork: `counts` carries `more_available` PER CATEGORY, seeded from the
 // bounded SOURCES through `categoryOfSource` (reach.go).
-
-const MEETINGS = "meetings";
-const LEADS = "leads";
-const DECISIONS = "decisions";
-
-// Which categories came back at a bound, as the server marked them.
-//
-// An ABSENT category is not a bounded one. The server seeds `counts` from the
-// bounded sources BEFORE it walks the rows (reach.go), so a lane that stopped
-// early always leaves an entry even when the scope filter took every row it
-// found. A category with no entry at all therefore had no bound and no rows —
-// an honest nothing — and marking it would put a `+` on the zeros.
-//
-// A lane that could not be read AT ALL is a different fact and is not in
-// `counts`: it travels in `sources_unavailable`, and the strip-wide
-// `readings.more_available` already covers it.
-function boundedCategories(day: Worklist): ReadonlySet<string> {
-  const out = new Set<string>();
-  for (const count of day.counts) {
-    if (count.more_available) {
-      out.add(count.category);
-    }
-  }
-  return out;
-}
 
 // Open the worklist on the lane a reading counted.
 //
@@ -189,6 +171,7 @@ export function BriefReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
   const readings = day.readings;
   const meetings = meetingsReading(day);
   const soonest = soonestLeadDeadline(day);
+  const blocking = decisionsBlocking(day);
   // A lane that never ANSWERED is the case the per-category narrowing does not
   // reach: it travels in `sources_unavailable`, which names a source, and only
   // the server maps a source to its lane. Re-deriving that here would be a
@@ -253,7 +236,16 @@ export function BriefReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
           label={t("brief.readings.decisions")}
           count={readings.review}
           floor={floorOf(DECISIONS)}
-          basis={t("brief.readings.decisionsBasis")}
+          // Only where something IS held up, and how much of it. Otherwise the
+          // plain basis, which says what the figure was taken over and claims
+          // nothing about who is waiting.
+          basis={
+            blocking === null || blocking === 0
+              ? t("brief.readings.decisionsBasis")
+              : plural("brief.readings.decisionsBlocking", blocking, {
+                  count: formatNumber(blocking, locale),
+                })
+          }
           openLabel={t("brief.readings.openDecisions")}
           lane="decisions"
         />


### PR DESCRIPTION
The Morning Brief's "Decisions waiting" card carried a fixed line: **"somebody is blocked until you answer"** — under every pending decision, whatever kind.

Most decisions are not that. The ranker puts a decision about a SEND at the blocking level and contact hygiene (a duplicate pair, a captured counterparty) a level below it, precisely so a queue of identical contact questions never reads as a customer waiting. A line claiming a person is held up by a merge suggestion is one a reader learns to discount — and then discounts on the day it is true.

The basis now counts rows carrying the server's own `work_blocked` consequence, so the strip and the row a reader opens cannot disagree. Where nothing is blocking it says what the figure was taken over and claims nothing about who is waiting.

## Withheld rather than guessed

The count beside it (`readings.review`) is taken over everything the read weighed. This one can only see the rows the page carries. On a day whose decisions run past page one those are different populations, and pairing them prints "30 · 25 holding up customer work" when the true number is higher — understating a block, silently.

So the claim is made **only where the page carries every decision the read counted**, the same rule the leads deadline and the meetings readiness already follow.

## A gate did its job

Removing "somebody" from the value spent its entry on the human-sense allowlist in `record-noun.test.ts`, and that test failed until the entry came out. That is the census working as designed.

## The extraction

`brief.readings.tsx` hit its 500-line cap for the third time, so the two questions that are about **honesty** rather than layout — which figures are floors, and how many decisions hold work up — moved to `brief.readings.honesty.ts`, where a test can ask them without rendering five cards.

## Verification

- `make check-fe` green, 668 test files; `make craft-static` green
- Mutation-checked three ways: counting every decision as blocking fails 2 tests; returning 1 whenever any blocker exists fails 1; dropping the page-truncation guard fails 1

## Codex review addressed

- **The count was over the page while the figure above it was over everything** — the understating bug described above. Now withheld when the page is partial.
- **The fixture omitted `kind`**, which is what `blocksCustomerWork` actually reads, so it could not have been the blocking row it claimed to be.
- **Tests proved only zero-versus-one.** Added a three-blocker case that catches a wrong count, and a page-truncation case.
- **A comment claimed a protection that did not exist.** Rewritten to describe what the code does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The decisions card in the Morning Brief claimed "somebody is blocked until you answer" under every pending decision, even when the decision was contact hygiene that holds nobody up. It now counts only rows carrying the server's `work_blocked` consequence, so the strip and the row a reader opens cannot disagree: a held SEND shows how many decisions are holding up customer work, and everything else just says the decision is waiting on your answer.

The blocking count is withheld when the page carries a partial decisions lane, so pairing it with the review count cannot understate a block. Honesty helpers moved to `brief.readings.honesty.ts` so tests can ask the count questions without rendering the strip, and the old claim's string left the human-sense allowlist in `record-noun.test.ts`.

<sup>Written for commit fd77624a5c8c54cca9dca9d22f2b4db0e908a00d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The brief now highlights how many pending decisions are holding up customer work.
  - Singular and plural wording is displayed appropriately.
  - The blocking count is shown only when the complete decision information is available.

- **Localization**
  - Updated English, German, and Vietnamese wording for waiting decisions.
  - Added translated messages for one or multiple decisions blocking customer work.

- **Tests**
  - Added coverage for blocking counts, singular/plural wording, and incomplete decision data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->