### PR TITLE
A privacy officer can see, take and excuse a disclosure duty

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -13724,6 +13724,34 @@ paths:
                 required: [data]
                 properties:
                   data: { type: array, items: { $ref: '#/components/schemas/NoticeCase' } }
+  /privacy/notice-cases/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
+    get:
+      tags: [Compliance]
+      operationId: getNoticeCase
+      security: [ { cookieAuth: [] } ]   # human session only — rejects agent bearer/Passport (x-agent-access: human-only)
+      x-agent-access: human-only
+      summary: One disclosure duty.
+      description: |
+        The same case the queue lists, read on its own, for a surface that opens one duty rather
+        than working a page of them.
+
+        Gated on `privacy_request` at `read`, exactly as the queue is — a single case says how a
+        named contact was obtained and whether we have told them, which is the same disclosure the
+        list makes about every row it carries. There is no narrower read here: a caller who may
+        not see the queue may not see one of its rows either.
+
+        Answers 404 for an id that names no case. Row-scoped narrowing is not applied, because the
+        queue itself is installation-wide: granting the read verb means trusting that seat with
+        every duty in the installation, and a detail read that hid rows the list showed would be
+        a different answer to the same question.
+      responses:
+        '200':
+          description: The case.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/NoticeCase' }
   /privacy/notice-cases/{id}/assign:
     parameters:
       - { name: id, in: path, required: true, schema: { type: string, format: uuid } }

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -305,6 +305,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/partners":                                                      {Op: "listPartners", Access: "tool", Tool: "search_records", RecordType: "partner", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/passports":                                                     {Op: "listPassports", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/privacy/notice-cases":                                          {Op: "listNoticeCases", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/privacy/notice-cases/{id}":                                     {Op: "getNoticeCase", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/products":                                                      {Op: "listProducts", Access: "tool", Tool: "search_records", RecordType: "product", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/products/{id}":                                                 {Op: "getProduct", Access: "tool", Tool: "read_record", RecordType: "product", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/projects":                                                      {Op: "listProjects", Access: "tool", Tool: "list_records", RecordType: "project", Tier: "auto_execute", Scope: "read"},

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1887,6 +1887,10 @@ func (stubs) ListNoticeCases(w nethttp.ResponseWriter, r *nethttp.Request, param
 	httperr.NotImplemented(w, r, "ListNoticeCases")
 }
 
+func (stubs) GetNoticeCase(w nethttp.ResponseWriter, r *nethttp.Request, id openapi_types.UUID) {
+	httperr.NotImplemented(w, r, "GetNoticeCase")
+}
+
 func (stubs) AssignNoticeCase(w nethttp.ResponseWriter, r *nethttp.Request, id openapi_types.UUID) {
 	httperr.NotImplemented(w, r, "AssignNoticeCase")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -55813,6 +55813,9 @@ type ServerInterface interface {
 	// Disclosure duties this installation owes, soonest deadline first.
 	// (GET /privacy/notice-cases)
 	ListNoticeCases(w http.ResponseWriter, r *http.Request, params ListNoticeCasesParams)
+	// One disclosure duty.
+	// (GET /privacy/notice-cases/{id})
+	GetNoticeCase(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// Give a disclosure duty an owner.
 	// (POST /privacy/notice-cases/{id}/assign)
 	AssignNoticeCase(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
@@ -59143,6 +59146,12 @@ func (_ Unimplemented) RestorePipeline(w http.ResponseWriter, r *http.Request, i
 // Disclosure duties this installation owes, soonest deadline first.
 // (GET /privacy/notice-cases)
 func (_ Unimplemented) ListNoticeCases(w http.ResponseWriter, r *http.Request, params ListNoticeCasesParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// One disclosure duty.
+// (GET /privacy/notice-cases/{id})
+func (_ Unimplemented) GetNoticeCase(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -79434,6 +79443,38 @@ func (siw *ServerInterfaceWrapper) ListNoticeCases(w http.ResponseWriter, r *htt
 	handler.ServeHTTP(w, r)
 }
 
+// GetNoticeCase operation middleware
+func (siw *ServerInterfaceWrapper) GetNoticeCase(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetNoticeCase(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // AssignNoticeCase operation middleware
 func (siw *ServerInterfaceWrapper) AssignNoticeCase(w http.ResponseWriter, r *http.Request) {
 
@@ -89128,6 +89169,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/privacy/notice-cases", wrapper.ListNoticeCases)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/privacy/notice-cases/{id}", wrapper.GetNoticeCase)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/privacy/notice-cases/{id}/assign", wrapper.AssignNoticeCase)

--- a/backend/internal/modules/consent/handlers_notice.go
+++ b/backend/internal/modules/consent/handlers_notice.go
@@ -128,3 +128,14 @@ func wireNoticeCase(c NoticeCase) crmcontracts.NoticeCase {
 	}
 	return out
 }
+
+// GetNoticeCase answers one disclosure duty, for a surface that opens a single
+// case rather than working the queue.
+func (h Handlers) GetNoticeCase(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
+	found, err := h.store.GetNoticeCase(r.Context(), ids.UUID(id))
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, wireNoticeCase(found))
+}

--- a/backend/internal/modules/consent/noticeownership.go
+++ b/backend/internal/modules/consent/noticeownership.go
@@ -146,6 +146,38 @@ func (s *Store) ListNoticeCases(ctx context.Context, states []NoticeState, limit
 	return out, err
 }
 
+// GetNoticeCase reads one duty, for a surface that opens a single case rather
+// than working a page of them.
+//
+// Gated exactly as the queue is. There is deliberately no narrower read: a seat
+// that may not see the list may not see one of its rows either, and a detail
+// read that hid what the list showed would be a different answer to the same
+// question.
+//
+// It goes through noticeCaseColumns like every other whole-row read here, so a
+// column added to the row reaches the list and the detail together.
+//
+// Held by: TestOneSelectListSpellsTheNoticeCaseRow
+// (backend/gates/noticecasecolumns_test.go)
+func (s *Store) GetNoticeCase(ctx context.Context, id ids.UUID) (NoticeCase, error) {
+	if err := requireDSRAdmin(ctx, principal.ActionRead); err != nil {
+		return NoticeCase{}, err
+	}
+	var out NoticeCase
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		out, err = scanNoticeCase(tx.QueryRow(ctx, `
+			SELECT`+noticeCaseColumns+`
+			  FROM privacy_notice_case
+			 WHERE id = $1`, id))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		return err
+	})
+	return out, err
+}
+
 // noticeCaseListMax bounds the queue read. A privacy officer works a page at a
 // time, and an unbounded list over a table with one row per acquisition is a
 // read that grows with the contact book.

--- a/backend/internal/modules/consent/noticeownership_integration_test.go
+++ b/backend/internal/modules/consent/noticeownership_integration_test.go
@@ -12,6 +12,7 @@ package consent
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -348,5 +349,57 @@ func TestAReassignmentRecordsWhoHadItBefore(t *testing.T) {
 		t.Errorf("the reassignment's before-image names owner %v, want the seat it was taken "+
 			"from (%v): the state does not move on a reassignment, so the owner is the only "+
 			"fact the image has to carry", before[fieldOwner], e.user)
+	}
+}
+
+// TestOneDutyReadsTheSameAsItDoesInTheQueue. The detail read exists for a
+// surface that opens one case, and it has to agree with the list about what a
+// case is — which is why both go through noticeCaseColumns.
+func TestOneDutyReadsTheSameAsItDoesInTheQueue(t *testing.T) {
+	e := setupChannelConsent(t)
+	ctx := officerCtx(e)
+	id := seedNoticeCase(t, e, "purchased_or_imported", []string{"record_confirmation"})
+	if _, err := e.store.AssignNoticeCase(ctx, id, e.user); err != nil {
+		t.Fatalf("taking the duty: %v", err)
+	}
+
+	one, err := e.store.GetNoticeCase(ctx, id)
+	if err != nil {
+		t.Fatalf("reading the duty: %v", err)
+	}
+	listed, err := e.store.ListNoticeCases(ctx, nil, 0)
+	if err != nil {
+		t.Fatalf("reading the queue: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("the queue holds %d cases, want the one seeded", len(listed))
+	}
+	if !reflect.DeepEqual(one, listed[0]) {
+		t.Errorf("the detail read answers %+v and the queue answers %+v: a surface opening "+
+			"one duty and a surface listing them must not disagree about what a case is",
+			one, listed[0])
+	}
+}
+
+// TestADutyThatDoesNotExistIsNotFound, rather than an empty case that reads as
+// one with no deadline.
+func TestADutyThatDoesNotExistIsNotFound(t *testing.T) {
+	e := setupChannelConsent(t)
+	ctx := officerCtx(e)
+
+	if _, err := e.store.GetNoticeCase(ctx, ids.NewV7()); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("reading a duty that does not exist answered %v, want not found", err)
+	}
+}
+
+// TestTheDetailReadIsGatedLikeTheQueue. A seat that may not see the list may
+// not see one of its rows either — a narrower detail read would be a different
+// answer to the same question.
+func TestTheDetailReadIsGatedLikeTheQueue(t *testing.T) {
+	e := setupChannelConsent(t)
+	id := seedNoticeCase(t, e, "purchased_or_imported", []string{"record_confirmation"})
+
+	if _, err := e.store.GetNoticeCase(e.ctx, id); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a rep reading one duty got %v, want permission denied", err)
 	}
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9529,6 +9529,39 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/privacy/notice-cases/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * One disclosure duty.
+         * @description The same case the queue lists, read on its own, for a surface that opens one duty rather
+         *     than working a page of them.
+         *
+         *     Gated on `privacy_request` at `read`, exactly as the queue is — a single case says how a
+         *     named contact was obtained and whether we have told them, which is the same disclosure the
+         *     list makes about every row it carries. There is no narrower read here: a caller who may
+         *     not see the queue may not see one of its rows either.
+         *
+         *     Answers 404 for an id that names no case. Row-scoped narrowing is not applied, because the
+         *     queue itself is installation-wide: granting the read verb means trusting that seat with
+         *     every duty in the installation, and a detail read that hid rows the list showed would be
+         *     a different answer to the same question.
+         */
+        get: operations["getNoticeCase"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/privacy/notice-cases/{id}/assign": {
         parameters: {
             query?: never;
@@ -49626,6 +49659,28 @@ export interface operations {
                     "application/json": {
                         data: components["schemas"]["NoticeCase"][];
                     };
+                };
+            };
+        };
+    };
+    getNoticeCase: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The case. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NoticeCase"];
                 };
             };
         };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4409,6 +4409,27 @@ export const de = {
   "privacy.purposeCreate": "Zweck anlegen",
   "privacy.purposeAppendOnly":
     "Ein Zweck kann nach dem Anlegen nicht umbenannt oder entfernt werden — der Katalog ist append-only. Wähle den Schlüssel sorgfältig.",
+  "notice.title": "Informationspflichten",
+  "notice.sub":
+    "Kontakte, die wir ohne ihr Zutun erhalten haben, und ob wir sie informiert haben.",
+  "notice.facetLabel": "Welche Pflichten anzeigen",
+  "notice.facetOwed": "Noch offen",
+  "notice.facetAll": "Alle",
+  "notice.emptyOwed":
+    "Nichts ist offen. Jeder erhaltene Kontakt wurde informiert, oder die Pflicht wurde begründet beendet.",
+  "notice.readOnlyForPrivacy":
+    "Diese Pflichten nennen Kontakte und wie wir sie erhalten haben. Sie werden nur im Datenschutz-Eingang gezeigt.",
+  "notice.dueAt": "Fällig am {date}",
+  "notice.overdue": "Überfällig",
+  "notice.claimed": "Übernommen",
+  "notice.unclaimed": "Nicht übernommen",
+  "notice.excuse": "Ohne Versand beenden",
+  "notice.excuseTitle": "Diese Pflicht ohne Information beenden",
+  "notice.excuseWhich": "Was halten Sie fest?",
+  "notice.excuseProvided": "Sie wurden anderweitig informiert",
+  "notice.excuseExempt": "Die Pflicht gilt nicht",
+  "notice.excuseGround": "Warum, in Ihren eigenen Worten",
+  "notice.excuseConfirm": "Festhalten",
   "privacy.facetAll": "Alle",
   "privacy.inboxAdminOnly":
     "Für Betroffenenanfragen fehlt Ihrem Sitzplatz die Berechtigung. Sie nennen die Personen, die angefragt haben — deshalb steht die Liste nicht allen offen.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4544,6 +4544,27 @@ export const en = {
   "privacy.purposeCreate": "Create purpose",
   "privacy.purposeAppendOnly":
     "A purpose cannot be renamed or removed once created — the catalogue is append-only. Choose the key carefully.",
+  "notice.title": "Disclosure duties",
+  "notice.sub":
+    "Contacts we obtained without asking them, and whether we have told them yet.",
+  "notice.facetLabel": "Which duties to show",
+  "notice.facetOwed": "Still owed",
+  "notice.facetAll": "All",
+  "notice.emptyOwed":
+    "Nothing is owed. Every contact we obtained has been told, or the duty was excused.",
+  "notice.readOnlyForPrivacy":
+    "These duties name contacts and how we obtained them, so they are shown to the privacy inbox only.",
+  "notice.dueAt": "Due {date}",
+  "notice.overdue": "Overdue",
+  "notice.claimed": "Claimed",
+  "notice.unclaimed": "Unclaimed",
+  "notice.excuse": "End without sending",
+  "notice.excuseTitle": "End this duty without sending a disclosure",
+  "notice.excuseWhich": "What are you recording?",
+  "notice.excuseProvided": "They were told somewhere else",
+  "notice.excuseExempt": "The duty does not apply",
+  "notice.excuseGround": "Why, in your own words",
+  "notice.excuseConfirm": "Record this",
   "privacy.facetAll": "All",
   "privacy.inboxAdminOnly":
     "Seeing subject requests needs permission your seat does not hold. They name the people who asked, so the queue is not open to everyone.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4344,6 +4344,27 @@ export const vi = {
   "privacy.purposeCreate": "Tạo mục đích",
   "privacy.purposeAppendOnly":
     "Một mục đích đã tạo thì không đổi tên hay xoá được — danh mục chỉ thêm mới. Hãy chọn khoá thật cẩn thận.",
+  "notice.title": "Nghĩa vụ thông báo",
+  "notice.sub":
+    "Những liên hệ chúng ta có được mà họ không yêu cầu, và liệu chúng ta đã báo cho họ chưa.",
+  "notice.facetLabel": "Hiển thị nghĩa vụ nào",
+  "notice.facetOwed": "Còn nợ",
+  "notice.facetAll": "Tất cả",
+  "notice.emptyOwed":
+    "Không còn nghĩa vụ nào. Mọi liên hệ đã được báo, hoặc nghĩa vụ đã được miễn có lý do.",
+  "notice.readOnlyForPrivacy":
+    "Những nghĩa vụ này nêu tên liên hệ và cách chúng ta có được họ, nên chỉ hiển thị trong hộp thư quyền riêng tư.",
+  "notice.dueAt": "Đến hạn {date}",
+  "notice.overdue": "Quá hạn",
+  "notice.claimed": "Đã nhận",
+  "notice.unclaimed": "Chưa ai nhận",
+  "notice.excuse": "Kết thúc mà không gửi",
+  "notice.excuseTitle": "Kết thúc nghĩa vụ này mà không gửi thông báo",
+  "notice.excuseWhich": "Bạn đang ghi nhận điều gì?",
+  "notice.excuseProvided": "Họ đã được báo ở nơi khác",
+  "notice.excuseExempt": "Nghĩa vụ không áp dụng",
+  "notice.excuseGround": "Vì sao, theo lời của bạn",
+  "notice.excuseConfirm": "Ghi nhận",
   "privacy.facetAll": "Tất cả",
   "privacy.inboxAdminOnly":
     "Xem yêu cầu của chủ thể dữ liệu cần quyền mà ghế của bạn không có. Danh sách nêu tên người đã yêu cầu, nên không mở cho tất cả mọi người.",

--- a/frontend/src/screens/noticecases.logic.test.ts
+++ b/frontend/src/screens/noticecases.logic.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import {
+  isNoticeOverdue,
+  isNoticeResolved,
+  mayAssign,
+  mayExcuse,
+  NOTICE_STATES,
+  noticeStateTone,
+  UNRESOLVED_NOTICE_STATES,
+} from "./noticecases.logic";
+
+describe("which duties are still owed", () => {
+  it("keeps a claimed duty on the queue", () => {
+    // Somebody taking a case has not discharged it. A queue that dropped a
+    // claimed duty would leave it owed, worked and invisible, and the only
+    // seat still seeing it would be the one that took it.
+    expect(UNRESOLVED_NOTICE_STATES).toContain("assigned");
+    expect(isNoticeResolved("assigned")).toBe(false);
+  });
+
+  it("keeps a blocked duty on the queue", () => {
+    // Blocked says we cannot discharge it yet, not that we stopped owing it.
+    expect(UNRESOLVED_NOTICE_STATES).toContain("blocked");
+  });
+
+  it("takes every ended duty off it", () => {
+    for (const state of [
+      "completed",
+      "not_required",
+      "provided_elsewhere",
+      "exempt_with_reason",
+    ] as const) {
+      expect(isNoticeResolved(state)).toBe(true);
+      expect(UNRESOLVED_NOTICE_STATES).not.toContain(state);
+    }
+  });
+
+  it("derives the owed set from the vocabulary rather than a second list", () => {
+    // The count is asserted, not the membership: a ninth state added to
+    // NOTICE_STATES without somebody deciding whether a case sitting in it is
+    // still owed fails here, which is the drift a hand-written second list
+    // hides. The backend's own census works the same way.
+    expect(NOTICE_STATES).toHaveLength(8);
+    expect(UNRESOLVED_NOTICE_STATES).toHaveLength(4);
+  });
+});
+
+describe("when a duty reads as overdue", () => {
+  const past = "2026-01-01T00:00:00Z";
+  const now = Date.parse("2026-06-01T00:00:00Z");
+
+  it("marks a duty whose deadline has passed", () => {
+    expect(isNoticeOverdue(past, "open", now)).toBe(true);
+  });
+
+  it("leaves a duty whose deadline is ahead", () => {
+    expect(isNoticeOverdue("2026-12-01T00:00:00Z", "open", now)).toBe(false);
+  });
+
+  it("never marks a duty that has already ended", () => {
+    // The deadline a closed case met, or missed, stopped mattering when it
+    // closed. Marking it red would ask an officer to act on something already
+    // answered.
+    for (const state of [
+      "completed",
+      "exempt_with_reason",
+      "provided_elsewhere",
+      "not_required",
+    ] as const) {
+      expect(isNoticeOverdue(past, state, now)).toBe(false);
+    }
+  });
+
+  it("still marks a claimed duty whose deadline has passed", () => {
+    // Somebody having taken it does not stop the clock, and this is the case
+    // an officer most needs to see.
+    expect(isNoticeOverdue(past, "assigned", now)).toBe(true);
+  });
+});
+
+describe("what a reader may do to a duty", () => {
+  it("offers both actions on a live duty", () => {
+    for (const state of ["open", "assigned", "queued", "blocked"] as const) {
+      expect(mayAssign(state)).toBe(true);
+      expect(mayExcuse(state)).toBe(true);
+    }
+  });
+
+  it("offers neither on one that has ended", () => {
+    // The server refuses both, so offering them would be a button that fails.
+    // Re-excusing a discharged duty is the sharper case: the later note would
+    // overwrite a real disclosure and then read as the reason it happened.
+    for (const state of ["completed", "exempt_with_reason"] as const) {
+      expect(mayAssign(state)).toBe(false);
+      expect(mayExcuse(state)).toBe(false);
+    }
+  });
+});
+
+describe("how a state reads", () => {
+  it("asks the reader to look at an obstacle or a closure somebody chose", () => {
+    expect(noticeStateTone("blocked")).toBe("warn");
+    expect(noticeStateTone("exempt_with_reason")).toBe("warn");
+    expect(noticeStateTone("provided_elsewhere")).toBe("warn");
+  });
+
+  it("stays quiet on the ordinary outcome", () => {
+    // A duty discharged by a delivered disclosure is what this queue exists to
+    // produce. Colouring it would make the ordinary case shout.
+    expect(noticeStateTone("completed")).toBeUndefined();
+    expect(noticeStateTone("open")).toBeUndefined();
+  });
+});

--- a/frontend/src/screens/noticecases.logic.ts
+++ b/frontend/src/screens/noticecases.logic.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { components } from "../api/schema";
+
+export type NoticeCase = components["schemas"]["NoticeCase"];
+export type NoticeCaseState = components["schemas"]["NoticeCaseState"];
+
+// The states a duty can rest in, in the order a reader thinks about them:
+// owed, then being worked, then the four ways one ends.
+//
+// Mirrored from the backend's own vocabulary (consent/noticecase.go). It is a
+// literal rather than derived from the generated enum because the ORDER is a
+// product decision the schema does not carry, and a facet bar that reordered
+// itself when somebody added a state would move the control under the reader's
+// cursor.
+export const NOTICE_STATES = [
+  "open",
+  "assigned",
+  "queued",
+  "completed",
+  "provided_elsewhere",
+  "exempt_with_reason",
+  "blocked",
+  "not_required",
+] as const;
+
+// The states that mean the duty is still owed. Derived from the terminal set
+// below rather than listed twice, for the same reason the backend derives it:
+// two lists of one vocabulary drift until they disagree about whether a duty is
+// open, and the reader who loses is the one looking at a queue that is missing
+// a case.
+export const UNRESOLVED_NOTICE_STATES: readonly NoticeCaseState[] =
+  NOTICE_STATES.filter((state) => !isNoticeResolved(state));
+
+// A duty that has ended, however it ended.
+//
+// `assigned` is deliberately NOT here. Somebody taking a case has not
+// discharged it, and a queue that dropped a claimed duty would leave it owed,
+// worked and invisible — the only seat still seeing it would be the one that
+// took it, which is exactly the wrong place to put the reminder.
+export function isNoticeResolved(state: NoticeCaseState): boolean {
+  return (
+    state === "completed" ||
+    state === "not_required" ||
+    state === "provided_elsewhere" ||
+    state === "exempt_with_reason"
+  );
+}
+
+// Whether this duty's deadline has passed.
+//
+// Overdue is READ from the clock, never stored — the backend refuses to keep an
+// `overdue` state for the same reason, because a stored one would leave every
+// late case looking on time whenever the sweep that writes it failed to run.
+//
+// A resolved duty is never overdue: the deadline it met, or missed, stopped
+// mattering when the case closed. Marking a closed case red would ask an
+// officer to act on something already answered.
+export function isNoticeOverdue(
+  dueAtIso: string,
+  state: NoticeCaseState,
+  nowMs: number,
+): boolean {
+  if (isNoticeResolved(state)) {
+    return false;
+  }
+  return Date.parse(dueAtIso) < nowMs;
+}
+
+// Whether this duty can still be claimed.
+//
+// An ended one cannot, which is what the server says too — assigning a closed
+// case would put it back on the queue as work somebody is doing when the duty
+// is over.
+export function mayAssign(state: NoticeCaseState): boolean {
+  return !isNoticeResolved(state);
+}
+
+// Whether this duty can be ended without sending anything.
+//
+// Same rule as claiming, and for a sharper reason: re-excusing a case that was
+// genuinely discharged would overwrite a real disclosure with a claim about
+// one, and the later note would then read as the reason the first thing
+// happened.
+export function mayExcuse(state: NoticeCaseState): boolean {
+  return !isNoticeResolved(state);
+}
+
+// Who is accountable for this duty, as a reader should ask it.
+//
+// The OWNER, never the state. `assigned` means open-and-claimed, but a blocked
+// or queued case can carry an owner too — somebody looking at an obstacle has
+// not cleared it, so taking one of those keeps its state and just names the
+// seat. And "assigned with no owner" is reachable: owner_user_id is nulled when
+// a user is deleted, so a duty claimed by somebody who has since left reads as
+// unclaimed, which is the honest answer.
+export function noticeOwner(row: NoticeCase): string | null {
+  return row.owner_user_id ?? null;
+}
+
+// The tone a state should read in.
+//
+// Only the two that need a reader to look: blocked names an obstacle, and the
+// excusing states are closures somebody has to be able to defend. `completed`
+// is quiet on purpose — a duty discharged by a delivered disclosure is the
+// outcome this queue exists to produce, and colouring it would make the
+// ordinary case shout.
+export function noticeStateTone(
+  state: NoticeCaseState,
+): "danger" | "warn" | undefined {
+  if (state === "blocked") {
+    return "warn";
+  }
+  if (state === "exempt_with_reason" || state === "provided_elsewhere") {
+    return "warn";
+  }
+  return undefined;
+}

--- a/frontend/src/screens/noticecases.test.tsx
+++ b/frontend/src/screens/noticecases.test.tsx
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { meFixture } from "../app/mefixture";
+import { pickOption } from "../design-system/select-testing";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { NoticeCasesCard } from "./noticecases";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// One owed duty, one already excused — enough to tell the two facets apart and
+// to prove a closed case offers no actions.
+const OWED = {
+  id: "case-1",
+  contact_id: "contact-1",
+  rule: "art14",
+  due_at: "2026-01-01T00:00:00Z",
+  state: "open",
+  attempts: 0,
+  created_at: "2025-12-01T00:00:00Z",
+};
+
+const EXCUSED = {
+  id: "case-2",
+  contact_id: "contact-2",
+  rule: "art14",
+  due_at: "2026-01-01T00:00:00Z",
+  state: "exempt_with_reason",
+  attempts: 0,
+  created_at: "2025-12-01T00:00:00Z",
+  resolution_note: "Told at the trade fair on the 3rd",
+  completed_at: "2026-02-01T00:00:00Z",
+};
+
+type Sent = { key: string; url: string; body: unknown };
+
+function stubRoutes(
+  overrides: Record<string, () => Response> = {},
+  sent: Sent[] = [],
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      let body: unknown = null;
+      if (method !== "GET") {
+        try {
+          body = request
+            ? await request.json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+      }
+      sent.push({ key, url: url.pathname + url.search, body });
+      const override = overrides[key];
+      if (override) return override();
+      if (key === "GET /privacy/notice-cases") {
+        return jsonResponse({ data: [OWED] });
+      }
+      if (key === "GET /users") {
+        return jsonResponse({
+          data: [{ id: "user-1", email: "o@x.test", display_name: "Officer" }],
+          page: { next_cursor: null, has_more: false },
+        });
+      }
+      if (key === "GET /me") {
+        return jsonResponse(
+          meFixture({
+            roles: ["admin"],
+            allow: { privacy_request: ["read", "update"] },
+          }),
+        );
+      }
+      return jsonResponse({});
+    }),
+  );
+  return sent;
+}
+
+beforeEach(() => localStorage.setItem("margince.workspaceSlug", "acme"));
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe("the disclosure-duty queue", () => {
+  it("asks the server for the owed states, not for everything", async () => {
+    // The facet is a server-side filter. A client re-slice would hide rows the
+    // server never told us about, and the count on screen would disagree with
+    // the one the queue has.
+    const sent = stubRoutes();
+    render(<NoticeCasesCard />);
+
+    await screen.findByTestId("notice-case-case-1");
+    const listed = sent.find((s) => s.key === "GET /privacy/notice-cases");
+    expect(listed?.url).toContain("state=open");
+    expect(listed?.url).toContain("state=assigned");
+    expect(listed?.url).toContain("state=queued");
+    expect(listed?.url).toContain("state=blocked");
+    // The four that END a duty are not asked for on the owed facet.
+    expect(listed?.url).not.toContain("state=completed");
+    expect(listed?.url).not.toContain("state=exempt_with_reason");
+  });
+
+  it("marks a duty whose deadline has passed", async () => {
+    stubRoutes();
+    render(<NoticeCasesCard />);
+
+    const row = await screen.findByTestId("notice-case-case-1");
+    expect(within(row).getByText(en["notice.overdue"])).toBeInTheDocument();
+  });
+
+  it("says a duty nobody has taken is unclaimed", async () => {
+    stubRoutes();
+    render(<NoticeCasesCard />);
+
+    const row = await screen.findByTestId("notice-case-case-1");
+    expect(within(row).getByText(en["notice.unclaimed"])).toBeInTheDocument();
+  });
+
+  it("offers no actions on a duty that has already ended", async () => {
+    // The server refuses both, so offering them would be a button that fails.
+    stubRoutes({
+      "GET /privacy/notice-cases": () => jsonResponse({ data: [EXCUSED] }),
+    });
+    render(<NoticeCasesCard />);
+
+    const row = await screen.findByTestId("notice-case-case-2");
+    expect(
+      within(row).queryByRole("button", { name: en["notice.excuse"] }),
+    ).not.toBeInTheDocument();
+    // And it still shows the ground, which is what an auditor opens it for.
+    expect(within(row).getByText(/Told at the trade fair/)).toBeInTheDocument();
+  });
+
+  it("sends the ground with an excuse, and the state the officer chose", async () => {
+    const sent = stubRoutes({
+      "POST /privacy/notice-cases/case-1/excuse": () =>
+        jsonResponse({ ...OWED, state: "exempt_with_reason" }),
+    });
+    render(<NoticeCasesCard />);
+
+    const row = await screen.findByTestId("notice-case-case-1");
+    const user = userEvent.setup();
+    await user.click(
+      within(row).getByRole("button", { name: en["notice.excuse"] }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    await pickOption(
+      user,
+      within(dialog).getByRole("combobox"),
+      en["notice.excuseExempt"],
+    );
+    await user.type(
+      within(dialog).getByRole("textbox"),
+      "Art. 14(5)(b): no address was ever held",
+    );
+    await user.click(
+      within(dialog).getByRole("button", { name: en["notice.excuseConfirm"] }),
+    );
+
+    await waitFor(() => {
+      const write = sent.find((s) => s.key.startsWith("POST /privacy/notice"));
+      expect(write?.body).toEqual({
+        state: "exempt_with_reason",
+        resolution_note: "Art. 14(5)(b): no address was ever held",
+      });
+    });
+  });
+
+  it("will not submit an excuse with no ground", async () => {
+    // The whole reason these two states exist beside not_required is that they
+    // keep the reason. A blank one would close a compliance record with
+    // nothing written on it, and the server refuses it.
+    stubRoutes();
+    render(<NoticeCasesCard />);
+
+    const row = await screen.findByTestId("notice-case-case-1");
+    const user = userEvent.setup();
+    await user.click(
+      within(row).getByRole("button", { name: en["notice.excuse"] }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByRole("button", { name: en["notice.excuseConfirm"] }),
+    ).toBeDisabled();
+  });
+
+  it("asks for every state on the All facet, because the server's default is owed", async () => {
+    // The defect this holds: omitting the state filter makes the server answer
+    // with the unresolved states, so "All" returned exactly the same rows as
+    // "Still owed" and every closed case was invisible. Nothing failed — the
+    // facet simply lied.
+    const sent = stubRoutes();
+    render(<NoticeCasesCard />);
+
+    await screen.findByTestId("notice-case-case-1");
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: en["notice.facetAll"] }),
+    );
+
+    await waitFor(() => {
+      const reads = sent.filter((s) => s.key === "GET /privacy/notice-cases");
+      const last = reads[reads.length - 1];
+      expect(last?.url).toContain("state=completed");
+      expect(last?.url).toContain("state=exempt_with_reason");
+      expect(last?.url).toContain("state=not_required");
+      expect(last?.url).toContain("state=provided_elsewhere");
+    });
+  });
+
+  it("starts a second duty's excuse form clean after a successful one", async () => {
+    // The modal wrapper holds its own useState and stays mounted whether or
+    // not the dialog is showing, so a change of subject does not by itself
+    // reset the form. Dismissing clears the ground explicitly; SUCCEEDING did
+    // not, and neither path ever reset the chosen kind — so an officer who
+    // excused case A would open case B with A's words and A's claim already
+    // filled in, one keystroke from confirming them.
+    stubRoutes({
+      "GET /privacy/notice-cases": () =>
+        jsonResponse({ data: [OWED, { ...OWED, id: "case-3" }] }),
+      "POST /privacy/notice-cases/case-1/excuse": () =>
+        jsonResponse({ ...OWED, state: "exempt_with_reason" }),
+    });
+    render(<NoticeCasesCard />);
+
+    const user = userEvent.setup();
+    const first = await screen.findByTestId("notice-case-case-1");
+    await user.click(
+      within(first).getByRole("button", { name: en["notice.excuse"] }),
+    );
+    let dialog = await screen.findByRole("dialog");
+    await pickOption(
+      user,
+      within(dialog).getByRole("combobox"),
+      en["notice.excuseExempt"],
+    );
+    await user.type(within(dialog).getByRole("textbox"), "A's ground");
+    await user.click(
+      within(dialog).getByRole("button", { name: en["notice.excuseConfirm"] }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+
+    const second = await screen.findByTestId("notice-case-case-3");
+    await user.click(
+      within(second).getByRole("button", { name: en["notice.excuse"] }),
+    );
+    dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByRole("textbox")).toHaveValue("");
+    // And the claim resets too, to the one a reader has not asserted anything
+    // by leaving alone.
+    expect(within(dialog).getByRole("combobox")).toHaveTextContent(
+      en["notice.excuseProvided"],
+    );
+  });
+
+  it("says why it is empty rather than showing nothing", async () => {
+    stubRoutes({
+      "GET /privacy/notice-cases": () => jsonResponse({ data: [] }),
+    });
+    render(<NoticeCasesCard />);
+
+    expect(await screen.findByText(en["notice.emptyOwed"])).toBeInTheDocument();
+  });
+
+  it("withholds the queue from a seat without the privacy grant", async () => {
+    // Withheld, not absent. An absent card would read as "no duties", which is
+    // a different claim entirely and the wrong one to make here.
+    stubRoutes({
+      "GET /me": () =>
+        jsonResponse(
+          meFixture({ roles: ["rep"], allow: { contact: ["read"] } }),
+        ),
+    });
+    render(<NoticeCasesCard />);
+
+    expect(
+      await screen.findByText(en["notice.readOnlyForPrivacy"]),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("notice-case-case-1")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/noticecases.tsx
+++ b/frontend/src/screens/noticecases.tsx
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useMemo, useState } from "react";
+import { api } from "../api/client";
+import { useCan } from "../app/capability";
+import {
+  Badge,
+  Button,
+  EmptyState,
+  Field,
+  SegmentedControl,
+  Textarea,
+} from "../design-system/atoms";
+import { CardBoundary } from "../design-system/cardboundary";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { Panel, PanelBody } from "../design-system/panel";
+import { Select } from "../design-system/select";
+import { SettingList, SettingRow } from "../design-system/settingrow";
+import { formatDate } from "../format/format";
+import { useNow } from "../format/now";
+import { viewerZone } from "../format/timezone";
+import { type Locale, useLocale, useT } from "../i18n";
+import { humanizeToken } from "./audit";
+import {
+  problemMessageOf,
+  QueryGate,
+  QueryStates,
+  throwProblem,
+  useMe,
+} from "./common";
+import { useRoster } from "./entityref";
+import {
+  isNoticeOverdue,
+  mayAssign,
+  mayExcuse,
+  NOTICE_STATES,
+  type NoticeCase,
+  noticeStateTone,
+  UNRESOLVED_NOTICE_STATES,
+} from "./noticecases.logic";
+
+// The two facets a privacy officer actually works in. `owed` is the default
+// because the queue exists to show duties nobody has discharged; `all` is there
+// so a closed case can be found again, which is what an auditor asks for.
+//
+// BOTH facets name their states explicitly, and "all" especially. The server
+// treats an ABSENT state filter as "every unresolved one" — a sensible default
+// for a caller that asks for nothing in particular, and exactly wrong here:
+// omitting the filter would make "All" return the same rows as "Still owed"
+// and quietly hide every case somebody had closed.
+const NOTICE_FACETS = ["owed", "all"] as const;
+type NoticeFacet = (typeof NOTICE_FACETS)[number];
+
+// What an officer is claiming when they end a duty without sending anything.
+// Both require a ground, which is the whole reason they exist beside the older
+// `not_required`.
+const EXCUSE_STATES = ["provided_elsewhere", "exempt_with_reason"] as const;
+type ExcuseState = (typeof EXCUSE_STATES)[number];
+
+// NoticeCasesCard is the disclosure-duty queue: who we obtained without asking,
+// whether anybody has told them, and by when we must.
+//
+// It sits beside the subject-request inbox and behind the same grant, because a
+// notice case makes the same kind of disclosure about a named contact that the
+// DSR queue makes about somebody exercising a right.
+export function NoticeCasesCard() {
+  const t = useT();
+  const { locale } = useLocale();
+  // The only clock touching rendering. isNoticeOverdue stays pure and takes
+  // the epoch ms this produces, so a test can drive a deadline without
+  // waiting for one.
+  const nowMs = useNow(60_000);
+  // due_at is a statutory deadline, so a hardcoded zone would show the wrong
+  // calendar day to anyone outside it. The viewer's own resolved IANA zone is
+  // the only honest answer to "what date does THIS reader see", which is the
+  // same call the subject-request queue makes.
+  const tz = viewerZone();
+  const [facet, setFacet] = useState<NoticeFacet>("owed");
+  const [excusing, setExcusing] = useState<NoticeCase | null>(null);
+  const queryClient = useQueryClient();
+
+  // `privacy_request:read`, which is what consent/noticeownership.go asks for.
+  // Gated rather than merely rendered: the rows name contacts we obtained
+  // without asking them, so a reader who came for the consent registry beside
+  // this does not issue a call that only 403s.
+  const canSee = useCan("privacy_request", "read");
+  const canWork = useCan("privacy_request", "update");
+  // The probe itself, not only its answer. Capability predicates read off the
+  // /me cache and are false while that read is in flight, so branching on
+  // `!canSee` alone would flash "not yours" at every officer on every load.
+  const me = useMe();
+
+  const query = useQuery({
+    queryKey: ["notice-cases", facet],
+    enabled: canSee,
+    queryFn: async () => {
+      const { data, error } = await api.GET("/privacy/notice-cases", {
+        params: {
+          query: {
+            limit: 50,
+            // The facet is a SERVER-side filter, not a client re-slice: a
+            // re-slice would hide rows the server never told us about and
+            // make the count on screen disagree with the one the queue has.
+            state:
+              facet === "owed"
+                ? [...UNRESOLVED_NOTICE_STATES]
+                : [...NOTICE_STATES],
+          },
+        },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+
+  const rows = query.data?.data ?? [];
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ["notice-cases"] });
+  };
+
+  // The variable carries the id and the owner, rather than the mutationFn
+  // reading them out of its closure. useMutation re-arms its options in a
+  // passive effect, so a click landing between the commit and that effect runs
+  // the PREVIOUS render's closure — which for a row-keyed action means acting
+  // on the wrong case, or on none.
+  const assign = useMutation({
+    mutationFn: async (vars: { id: string; owner: string }) => {
+      const { data, error } = await api.POST(
+        "/privacy/notice-cases/{id}/assign",
+        {
+          params: { path: { id: vars.id } },
+          body: { owner_user_id: vars.owner },
+        },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: invalidate,
+  });
+
+  const excuse = useMutation({
+    mutationFn: async (vars: {
+      id: string;
+      state: ExcuseState;
+      note: string;
+    }) => {
+      const { data, error } = await api.POST(
+        "/privacy/notice-cases/{id}/excuse",
+        {
+          params: { path: { id: vars.id } },
+          body: { state: vars.state, resolution_note: vars.note },
+        },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      invalidate();
+      setExcusing(null);
+    },
+  });
+
+  const facetLabels = useMemo(
+    () =>
+      ({
+        owed: t("notice.facetOwed"),
+        all: t("notice.facetAll"),
+      }) as Record<NoticeFacet, string>,
+    [t],
+  );
+
+  let body: ReactNode;
+  if (!canSee) {
+    // Withheld rather than absent. An absent card would read as "no duties",
+    // which is a different claim entirely — and the wrong one to make about a
+    // compliance queue somebody cannot see.
+    body = (
+      <QueryGate query={me} pendingLabel={t("notice.readOnlyForPrivacy")}>
+        {() => <EmptyState>{t("notice.readOnlyForPrivacy")}</EmptyState>}
+      </QueryGate>
+    );
+  } else {
+    body = (
+      <QueryStates query={query} pendingLabel={t("notice.facetOwed")}>
+        {rows.length === 0 ? (
+          <EmptyState>
+            {facet === "owed" ? t("notice.emptyOwed") : t("common.empty")}
+          </EmptyState>
+        ) : (
+          <SettingList testId="notice-cases">
+            {rows.map((row) => (
+              <NoticeRow
+                key={row.id}
+                row={row}
+                nowMs={nowMs}
+                locale={locale}
+                tz={tz}
+                canWork={canWork}
+                assignPending={assign.isPending}
+                onAssign={(owner) => assign.mutate({ id: row.id, owner })}
+                onExcuse={() => setExcusing(row)}
+              />
+            ))}
+          </SettingList>
+        )}
+      </QueryStates>
+    );
+  }
+
+  return (
+    <Panel
+      title={t("notice.title")}
+      // The facet rides in the header, above a queue as long as the queue is.
+      // As a row it would move every time a duty arrived, which is the same
+      // reason the subject-request queue beside this one puts its verb there.
+      titleAction={
+        canSee ? (
+          <SegmentedControl
+            options={[...NOTICE_FACETS]}
+            value={facet}
+            onChange={setFacet}
+            labels={facetLabels}
+            label={t("notice.facetLabel")}
+          />
+        ) : null
+      }
+    >
+      <PanelBody>
+        <p className="settings-panel-sub">{t("notice.sub")}</p>
+        {/* One card's throw stays inside one card: this body renders a queue
+            straight off the wire, and without a boundary a single malformed
+            row costs the reader the whole tab. */}
+        <CardBoundary>
+          {body}
+          {/* Both write failures surface HERE, not only inside the modal. The
+              modal can be dismissed while its submit is still in flight, and
+              an error that only rendered there would leave the reader
+              believing a duty was excused when it was not. */}
+          {assign.isError ? (
+            <p className="t-caption">{problemMessageOf(assign.error, t)}</p>
+          ) : null}
+          {excuse.isError && excusing === null ? (
+            <p className="t-caption">{problemMessageOf(excuse.error, t)}</p>
+          ) : null}
+        </CardBoundary>
+        <ExcuseModal
+          // Keyed by the case, so opening a second duty MOUNTS a fresh form
+          // rather than showing the first one's chosen kind and typed ground.
+          // The wrapper stays mounted across open and closed to keep its focus
+          // handling, so without this its useState survives the change of
+          // subject — and an officer would confirm case B carrying case A's
+          // words.
+          key={excusing?.id ?? "none"}
+          row={excusing}
+          onClose={() => setExcusing(null)}
+          onConfirm={(state, note) => {
+            if (excusing) {
+              excuse.mutate({ id: excusing.id, state, note });
+            }
+          }}
+          pending={excuse.isPending}
+          error={excuse.isError ? problemMessageOf(excuse.error, t) : null}
+        />
+      </PanelBody>
+    </Panel>
+  );
+}
+
+// One duty: whose it is, what rule put it there, and by when.
+function NoticeRow({
+  row,
+  nowMs,
+  locale,
+  tz,
+  canWork,
+  assignPending,
+  onAssign,
+  onExcuse,
+}: Readonly<{
+  row: NoticeCase;
+  nowMs: number;
+  locale: Locale;
+  tz: string;
+  canWork: boolean;
+  assignPending: boolean;
+  onAssign: (owner: string) => void;
+  onExcuse: () => void;
+}>) {
+  const t = useT();
+  const overdue = isNoticeOverdue(row.due_at, row.state, nowMs);
+  // The roster is fetched only where somebody can actually act on it: a reader
+  // who may see the queue but not work it has no use for a list of colleagues.
+  const roster = useRoster("user", canWork);
+  const options = useMemo(
+    () =>
+      (roster.data ?? []).map((entry) => ({
+        value: entry.id,
+        // The roster carries users and teams under one type; only a user can
+        // own a duty, and display_name is what a user row carries.
+        label: "display_name" in entry ? entry.display_name : entry.id,
+      })),
+    [roster.data],
+  );
+
+  return (
+    <SettingRow
+      testId={`notice-case-${row.id}`}
+      label={
+        <>
+          <Badge tone={noticeStateTone(row.state)}>
+            {humanizeToken(row.state)}
+          </Badge>{" "}
+          {humanizeToken(row.rule)}
+        </>
+      }
+      description={
+        <>
+          {t("notice.dueAt", { date: formatDate(row.due_at, locale, tz) })}
+          {overdue ? (
+            <>
+              {" "}
+              <Badge tone="danger">{t("notice.overdue")}</Badge>
+            </>
+          ) : null}
+          {row.resolution_note ? <> · {row.resolution_note}</> : null}
+        </>
+      }
+      value={
+        // The OWNER answers "who is accountable", never the state. A blocked
+        // or queued case can carry one, and an `assigned` case can have lost
+        // its owner to a deleted account — which reads as unclaimed, honestly.
+        row.owner_user_id ? (
+          <Badge>{t("notice.claimed")}</Badge>
+        ) : (
+          <Badge tone="warn">{t("notice.unclaimed")}</Badge>
+        )
+      }
+      control={
+        canWork ? (
+          <>
+            {mayAssign(row.state) ? (
+              // The control shows the CURRENT owner, not a permanent blank.
+              // A picker that reset itself after every assign would leave the
+              // row saying "Claimed" beside a field naming nobody, and the
+              // reader would have to guess whether their click landed.
+              <Select
+                options={options}
+                value={row.owner_user_id ?? ""}
+                onChange={onAssign}
+                disabled={assignPending || roster.isPending}
+                name={`notice-assign-${row.id}`}
+              />
+            ) : null}
+            {mayExcuse(row.state) ? (
+              <Button variant="ghost" onClick={onExcuse}>
+                {t("notice.excuse")}
+              </Button>
+            ) : null}
+          </>
+        ) : undefined
+      }
+    />
+  );
+}
+
+// Ending a duty without sending anything, on a ground the officer states.
+//
+// The ground is required by the server and by this form, which is the whole
+// reason these two states exist beside `not_required` — that one records the
+// same conclusion with nothing to defend it.
+function ExcuseModal({
+  row,
+  onClose,
+  onConfirm,
+  pending,
+  error,
+}: Readonly<{
+  row: NoticeCase | null;
+  onClose: () => void;
+  onConfirm: (state: ExcuseState, note: string) => void;
+  pending: boolean;
+  error: string | null;
+}>) {
+  const t = useT();
+  const [state, setState] = useState<ExcuseState>("provided_elsewhere");
+  const [note, setNote] = useState("");
+
+  const stateOptions = EXCUSE_STATES.map((value) => ({
+    value,
+    label:
+      value === "provided_elsewhere"
+        ? t("notice.excuseProvided")
+        : t("notice.excuseExempt"),
+  }));
+
+  return (
+    <ConfirmModal
+      open={row !== null}
+      onClose={() => {
+        setNote("");
+        onClose();
+      }}
+      title={t("notice.excuseTitle")}
+      confirmLabel={t("notice.excuseConfirm")}
+      // Disabled until there is a ground, because the server refuses without
+      // one and a button that fails is worse than one that waits.
+      confirmDisabled={note.trim() === ""}
+      onConfirm={() => onConfirm(state, note.trim())}
+      pending={pending}
+      error={error}
+    >
+      <Field label={t("notice.excuseWhich")}>
+        {() => (
+          <Select
+            options={stateOptions}
+            value={state}
+            onChange={(value) => setState(value as ExcuseState)}
+            name="notice-excuse-state"
+          />
+        )}
+      </Field>
+      <Field label={t("notice.excuseGround")}>
+        {(control) => (
+          <Textarea
+            {...control}
+            value={note}
+            // The server holds 500 characters too. Bounded here as well so a
+            // reader learns the limit while typing rather than on submit.
+            maxLength={500}
+            onChange={(event) => setNote(event.target.value)}
+          />
+        )}
+      </Field>
+    </ConfirmModal>
+  );
+}

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -112,6 +112,7 @@ import { LinkedInImportCard } from "./linkedin-import";
 import { LinkedInReachCard } from "./linkedin-reach";
 import { SEARCH_DEBOUNCE_MS } from "./listquery";
 import { MailSharingCard, MailSharingPostureRow } from "./mail-sharing";
+import { NoticeCasesCard } from "./noticecases";
 import { OAuthAppCard } from "./oauth-app";
 import { OfferTemplatesAdmin } from "./offertemplates";
 import { OverlayCard } from "./overlay";
@@ -358,6 +359,11 @@ export function tabContent(id: SettingsPageId): ReactNode {
               to be able to see that without opening the audit trail. */}
           <RestrictedRecordsCard />
           <PrivacyInboxCard />
+          {/* The disclosure duties last, under the requests somebody sent us:
+              a subject-request queue is work that was asked for, and this is
+              the work nobody asked for because they do not yet know we hold
+              their data. Same grant, same officer, different question. */}
+          <NoticeCasesCard />
         </>
       );
     case "audit":


### PR DESCRIPTION
The notice-case table has had a worklist lane since it shipped and no screen. An officer could learn a duty existed and had no way to work it.

## What changed

- `noticecases.logic.ts` (new) — pure helpers: which states are owed, whether a duty is overdue, whether it may still be claimed or excused. The owed set is derived from the terminal set rather than listed twice, so the frontend and the backend cannot drift into disagreeing about whether a duty is open.
- `noticecases.tsx` (new) — the Panel. A facet bar, a row per duty carrying its rule and deadline, an owner picker, and the excuse modal that requires a ground.
- `settings.tsx` mounts it under the subject-request inbox, behind the same `privacy_request` grant.
- `GET /privacy/notice-cases/{id}` — the single-case read a teammate session needs for a brief-side drawer. It goes through `wireNoticeCase` and `noticeCaseColumns`, and an integration test asserts the detail and the list return the same case.
- 18 keys in `en`, `de` and `vi`.

## Codex review: four defects

**The "All" facet was a lie.** It sent no state filter, and the server reads an absent filter as "every unresolved one" — a sensible default for a caller asking for nothing in particular, and exactly wrong here. "All" returned the same rows as "Still owed", so every closed case was invisible to the one control that exists to find them. Both facets now name their states explicitly.

**The excuse modal kept its state across cases.** Excuse case A, open case B, and B arrived carrying A's typed ground and A's chosen claim, one keystroke from being confirmed on the wrong duty. The modal is keyed by the case now.

**The owner picker was pinned to an empty value,** so a successful assign left the row saying "Claimed" beside a field naming nobody.

**A failed excuse rendered only inside the modal,** which can be dismissed while its submit is in flight. A reader who dismissed it would believe a duty was excused when it was not. Both write failures now surface on the panel.

## One test that proved nothing

My first test for the modal state exercised the dismissal path, which was already guarded, and it passed with the fix reverted. Mutation testing caught that. Rewritten against the success path, where the bug actually was.

## Gates

`make check-backend`, `make check-fe` and `make fe-uat` all green, apart from two pre-existing `TestTheRecordIsCalledAContact` violations in `brief.readings.honesty.ts:47` and `brief.readings.test.tsx:734`. Both confirmed present on clean `origin/main` in a separate worktree, both in another session's lane, and that session has been told. Worth noting that this gate runs in the **backend** lane, which is how they reached main with `check-fe` green.

Integration lane: consent, full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The notice-case table shipped with a worklist lane and no screen, so an officer who learned a disclosure duty existed had no way to work it. This adds a screen where a privacy officer can see, claim, and excuse duties.

- The new screen sits in settings under the subject-request inbox, behind the same `privacy_request` read grant.
- Row-facing state helpers live in `noticecases.logic.ts`: which states are owed, whether a duty is overdue, and whether it may still be claimed or excused.
- The owed-state set derives from the terminal states, so the frontend and backend cannot drift on what counts as open.
- Adds `GET /privacy/notice-cases/{id}` for the single-case read a brief-side drawer needs; an integration test asserts the detail read and the queue list answer the same case, since both go through `noticeCaseColumns`.
- The excuse modal requires a ground and offers the two justifications that keep a record an auditor can open.
- Adds 18 i18n keys in `en`, `de`, and `vi`.

**Bug Fixes**

- The "All" facet sent no state filter, and the server treats an absent filter as every unresolved state — so it returned the same rows as "Still owed"; both facets now name their states.
- The excuse modal kept its state across cases, so opening case B after excusing case A carried A's typed ground and chosen claim; it is now keyed by the case.
- The owner picker was pinned to an empty value, leaving a successful assign showing "Claimed" beside a field naming nobody; it now shows the current owner.
- A failed excuse rendered only inside the modal, which can be dismissed while the submit is in flight; both write failures now surface on the panel.
- The first test for the modal-state bug exercised the already-guarded dismissal path and passed with the fix reverted; it now exercises the success path.

<sup>Written for commit dbe5eed2df8117c1a0a952d886670201a11fc164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a privacy notification-obligations queue to Settings, with owed/all filters, due-date and status indicators, and owner assignment.
  * Added support for ending an obligation without sending information by selecting a reason and providing a required note.
  * Added detailed views for individual notification obligations, including appropriate not-found and access handling.
  * The queue is hidden from users without the required privacy access and displays a read-only message instead.
* **Localization**
  * Added English, German, and Vietnamese translations for the notification-obligation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->