### PR TITLE
feat(worklist): the urgent count opens the urgent lane

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -11673,13 +11673,22 @@ paths:
             licence to read a colleague's inbox.
         - name: filter
           in: query
-          schema: { type: string, enum: [all, customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system, except_decisions, changed_since_brief] }
+          schema: { type: string, enum: [all, urgent, customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system, except_decisions, changed_since_brief] }
           description: |
             Narrow the queue. Omitted means everything, which is the default view.
 
-            Most values name ONE kind of work. Two do not, and exist because a surface
+            Most values name ONE kind of work. Three do not, and exist because a surface
             counted a population this vocabulary could not then ask for — a count whose
             link lands on a different population is a number that lies about where it goes.
+
+            `urgent` is the population `WorklistSummary.urgent` counts: somebody waiting
+            or a promise breaking, which is levels 0 to 2. It is a LEVEL and not a
+            category, so it crosses every lane — a customer waiting, an overdue promise
+            and a failed approved action are one question about the morning, and the
+            figure that asks it had no door of its own until this value existed. Read
+            from the row's own level, never the one a pin overwrote: a reader who pins
+            hygiene to the top of their morning has made nothing urgent, so the pin moves
+            neither this list nor the count above it.
 
             `except_decisions` is everything a decisions-drawing surface has NOT already
             answered: every row whose SOURCE is not `approval`. Not a kind of work, and
@@ -44432,7 +44441,7 @@ components:
             The scopes this reader may ask for, narrowest first — derived from their own
             row scope. A client draws a control only when there is more than one, so a
             rep who can only see their own work is never offered a switch that would 403.
-        filter: { type: string, enum: [all, customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system, except_decisions, changed_since_brief], description: 'The narrowing this read applied. The same vocabulary the query parameter takes.' }
+        filter: { type: string, enum: [all, urgent, customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system, except_decisions, changed_since_brief], description: 'The narrowing this read applied. The same vocabulary the query parameter takes.' }
         summary: { $ref: '#/components/schemas/WorklistSummary' }
         queue:
           type: array

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -269,10 +269,17 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 		// arrive in the lane's own order, which is not urgency, so taking the
 		// first would rank an incident by whichever failure happened to be
 		// read first and could file an urgent one below a routine row.
-		level, consequence = members[0].item.Level, members[0].item.Consequence
+		//
+		// Read through semanticLevelOf, so a PIN cannot mint an urgent group.
+		// A pin writes level 0 into `item.Level`, and this row is synthetic: it
+		// carries no pin of its own for a later reader to see through, so a
+		// member's ordering preference taken literally here became the whole
+		// group's band — and three routine failures reached a lane that counts
+		// only somebody waiting or a promise breaking.
+		level, consequence = semanticLevelOf(members[0]), members[0].item.Consequence
 		for _, member := range members[1:] {
-			if member.item.Level < level {
-				level, consequence = member.item.Level, member.item.Consequence
+			if semanticLevelOf(member) < level {
+				level, consequence = semanticLevelOf(member), member.item.Consequence
 			}
 		}
 		category = categorySystem

--- a/backend/internal/compose/attention/linkedfilter_test.go
+++ b/backend/internal/compose/attention/linkedfilter_test.go
@@ -3,7 +3,7 @@
 
 package attention
 
-// The two filter values a count links to.
+// The three filter values a count links to.
 //
 // Both exist for one reason: a Brief surface counted a population this
 // vocabulary could not then ask for, so its "N more" link opened a queue holding
@@ -104,6 +104,124 @@ func TestExceptDecisionsKeepsEveryKindButDecisions(t *testing.T) {
 			t.Fatalf("kept a %q row: the complement of decisions holds none",
 				row.item.Category)
 		}
+	}
+}
+
+// TestUrgentKeepsExactlyWhatTheSummaryCounted is the one that matters, because
+// it is the defect stated as an equation.
+//
+// The Brief's first reading counts `summary.urgent` and its door opened `all`,
+// so a figure of two sent a reader into a queue of five with nothing saying
+// which two. The filter and the figure must agree on every day, so this asserts
+// the COUNT rather than a row list — and spans the whole ladder, because a
+// predicate written `== levelWaiting` passes a fixture holding only that level.
+func TestUrgentKeepsExactlyWhatTheSummaryCounted(t *testing.T) {
+	t.Parallel()
+
+	rows := []ranked{
+		candidate("waiting", levelWaiting),
+		candidate("promise", levelPromise),
+		candidate("risk", levelMaterialRisk),
+		candidate("agreed", levelAgreed),
+		candidate("blocking", levelBlocking),
+		candidate("hygiene", levelRoutine),
+	}
+
+	kept := keepFiltered(rows, filterUrgent)
+	summary := summarize(rows, materialBar{})
+
+	if len(kept) != int(summary.Urgent) {
+		t.Fatalf("the urgent lane holds %d rows and the figure above it says %d: "+
+			"a count whose door opens a different population is a number that lies",
+			len(kept), summary.Urgent)
+	}
+	// The positive control: two zeros satisfy the equation and prove neither
+	// side of it.
+	if summary.Urgent != 2 {
+		t.Fatalf("counted %d urgent over a waiting row and a breaking promise, "+
+			"wanted 2", summary.Urgent)
+	}
+	for _, row := range kept {
+		if semanticLevelOf(row) > levelPromise {
+			t.Fatalf("kept a level-%d row: urgent is somebody waiting or a promise "+
+				"breaking, and nothing below that", semanticLevelOf(row))
+		}
+	}
+}
+
+// TestAPinnedRowIsNotUrgentInEitherPlace holds the half of the rule a reader
+// controls.
+//
+// A pin is one reader's ordering preference. It moves a row to the top of their
+// own morning and makes nothing urgent — so pinning hygiene must grow neither
+// the figure nor the list it opens. The two read ONE predicate for exactly this
+// reason: a filter reading `item.Level` while the summary reads the semantic one
+// would let a pin inflate the lane but not the count, and the door would open
+// more than the number that sent the reader.
+func TestAPinnedRowIsNotUrgentInEitherPlace(t *testing.T) {
+	t.Parallel()
+
+	// Pinned through the real writer, so the row carries whatever shape
+	// production gives a pinned row rather than one this test invented.
+	rows := applyPins(
+		[]ranked{candidate("waiting", levelWaiting), candidate("hygiene", levelRoutine)},
+		map[RowRef]bool{{RowID: "hygiene"}: true}, // candidate() sets no Source
+	)
+
+	kept := keepFiltered(rows, filterUrgent)
+	summary := summarize(rows, materialBar{})
+
+	if len(kept) != int(summary.Urgent) {
+		t.Fatalf("pinned: the lane holds %d and the figure says %d", len(kept),
+			summary.Urgent)
+	}
+	for _, row := range kept {
+		if row.item.Id == "hygiene" {
+			t.Fatal("a pinned routine row reached the urgent lane: a reader's " +
+				"ordering preference made hygiene urgent")
+		}
+	}
+}
+
+// TestAPinnedMemberDoesNotDragItsGroupIntoTheUrgentLane holds the seam between
+// the pin, the fold and the filter.
+//
+// A system incident folds its members whatever their level, and the synthetic
+// row takes the MOST urgent member's `item.Level`. A pin writes level 0 into
+// exactly that field — so a reader pinning one automation failure minted a
+// level-0 group, and `semanticLevelOf` had no `pinned` flag on the synthetic
+// row to see through it. Three routine failures then reached the urgent lane
+// while the figure above it still said none of them were urgent.
+//
+// The two previous tests cannot catch this: one never folds, the other pins
+// without folding. This one pins, folds, and filters, in that order.
+func TestAPinnedMemberDoesNotDragItsGroupIntoTheUrgentLane(t *testing.T) {
+	t.Parallel()
+
+	cause := "one-broken-rule"
+	incident := func(id string) ranked {
+		return candidate(id, levelBlocking, func(r *ranked) {
+			r.item.Category = categorySystem
+			r.item.Source = "automation_run"
+			r.item.CauseRef = &cause
+		})
+	}
+	rows := applyPins(
+		[]ranked{incident("run-1"), incident("run-2"), incident("run-3")},
+		map[RowRef]bool{{Source: "automation_run", RowID: "run-1"}: true},
+	)
+
+	folded := foldRoutineDecisions(rows)
+	kept := keepFiltered(folded, filterUrgent)
+	summary := summarize(rows, materialBar{})
+
+	if summary.Urgent != 0 {
+		t.Fatalf("three routine failures counted %d urgent before the fold",
+			summary.Urgent)
+	}
+	if len(kept) != 0 {
+		t.Fatalf("the urgent lane kept %d row(s) over work the figure called "+
+			"none: a pin on one member minted a level-0 group", len(kept))
 	}
 }
 

--- a/backend/internal/compose/attention/page.go
+++ b/backend/internal/compose/attention/page.go
@@ -59,6 +59,11 @@ const (
 	filterExceptDecisions = crmcontracts.WorklistFilter("except_decisions")
 	// filterChangedSinceBrief is the rows the overnight run did not see.
 	filterChangedSinceBrief = crmcontracts.WorklistFilter("changed_since_brief")
+	// filterUrgent is the population `summary.urgent` counts: somebody waiting
+	// or a promise breaking. It exists because the strip's first figure had no
+	// door of its own and opened the WHOLE queue — a count of 4 landing a
+	// reader in a list of 30, which is the reading this filter closes.
+	filterUrgent = crmcontracts.WorklistFilter("urgent")
 )
 
 // opensTheDeck says whether a filter is a request to see inside a folded group.
@@ -120,6 +125,13 @@ func keepFiltered(rows []ranked, want crmcontracts.WorklistFilter) []ranked {
 
 func keepsRow(row ranked, want crmcontracts.WorklistFilter) bool {
 	switch want {
+	case filterUrgent:
+		// The row's OWN level, through the same predicate the summary counts
+		// through. A pin is a reader's ordering preference and makes nothing
+		// urgent, so pinning hygiene to the top of a morning must not grow the
+		// figure OR the list it opens — and the two cannot drift, because there
+		// is one spelling of "urgent" and this is a call to it.
+		return semanticLevelOf(row) <= levelPromise
 	case filterExceptDecisions:
 		return !alreadyACard(row)
 	case filterChangedSinceBrief:

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14617,6 +14617,7 @@ const (
 	WorklistFilterMeetings          WorklistFilter = "meetings"
 	WorklistFilterSystem            WorklistFilter = "system"
 	WorklistFilterTasks             WorklistFilter = "tasks"
+	WorklistFilterUrgent            WorklistFilter = "urgent"
 )
 
 // Valid indicates whether the value is a known member of the WorklistFilter enum.
@@ -14641,6 +14642,8 @@ func (e WorklistFilter) Valid() bool {
 	case WorklistFilterSystem:
 		return true
 	case WorklistFilterTasks:
+		return true
+	case WorklistFilterUrgent:
 		return true
 	default:
 		return false
@@ -17452,6 +17455,7 @@ const (
 	GetWorklistParamsFilterMeetings          GetWorklistParamsFilter = "meetings"
 	GetWorklistParamsFilterSystem            GetWorklistParamsFilter = "system"
 	GetWorklistParamsFilterTasks             GetWorklistParamsFilter = "tasks"
+	GetWorklistParamsFilterUrgent            GetWorklistParamsFilter = "urgent"
 )
 
 // Valid indicates whether the value is a known member of the GetWorklistParamsFilter enum.
@@ -17476,6 +17480,8 @@ func (e GetWorklistParamsFilter) Valid() bool {
 	case GetWorklistParamsFilterSystem:
 		return true
 	case GetWorklistParamsFilterTasks:
+		return true
+	case GetWorklistParamsFilterUrgent:
 		return true
 	default:
 		return false
@@ -43997,9 +44003,18 @@ type GetWorklistParams struct {
 
 	// Filter Narrow the queue. Omitted means everything, which is the default view.
 	//
-	// Most values name ONE kind of work. Two do not, and exist because a surface
+	// Most values name ONE kind of work. Three do not, and exist because a surface
 	// counted a population this vocabulary could not then ask for — a count whose
 	// link lands on a different population is a number that lies about where it goes.
+	//
+	// `urgent` is the population `WorklistSummary.urgent` counts: somebody waiting
+	// or a promise breaking, which is levels 0 to 2. It is a LEVEL and not a
+	// category, so it crosses every lane — a customer waiting, an overdue promise
+	// and a failed approved action are one question about the morning, and the
+	// figure that asks it had no door of its own until this value existed. Read
+	// from the row's own level, never the one a pin overwrote: a reader who pins
+	// hygiene to the top of their morning has made nothing urgent, so the pin moves
+	// neither this list nor the count above it.
 	//
 	// `except_decisions` is everything a decisions-drawing surface has NOT already
 	// answered: every row whose SOURCE is not `approval`. Not a kind of work, and

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -33513,7 +33513,7 @@ export interface components {
              * @description The narrowing this read applied. The same vocabulary the query parameter takes.
              * @enum {string}
              */
-            filter?: "all" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system" | "except_decisions" | "changed_since_brief";
+            filter?: "all" | "urgent" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system" | "except_decisions" | "changed_since_brief";
             summary: components["schemas"]["WorklistSummary"];
             /** @description Everything actionable, best-first. The order is the product of this endpoint. */
             queue: components["schemas"]["WorklistItem"][];
@@ -47896,9 +47896,18 @@ export interface operations {
                 /**
                  * @description Narrow the queue. Omitted means everything, which is the default view.
                  *
-                 *     Most values name ONE kind of work. Two do not, and exist because a surface
+                 *     Most values name ONE kind of work. Three do not, and exist because a surface
                  *     counted a population this vocabulary could not then ask for — a count whose
                  *     link lands on a different population is a number that lies about where it goes.
+                 *
+                 *     `urgent` is the population `WorklistSummary.urgent` counts: somebody waiting
+                 *     or a promise breaking, which is levels 0 to 2. It is a LEVEL and not a
+                 *     category, so it crosses every lane — a customer waiting, an overdue promise
+                 *     and a failed approved action are one question about the morning, and the
+                 *     figure that asks it had no door of its own until this value existed. Read
+                 *     from the row's own level, never the one a pin overwrote: a reader who pins
+                 *     hygiene to the top of their morning has made nothing urgent, so the pin moves
+                 *     neither this list nor the count above it.
                  *
                  *     `except_decisions` is everything a decisions-drawing surface has NOT already
                  *     answered: every row whose SOURCE is not `approval`. Not a kind of work, and
@@ -47915,7 +47924,7 @@ export interface operations {
                  *     than everything: absent is not false, and a reader asking what changed since a
                  *     night that never happened is owed nothing, not the whole queue.
                  */
-                filter?: "all" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system" | "except_decisions" | "changed_since_brief";
+                filter?: "all" | "urgent" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system" | "except_decisions" | "changed_since_brief";
                 /** @description How many ranked items to return. */
                 limit?: number;
                 /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -9195,6 +9195,8 @@ export const de = {
   "worklist.filter.tasks": "Aufgaben",
   "worklist.filter.decisions": "Entscheidungen",
   "worklist.filter.system": "System",
+  "worklist.filter.linked.urgent":
+    "Nur Dringendes: jemand wartet, oder eine Zusage bricht.",
   "worklist.filter.linked.except_decisions":
     "Alles außer den Entscheidungen, nach denen Ihr Briefing bereits gefragt hat.",
   "worklist.filter.linked.changed_since_brief":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -9356,6 +9356,8 @@ export const en = {
   "worklist.filter.tasks": "Tasks",
   "worklist.filter.decisions": "Decisions",
   "worklist.filter.system": "System",
+  "worklist.filter.linked.urgent":
+    "Showing only what is urgent: somebody waiting, or a promise breaking.",
   "worklist.filter.linked.except_decisions":
     "Showing everything except the decisions your brief already asked you about.",
   "worklist.filter.linked.changed_since_brief":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -9075,6 +9075,8 @@ export const vi = {
   "worklist.filter.tasks": "Công việc",
   "worklist.filter.decisions": "Quyết định",
   "worklist.filter.system": "Hệ thống",
+  "worklist.filter.linked.urgent":
+    "Chỉ việc gấp: đang có bên chờ, hoặc một cam kết sắp trễ.",
   "worklist.filter.linked.except_decisions":
     "Hiển thị mọi thứ trừ các quyết định mà bản tóm tắt của bạn đã hỏi.",
   "worklist.filter.linked.changed_since_brief":

--- a/frontend/src/screens/brief.readings.honesty.ts
+++ b/frontend/src/screens/brief.readings.honesty.ts
@@ -44,7 +44,7 @@ export function boundedCategories(day: Worklist): ReadonlySet<string> {
 // about a SEND at the blocking level and contact hygiene — capturing a
 // counterparty, merging two records — a level below it, because a queue of
 // identical contact questions must never read as a customer waiting
-// (classifydecision.go). Claiming a person is held up by a duplicate pair is
+// (classifydecision.go). Claiming somebody is held up by a duplicate pair is
 // the sentence that teaches a reader to discount the line.
 //
 // Counted off the rows' own `work_blocked` consequence, which is the server's

--- a/frontend/src/screens/brief.readings.test.tsx
+++ b/frontend/src/screens/brief.readings.test.tsx
@@ -731,7 +731,7 @@ describe("the pipeline period", () => {
   // NOBODY IS BLOCKED BY A DUPLICATE PAIR. The strip said "somebody is blocked
   // until you answer" under every pending decision, and most of them are
   // contact hygiene the ranker deliberately puts BELOW a waiting customer. A
-  // line that claims a person is held up by a merge suggestion is the one a
+  // line that claims somebody is held up by a merge suggestion is the one a
   // reader learns to discount.
   it("claims nobody is blocked when no decision holds work up", () => {
     draw(
@@ -816,7 +816,7 @@ describe("the pipeline period", () => {
   // door to the leads lane — passes it. This one presses each door and reads
   // where it landed.
   it.each([
-    { door: "openUrgent", filter: "all" },
+    { door: "openUrgent", filter: "urgent" },
     { door: "openMeetings", filter: "meetings" },
     { door: "openLeads", filter: "leads" },
     { door: "openDecisions", filter: "decisions" },

--- a/frontend/src/screens/brief.readings.tsx
+++ b/frontend/src/screens/brief.readings.tsx
@@ -200,7 +200,10 @@ export function BriefReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
           // twice and drops the one fact it could add.
           basis={t("brief.readings.urgentBasis")}
           openLabel={t("brief.readings.openUrgent")}
-          lane="all"
+          // ITS OWN LANE, not the whole queue. This figure counts levels 0 to
+          // 2; opening `all` landed a reader who was sent by a 4 in a list of
+          // thirty, with nothing saying which four it meant.
+          lane="urgent"
         />
         <LaneReading
           label={t("brief.readings.meetings")}

--- a/frontend/src/screens/worklist.header.tsx
+++ b/frontend/src/screens/worklist.header.tsx
@@ -44,14 +44,16 @@ const FILTERS = [
 
 // The narrowings that are reachable by ADDRESS but are not pills.
 //
-// Both are the destination of a count on another screen — Brief's feed footer
-// and its overnight notice — and both exist so that count and its link read one
-// filter. Neither is a lane a reader picks: `except_decisions` is a complement
-// that only means something on a screen already drawing its own decisions, and
-// `changed_since_brief` describes a moment rather than a kind of work. Offered
-// as pills they would be two cuts nobody asked for, so the row stays the seven
-// kinds plus `all` and these arrive by link.
+// Each is the destination of a count on another screen — Brief's urgent
+// reading, its feed footer, its overnight notice — and each exists so that
+// count and its link read ONE filter. None is a lane a reader picks:
+// `urgent` is a level rather than a kind of work and already has a figure that
+// sends them here, `except_decisions` is a complement that only means something
+// on a screen already drawing its own decisions, and `changed_since_brief`
+// describes a moment. Offered as pills they would be three cuts nobody asked
+// for, so the row stays the seven kinds plus `all` and these arrive by link.
 const LINKED_ONLY = [
+  "urgent",
   "except_decisions",
   "changed_since_brief",
 ] as const satisfies readonly WorklistFilter[];

--- a/frontend/src/screens/worklist.narrowing.ts
+++ b/frontend/src/screens/worklist.narrowing.ts
@@ -14,10 +14,13 @@ import type { Worklist, WorklistFilter } from "./worklist.queries";
  * The per-category figures a narrowing is measured over, or null where they
  * cannot express it.
  *
- * The seven kinds are one category each and `all` is all of them. NEITHER
- * link-only narrowing is a category, and neither can be assembled from these
- * figures:
+ * The seven kinds are one category each and `all` is all of them. NONE of the
+ * three link-only narrowings is a category, and none can be assembled from
+ * these figures:
  *
+ *   - `urgent` is a LEVEL — somebody waiting or a promise breaking — and cuts
+ *     across every category. A customer waiting and an overdue promise are two
+ *     categories and one urgency, so no sum of these figures reaches it.
  *   - `changed_since_brief` cuts across every category on a per-row freshness
  *     the counts do not carry.
  *   - `except_decisions` excludes by SOURCE — the rows a brief draws as cards
@@ -42,7 +45,11 @@ export function countsUnder(
   if (filter === "all") {
     return day.counts;
   }
-  if (filter === "except_decisions" || filter === "changed_since_brief") {
+  if (
+    filter === "urgent" ||
+    filter === "except_decisions" ||
+    filter === "changed_since_brief"
+  ) {
     return null;
   }
   return day.counts.filter((count) => count.category === filter);


### PR DESCRIPTION
The Brief's first reading counts `summary.urgent` — somebody waiting or a promise breaking — and its door opened the **whole queue**. A figure of four landed a reader in a list of thirty, with nothing saying which four. That is the reading a count exists to prevent.

`urgent` joins the filter vocabulary as a third link-only narrowing, beside `except_decisions` and `changed_since_brief`, for the reason the contract already states for those two: *a surface counted a population this vocabulary could not then ask for.*

It is a **level**, not a category, so it crosses every lane — a customer waiting, an overdue promise and a failed approved action are one question about the morning. It reads `semanticLevelOf`, the same predicate the summary counts through, so the figure and the list cannot drift and a reader's pin moves neither. Not offered as a pill: the row stays the seven kinds plus `all`.

## A real defect this uncovered, in code the change did not touch

A **system incident folds its members at any level** and the synthetic row takes the most urgent member's `item.Level`. A pin writes level 0 into exactly that field, and a folded row carries no `pinned` flag for a later reader to see through — so pinning one automation failure minted a level-0 group, and three routine failures reached a lane whose figure said none of them were urgent.

`batches.go` now reads each member through `semanticLevelOf`, so a member's ordering preference cannot become the group's band.

This predates the urgent filter: the same bug already let a pinned member outrank real work in the ordering. The filter is what made it visible.

## Verification

- `make check-backend` and `make check-fe` both green on the final rebase (671 frontend test files)
- Pre-push hook green diff-scoped: `craft static` on the 2 changed Go files, plus the RLS and jurisdiction checks
- Mutation-checked four ways: reading `item.Level` instead of `semanticLevelOf` in the filter fails the pin test; widening to level 3 fails the equation test; reverting the fold fix fails the fold test
- Contract regenerated with both generators (`make gen` and `pnpm gen:api`)

## Codex review addressed

Codex found the fold defect above — the most valuable finding of the session so far — and that my pinning test never actually pinned, because `RowRef` needs `Source` and my fixture omitted it. The test passed while proving nothing. Both fixed, and the new test pins, folds, and filters in that order, which neither earlier test did.

## Also in this branch

Two comments using the retired record noun, which reached `main` with #5413 and left the backend prose gate red. They are one word each and are fixed here rather than in a separate PR. Filed separately: #5419, a pre-existing craft finding in `dealmoney.go` that arrived with #5415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `urgent` filter to the worklist so the Brief's urgent count opens a lane that shows only urgent rows, not the whole queue. Also fixes a bug where pinning a member of a folded system incident could make the whole group appear urgent.

**Changes**
- `urgent` is a link-only narrowing (like `except_decisions` and `changed_since_brief`) and reads `semanticLevelOf` so the figure and list stay consistent.
- The filter is not offered as a pill; the header row keeps the seven kinds plus `all`.
- Fixes a bug in `batches.go` where a pinned member's `Level` could be used as the group's level, so a routine folded group could appear urgent. Now reads through `semanticLevelOf`.

<sup>Written for commit 03baf2fbdb01f1268360558dca86ba364f5b8060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an **Urgent** worklist filter for items at urgent levels, across all lanes.
  - Selecting the urgent reading now opens the worklist in the urgent view.
  - Added English, German, and Vietnamese translations for the urgent filter.

- **Bug Fixes**
  - Pinned items and pinned incident members no longer incorrectly appear urgent or inflate urgent counts.

- **Tests**
  - Added coverage for urgent filtering, counts, pinned rows, and grouped incidents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->