### PR TITLE
feat(worklist): a system row names the broken thing, not the software

### DIFF
--- a/frontend/src/screens/worklist.eyebrow.test.ts
+++ b/frontend/src/screens/worklist.eyebrow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { eyebrowKeyFor } from "./worklist.eyebrow";
+import { conditionOf, eyebrowKeyFor } from "./worklist.eyebrow";
 import type { WorklistItem } from "./worklist.queries";
 
 function row(over: Partial<WorklistItem>): WorklistItem {
@@ -44,5 +44,56 @@ describe("the word above a queue row", () => {
     expect(eyebrowKeyFor(row({ source: "brief_item" }))).toBe(
       "worklist.category.deals_at_risk",
     );
+  });
+
+  // SIX CATEGORIES NAME A KIND OF WORK AND THE SEVENTH NAMED THE SOFTWARE.
+  // `system` is the queue's catch-all for the product reporting on itself — a
+  // mailbox that stopped, a failed automation, a bounced message, a privacy
+  // deadline — so a column of different broken things all read "System" and a
+  // reader running down it learned nothing about any of them.
+  it("names the broken thing on a system row", () => {
+    expect(
+      conditionOf(
+        row({ category: "system", cause_label: "Gmail · lena@acme.example" }),
+      ),
+    ).toBe("Gmail · lena@acme.example");
+  });
+
+  // ABSENT IS A REAL ANSWER. A lane whose candidate is a vocabulary rather than
+  // a record mints no label, and an empty eyebrow would be worse than a vague
+  // one — so the caller keeps the category word.
+  it("says nothing where a system row named no cause", () => {
+    expect(conditionOf(row({ category: "system" }))).toBeNull();
+  });
+
+  // And never on the six that already name their work: a deal at risk whose
+  // lane happened to mint a cause is still a deal at risk, and swapping its
+  // eyebrow for a condition's name would lose the grouping the column exists
+  // to show.
+  it("leaves every other category its own word", () => {
+    expect(
+      conditionOf(row({ category: "deals_at_risk", cause_label: "a cause" })),
+    ).toBeNull();
+    expect(
+      conditionOf(row({ category: "decisions", cause_label: "a cause" })),
+    ).toBeNull();
+  });
+
+  // A FOLDED INCIDENT KEEPS THE WORD TOO. The fold mints a fresh row and puts
+  // the group's name in `batch.label`, never in `cause_label` — so the helper
+  // finds nothing and the category word stands. Asserted rather than left to
+  // chance: a later fold that started copying the label would change what this
+  // column says on a whole class of rows, and the group's headline already
+  // reads "{cause} failed {count} times".
+  it("keeps the category word on a folded incident", () => {
+    expect(
+      conditionOf(
+        row({
+          category: "system",
+          source: "batch",
+          batch: { key: "system_incident", count: 3, label: "Nightly sync" },
+        } as Partial<WorklistItem>),
+      ),
+    ).toBeNull();
   });
 });

--- a/frontend/src/screens/worklist.eyebrow.ts
+++ b/frontend/src/screens/worklist.eyebrow.ts
@@ -10,7 +10,7 @@ const BRIEF_SIGNALS = [
 ] as const;
 
 /**
- * The word above a queue row.
+ * The word above a queue row, where the row's own category is the word.
  *
  * Normally the row's category, which is the queue's own grouping. A brief row
  * is the exception: every one of them sits in `deals_at_risk`, because that is
@@ -30,4 +30,55 @@ export function eyebrowKeyFor(item: WorklistItem): MessageKey {
     }
   }
   return `worklist.category.${item.category}` as MessageKey;
+}
+
+/**
+ * The eyebrow as WORDS, which is `cause_label` where the row has one.
+ *
+ * `system` is the category that needed this. It is the queue's catch-all — the
+ * product reporting on ITSELF: a mailbox that stopped, an automation that
+ * failed, mail that bounced, a privacy deadline. Six categories name a kind of
+ * work a reader recognises and the seventh named the software, so a column of
+ * different broken things all read "System" and a reader ran down it learning
+ * nothing about any of them.
+ *
+ * `cause_label` is the server's own words for the condition — minted by the
+ * lane that knows which record IS the condition, never sampled from a member's
+ * title. Nothing drew it before this.
+ *
+ * MOST SYSTEM ROWS STILL SAY "System", and that is the honest state rather than
+ * an oversight. Three producers mint a label today — capture health names the
+ * account, AI work health names the task, a failed automation names the rule
+ * (renderhealthlanes.go). Sync health, bounces, undelivered mail, failed
+ * approvals, privacy deadlines and relationship decay mint none, so those rows
+ * keep the category word. Naming them needs each producer to say which record
+ * IS its condition, which is work in the lane and not here; a browser inventing
+ * a name from a row's title would be the sampled-member guess the contract
+ * refuses. A folded incident is the same case: the fold mints a fresh row and
+ * puts the group's name in `batch.label`, not here, so it keeps the word too —
+ * and its headline already reads "{cause} failed {count} times".
+ *
+ * Null where the row has none, and the caller keeps the category word: absent
+ * is a real answer here, and an empty eyebrow would be worse than a vague one.
+ */
+export function conditionOf(item: WorklistItem): string | null {
+  return item.category === "system" && item.cause_label
+    ? item.cause_label
+    : null;
+}
+
+/**
+ * The kind cell's class, which depends on what the cell holds.
+ *
+ * A category word fits the track it was sized for. A named condition does not
+ * — "Notify sales on a new lead" is several times "Meeting" — and the badge
+ * inside is `nowrap`, so it ran out of the cell and under the title. The named
+ * variant clips with an ellipsis rather than wrapping: the column's argument is
+ * that a reader runs DOWN it, and one row growing to two lines breaks the scan.
+ * The caller puts the full name in `title` for a pointer.
+ */
+export function kindClass(named: string | null): string {
+  return named === null
+    ? "worklist-row-kind"
+    : "worklist-row-kind worklist-row-kind-named";
 }

--- a/frontend/src/screens/worklist.row.css
+++ b/frontend/src/screens/worklist.row.css
@@ -96,6 +96,21 @@
   min-width: 0;
 }
 
+/* A named condition is longer than a category word and the badge is `nowrap`,
+   so it ran out of its cell and under the title. Clipped, never wrapped — see
+   `eyebrowClass` for why the column cannot grow a second line. */
+.worklist-row-kind-named {
+  overflow: hidden;
+}
+
+.worklist-row-kind-named > * {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
 .worklist-row-text {
   display: flex;
   flex-direction: column;

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -47,7 +47,7 @@ import {
 } from "./worklist.copy";
 import { PutDownByThumb } from "./worklist.dispositions";
 import { WaitingEmailLine } from "./worklist.emailtitle";
-import { eyebrowKeyFor } from "./worklist.eyebrow";
+import { conditionOf, eyebrowKeyFor, kindClass } from "./worklist.eyebrow";
 import { PairDecision } from "./worklist.pair";
 import {
   useApproval,
@@ -215,6 +215,7 @@ export function WorklistRow({
     sample,
     zone,
   };
+  const named = conditionOf(item);
   return (
     <PanelRow
       // A CLASS and not a data attribute: `PanelRow` takes a className and
@@ -258,10 +259,11 @@ export function WorklistRow({
             carrying one per row: the tone survives as a dot and the label as
             plain text, where a filled pill down a queue reads as decoration a
             reader learns to skip. The span is PLACEMENT — the grid cell and the
-            width the kinds share — and draws nothing itself. */}
-        <span className="worklist-row-kind">
+            width the kinds share; `conditionOf` says what a system row
+            draws there instead. */}
+        <span className={kindClass(named)} title={named ?? undefined}>
           <Badge quiet tone={item.band === "now" ? "warn" : undefined}>
-            {t(eyebrowKeyFor(item))}
+            {named ?? t(eyebrowKeyFor(item))}
           </Badge>
         </span>
         <div className="worklist-row-text">

--- a/frontend/src/screens/worklist.systemeyebrow.test.tsx
+++ b/frontend/src/screens/worklist.systemeyebrow.test.tsx
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { en } from "../i18n/en";
+import { day, renderWorklist, row, stub } from "./worklist.testkit";
+
+// A system row says WHICH thing is broken.
+//
+// Six of the queue's seven categories name a kind of work a reader recognises
+// — a lead, a meeting, a decision. The seventh named the software: `system` is
+// the catch-all for the product reporting on itself, so a mailbox that stopped,
+// a failed automation and a bounced message all wore the word "System" and a
+// reader running down the column learned nothing about any of them.
+//
+// `cause_label` is the server's own words for the condition, minted by the lane
+// that knows which record IS the condition. It was on the row already and
+// nothing drew it.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the word above a system row", () => {
+  it("names the broken thing rather than the software", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "run-1",
+            // A failed automation, which is one of the three producers that
+            // actually mints a label today (renderhealthlanes.go): the rule's
+            // own name, beside a cause_ref that is its id.
+            source: "automation_run",
+            category: "system",
+            level: 4,
+            title: "Notify sales on a new lead",
+            cause_label: "Notify sales on a new lead",
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    const eyebrow = (
+      await screen.findAllByText("Notify sales on a new lead")
+    )[0];
+    // The category word is GONE from the row, not merely joined: two eyebrows
+    // on one row would be the column saying the same thing twice. Scoped to the
+    // ROW, because "System" is also a filter pill on this screen and a bare
+    // query would find that instead and pass whatever the row drew.
+    const kind = eyebrow.closest(".worklist-row-kind");
+    expect(kind).not.toBeNull();
+    expect(kind?.textContent).toBe("Notify sales on a new lead");
+  });
+
+  // Absent is a real answer. A lane whose candidate is a vocabulary rather than
+  // a record mints no label, and an empty eyebrow is worse than a vague one.
+  it("keeps the category word where the row named no cause", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            // Sync health mints NO label, which is the common case rather than
+            // an edge one: six of the nine system sources are like this.
+            id: "sync-1",
+            source: "sync_health",
+            category: "system",
+            level: 4,
+            title: "Reconnect the mailbox",
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    await screen.findByText("Reconnect the mailbox");
+    const kind = document.querySelector(".worklist-row-kind");
+    expect(kind?.textContent).toBe(en["worklist.category.system"]);
+  });
+});


### PR DESCRIPTION
Six of the queue's seven categories name a kind of work a reader recognises — a lead, a meeting, a decision. The seventh named the software. `system` is the catch-all for the product reporting on itself, so a failed automation, a stopped mailbox, a bounced message and a privacy deadline all wore the word **"System"**, and a reader running down the column learned nothing about any of them.

A `system` row now shows `cause_label` — the server's own words for the condition, minted by the lane that knows which record *is* the condition rather than sampled from a member's title. It was already on the row and nothing drew it.

## What this does not fix, said plainly

**Most system rows still say "System", and that is the honest state rather than an oversight.** Three producers mint a label today: capture health names the account, AI work health names the task, a failed automation names the rule. Sync health, bounces, undelivered mail, failed approvals, privacy deadlines and relationship decay mint none, so those rows keep the category word.

Naming them needs each producer to say which record *is* its condition — work in the lane, not here. A browser inventing a name from the row's title would be exactly the sampled-member guess the contract refuses. A folded incident is the same case: the fold mints a fresh row and puts the group's name in `batch.label`, so it keeps the word too, and its headline already reads "{cause} failed {count} times".

## Why this departs from the original finding

MB-16 asked to remove the tag entirely and put "Raised automatically" in row details. Both halves turned out to be wrong for this tree:

- The column is **shared by all seven categories**. Removing the word leaves system rows with an empty cell while the other six keep theirs.
- `WorklistItem` carries **no provenance field**. "Raised automatically" would be a claim the data cannot support.

## Verification

- `make check-fe` green, 674 test files; full `go test ./gates` green including both prose gates
- Mutation-checked: dropping the substitution fails the render test
- `worklist.row.tsx` finished at 1206 lines, under main's 1208 freeze — the length budget was paid by tightening comments and shortening two helper names, not by re-freezing a waiver upward

## Codex review addressed

- **A false claim in a comment.** I wrote that `cause_label` "was on every such row already". It is on three of eleven sources. The comment now names which, and which keep the word.
- **A fixture that could not happen.** My test gave a `cause_label` to `sync_health`, whose producer never sets one. It now models `automation_run`, which does.
- **A real layout defect.** `.worklist-row-kind` is a fixed 7.5rem track and the badge inside is `nowrap`, so a long rule name ran out of the cell and under the title. Now clipped with an ellipsis, with the full name in `title` for a pointer. Clipped rather than wrapped: the column exists to be scanned downward, and one row growing to two lines breaks that.
- **An untested case.** Added a folded-incident test, so a later fold that started copying the label cannot silently change what this column says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
System rows in the worklist now show the server's own label for the condition — a failed automation's name, a stopped mailbox — instead of the word "System," which told readers nothing about which thing was broken. The label (`cause_label`) was already on rows; nothing drew it.

Three of nine system producers mint a label today, so most system rows still say "System" — naming the rest requires each lane to say which record is its condition, which is work outside this PR. A folded incident keeps the word too, since the fold puts the group's name in `batch.label` and its headline already reads "{cause} failed {count} times". Long labels in the kind column are now clipped with an ellipsis rather than running under the title; the full name is available on hover.

This deliberately departs from MB-16's original ask to remove the tag and add "Raised automatically": the column is shared by all seven categories, leaving system rows with an empty cell, and `WorklistItem` has no provenance field to back that claim.

<sup>Written for commit 0fb304acee8bd045bf8d661ff99078bce8e82db8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worklist system rows now display their specific condition or cause label when available.
  - Rows without a condition continue to show the localized “System” category label.
  - Condition labels include contextual tooltips for easier identification.

- **Style**
  - Long condition labels now remain on one line and truncate cleanly with an ellipsis to prevent layout overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->