### PR TITLE
feat(worklist): the pin says what pinning does

### DIFF
--- a/frontend/src/design-system/iconaction.test.tsx
+++ b/frontend/src/design-system/iconaction.test.tsx
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { IconAction } from "./iconaction";
+
+// A glyph verb's second sentence.
+//
+// `label` answers "what is this control" and stops there. Some verbs need more
+// — a pin is a personal ordering preference that holds until it is undone, and
+// none of that is in the word "Pin". `hint` carries it.
+//
+// The split is the whole point: the hint is a DESCRIPTION, never part of the
+// NAME. A control list that read the sentence once per row would be worse than
+// the bare word, so a screen reader must still hear "Pin" as the name.
+
+afterEach(cleanup);
+
+function describedTextOf(control: HTMLElement): string {
+  return (control.getAttribute("aria-describedby") ?? "")
+    .split(/\s+/)
+    .map((id) => document.getElementById(id)?.textContent ?? "")
+    .join(" ")
+    .trim();
+}
+
+describe("a glyph verb that needs a second sentence", () => {
+  it("keeps the hint out of the name and in the description", () => {
+    render(
+      <IconAction
+        label="Pin"
+        hint="Only you see it."
+        icon={<span aria-hidden="true">*</span>}
+      />,
+    );
+
+    // The NAME is the bare verb: this is what a control list reads.
+    const control = screen.getByRole("button", { name: "Pin" });
+    expect(describedTextOf(control)).toBe("Only you see it.");
+  });
+
+  // A caller that passes none is exactly the control it was — nineteen callers
+  // do, and none of them should gain a description they never asked for.
+  it("describes nothing where the caller gave no hint", () => {
+    render(<IconAction label="Pin" icon={<span aria-hidden="true">*</span>} />);
+
+    const control = screen.getByRole("button", { name: "Pin" });
+    expect(control.getAttribute("aria-describedby")).toBeNull();
+  });
+});

--- a/frontend/src/design-system/iconaction.tsx
+++ b/frontend/src/design-system/iconaction.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import type { ReactNode } from "react";
+import { type ReactNode, useId } from "react";
 import { Button } from "./atoms";
 import { useTooltip } from "./tooltip";
 import "./iconaction.css";
@@ -33,6 +33,7 @@ import "./iconaction.css";
  */
 export function IconAction({
   label,
+  hint,
   icon,
   variant,
   small,
@@ -46,6 +47,19 @@ export function IconAction({
 }: Readonly<{
   /** The verb, translated. Spoken as the name and shown as the tip. */
   label: string;
+  /**
+   * What the verb DOES, where the word alone cannot say it.
+   *
+   * A glyph verb answers "what is this" with its label and stops there. Some
+   * verbs need a second sentence — a pin is a personal ordering preference that
+   * holds until it is undone, and none of that is in the word "Pin".
+   *
+   * It joins the TIP and becomes the accessible DESCRIPTION, never part of the
+   * name: a control list that read "Pin to the top of your own worklist, only
+   * you see it…" once per row would be worse than the bare word. Omitted, the
+   * control is exactly what it was.
+   */
+  hint?: string;
   /** The glyph, `aria-hidden` — the label is what names this control. */
   icon: ReactNode;
   variant?: "primary" | "ghost" | "danger";
@@ -80,7 +94,10 @@ export function IconAction({
   /** Passed through, for a control a test already reaches by its own handle. */
   testId?: string;
 }>) {
-  const { ref, trigger, tip } = useTooltip<HTMLSpanElement>(label);
+  const hintId = useId();
+  const { ref, trigger, tip } = useTooltip<HTMLSpanElement>(
+    hint === undefined ? label : `${label}. ${hint}`,
+  );
   return (
     <span className="icon-action" ref={ref} {...trigger}>
       <Button
@@ -92,6 +109,7 @@ export function IconAction({
         disabled={disabled}
         pending={pending}
         aria-label={label}
+        aria-describedby={hint === undefined ? undefined : hintId}
         aria-pressed={pressed}
         data-testid={testId}
         onClick={onClick}
@@ -99,6 +117,14 @@ export function IconAction({
         {icon}
       </Button>
       {tip}
+      {/* The description a screen reader reads AFTER the name, and the one a
+          pointer gets from the tip above. Visually hidden because the row has
+          no space for it — the tip is where a sighted reader meets it. */}
+      {hint !== undefined && (
+        <span id={hintId} className="sr-only">
+          {hint}
+        </span>
+      )}
     </span>
   );
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -9382,6 +9382,10 @@ export const de = {
   "worklist.verb.completeFailed":
     "Diese Aufgabe konnte nicht abgeschlossen werden.",
   "worklist.verb.pin": "Anheften",
+  "worklist.verb.pinHint":
+    "Setzt das in deiner eigenen Liste nach oben, solange es zu deinen neuesten Anheftungen zählt. Ändert deine Reihenfolge, nicht die Dringlichkeit.",
+  "worklist.verb.unpinHint":
+    "Stellt das an seinen gewohnten Platz in deiner Liste zurück.",
   "worklist.verb.unpin": "Lösen",
   "worklist.verb.pinFailed": "Diese Zeile konnte nicht angeheftet werden.",
   "worklist.verb.unpinFailed": "Diese Zeile konnte nicht gelöst werden.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -9534,6 +9534,27 @@ export const en = {
   "worklist.verb.acknowledgeFailed": "That could not be marked as seen.",
   "worklist.verb.completeFailed": "That task could not be completed.",
   "worklist.verb.pin": "Pin",
+  // WHAT A PIN ACTUALLY DOES, because the word says none of it. Each clause
+  // is checked against the code and none of them may be written loosely:
+  //
+  //   - "your own queue" rather than "only you see it": the ORDERING is
+  //     reader-scoped (worklist_pin is keyed by reader_id), but the act is
+  //     written to the audit log, so an authorised audit reader can see that
+  //     you pinned something. "Only you see it" would be false there.
+  //   - "while it stays among your most recent" rather than "until you unpin
+  //     it": a reader's newest 50 pins are read (maxPinsPerReader,
+  //     worklistpin.go) and older ones silently stop taking effect.
+  //   - Nothing about urgency, because a pin moves the ORDER and not the
+  //     figure — semanticLevelOf keeps the summary honest.
+  //
+  // A reminder or a timed snooze is not on offer: the table has no expiry.
+  "worklist.verb.pinHint":
+    "Moves this to the top of your own queue while it stays among your most recent pins. It changes your order, not its urgency.",
+  // The SAME control, one state over, and it had better not say the pin
+  // sentence: a button that now removes the pin described as keeping it is the
+  // control contradicting itself.
+  "worklist.verb.unpinHint":
+    "Puts this back in its ranked place in your queue.",
   "worklist.verb.unpin": "Unpin",
   "worklist.verb.pinFailed": "That row could not be pinned.",
   "worklist.verb.unpinFailed": "That row could not be unpinned.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -9249,6 +9249,10 @@ export const vi = {
   "worklist.verb.acknowledgeFailed": "Không thể đánh dấu là đã xem.",
   "worklist.verb.completeFailed": "Không thể hoàn thành nhiệm vụ này.",
   "worklist.verb.pin": "Ghim",
+  "worklist.verb.pinHint":
+    "Đưa mục này lên đầu danh sách của riêng bạn, khi nó còn nằm trong những mục bạn ghim gần đây nhất. Đổi thứ tự của bạn, không đổi mức gấp.",
+  "worklist.verb.unpinHint":
+    "Trả mục này về đúng vị trí xếp hạng trong danh sách của bạn.",
   "worklist.verb.unpin": "Bỏ ghim",
   "worklist.verb.pinFailed": "Không thể ghim hàng này.",
   "worklist.verb.unpinFailed": "Không thể bỏ ghim hàng này.",

--- a/frontend/src/screens/worklist.pinhint.test.tsx
+++ b/frontend/src/screens/worklist.pinhint.test.tsx
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { en } from "../i18n/en";
+import { day, renderWorklist, row, stub } from "./worklist.testkit";
+
+// The pin says what it does.
+//
+// The control is a glyph and its whole vocabulary was "Pin" / "Unpin". A reader
+// could not tell from it whether pinning marks the row urgent, whether a
+// colleague sees it, or how long it lasts — and the answers matter: it is a
+// personal ordering preference, private to one reader, that holds until undone.
+//
+// The row has no space for a sentence, so it is the control's DESCRIPTION,
+// reached by hover, by focus and by a screen reader.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the pin verb", () => {
+  it("explains what pinning does without renaming the control", async () => {
+    stub(
+      day({
+        queue: [row({ id: "t-1", title: "Call the buyer back" })],
+        summary: { urgent: 0, due: 1, lower_priority: 0, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    // Still named by the bare verb: the sentence must not reach the NAME, or a
+    // queue of thirty rows repeats it thirty times in a control list.
+    const pin = await screen.findByRole("button", {
+      name: en["worklist.verb.pin"],
+    });
+
+    const described = (pin.getAttribute("aria-describedby") ?? "")
+      .split(/\s+/)
+      .map((id) => document.getElementById(id)?.textContent ?? "")
+      .join(" ");
+    expect(described).toContain(en["worklist.verb.pinHint"]);
+  });
+
+  // THE OTHER STATE, which is where a shared sentence goes wrong. One hint for
+  // both had the Unpin button describing itself as keeping the row on top —
+  // the control saying the opposite of what pressing it now does.
+  it("describes removing the pin once the row is pinned", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "t-1",
+            title: "Call the buyer back",
+            because: [{ kind: "pinned" }],
+          }),
+        ],
+        summary: { urgent: 0, due: 1, lower_priority: 0, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    const unpin = await screen.findByRole("button", {
+      name: en["worklist.verb.unpin"],
+    });
+
+    const described = (unpin.getAttribute("aria-describedby") ?? "")
+      .split(/\s+/)
+      .map((id) => document.getElementById(id)?.textContent ?? "")
+      .join(" ");
+    expect(described).toContain(en["worklist.verb.unpinHint"]);
+    // And not the pin's own sentence, which is the defect this holds.
+    expect(described).not.toContain(en["worklist.verb.pinHint"]);
+  });
+});

--- a/frontend/src/screens/worklist.rowverbs.tsx
+++ b/frontend/src/screens/worklist.rowverbs.tsx
@@ -366,6 +366,17 @@ function PinVerb({ item }: Readonly<{ item: WorklistItem }>) {
       // speaks it and shows it on hover from the one `label`.
       icon={pinned ? <PinOff aria-hidden="true" /> : <Pin aria-hidden="true" />}
       label={t(pinned ? "worklist.verb.unpin" : "worklist.verb.pin")}
+      // WHAT THE GLYPH CANNOT SAY. "Pin" answers what the control IS and
+      // nothing about what it does: a reader could not tell whether it marks
+      // the row urgent, whose order it changes, or how long it lasts.
+      //
+      // Per STATE, like the label beside it. One sentence for both states had
+      // the Unpin button describing itself as keeping the row on top, which is
+      // the control contradicting what pressing it now does.
+      //
+      // A description rather than part of the name: a control list repeating a
+      // sentence once per row would be worse than the bare word.
+      hint={t(pinned ? "worklist.verb.unpinHint" : "worklist.verb.pinHint")}
       // It SETS rather than does, and the two states of one switch look
       // identical without it: a glyph has no label on screen to carry the
       // difference, so the pressed state is what tells a reader this row is


### PR DESCRIPTION
The pin is an icon-only control and its whole vocabulary was **"Pin" / "Unpin"**. A reader could not tell from it whether pinning marks the row urgent, whose order it changes, or how long it lasts.

It now carries a sentence, as the control's **description** — reached by hover, by focus and by a screen reader — never as part of its name. A queue of thirty rows repeating the sentence thirty times in a control list would be worse than the bare word. `IconAction` gains an optional `hint` for this; the nineteen callers that pass none are exactly the control they were.

## No visible label, deliberately

The finding also asked for "Pin to top of my worklist" on the row. The comment there says the word was dropped because a row carrying a move, an Open, three judgements, a hand-off and an answer has no width for it — and that constraint still holds. The label question belongs after the "System" tag has actually freed the space, measured against a real row, not predicted.

## Every clause of the copy is checked against the code

This is the part Codex earned its keep on. My first draft said *"only you see it, and it holds until you unpin it."* Both halves were false:

- **"Only you see it"** — the *ordering* is reader-scoped, but pinning writes an audit row, so an authorised audit reader can see that you pinned something. Now "your own queue".
- **"Until you unpin it"** — a reader's newest **50** pins are read (`maxPinsPerReader`); older ones silently stop taking effect with no unpin action. Now "while it stays among your most recent pins".
- **Urgency** — pinning moves the order and not the figure, so the sentence says so rather than leaving a reader to wonder.

The i18n comment records each check, so the next person to reword it knows which clauses are load-bearing.

## One sentence was the wrong shape

The hint is now **per state**. A single sentence had the *Unpin* button describing itself as keeping the row on top — the control saying the opposite of what pressing it does. Codex found this, and the reason nothing caught it was a test gap: every fixture rendered the unpinned state. There is now a pinned-state test, and reverting the per-state wiring fails it.

## Verification

- `make check-fe` green, 676 test files; full `go test ./gates` green
- Mutation-checked three ways: folding the hint into the accessible name fails 2 tests, dropping the description fails 2, sharing one sentence across both states fails 1
- An existing gate caught the first draft too — `worklist.test.tsx` bans i18n-key-shaped text on screen, and my sentence ended "…your own worklist." which matched its `worklist.` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The worklist Pin/Unpin control now explains what pinning does, instead of leaving the icon to speak for itself. The hint appears on hover, on focus, and to screen readers, while the control name stays the bare verb.

`IconAction` gains an optional `hint` prop; existing callers are unchanged. The pinned and unpinned states use different hints, so Unpin doesn't describe itself as keeping the row on top.

<sup>Written for commit daab2e9f29bcd287bff60cbf49474d9706b2d526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive hints to worklist pin and unpin actions while keeping their accessible labels concise.

* **User Experience**
  * Pinning and unpinning now explain their effects, including queue placement and urgency behavior.
  * Added German and Vietnamese translations for the new hints.

* **Tests**
  * Added coverage verifying accessible descriptions and pin/unpin hint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->