### PR TITLE
claim: main-red — currency-redenomination-on-draft regression

### DIFF
--- a/backend/internal/compose/datasweep.go
+++ b/backend/internal/compose/datasweep.go
@@ -120,6 +120,13 @@ var preservedResetTables = map[string]bool{
 	// is entitled to clear it, in which case the trigger needs the
 	// row-conditional shape activity_retention_evidence's own guard has).
 	"communication_instruction": true,
+	// A project's health history (migration 1789170100), on the same footing
+	// as activity_retention_evidence above: the row goes only with the
+	// project it judged, through the FK's CASCADE — the trigger refuses every
+	// other delete, superseding being the one legitimate withdrawal and that
+	// is an INSERT. `project` is not preserved, so a reset still clears these
+	// rows; preserved here means "not a target", never "kept".
+	"project_health_assessment": true,
 }
 
 // resetTargetTables lists every public base table a reset sweeps: all of them,

--- a/backend/internal/compose/integration/contract_fx_freeze_integration_test.go
+++ b/backend/internal/compose/integration/contract_fx_freeze_integration_test.go
@@ -179,9 +179,13 @@ func TestAnActivatedContractKeepsTheCurrencyItsRateWasFrozenFor(t *testing.T) {
 		t.Fatalf("pricing an active contract that froze no rate answered %v, want a refusal on currency", err)
 	}
 
-	// A draft has frozen nothing, so its currency is still the human's to fix.
+	// A draft has frozen nothing, so its currency is still the human's to fix
+	// — but the stored value carries no unit, so the move restates it rather
+	// than silently re-denominating 250,000 USD as 250,000 EUR.
 	draft := draftInCurrency(t, e, company, "USD")
-	moved, err := e.Contracts.UpdateContract(e.Admin(), draft, crmcontracts.UpdateContractRequest{Currency: &eur}, nil)
+	restated := int64(250_000)
+	moved, err := e.Contracts.UpdateContract(e.Admin(), draft,
+		crmcontracts.UpdateContractRequest{Currency: &eur, ValueMinor: &restated}, nil)
 	if err != nil {
 		t.Fatalf("correcting a draft's currency: %v", err)
 	}

--- a/backend/internal/compose/integration/contract_fx_freeze_integration_test.go
+++ b/backend/internal/compose/integration/contract_fx_freeze_integration_test.go
@@ -45,10 +45,16 @@ func seedRate(t *testing.T, e *Env, from, to string, rate string, on time.Time) 
 	}
 }
 
+// draftValueMinor is the value every draftInCurrency fixture carries, shared
+// with the callers that restate it: a hand-copied literal would keep passing
+// if the fixture's value ever changed, silently testing a re-price instead of
+// the restatement it names.
+const draftValueMinor = int64(250_000)
+
 // draftInCurrency stages a contract carrying a value in the named currency.
 func draftInCurrency(t *testing.T, e *Env, company ids.UUID, currency string) ids.ContractID {
 	t.Helper()
-	value := int64(250_000)
+	value := draftValueMinor
 	created, err := e.Contracts.CreateContract(e.Admin(), contracts.CreateContractInput{
 		CompanyID:  ids.From[ids.CompanyKind](company),
 		Title:      "A foreign-currency agreement",
@@ -179,11 +185,12 @@ func TestAnActivatedContractKeepsTheCurrencyItsRateWasFrozenFor(t *testing.T) {
 		t.Fatalf("pricing an active contract that froze no rate answered %v, want a refusal on currency", err)
 	}
 
-	// A draft has frozen nothing, so its currency is still the human's to fix
-	// — but the stored value carries no unit, so the move restates it rather
-	// than silently re-denominating 250,000 USD as 250,000 EUR.
+	// A draft has frozen nothing, so its currency is still the human's to
+	// fix — but a currency move must resend every populated figure
+	// (refuseARedenominatedDraft). This draft's price is unchanged in the
+	// new code, so the same numeral is resent on purpose.
 	draft := draftInCurrency(t, e, company, "USD")
-	restated := int64(250_000)
+	restated := draftValueMinor
 	moved, err := e.Contracts.UpdateContract(e.Admin(), draft,
 		crmcontracts.UpdateContractRequest{Currency: &eur, ValueMinor: &restated}, nil)
 	if err != nil {

--- a/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
+++ b/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
@@ -421,9 +421,14 @@ func TestRepricingAClosedDealRefreezesFx(t *testing.T) {
 		t.Fatal("closed deal gained an amount but no frozen FX — deal_closed_fx would have 500ed before the fix")
 	}
 
-	// Switching the closed deal's currency re-freezes for the NEW pair.
+	// Switching the closed deal's currency re-freezes for the NEW pair. The
+	// amount is restated alongside it — the stored numeral carries no unit,
+	// so a currency move requires every populated figure to be resent in the
+	// same request rather than silently re-denominating 48000 EUR as 48000
+	// USD.
 	usd := "USD"
-	if _, err := e.Deals.UpdateDeal(admin, ids.From[ids.DealKind](ids.UUID(d.Id)), deals.UpdateDealInput{Currency: &usd}); err != nil {
+	if _, err := e.Deals.UpdateDeal(admin, ids.From[ids.DealKind](ids.UUID(d.Id)),
+		deals.UpdateDealInput{Currency: &usd, AmountMinor: &amount}); err != nil {
 		t.Fatalf("re-currencying a closed deal: %v", err)
 	}
 	rate, _ = readFx()

--- a/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
+++ b/backend/internal/compose/integration/lifecycle_invariants_integration_test.go
@@ -421,11 +421,10 @@ func TestRepricingAClosedDealRefreezesFx(t *testing.T) {
 		t.Fatal("closed deal gained an amount but no frozen FX — deal_closed_fx would have 500ed before the fix")
 	}
 
-	// Switching the closed deal's currency re-freezes for the NEW pair. The
-	// amount is restated alongside it — the stored numeral carries no unit,
-	// so a currency move requires every populated figure to be resent in the
-	// same request rather than silently re-denominating 48000 EUR as 48000
-	// USD.
+	// Switching the closed deal's currency re-freezes for the NEW pair. A
+	// currency move must resend every populated figure (currencyRestatementError),
+	// so the amount is restated alongside it — unchanged, since this deal's
+	// price does not move, only its currency.
 	usd := "USD"
 	if _, err := e.Deals.UpdateDeal(admin, ids.From[ids.DealKind](ids.UUID(d.Id)),
 		deals.UpdateDealInput{Currency: &usd, AmountMinor: &amount}); err != nil {

--- a/backend/internal/compose/recordrestoremoney_integration_test.go
+++ b/backend/internal/compose/recordrestoremoney_integration_test.go
@@ -50,10 +50,14 @@ func TestAnAmountRestoreIsRefusedWhenTheCurrencyMovedUnderIt(t *testing.T) {
 	}
 	entry := latestAuditRowID(t, e, "deal", id, "update")
 
-	// The currency alone, afterwards. 225000 minor units meant euro cents when
-	// it was written; it does not mean the same thing now.
+	// The currency, restated together with the amount it now prices: a
+	// currency move requires every populated figure to be resent in the same
+	// request, so 225000 is restated rather than left to mean euro cents
+	// under a new code. 225000 minor units meant euro cents when it was
+	// written; it does not mean the same thing now.
 	moved := "JPY"
-	if _, err := e.Deals.UpdateDeal(ctx, dealID, deals.UpdateDealInput{Currency: &moved}); err != nil {
+	if _, err := e.Deals.UpdateDeal(ctx, dealID,
+		deals.UpdateDealInput{Currency: &moved, AmountMinor: &raised}); err != nil {
 		t.Fatalf("move the currency: %v", err)
 	}
 

--- a/backend/internal/compose/recordrestoremoney_integration_test.go
+++ b/backend/internal/compose/recordrestoremoney_integration_test.go
@@ -50,11 +50,12 @@ func TestAnAmountRestoreIsRefusedWhenTheCurrencyMovedUnderIt(t *testing.T) {
 	}
 	entry := latestAuditRowID(t, e, "deal", id, "update")
 
-	// The currency, restated together with the amount it now prices: a
-	// currency move requires every populated figure to be resent in the same
-	// request, so 225000 is restated rather than left to mean euro cents
-	// under a new code. 225000 minor units meant euro cents when it was
-	// written; it does not mean the same thing now.
+	// The currency, moved to JPY. A currency move must resend every
+	// populated figure (currencyRestatementError), so the amount is resent
+	// alongside it — the caller is saying 225000 is still the price, now in
+	// yen, which is the deliberate reprice this test needs: 225000 minor
+	// units meant euro cents when it was written, and does not mean the same
+	// thing now.
 	moved := "JPY"
 	if _, err := e.Deals.UpdateDeal(ctx, dealID,
 		deals.UpdateDealInput{Currency: &moved, AmountMinor: &raised}); err != nil {

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -343,7 +343,7 @@ func (s *Store) applyMoneyInvariants(ctx context.Context, tx pgx.Tx,
 	// another offer is how it changes, and that path replaces the figure and
 	// its provenance together.
 	_, arrMoved := after[arrField]
-	if err := refuseManualArrEdit(current, resultingArr, arrMoved, currencyMoved); err != nil {
+	if err := refuseManualArrEdit(current, resultingArr, arrEditMove{Arr: arrMoved, Currency: currencyMoved}); err != nil {
 		return err
 	}
 	if string(current.Status) != "open" && resultingAmount != nil && (amountMoved || currencyMoved) {

--- a/backend/internal/modules/deals/dealmoney.go
+++ b/backend/internal/modules/deals/dealmoney.go
@@ -181,9 +181,14 @@ func refuseManualArrEdit(current crmcontracts.Deal, resultingArr *int64, moved a
 }
 
 // arrEditMove says which of the two moves that can invalidate an
-// offer-derived ARR the request made. Named rather than two bare bools at the
-// call site, where `(true, false)` says nothing about which field moved and a
-// transposed pair reads exactly like a correct one.
+// offer-derived ARR the PATCH records — unlike moneyRestatement above, whose
+// fields answer on the REQUEST. This lock has no restatement escape (an
+// offer-derived figure cannot be resaved back into legality the way an
+// ordinary one can), so there is no request/patch distinction to preserve
+// here; the patch is what the caller already has to hand at the call site.
+// Named rather than two bare bools at the call site, where `(true, false)`
+// says nothing about which field moved and a transposed pair reads exactly
+// like a correct one.
 type arrEditMove struct {
 	Arr      bool
 	Currency bool

--- a/backend/internal/modules/deals/dealmoney.go
+++ b/backend/internal/modules/deals/dealmoney.go
@@ -160,9 +160,7 @@ func patchedMoney(after map[string]any, column string, current *int64) *int64 {
 //
 // Every other field stays editable. This is a lock on one figure, not on the
 // deal.
-func refuseManualArrEdit(current crmcontracts.Deal, resultingArr *int64,
-	arrMoved, currencyMoved bool,
-) error {
+func refuseManualArrEdit(current crmcontracts.Deal, resultingArr *int64, moved arrEditMove) error {
 	if current.ArrSourceOfferId == nil {
 		return nil
 	}
@@ -173,13 +171,22 @@ func refuseManualArrEdit(current crmcontracts.Deal, resultingArr *int64,
 	// euros. Without this the restatement rule lets exactly that through: it
 	// asks only that every figure be RESENT, and resending the same numeral
 	// under a new code satisfies it.
-	if !arrMoved && !currencyMoved {
+	if !moved.Arr && !moved.Currency {
 		return nil
 	}
 	return &ArrFromOfferError{
 		Offer:   current.ArrSourceOfferId.String(),
-		Cleared: arrMoved && resultingArr == nil,
+		Cleared: moved.Arr && resultingArr == nil,
 	}
+}
+
+// arrEditMove says which of the two moves that can invalidate an
+// offer-derived ARR the request made. Named rather than two bare bools at the
+// call site, where `(true, false)` says nothing about which field moved and a
+// transposed pair reads exactly like a correct one.
+type arrEditMove struct {
+	Arr      bool
+	Currency bool
 }
 
 // ArrFromOfferError refuses a manual edit to an offer-derived recurring figure.

--- a/scripts/seed-reset.sql
+++ b/scripts/seed-reset.sql
@@ -52,6 +52,7 @@ DECLARE
     'lead_source',
     'overlay_mode',
     'passport',
+    'project_health_assessment',
     'role',
     'role_assignment',
     'session',
@@ -126,6 +127,15 @@ BEGIN
   -- on its own.
   DELETE FROM communication_instruction ci
    WHERE NOT EXISTS (SELECT 1 FROM communication_review cr WHERE cr.id = ci.review_id);
+
+  -- project_health_assessment is the SAME shape as activity_retention_evidence
+  -- above: its own trigger refuses a direct DELETE while the project it
+  -- judged still exists, and this script's replica mode suppresses both that
+  -- trigger and project's ON DELETE CASCADE into it. Without this statement,
+  -- sweeping `project` above would leave every assessment behind, now naming
+  -- a project that no longer exists.
+  DELETE FROM project_health_assessment pha
+   WHERE NOT EXISTS (SELECT 1 FROM project p WHERE p.id = pha.project_id);
 
   -- event_outbox is preserved the same way: "not a target" of the generic
   -- sweep, never "kept" outright. Clearing it here removes only the DATABASE


### PR DESCRIPTION
## Claiming main red — fixed

Main has been red since PR #5415 (`06c9dfaf1`, "A deal and a contract carry
recurring value beside their one-off figure"), which introduced a real,
intentional rule change — a currency move now requires every populated money
figure to be restated in the same request — but left pre-existing tests
exercising the OLD, lenient behaviour.

### What was actually wrong, and the fix

1. **`TestAnAmountRestoreIsRefusedWhenTheCurrencyMovedUnderIt`** (deals) and
   **`TestAnActivatedContractKeepsTheCurrencyItsRateWasFrozenFor`** /
   **`TestRepricingAClosedDealRefreezesFx`** (contracts/deals): both moved a
   deal/contract's currency alone, without restating the existing
   amount/value — exactly what PR #5415's new `currencyRestatementError` /
   `refuseARedenominatedDraft` guards now refuse by design. Fixed by
   restating the figure alongside the currency in each test, matching the
   documented intent ("every populated figure must be restated in the same
   request, even to the same numeral").

2. **craft-static MAJOR** (boolean-trap, `dealmoney.go:163`): PR #5428
   replaced one 3-bool call site with a named `moneyRestatement` struct (per
   #5419) but introduced a fresh 2-bool call site in `refuseManualArrEdit`.
   Replaced with a named `arrEditMove` struct.

3. **`TestSweepTargetsCarryNoDeleteBlockingTrigger`**: a separate, older
   regression — PR #5397 added `project_health_assessment` with an
   append-only, cascade-aware DELETE trigger but never classified it for the
   reset sweep census. Preserved it the same way `activity_retention_evidence`
   already is (cleared only through `project`'s CASCADE) in both
   `datasweep.go` and its `seed-reset.sql` mirror, which
   `TestTheTwoResetsPreserveTheSameTables` holds equal.

Between #5415 landing and now, several PRs' `ci` runs reported success only
because their changed files were frontend-only, so the backend/integration
lane was skipped rather than green — the regression was never actually
retested, just not re-triggered.

### Verified
- `backend/internal/compose`, `backend/internal/compose/integration`,
  `backend/internal/modules/deals`, `backend/internal/modules/contracts`,
  and `backend/gates` all green (the one remaining local `gates` failure,
  `TestEveryShippedConfigValidatesAgainstTheSchema`, is against a gitignored
  local-only `config/margince.yaml` and never reaches CI).
- `make check-fe` green.
- `craft-static` clean (the boolean-trap finding is gone).

Ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dmAATTYnrwqUEqrwF2fgo