### PR TITLE
fix(deals): the ARR lock names which figure moved

### DIFF
--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -343,7 +343,10 @@ func (s *Store) applyMoneyInvariants(ctx context.Context, tx pgx.Tx,
 	// another offer is how it changes, and that path replaces the figure and
 	// its provenance together.
 	_, arrMoved := after[arrField]
-	if err := refuseManualArrEdit(current, resultingArr, arrMoved, currencyMoved); err != nil {
+	if err := refuseManualArrEdit(current, resultingArr, moneyMoved{
+		Arr:      arrMoved,
+		Currency: currencyMoved,
+	}); err != nil {
 		return err
 	}
 	if string(current.Status) != "open" && resultingAmount != nil && (amountMoved || currencyMoved) {

--- a/backend/internal/modules/deals/dealmoney.go
+++ b/backend/internal/modules/deals/dealmoney.go
@@ -116,6 +116,16 @@ type moneyRestatement struct {
 	Arr      bool
 }
 
+// moneyMoved says which of a deal's money fields one patch actually CHANGED —
+// the question moneyRestatement's neighbour asks about what a request carried.
+// Named for that type's own reason: `(true, false)` at a call site says nothing
+// about which field is which, and a transposed pair reads exactly like a
+// correct one.
+type moneyMoved struct {
+	Arr      bool
+	Currency bool
+}
+
 // CurrencyRestatementError names the figure the caller has to send again.
 type CurrencyRestatementError struct{ Field string }
 
@@ -160,9 +170,7 @@ func patchedMoney(after map[string]any, column string, current *int64) *int64 {
 //
 // Every other field stays editable. This is a lock on one figure, not on the
 // deal.
-func refuseManualArrEdit(current crmcontracts.Deal, resultingArr *int64,
-	arrMoved, currencyMoved bool,
-) error {
+func refuseManualArrEdit(current crmcontracts.Deal, resultingArr *int64, moved moneyMoved) error {
 	if current.ArrSourceOfferId == nil {
 		return nil
 	}
@@ -173,12 +181,12 @@ func refuseManualArrEdit(current crmcontracts.Deal, resultingArr *int64,
 	// euros. Without this the restatement rule lets exactly that through: it
 	// asks only that every figure be RESENT, and resending the same numeral
 	// under a new code satisfies it.
-	if !arrMoved && !currencyMoved {
+	if !moved.Arr && !moved.Currency {
 		return nil
 	}
 	return &ArrFromOfferError{
 		Offer:   current.ArrSourceOfferId.String(),
-		Cleared: arrMoved && resultingArr == nil,
+		Cleared: moved.Arr && resultingArr == nil,
 	}
 }
 


### PR DESCRIPTION
`main` is craft-red:

```
backend/internal/modules/deals/dealmoney.go
  163: [MAJOR] boolean-trap — 2 bool parameters are a boolean trap — use named types or an options struct
```

Checked on pristine `main` at `e9ca2fb79` before touching anything; no open PR is fixing it. Every open PR's `craftsmanship` job fails on it.

## The fix the file already contains

`refuseManualArrEdit` takes `(arrMoved, currencyMoved bool)`, and `(true, false)` at the call site says nothing about which is which — a transposed pair reads exactly like a correct one, and these two decide whether a signed offer's recurring figure may be overwritten by a manual edit.

Twenty lines up, `moneyRestatement` is a named struct for the same shape, with the reason spelled out:

> Named rather than three bare bools at the call site, where `(true, false, true)` says nothing about which field is which and a transposed pair reads exactly like a correct one.

`moneyMoved` is its twin: that type says which figures a *request carried*, this one says which the *patch changed*. Same two questions the money path has always asked apart.

`make craft-static` is 0/0/0 and the deals package is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deal money changes when editing offer-derived deals.
  * ARR changes, currency movements, and cleared values are now correctly identified and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->