### PR TITLE
fix(release): the patch is cut from what was published, not from the last push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,15 +390,25 @@ jobs:
     permissions:
       contents: write
     steps:
+      # The whole history, because the move is ORDERED: the script refuses a
+      # revision the tag's current one does not lead to, and a shallow checkout
+      # cannot answer that question about anything.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: Move the published tag
         env:
           PUBLISHED: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          git tag -f "$PUBLISHED_TAG" "$PUBLISHED"
-          # --force because the tag MOVES: it names one revision, the newest
-          # published one, and a reader asking "what does a consumer have"
-          # wants exactly that. The history of what was published lives in the
-          # dist service, which is its owner; this is a pointer.
-          git push --force origin "refs/tags/$PUBLISHED_TAG"
+        # The tag MOVES: it names one revision, the newest published one, and a
+        # reader asking "what does a consumer have" wants exactly that. The
+        # history of what was published lives in the dist service, which is its
+        # owner; this is a pointer.
+        #
+        # FORWARD ONLY, and in a script of its own so that rule has a test. This
+        # job is outside the publish concurrency group — it has to be, or a
+        # release would hold the group while tagging — so two releases in flight
+        # are serialized at the publish and not here, and an older one's move
+        # can land last. Moving the tag backward cuts every later patch from a
+        # base ahead of what consumers have, which is the defect this whole
+        # change is about, arriving by the other door.
+        run: bash scripts/publish-released-tag.sh "$PUBLISHED_TAG" "$PUBLISHED" origin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,14 @@ env:
   # both draft into it; this becomes a per-ref selection when a production
   # constellation exists.
   MARGINCE_RELEASE_MANAGEMENT_DIST_URL: https://dist.test.margince.com
+  # The tag naming the last revision that actually PUBLISHED, moved by the job
+  # at the end of this file once publish-release has succeeded. It is what the
+  # next patch is cut from — a consumer's tree is the last release they
+  # received, not this ref's previous tip — and it is a cache of the dist
+  # service's own answer rather than a second authority: written only after a
+  # success, so the worst a lost write can do is make the next patch wider
+  # than necessary.
+  PUBLISHED_TAG: released
 
 jobs:
   draft:
@@ -139,28 +147,21 @@ jobs:
           # release, so nothing cut here can ever shadow one.
           version="1970.${GITHUB_RUN_NUMBER}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          # A push carries its previous tip in BEFORE; a manual dispatch carries
-          # nothing, so fall back to the parent commit. Two shapes of BEFORE
-          # mean there is no ancestor to diff from, and the release drafts
-          # without a patch: all-zeros (branch creation), and a commit the
-          # fetched history no longer reaches (a force-push discards its old
-          # tip, so even a full fetch of the new tip cannot resolve it).
-          # Ancestry is deliberately NOT required beyond that: a resolvable
-          # BEFORE that is no ancestor of AFTER (a force-push whose old tip
-          # another ref still reaches) still names the previously drafted
-          # state, and the tree diff from it is exactly the increment a
-          # consumer on that state needs.
-          base="$BEFORE"
-          if [ -z "$base" ]; then
-            base="$(git rev-parse --verify HEAD~1 2>/dev/null || true)"
-          fi
+          # The base is the last PUBLISHED revision, not this push's previous
+          # tip: a patch is applied by somebody whose tree is the last release
+          # they received, and the two agree only while every lane publishes.
+          # A cancelled or failed run leaves a commit published by nobody, and
+          # basing on BEFORE then drops its files from every patch a consumer
+          # will ever apply. scripts/release-patch-base.sh states the rule and
+          # its fallbacks, and its own test walks the three-commit sequence
+          # that made this a defect rather than a hazard.
+          base="$(bash scripts/release-patch-base.sh "$PUBLISHED_TAG" "$BEFORE" HEAD~1)"
           patch_args=()
           # The ref name is part of the patch filename; a branch name with a
           # slash would make it a path into a directory that does not exist
           # inside the CLI's mount, so flatten the separators.
           patch_file="${GITHUB_REF_NAME//\//-}-$AFTER.patch"
-          if [ -n "$base" ] && ! printf '%s' "$base" | grep -qE '^0+$' \
-            && git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+          if [ -n "$base" ]; then
             # The image ENTRYPOINT is the CLI (WORKDIR /work); mount the checkout
             # there and diff it with -repo. The image's own user is non-root and
             # does not own the runner's checkout, so run as the runner's uid/gid —
@@ -362,3 +363,42 @@ jobs:
             -e MARGINCE_RELEASE_MANAGEMENT_DIST_TOKEN \
             "$RELEASE_MANAGEMENT_IMAGE" \
             publish-release -version "$VERSION"
+
+  # What was PUBLISHED, recorded where the next patch can read it.
+  #
+  # The patch a consumer applies has to start from the tree they are holding,
+  # which is the last release that actually reached them — and a lane that
+  # cancelled or failed published nothing while still moving this ref's tip. So
+  # the base cannot be the tip, and this job is what makes the true answer
+  # available to a later run: a moving tag on the revision publish-release just
+  # accepted.
+  #
+  # AFTER the publish, and only on its success, which is what makes a tag safe
+  # as a cache of the dist service's own record. A write that is lost leaves the
+  # next patch WIDER than it needs to be — a consumer applies it without harm —
+  # while a write that ran too early is the narrow patch this whole change
+  # exists to prevent.
+  #
+  # Its own job rather than a step in the publish, so `contents: write` does not
+  # join the job holding the dist publisher token. It carries no secrets of its
+  # own beyond the default token the push needs.
+  mark-published:
+    name: Record the published revision
+    timeout-minutes: 10
+    needs: [publish]
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Move the published tag
+        env:
+          PUBLISHED: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git tag -f "$PUBLISHED_TAG" "$PUBLISHED"
+          # --force because the tag MOVES: it names one revision, the newest
+          # published one, and a reader asking "what does a consumer have"
+          # wants exactly that. The history of what was published lives in the
+          # dist service, which is its owner; this is a pointer.
+          git push --force origin "refs/tags/$PUBLISHED_TAG"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ROOT_SCRIPT_GATES := check-craft-doc test-dev-isolation \
   no-jurisdiction test-no-jurisdiction \
   pkg-freeze test-desktop-launcher changelog-sections \
   test-changelog-sections test-dev-postgres-container test-e2e-llm-check \
-  test-release-version-stamped test-closing-declaration \
+  test-release-version-stamped test-closing-declaration test-release-patch-base \
   test-craft-review test-release-tag-version
 
 # How wide the gate fan-out runs: the machine's online core count, so a 4-core
@@ -64,7 +64,7 @@ MINIO_PORT ?= 29000
 # answer lands in its own assignment so `set -e` sees the refusal — a helper
 # called inside another command's argument would fail unnoticed.
 
-.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture bench-dispatch perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-snapshot dev-restore dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm e2e-llm-guards fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-edge-padding fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-review test-craft-review craft-residue craft-prose check-craft-doc test-craft-pin test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-review-coverage test-laneorder secret-scan test-secret-scan test-sbom-sign test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length fe-file-length rls-store-path no-jurisdiction test-no-jurisdiction pkg-freeze changelog-sections test-changelog-sections test-release-tag-version test-release-version-stamped test-closing-declaration test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
+.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture bench-dispatch perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-snapshot dev-restore dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm e2e-llm-guards fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-edge-padding fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-review test-craft-review craft-residue craft-prose check-craft-doc test-craft-pin test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-review-coverage test-laneorder secret-scan test-secret-scan test-sbom-sign test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length fe-file-length rls-store-path no-jurisdiction test-no-jurisdiction pkg-freeze changelog-sections test-changelog-sections test-release-tag-version test-release-version-stamped test-closing-declaration test-release-patch-base test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -1189,6 +1189,15 @@ test-release-version-stamped:
 ## for and report the defect as absent.
 test-closing-declaration:
 	@./scripts/check-closing-declaration.test.sh
+
+## test-release-patch-base — prove a release patch is cut from what was last
+## PUBLISHED, not from this push's previous tip. The two agree only while every
+## lane publishes, and a cancelled or failed one drops its commit's files from
+## every patch a consumer will ever apply — silently, and identically to a
+## correct run from the publishing side. The case that matters walks the
+## sequence that made it a defect: publish, skip, publish.
+test-release-patch-base:
+	@./scripts/release-patch-base.test.sh
 
 ## test-release-tag-version — the release tag reader's own test: what the
 ## grammar accepts, and what shelf each accepted tag lands on. The reader has

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ ROOT_SCRIPT_GATES := check-craft-doc test-dev-isolation \
   pkg-freeze test-desktop-launcher changelog-sections \
   test-changelog-sections test-dev-postgres-container test-e2e-llm-check \
   test-release-version-stamped test-closing-declaration test-release-patch-base \
+  test-published-tag \
   test-craft-review test-release-tag-version
 
 # How wide the gate fan-out runs: the machine's online core count, so a 4-core
@@ -64,7 +65,7 @@ MINIO_PORT ?= 29000
 # answer lands in its own assignment so `set -e` sees the refusal — a helper
 # called inside another command's argument would fail unnoticed.
 
-.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture bench-dispatch perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-snapshot dev-restore dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm e2e-llm-guards fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-edge-padding fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-review test-craft-review craft-residue craft-prose check-craft-doc test-craft-pin test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-review-coverage test-laneorder secret-scan test-secret-scan test-sbom-sign test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length fe-file-length rls-store-path no-jurisdiction test-no-jurisdiction pkg-freeze changelog-sections test-changelog-sections test-release-tag-version test-release-version-stamped test-closing-declaration test-release-patch-base test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
+.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture bench-dispatch perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-snapshot dev-restore dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm e2e-llm-guards fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-edge-padding fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-review test-craft-review craft-residue craft-prose check-craft-doc test-craft-pin test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-review-coverage test-laneorder secret-scan test-secret-scan test-sbom-sign test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length fe-file-length rls-store-path no-jurisdiction test-no-jurisdiction pkg-freeze changelog-sections test-changelog-sections test-release-tag-version test-release-version-stamped test-closing-declaration test-release-patch-base test-published-tag test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -1198,6 +1199,16 @@ test-closing-declaration:
 ## sequence that made it a defect: publish, skip, publish.
 test-release-patch-base:
 	@./scripts/release-patch-base.test.sh
+
+## test-published-tag — prove the tag that base is read from only ever moves
+## FORWARD. The move is a job outside the publish concurrency group, so two
+## releases in flight are serialized at the publish and not at the tag: an older
+## one's move landing last would point the tag backward, and every later patch
+## would then be cut from a base ahead of what consumers actually have. The case
+## that matters records an older release after a newer one already recorded
+## itself.
+test-published-tag:
+	@./scripts/publish-released-tag.test.sh
 
 ## test-release-tag-version — the release tag reader's own test: what the
 ## grammar accepts, and what shelf each accepted tag lands on. The reader has

--- a/docs/how-to/cut-a-release.md
+++ b/docs/how-to/cut-a-release.md
@@ -52,6 +52,32 @@ Two release kinds live here, and they carry different versions:
 | Publishes to | the GitHub release page | the dist service at `dist.test.margince.com` |
 | Carries | both desktop bundles | the incremental patch, SBOMs, role images |
 
+### What the incremental patch is cut from
+
+`release.yml`'s patch starts at the last revision that actually **published**,
+recorded as the moving `released` tag the lane writes once `publish-release`
+succeeds — not at the ref's previous tip.
+
+The two agree only while every lane publishes. A run that is cancelled (the
+release group holds one queued slot, so a merge evicts the run behind it) or
+that fails leaves a commit published by nobody; basing the next patch on the
+previous tip would then drop that commit's files from every patch a consumer
+ever applies, silently and indistinguishably from a correct run.
+
+Two things follow, and both are correct rather than surprising:
+
+- **the first patch after a skipped lane is wider than usual**, covering what
+  that lane dropped;
+- **a `released` tag that failed to move makes the next patch wider still**,
+  which a consumer applies without harm. The tag is a pointer at the dist
+  service's own record, written only after a success, so its failure mode is
+  the safe direction.
+
+`scripts/release-patch-base.sh` states the rule and its fallbacks — the first
+release of a repository has nothing behind it and draws no patch at all — and
+`make test-release-patch-base` walks the publish/skip/publish sequence that made
+this a defect.
+
 The dist service's version grammar (`pkg/version` in
 `gradionhq/margince-constellation`) rejects a `v`-prefixed string by
 construction, and its scheme is a product commitment — evergreen editions, LTS

--- a/scripts/publish-released-tag.sh
+++ b/scripts/publish-released-tag.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Move the tag naming the last published revision — FORWARD ONLY.
+#
+# The tag is the base every release patch is cut from
+# (scripts/release-patch-base.sh), and its whole safety argument is ordering: a
+# tag that failed to move leaves the next patch WIDER than necessary, which a
+# consumer applies without harm, while a tag that moved BACKWARD is the narrow
+# patch that silently drops a commit's files from every patch anyone will ever
+# apply.
+#
+# Backward is not hypothetical. The publish job holds a concurrency group and
+# the tag move is a job of its own, so two releases in flight are serialized at
+# the publish and NOT at the move: an older release's move can land after a
+# newer one's, and `git tag -f` would then point the tag at the older revision.
+#
+# Two rules make that impossible rather than unlikely:
+#
+#   1. The new revision must be a DESCENDANT of the tag's current one. An older
+#      release is an ancestor and stops here, reporting that it did nothing.
+#   2. The push is a compare-and-swap (--force-with-lease against the value just
+#      read), so a move that lands between the check and the push is rejected
+#      rather than overwritten. A rejection is retried once against the value
+#      that won, which either finds itself an ancestor and stops or moves on.
+#
+# Usage: scripts/publish-released-tag.sh <tag> <revision> [remote]
+set -euo pipefail
+
+tag="${1-}"
+revision="${2-}"
+remote="${3:-origin}"
+
+if [ -z "$tag" ] || [ -z "$revision" ]; then
+	echo "usage: publish-released-tag.sh <tag> <revision> [remote]" >&2
+	exit 2
+fi
+
+target="$(git rev-parse --verify -q "$revision^{commit}")" || {
+	echo "publish-released-tag: $revision is not a commit in this checkout" >&2
+	exit 1
+}
+
+# The REMOTE's value, not the checkout's: the tag lives on the remote and a
+# fetched copy is as old as the fetch. An empty answer is the first publish.
+remote_value() {
+	git ls-remote --tags "$remote" "refs/tags/$tag" | awk 'NR == 1 { print $1 }'
+}
+
+attempt() {
+	local current="$1"
+	if [ -z "$current" ]; then
+		# No tag yet: the lease is "it does not exist", which --force-with-lease
+		# spells as an empty expected value.
+		git push --force-with-lease="refs/tags/$tag:" "$remote" "$target:refs/tags/$tag"
+		return
+	fi
+	# A tag object rather than a commit resolves through ^{commit}; a lightweight
+	# one already is the commit. Either way the comparison is between commits.
+	local current_commit
+	if ! current_commit="$(git rev-parse --verify -q "$current^{commit}")"; then
+		# The tag names something this checkout has not fetched. Refusing is the
+		# safe answer: moving a tag past a revision we cannot order ourselves
+		# against is exactly the backward move this script exists to prevent.
+		echo "publish-released-tag: $tag names $current, which this checkout cannot resolve — not moving it" >&2
+		exit 1
+	fi
+	if [ "$current_commit" = "$target" ]; then
+		echo "publish-released-tag: $tag already names $target"
+		return
+	fi
+	if ! git merge-base --is-ancestor "$current_commit" "$target"; then
+		echo "publish-released-tag: $tag names $current_commit, which $target does not descend from — a newer release has already recorded itself, so this one leaves it alone"
+		return
+	fi
+	git push --force-with-lease="refs/tags/$tag:$current" "$remote" "$target:refs/tags/$tag"
+}
+
+current="$(remote_value)"
+if attempt "$current"; then
+	exit 0
+fi
+# One retry, against whatever won the race. A second rejection is a real
+# failure: two retries would be a loop waiting for a quiet moment that a busy
+# release day may never have, and the lane must report rather than wait.
+echo "publish-released-tag: $tag moved under us, re-reading it" >&2
+attempt "$(remote_value)"

--- a/scripts/publish-released-tag.test.sh
+++ b/scripts/publish-released-tag.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# The tag mover's own test, over a real repository and a real remote.
+#
+# Every case pushes against a bare repository rather than mocking git, because
+# the question is what git does: whether --force-with-lease rejects a stale
+# expectation, and whether an ancestor is recognised as one. A stub would
+# assert this file's idea of those answers.
+#
+# The case that matters most is the THIRD — an older release recording itself
+# after a newer one already did — because it is the defect. The tag must stay
+# on the newer revision; moving it back is what cuts the next patch from a base
+# ahead of what consumers actually have, and it looks identical from the
+# publishing side.
+#
+# Usage: bash scripts/publish-released-tag.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MOVE="$SCRIPT_DIR/publish-released-tag.sh"
+
+FAILURES=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+TAG=released
+
+fail() {
+	printf 'FAIL: %s\n' "$1"
+	FAILURES=$((FAILURES + 1))
+}
+
+# tagged answers the commit the remote's tag names, or nothing.
+tagged() {
+	git -C "$WORK/work" ls-remote --tags origin "refs/tags/$TAG" | awk 'NR == 1 { print $1 }'
+}
+
+commit() {
+	git -C "$WORK/work" rev-parse --verify "$1"
+}
+
+git init -q --bare "$WORK/remote.git"
+git init -q "$WORK/work"
+cd "$WORK/work"
+git config user.email gate@example.test
+git config user.name "Release Gate"
+git remote add origin "$WORK/remote.git"
+for n in 1 2 3; do
+	echo "$n" > file.txt
+	git add file.txt
+	git commit -qm "commit $n"
+done
+git push -q origin HEAD:refs/heads/main
+C1="$(commit HEAD~2)"
+C2="$(commit HEAD~1)"
+C3="$(commit HEAD)"
+
+# 1. The first publish, with no tag on the remote at all.
+bash "$MOVE" "$TAG" "$C1" origin >/dev/null
+[ "$(tagged)" = "$C1" ] || fail "the first publish did not record its revision"
+printf 'ok    the first publish records its revision against no tag\n'
+
+# 2. A later publish moves it forward.
+bash "$MOVE" "$TAG" "$C3" origin >/dev/null
+[ "$(tagged)" = "$C3" ] || fail "a descendant did not move the tag forward"
+printf 'ok    a descendant moves it forward\n'
+
+# 3. THE DEFECT: an older release recording itself after a newer one already did.
+bash "$MOVE" "$TAG" "$C2" origin >/dev/null
+if [ "$(tagged)" != "$C3" ]; then
+	fail "an ancestor moved the tag BACKWARD — every later patch is then cut from a base ahead of what consumers have"
+else
+	printf 'ok    an ancestor leaves the newer revision alone\n'
+fi
+
+# 4. Re-recording the revision already there is a no-op and not a failure: a
+#    re-run of a succeeded job must not fail the lane.
+bash "$MOVE" "$TAG" "$C3" origin >/dev/null
+[ "$(tagged)" = "$C3" ] || fail "re-recording the same revision disturbed the tag"
+printf 'ok    re-recording the same revision changes nothing\n'
+
+# 5. A revision this checkout does not have is refused rather than guessed at.
+if bash "$MOVE" "$TAG" 0000000000000000000000000000000000000000 origin >/dev/null 2>&1; then
+	fail "an unknown revision was accepted"
+else
+	printf 'ok    an unknown revision is refused\n'
+fi
+
+# 6. A tag naming an object this checkout cannot resolve is refused, not
+#    overwritten: ordering against a revision we cannot see is exactly the
+#    backward move this script exists to prevent.
+git -C "$WORK/remote.git" update-ref "refs/tags/$TAG" "$(git -C "$WORK/remote.git" hash-object -w -t blob /dev/null)" 2>/dev/null || true
+if git -C "$WORK/remote.git" rev-parse --verify -q "refs/tags/$TAG^{commit}" >/dev/null 2>&1; then
+	printf 'ok    (skipped) this git resolved the planted tag to a commit\n'
+elif bash "$MOVE" "$TAG" "$C3" origin >/dev/null 2>&1; then
+	fail "a tag naming an unresolvable object was overwritten"
+else
+	printf 'ok    a tag this checkout cannot order against is refused\n'
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+	printf 'publish-released-tag: %d case(s) failed\n' "$FAILURES" >&2
+	exit 1
+fi
+printf 'publish-released-tag: ok — 6 case(s)\n'

--- a/scripts/release-patch-base.sh
+++ b/scripts/release-patch-base.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# The commit a release patch is cut FROM.
+#
+# A patch is applied by somebody whose tree is the last release they RECEIVED.
+# The base therefore has to be what was last published, and it used to be
+# `github.event.before` — the ref's previous tip, which is a fact about this
+# push and not about anybody's installation. The two agree only while every
+# push publishes.
+#
+# They diverge whenever a lane does not. A cancelled run (the release group
+# holds one queued slot, so a merge evicts the run behind it) and a failed one
+# both leave a commit published by nobody, and the NEXT patch then starts after
+# it — so that commit's files are missing from every patch a consumer will ever
+# apply, and nothing says so. Two instances in one day is what made this a
+# defect with a history rather than a hazard.
+#
+# So the base is the last published revision, recorded in this repository by the
+# tag the publish job moves AFTER a publish succeeds. Ordering is what makes the
+# tag safe as a cache of the dist service's own answer: a tag that failed to
+# move leaves the next patch WIDER than necessary, which a consumer applies
+# without harm, while a tag that moved too early is the narrow patch this exists
+# to prevent.
+#
+# Usage: scripts/release-patch-base.sh <published-ref> <before> <fallback-ref>
+#   published-ref  the tag naming the last published revision ("released")
+#   before         github.event.before, empty on a manual dispatch
+#   fallback-ref   what to diff from when neither is available (HEAD~1)
+#
+# It prints the base commit, or nothing at all — and nothing is a real answer:
+# the first release of a repository has no previous published state, and a
+# release drafted without a patch is the honest shape for it.
+set -euo pipefail
+
+published="${1-}"
+before="${2-}"
+fallback="${3-}"
+
+# resolvable answers whether a name is a commit this checkout can reach. A
+# force-push discards its old tip, so a `before` the fetched history no longer
+# carries is not an error to report — it is simply not a base.
+resolvable() {
+	[ -n "$1" ] && git rev-parse --verify --quiet "$1^{commit}" >/dev/null 2>&1
+}
+
+# An all-zeros `before` is branch creation: there is no previous state at all.
+zeros() {
+	printf '%s' "$1" | grep -qE '^0+$'
+}
+
+# THE PUBLISHED REVISION WINS, and it wins even when it is not an ancestor of
+# the commit being released. A base that no longer sits on this branch still
+# names the tree a consumer is holding, and the diff from it is exactly the
+# increment they need — which is the same reasoning the previous-tip base
+# already carried, applied to a better answer about whose tree it is.
+if resolvable "$published"; then
+	git rev-parse --verify "$published^{commit}"
+	exit 0
+fi
+
+# No published revision recorded: either the first release, or a repository
+# whose tag has not been written yet. The previous tip is the old behaviour and
+# the best remaining guess — it is right whenever the lane before this one did
+# publish, which is the ordinary case.
+if [ -n "$before" ] && ! zeros "$before" && resolvable "$before"; then
+	git rev-parse --verify "$before^{commit}"
+	exit 0
+fi
+
+if resolvable "$fallback"; then
+	git rev-parse --verify "$fallback^{commit}"
+	exit 0
+fi
+
+# Nothing to diff from. Printing nothing is the interface: the caller drafts a
+# release with no patch, which is correct for a first release and honest for a
+# history this checkout cannot reach.
+exit 0

--- a/scripts/release-patch-base.test.sh
+++ b/scripts/release-patch-base.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# The base resolver's own test, over a real repository.
+#
+# Every case is built as commits rather than mocked, because the question is
+# what git resolves: a tag that moved, a tag that never existed, a `before` the
+# history no longer reaches. A stub of `git rev-parse` would assert this file's
+# idea of those answers rather than git's.
+#
+# The case that matters most is the THIRD one — publish at N-1, skip at N,
+# publish at N+1 — because it is the defect. The base must be N-1, so the patch
+# carries N's files; a base of N is what dropped them, and it looks identical
+# from the publishing side.
+#
+# Usage: bash scripts/release-patch-base.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESOLVE="$SCRIPT_DIR/release-patch-base.sh"
+
+FAILURES=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# expect <name> <want> <published> <before> <fallback>
+expect() {
+	local name="$1" want="$2" got
+	shift 2
+	got="$(cd "$WORK" && bash "$RESOLVE" "$@")"
+	if [ "$got" != "$want" ]; then
+		printf 'FAIL: %s — base %s, want %s\n' "$name" "${got:-<none>}" "${want:-<none>}"
+		FAILURES=$((FAILURES + 1))
+		return
+	fi
+	printf 'ok    %s\n' "$name"
+}
+
+cd "$WORK"
+git init -q .
+git config user.email gate@example.test
+git config user.name "Release Gate"
+for n in 1 2 3 4; do
+	echo "$n" >"file$n"
+	git add "file$n"
+	git commit -qm "commit $n"
+	eval "C$n=$(git rev-parse HEAD)"
+done
+
+# THE DEFECT. Published at commit 2, the lane at commit 3 did not publish, and
+# commit 4 is releasing now. The base has to be 2 — the tree a consumer holds —
+# so the patch carries commit 3's file. `before` says 3, which is what dropped it.
+git tag released "$C2"
+expect "a skipped lane leaves its files in the next patch" "$C2" released "$C3" HEAD~1
+
+# The ordinary case is the same rule, and it reads the same: every lane
+# published, so the tag and the previous tip agree.
+git tag -f released "$C3" >/dev/null 2>&1
+expect "an unbroken sequence resolves to the previous release" "$C3" released "$C3" HEAD~1
+
+# NOTHING PUBLISHED YET. The first release of a repository has no previous
+# state, and the previous tip is the best remaining answer rather than a
+# failure — it is right whenever the lane before this one published.
+git tag -d released >/dev/null 2>&1
+expect "no recorded release falls back to the previous tip" "$C3" released "$C3" HEAD~1
+
+# Branch creation carries an all-zeros before, which is not a commit and must
+# not be treated as one.
+expect "branch creation falls through to the fallback" "$C3" released "0000000000000000000000000000000000000000" HEAD~1
+
+# A manual dispatch carries no before at all.
+expect "a manual dispatch falls through to the fallback" "$C3" released "" HEAD~1
+
+# A force-push discards its old tip: `before` names a commit a full fetch of the
+# new tip cannot resolve. Not an error — simply not a base.
+expect "an unreachable before is skipped, not reported" "$C3" released "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" HEAD~1
+
+# And the honest empty answer: a first release with nothing behind it at all.
+(
+	cd "$WORK"
+	git init -q first
+	cd first
+	git config user.email gate@example.test
+	git config user.name "Release Gate"
+	echo one >file
+	git add file
+	git commit -qm "the first commit"
+	got="$(bash "$RESOLVE" released "" HEAD~1)"
+	if [ -n "$got" ]; then
+		printf 'FAIL: a first commit resolved a base (%s) — a release with nothing behind it owes no patch\n' "$got"
+		exit 1
+	fi
+	printf 'ok    a repository with one commit resolves no base at all\n'
+) || FAILURES=$((FAILURES + 1))
+
+if [ "$FAILURES" -ne 0 ]; then
+	printf '\nrelease-patch-base: %d case(s) failed\n' "$FAILURES" >&2
+	exit 1
+fi
+echo "OK: release-patch-base — every case, including the skipped lane that made this a defect"


### PR DESCRIPTION
Closes #1798.

## The defect, and it has instances

A patch is applied by somebody whose tree is **the last release they received**. The base was `github.event.before` — the ref's previous tip, a fact about *this push* and not about anybody's installation.

The two agree only while every lane publishes. They diverge whenever one does not:

- a **cancelled** run — the release group holds one queued slot, so a merge evicts the run behind it (commit `78dc5c3a`, killed at 2m27s);
- a **failed** run after the draft (commit `4cfaab41`).

Either leaves a commit published by nobody, and the next patch then starts *after* it. That commit's files are missing from every patch a consumer will ever apply, and nothing says so — from the publishing side it looks identical to a correct run. Two instances in one day.

## The base is what was published

Recorded in this repository as a moving `released` tag, written by a new job **after** `publish-release` succeeds.

**Why a tag is safe as a cache of the dist service's own record** is the ordering. A write that is lost leaves the next patch **wider** than necessary — a consumer applies it without harm — while a write that ran too early is exactly the narrow patch this prevents. The failure mode points the safe way.

**Its own job**, not a step in `publish`: `contents: write` should not join the job holding the dist publisher token.

## The rule is a script with a test

A release lane cannot be exercised on a pull request. The half that can be is the base resolution, so it lives in `scripts/release-patch-base.sh` with `make test-release-patch-base` beside it — the shape this repo already uses for `release-version-stamped.sh` and `check-closing-declaration.sh`.

The cases run against a **real repository built commit by commit**, because the question is what git resolves; a stubbed `rev-parse` would assert this file's idea of that instead:

- **publish at N-1, skip at N, publish at N+1** — the sequence from the ticket. The base must be N-1 so the patch carries N's files;
- an unbroken sequence, where the tag and the previous tip agree;
- **nothing published yet** — falls back to the previous tip, which is right whenever the lane before did publish;
- a **first commit with nothing behind it** — resolves *no base at all*, and the release drafts without a patch. Stated explicitly rather than left as an empty string that silently produces a whole-history diff (item 3 of the ruling);
- branch creation (all-zeros), a manual dispatch (empty), and a `before` a force-push left unreachable.

## Expect a wide first patch

The first run after this lands covers whatever the skipped lanes dropped. That is correct rather than a bug, and `docs/how-to/cut-a-release.md` now says so — along with why a `released` tag that failed to move makes a patch wider still, and why that direction is the safe one.

## Checks

`make check-backend`, `make test-release-patch-base`, `make make-target-parity` and `make craft-static` (0/0/0) all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Release patches now build from the last successfully published revision, producing accurate incremental changes even after skipped, failed, or force-pushed release runs.
  * The published revision is recorded automatically after a successful release.
  * Initial releases and situations without a valid prior revision continue to be handled safely.

* **Documentation**
  * Added guidance explaining release patch behavior, including skipped or failed release runs.

* **Tests**
  * Added coverage for release history, branch creation, manual runs, force-pushes, and first-release scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->