### PR TITLE
fix(httperr): a plan a migration invalidated is retryable, not an unknown 500

### DIFF
--- a/backend/internal/platform/database/storekit/sqlstate.go
+++ b/backend/internal/platform/database/storekit/sqlstate.go
@@ -20,6 +20,12 @@ const (
 	pgLockNotAvailable    = "55P03"
 	pgProgramLimitExceed  = "54000"
 
+	// 0A000 is "the server will not do that", and almost every member of it is
+	// a defect in the statement WE sent — an unsupported clause, a write to a
+	// view with no rule. Nothing branches on the class; the one member a caller
+	// can be told to retry is picked out by IsStaleStatementCache.
+	pgFeatureNotSupported = "0A000"
+
 	// The representation errors: a value the caller supplied is not of the type
 	// the column it was compared against holds. Listed rather than matched on
 	// the whole "22" class, which also carries arithmetic — a division by zero
@@ -167,4 +173,38 @@ func IsInvalidValueForType(err error) bool {
 	default:
 		return false
 	}
+}
+
+// staleStatementCacheRoutine is the backend function that raises the one 0A000
+// a retry clears (plancache.c). The routine travels on the wire beside the
+// SQLSTATE and is a C identifier, so unlike the message it is the same in every
+// lc_messages the server may be running under.
+const staleStatementCacheRoutine = "RevalidateCachedQuery"
+
+// staleStatementCacheMessage is that same refusal read off its English text,
+// for a connection whose routine did not survive the hop — a pooler between us
+// and Postgres relays the fields it chooses to.
+//
+// Matched as well as the routine and never instead of it: missing this error
+// is what costs a caller a false 500, and a 0A000 carrying that sentence is no
+// other fault.
+const staleStatementCacheMessage = "cached plan must not change result type"
+
+// IsStaleStatementCache detects a prepared statement that a schema change
+// invalidated: the connection planned a query against columns a migration has
+// since altered, and Postgres refuses the cached plan rather than answering
+// with the old result shape.
+//
+// It is nobody's input to fix and it is not a fault of the moment it happened
+// in — it is a deployment crossing a live connection, and the very next attempt
+// on that connection re-plans and succeeds. pgx does not absorb it (its own
+// suite asserts the error surfaces), so a caller sees it unless something maps
+// it, which makes it the rare database refusal whose honest advice IS to retry.
+func IsStaleStatementCache(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != pgFeatureNotSupported {
+		return false
+	}
+	return pgErr.Routine == staleStatementCacheRoutine ||
+		strings.Contains(pgErr.Message, staleStatementCacheMessage)
 }

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -288,6 +288,7 @@ type Fault struct {
 var transientCodes = map[string]struct{}{
 	"rate_limited":               {},
 	"incumbent_budget_exhausted": {},
+	schemaChangedCode:            {},
 }
 
 // Transient reports whether repeating the same call unchanged could succeed
@@ -370,9 +371,12 @@ func Classify(err error) (Fault, bool) {
 		}
 	}
 
-	// A constraint the DATABASE enforced that no path above translated. Last,
-	// so every typed refusal a module wrote wins over this — it is the net, not
-	// the answer.
+	// A statement the DATABASE refused that no path above translated. Last, so
+	// every typed refusal a module wrote wins over these two — they are the
+	// net, not the answer.
+	if fault, ok := stalePlanFault(err); ok {
+		return fault, true
+	}
 	if fault, ok := constraintFault(err); ok {
 		return fault, true
 	}

--- a/backend/internal/platform/httperr/staleplanfault.go
+++ b/backend/internal/platform/httperr/staleplanfault.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httperr
+
+// The one database refusal whose honest advice is "send it again".
+//
+// Separate from constraintfault.go because it answers the opposite question.
+// That file's whole rule is that a constraint breach is deterministic and must
+// never read as retryable; this one is a moment in a deployment, and reading it
+// as settled is the same defect pointing the other way.
+
+import (
+	"net/http"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// schemaChangedCode is what a client branches on, and it names the caller's
+// half of the event rather than ours. "Stale statement cache" is true and is
+// about a pool this caller cannot see; what they can act on is that the
+// installation's schema moved under a request that was otherwise fine.
+const schemaChangedCode = "schema_changed"
+
+// stalePlanFault answers a prepared statement that a migration invalidated.
+//
+// Without it the refusal is outside the taxonomy, so every surface reports the
+// opaque 500 whose advice is to retry — which is, for once, the right advice
+// arrived at by the wrong route. The cost is not the status: it is that the
+// event is logged as an unknown server fault, an operator goes looking for a
+// defect during exactly the window when a deploy explains it, and the agent
+// surface tells the caller the call was "settled" and must not be repeated.
+// Transient() is the half that matters, and a code is what carries it.
+//
+// InfraCause and no schema in the sentence, for constraintFault's reason: the
+// statement and the relation it was planned against are operator reading.
+func stalePlanFault(err error) (Fault, bool) {
+	if !storekit.IsStaleStatementCache(err) {
+		return Fault{}, false
+	}
+	return Fault{
+		Status: http.StatusServiceUnavailable, Code: schemaChangedCode,
+		Detail: "this installation's schema changed while the connection serving this request was " +
+			"holding a plan made against the old one. Nothing in the request is wrong and nothing " +
+			"was written; send it again — the plan is rebuilt on the next attempt.",
+		InfraCause: err,
+	}, true
+}

--- a/backend/internal/platform/httperr/staleplanfault_test.go
+++ b/backend/internal/platform/httperr/staleplanfault_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httperr
+
+// A deploy crossing a live connection, told apart from a defect in our own SQL.
+//
+// Both arrive as 0A000. One clears on the next attempt and the caller should be
+// told to make it; the other is a statement no retry will ever make legal, and
+// telling a client to repeat it spends their budget on a settled refusal. The
+// routine and the message are what separate them, and Postgres sends both.
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// The two ways the refusal identifies itself on the wire. A pooler relays the
+// fields it chooses to, so neither may be the one the mapping depends on.
+func TestASchemaChangeUnderALivePlanIsRetryable(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		cause *pgconn.PgError
+	}{
+		{
+			name: "identified by its routine",
+			cause: &pgconn.PgError{
+				Code: "0A000", Routine: "RevalidateCachedQuery",
+				Message: "cached plan must not change result type",
+			},
+		},
+		{
+			name: "identified by its message, the routine lost in a pooler",
+			cause: &pgconn.PgError{
+				Code: "0A000", Message: "cached plan must not change result type",
+			},
+		},
+		{
+			// A translated server keeps the routine and loses the sentence.
+			name: "identified by its routine, the message in another language",
+			cause: &pgconn.PgError{
+				Code: "0A000", Routine: "RevalidateCachedQuery",
+				Message: "der zwischengespeicherte Plan darf den Ergebnistyp nicht ändern",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fault, ok := Classify(fmt.Errorf("listing deals: %w", tc.cause))
+			if !ok {
+				t.Fatal("the refusal reached the unhandled path, where it is logged as an unknown " +
+					"server fault and reported to the caller as a settled one")
+			}
+			if fault.Status != http.StatusServiceUnavailable {
+				t.Errorf("status %d, want %d — the installation could not serve this request, and the "+
+					"caller did nothing wrong", fault.Status, http.StatusServiceUnavailable)
+			}
+			if !fault.Transient() {
+				t.Errorf("code %q is not transient, so every surface tells the caller repeating the "+
+					"call cannot help — the one thing that does help here", fault.Code)
+			}
+			if fault.InfraCause == nil {
+				t.Error("the cause did not reach InfraCause, so the operator's half of the event is lost")
+			}
+			if strings.Contains(fault.Detail, "cached plan") || strings.Contains(fault.Detail, "0A000") {
+				t.Errorf("the detail forwards database text to the caller: %q", fault.Detail)
+			}
+		})
+	}
+}
+
+// The rest of 0A000 is a statement WE sent that the server will not run, and no
+// number of retries makes it legal. Classifying the class rather than this one
+// member would turn every such defect into advice to try again — the exact
+// inversion the stale plan exists to correct.
+func TestAnUnsupportedStatementStaysASettledServerFault(t *testing.T) {
+	for _, cause := range []*pgconn.PgError{
+		{Code: "0A000", Routine: "DefineIndex", Message: "access method does not support this feature"},
+		{Code: "0A000", Routine: "transformInsertStmt", Message: "cannot insert into view"},
+	} {
+		if fault, ok := Classify(fmt.Errorf("running the report: %w", cause)); ok {
+			t.Errorf("%q was classified as %+v, want the opaque 500 — it is our defect, and a caller "+
+				"told to retry it will retry it forever", cause.Message, fault)
+		}
+	}
+}
+
+// A 0A000 is not a constraint, and the net that answers constraints must not
+// claim it: "a value in this request is outside what its field accepts" is a
+// false statement about a request whose values were all fine.
+func TestTheStalePlanIsNotAnsweredAsTheCallersInput(t *testing.T) {
+	cause := &pgconn.PgError{
+		Code: "0A000", Routine: "RevalidateCachedQuery",
+		Message: "cached plan must not change result type",
+	}
+	fault, ok := Classify(fmt.Errorf("updating the company: %w", cause))
+	if !ok {
+		t.Fatal("the refusal was not classified")
+	}
+	if fault.Status >= 400 && fault.Status < 500 {
+		t.Errorf("status %d blames the caller for a deployment of ours", fault.Status)
+	}
+	if !errors.Is(fault.InfraCause, error(cause)) {
+		t.Errorf("InfraCause = %v, want the pg error itself so the log names the routine", fault.InfraCause)
+	}
+}


### PR DESCRIPTION
A deploy that alters a column leaves every pooled connection holding a prepared statement planned against the old shape. Postgres refuses the next use of one with `0A000` / *"cached plan must not change result type"*, and pgx does not absorb it — pgx's own suite asserts the error surfaces.

Nothing in `httperr` matched the SQLSTATE, the phrase or the routine, so the refusal fell out of the taxonomy entirely. The status a caller saw was right by accident; everything around it was wrong:

- it was logged as an **unknown server fault**, sending an operator hunting for a defect during the one window where a deploy already explains it;
- `Fault.Transient()` reported false, which is how the agent surface tells a caller *"repeating it unchanged will be refused the same way"* — about the single database refusal whose honest advice is to send it again.

## What changed

- `storekit.IsStaleStatementCache` — `0A000` **and** (the `RevalidateCachedQuery` routine **or** the English message). Both clauses, never one: the routine survives a server running under a translated `lc_messages`, the message survives a pooler that drops the routine field. Under-recognition is the failure that costs a caller a false verdict, so the predicate is the union.
- `httperr.stalePlanFault` — 503 `schema_changed`, added to `transientCodes`. The statement and the relation go to `InfraCause`; the detail names no schema, for `constraintFault`'s reason.
- A new file rather than a branch in `constraintfault.go`: that file's whole rule is that a constraint breach is deterministic and must never read as retryable. This is the same defect pointing the other way, and putting them in one file would make the rule unreadable.

## The line the tests hold

The rest of `0A000` is a statement **we** sent that the server will not run — an unsupported access-method feature, a write to a view with no rule. Those are settled defects of ours and stay the opaque 500. `TestAnUnsupportedStatementStaysASettledServerFault` fails if the mapping ever claims the class, because claiming it would invert the advice for every other member.

Mutation-checked, five ways: dropping either identification clause fails the case it covers; claiming all of `0A000` fails the negative; removing the code from `transientCodes` or the dispatch from `Classify` fails the positives.

`make check-backend` green.

Instance 1 of #1496. Instance 2 there (a contract enum wider than the constraint behind it) is a schema/`crm.yaml` parity fix rather than a mapping one and stays on the tracker.