### PR TITLE
fix(platform): a statement cannot hold a connection for as long as it likes

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -449,29 +449,13 @@ func schemaPoolOptions(ctx context.Context, schemaDSN string, stdout io.Writer) 
 	// more than one DDL statement per table at a time; a handful of
 	// connections is a deliberately small footprint for a rare admin path,
 	// next to the app pool's MaxConns=16 default (database.NewPool).
-	pool, err := database.NewPool(ctx, withPoolMaxConns(schemaDSN, 3))
+	// No request ceiling: this pool runs ALTERs, and an index or constraint
+	// added to a populated table is not request-shaped work.
+	pool, err := database.NewPool(ctx,
+		database.WithoutRequestCeilings(database.WithDSNParam(schemaDSN, "pool_max_conns", "3")))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("api: schema pool: %w", err)
 	}
 	_, _ = fmt.Fprintln(stdout, "api custom-field schema changes enabled (schema pool configured)")
 	return []compose.Option{compose.WithSchemaPool(pool)}, pool, pool.Close, nil
-}
-
-// withPoolMaxConns appends a pool_max_conns limit to dsn unless the
-// operator already sized the pool themselves (database.NewPool's own
-// DSN-wins-over-default rule) — the URL and keyword/value DSN forms take
-// the query-parameter and space-separated keyword spellings respectively.
-func withPoolMaxConns(dsn string, n int) string {
-	if strings.Contains(dsn, "pool_max_conns") {
-		return dsn
-	}
-	param := fmt.Sprintf("pool_max_conns=%d", n)
-	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
-		sep := "?"
-		if strings.Contains(dsn, "?") {
-			sep = "&"
-		}
-		return dsn + sep + param
-	}
-	return dsn + " " + param
 }

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -163,7 +163,9 @@ func up(ctx context.Context, conn *pgx.Conn, dsn string, core, custom dbmigrate.
 	if err != nil {
 		return err
 	}
-	riverPool, err := database.NewPool(ctx, dsn)
+	// No request ceiling: River's own migrator and the index below are DDL,
+	// and this is the role that runs it.
+	riverPool, err := database.NewPool(ctx, database.WithoutRequestCeilings(dsn))
 	if err != nil {
 		return fmt.Errorf("migrate: opening river pool: %w", err)
 	}

--- a/backend/gates/lanepoolbudget_test.go
+++ b/backend/gates/lanepoolbudget_test.go
@@ -71,6 +71,7 @@ var unboundedPoolDoors = map[string][]string{
 // bound. Each is a file whose SUBJECT is the pool itself.
 var laneBudgetExempt = gatekit.Waive(map[string]string{
 	"internal/platform/database/idtypes_integration_test.go":      "the constructor's own test: its subject is that NewPool registers the uuid and uuid[] OIDs on every connection it hands out, which only NewPool can be asked — a pool opened through testdb would prove testdb's wrapper instead",
+	"internal/platform/database/poolceilings_integration_test.go": "the ceilings' own test: its subject is what NewPool puts on a connection and what a DSN that names a ceiling itself does to that, neither of which a pool opened through testdb can be asked — and package database cannot import testdb, which imports it. The pools it opens carry pool_max_conns=2, the one connection each assertion needs",
 	"internal/platform/testdb/pool_integration_test.go":           "the ceiling's own test: it asserts what testdb.Pool does to a DSN, which it can only do by opening one the other way and comparing",
 	"internal/platform/testdb/laneconnbudget_integration_test.go": "the lane arithmetic's own test — it opens pools to count them, which is the measurement",
 	"internal/platform/testdb/quiesce_integration_test.go":        "the quiesce probe's own test: it needs a pool it can leave busy, which the shared one must never be",

--- a/backend/internal/platform/database/database.go
+++ b/backend/internal/platform/database/database.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -71,18 +72,45 @@ func PoolConfig(dsn string) (*pgxpool.Config, error) {
 	// so a rep pays it on a query an unbounded admin runs for free. JIT
 	// earns its keep on long analytical scans; this product runs none on
 	// the request path. A DSN that names jit itself still wins.
-	if !strings.Contains(dsn, "jit") {
-		if cfg.ConnConfig.RuntimeParams == nil {
-			cfg.ConnConfig.RuntimeParams = map[string]string{}
-		}
-		cfg.ConnConfig.RuntimeParams["jit"] = "off"
-	}
+	setRuntimeParam(cfg, dsn, "jit", "off")
+	// Nothing else bounds how long one statement may hold a connection.
+	// http.Server's WriteTimeout ends the RESPONSE without cancelling the
+	// handler, so a query that has stopped making progress keeps its slot in a
+	// pool of sixteen until Postgres or the operator ends it — and the routes
+	// that cost the most slots per request are exactly the ones a user waits
+	// on. The ceilings and their sizing live beside CallerPredicateBudget,
+	// which is the tighter ceiling the caller-written predicates ask for.
+	setDurationParam(cfg, dsn, "statement_timeout", StatementCeiling)
+	setDurationParam(cfg, dsn, "idle_in_transaction_session_timeout", IdleTransactionCeiling)
 	// Typed entity ids ride uuid/uuid[] on every connection.
 	cfg.AfterConnect = func(_ context.Context, conn *pgx.Conn) error {
 		RegisterIDTypes(conn)
 		return nil
 	}
 	return cfg, nil
+}
+
+// setRuntimeParam fills in a Postgres runtime parameter the DSN left unset.
+// Same rule as every pool limit above: an operator who named the parameter in
+// the DSN meant it, so a DSN-provided value always wins — including a zero,
+// which Postgres reads as no bound at all and is how a role that must not be
+// bounded says so.
+func setRuntimeParam(cfg *pgxpool.Config, dsn, name, value string) {
+	if strings.Contains(dsn, name) {
+		return
+	}
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	cfg.ConnConfig.RuntimeParams[name] = value
+}
+
+// setDurationParam is setRuntimeParam in the unit Postgres reads a bare
+// duration in. The conversion lives here rather than at each ceiling, because
+// one off by a factor of a thousand either never fires or fires on everything,
+// and the config it was written into looks the same either way.
+func setDurationParam(cfg *pgxpool.Config, dsn, name string, value time.Duration) {
+	setRuntimeParam(cfg, dsn, name, strconv.FormatInt(value.Milliseconds(), 10))
 }
 
 // NewPool opens a pgxpool on PoolConfig's terms and proves it can reach the

--- a/backend/internal/platform/database/dsnparams.go
+++ b/backend/internal/platform/database/dsnparams.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package database
+
+import "strings"
+
+// WithDSNParam names a connection parameter in dsn, unless the DSN already
+// names it — PoolConfig's rule that an operator who stated a value meant it,
+// applied one level earlier so a ROLE can state one too.
+//
+// The two DSN spellings take different separators: the URL form carries
+// parameters as a query string, the keyword/value form as space-separated
+// pairs. Getting that wrong produces a DSN that parses and silently drops the
+// parameter, which is the failure this exists to avoid at two call sites
+// rather than one.
+//
+// Held by: TestADSNParameterIsNamedInTheSpellingTheDSNUses
+// (backend/internal/platform/database/dsnparams_test.go)
+func WithDSNParam(dsn, name, value string) string {
+	if strings.Contains(dsn, name) {
+		return dsn
+	}
+	param := name + "=" + value
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		sep := "?"
+		if strings.Contains(dsn, "?") {
+			sep = "&"
+		}
+		return dsn + sep + param
+	}
+	return dsn + " " + param
+}
+
+// WithoutRequestCeilings lifts StatementCeiling and IdleTransactionCeiling from
+// dsn, for the roles that run SCHEMA changes rather than serve requests: the
+// migrator's River lane and the API's custom-field schema pool.
+//
+// An index build or a table rewrite legitimately outruns any request-shaped
+// bound, and one cut half way leaves the schema short of head with nothing in
+// the failure to say that a timeout — rather than the DDL — is what ended it.
+// The advisory lock these paths queue on is a running statement too, so the
+// statement ceiling would end the WAIT as readily as the work.
+//
+// Postgres reads zero as no bound at all, which is why the lift is a value and
+// not a deletion: the parameter stays visible in the DSN, where an operator
+// reading it can see that this role has no ceiling and that saying so was
+// deliberate.
+func WithoutRequestCeilings(dsn string) string {
+	lifted := WithDSNParam(dsn, "statement_timeout", "0")
+	return WithDSNParam(lifted, "idle_in_transaction_session_timeout", "0")
+}

--- a/backend/internal/platform/database/dsnparams_test.go
+++ b/backend/internal/platform/database/dsnparams_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package database_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+)
+
+// TestADSNParameterIsNamedInTheSpellingTheDSNUses: the two DSN forms carry
+// parameters differently, and a parameter appended in the wrong one produces a
+// DSN that still parses while the parameter is silently gone — a pool that
+// looks configured and is not.
+func TestADSNParameterIsNamedInTheSpellingTheDSNUses(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{"a URL with no query string opens one", "postgres://h/db", "postgres://h/db?statement_timeout=5000"},
+		{"a URL that already has one appends", "postgres://h/db?sslmode=disable", "postgres://h/db?sslmode=disable&statement_timeout=5000"},
+		{"the postgresql scheme is the same form", "postgresql://h/db", "postgresql://h/db?statement_timeout=5000"},
+		{"a keyword/value DSN separates with a space", "host=h dbname=db", "host=h dbname=db statement_timeout=5000"},
+		{"a DSN that already names it keeps its own", "host=h statement_timeout=1", "host=h statement_timeout=1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := database.WithDSNParam(tc.dsn, "statement_timeout", "5000"); got != tc.want {
+				t.Errorf("WithDSNParam(%q) = %q, want %q", tc.dsn, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTheSchemaChangingRolesHaveNoCeilingAtAll: Postgres reads zero as no
+// bound, and a lift that wrote any other number would cap DDL at whatever it
+// happened to say.
+func TestTheSchemaChangingRolesHaveNoCeilingAtAll(t *testing.T) {
+	t.Parallel()
+	lifted := database.WithoutRequestCeilings("host=h dbname=db")
+	for _, name := range []string{"statement_timeout", "idle_in_transaction_session_timeout"} {
+		if !strings.Contains(lifted, name+"=0") {
+			t.Errorf("WithoutRequestCeilings left %s unlifted in %q; Postgres reads zero as no bound, and DDL needs that rather than a longer number", name, lifted)
+		}
+	}
+}
+
+// TestEveryCeilingAPoolSetsIsOneTheSchemaRolesCanLift derives its subject from
+// PoolConfig rather than listing it: the two functions are two writers of one
+// invariant — what bounds a connection — and a ceiling added to one and missed
+// by the other does not fail here, it fails as a half-built index on somebody's
+// installation. Anything named `*_timeout` counts, which is every shape a
+// Postgres duration ceiling comes in.
+func TestEveryCeilingAPoolSetsIsOneTheSchemaRolesCanLift(t *testing.T) {
+	t.Parallel()
+	const bare = "postgres://h/db"
+	bounded, err := database.PoolConfig(bare)
+	if err != nil {
+		t.Fatalf("PoolConfig: %v", err)
+	}
+	lifted, err := database.PoolConfig(database.WithoutRequestCeilings(bare))
+	if err != nil {
+		t.Fatalf("PoolConfig on a lifted DSN: %v", err)
+	}
+	var ceilings int
+	for name := range bounded.ConnConfig.RuntimeParams {
+		if !strings.HasSuffix(name, "_timeout") {
+			continue
+		}
+		ceilings++
+		if got := lifted.ConnConfig.RuntimeParams[name]; got != "0" {
+			t.Errorf("a pool sets %s but WithoutRequestCeilings leaves it at %q; the roles that run DDL lift what a pool sets, and this one they cannot", name, got)
+		}
+	}
+	if ceilings == 0 {
+		t.Fatal("found no ceiling on a pool at all — a pool of this product has always had some, so this read something smaller than it claims")
+	}
+}
+
+// TestAPoolCarriesTheCeilingsItWasNotGiven: the ceilings are the pool's, not
+// each caller's, so a pool opened by a role that never thought about them is
+// still bounded. Read as milliseconds because that is the unit Postgres reads
+// a bare integer in, and a timeout off by a factor of a thousand is a ceiling
+// that either never fires or fires on everything.
+func TestAPoolCarriesTheCeilingsItWasNotGiven(t *testing.T) {
+	t.Parallel()
+	cfg, err := database.PoolConfig("postgres://h/db")
+	if err != nil {
+		t.Fatalf("PoolConfig: %v", err)
+	}
+	for name, want := range map[string]int64{
+		"statement_timeout":                   database.StatementCeiling.Milliseconds(),
+		"idle_in_transaction_session_timeout": database.IdleTransactionCeiling.Milliseconds(),
+	} {
+		got := cfg.ConnConfig.RuntimeParams[name]
+		if got != strconv.FormatInt(want, 10) {
+			t.Errorf("a pool carries %s=%q, want %d milliseconds", name, got, want)
+		}
+	}
+}
+
+// TestAnOperatorsOwnCeilingWins is the same rule every pool limit above it
+// follows. Without it the lift the schema-changing roles ask for is written
+// into the DSN and then overwritten by the default it exists to remove.
+func TestAnOperatorsOwnCeilingWins(t *testing.T) {
+	t.Parallel()
+	cfg, err := database.PoolConfig(database.WithoutRequestCeilings("postgres://h/db"))
+	if err != nil {
+		t.Fatalf("PoolConfig: %v", err)
+	}
+	for _, name := range []string{"statement_timeout", "idle_in_transaction_session_timeout"} {
+		if got := cfg.ConnConfig.RuntimeParams[name]; got != "0" {
+			t.Errorf("a pool overrode the DSN's %s with %q; the DSN is where a role says it runs DDL", name, got)
+		}
+	}
+}

--- a/backend/internal/platform/database/poolceilings_integration_test.go
+++ b/backend/internal/platform/database/poolceilings_integration_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package database
+
+// What the pool's two ceilings are worth against a real server. A runtime
+// parameter that never reaches Postgres reads exactly like one that did: the
+// config carries the value, SHOW would answer it, and the statement still runs
+// forever. So these prove the KILL, not the setting.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// queryCanceled is the SQLSTATE Postgres ends a statement with when
+// statement_timeout fires.
+const queryCanceled = "57014"
+
+// rowQuerier is the one method these assertions need, so a pool and a
+// transaction can each be asked what IT runs under.
+type rowQuerier interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+// effectiveMilliseconds reads a duration setting in the unit Postgres stores
+// it in. pg_settings rather than SHOW, because SHOW renders the value for a
+// human — "1min", "20s" — and a test comparing those strings is asserting
+// Postgres's formatting rather than the ceiling.
+func effectiveMilliseconds(ctx context.Context, q rowQuerier, setting string) (int64, error) {
+	var raw string
+	if err := q.QueryRow(ctx,
+		`SELECT setting FROM pg_settings WHERE name = $1`, setting).Scan(&raw); err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(raw, 10, 64)
+}
+
+func ceilingTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("MARGINCE_TEST_DSN")
+	if dsn == "" {
+		t.Fatal("MARGINCE_TEST_DSN is not set — run `make db-up` and try again (integration tests fail loudly, they never skip)")
+	}
+	// Two connections, because each assertion below needs one and the lane's
+	// connection budget is shared with every package running beside this one.
+	return WithDSNParam(dsn, "pool_max_conns", "2")
+}
+
+// TestThePoolsCeilingsReachTheServer reads back what the connection actually
+// runs under. The ceilings are milliseconds on the wire and durations in Go,
+// and a factor of a thousand either way is a ceiling that never fires or one
+// that fires on everything.
+func TestThePoolsCeilingsReachTheServer(t *testing.T) {
+	ctx := context.Background()
+	pool, err := NewPool(ctx, ceilingTestDSN(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+
+	for setting, want := range map[string]time.Duration{
+		"statement_timeout":                   StatementCeiling,
+		"idle_in_transaction_session_timeout": IdleTransactionCeiling,
+	} {
+		got, err := effectiveMilliseconds(ctx, pool, setting)
+		if err != nil {
+			t.Fatalf("reading %s: %v", setting, err)
+		}
+		if got != want.Milliseconds() {
+			t.Errorf("a connection runs under %s = %dms, want %dms", setting, got, want.Milliseconds())
+		}
+	}
+}
+
+// TestAStatementPastTheCeilingIsEnded is the property the ceiling exists for.
+// It runs against a pool whose ceiling the DSN shortened, because the point is
+// that a ceiling named this way ENDS a statement — proving it at the product's
+// own thirty seconds would cost thirty seconds to learn the same thing.
+func TestAStatementPastTheCeilingIsEnded(t *testing.T) {
+	ctx := context.Background()
+	pool, err := NewPool(ctx, WithDSNParam(ceilingTestDSN(t), "statement_timeout", "100"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+
+	_, err = pool.Exec(ctx, `SELECT pg_sleep(5)`)
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != queryCanceled {
+		t.Fatalf("a statement past the ceiling ended with %v, want SQLSTATE %s — nothing else stops a query that has stopped making progress from holding its connection",
+			err, queryCanceled)
+	}
+}
+
+// TestATransactionsOwnBudgetOutranksThePoolsCeiling: the pool's ceiling is a
+// floor under queries nobody thought about, never a cap on the ones somebody
+// did. Every path that needs longer — the schema-changing roles, a background
+// sweep — depends on being able to say so and be believed.
+func TestATransactionsOwnBudgetOutranksThePoolsCeiling(t *testing.T) {
+	ctx := context.Background()
+	pool, err := NewPool(ctx, WithDSNParam(ceilingTestDSN(t), "statement_timeout", "100"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Reported rather than discarded: nothing here commits, so the rollback is
+	// how this transaction is meant to end and a refusal means something else
+	// already ended it — which would make the assertions below true of a
+	// transaction the test no longer holds.
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			t.Errorf("rolling back the probe transaction: %v", err)
+		}
+	}()
+
+	if err := BoundStatement(ctx, tx, 20*time.Second); err != nil {
+		t.Fatalf("widening the budget: %v", err)
+	}
+	got, err := effectiveMilliseconds(ctx, tx, "statement_timeout")
+	if err != nil {
+		t.Fatalf("reading the widened budget: %v", err)
+	}
+	if want := (20 * time.Second).Milliseconds(); got != want {
+		t.Fatalf("the transaction runs under statement_timeout = %dms, want %dms — the pool's ceiling outranked the budget the caller asked for", got, want)
+	}
+	// And it is the SERVER that agrees, not just the setting: a statement past
+	// the pool's own 100ms completes because the transaction said it may.
+	if _, err := tx.Exec(ctx, `SELECT pg_sleep(0.3)`); err != nil {
+		t.Fatalf("a statement inside the widened budget was ended anyway: %v", err)
+	}
+}

--- a/backend/internal/platform/database/statementbudget.go
+++ b/backend/internal/platform/database/statementbudget.go
@@ -66,3 +66,38 @@ func BoundStatement(ctx context.Context, tx pgx.Tx, budget time.Duration) error 
 	}
 	return nil
 }
+
+// StatementCeiling is how long ANY one statement may hold a connection when
+// nothing tighter has been asked for. It is the floor under every query this
+// product writes, not a budget any surface reasons about: a statement still
+// running at this point has stopped making progress, and the connection it
+// holds is the resource the next request needs.
+//
+// Thirty seconds is two orders of magnitude above what this product measures —
+// the slowest published server budget is 300 ms (PERF-7, context-graph
+// assembly) and the slowest measured p95 is 76 ms (PERF-3, search) — and six
+// times CallerPredicateBudget, the ceiling given to the one query shape that is
+// deliberately unbounded. So it cannot cut a statement that is merely large; it
+// can only cut one that is not going to finish. A ceiling tight enough to
+// argue about would have to be argued about per query, and the number that
+// needs no argument is the one that gets set.
+//
+// It reaches Postgres as a connection runtime parameter rather than a
+// statement before each transaction, because the read paths this protects run
+// tens of transactions per request and a round trip apiece to say "still
+// thirty seconds" would cost more than the pathology it catches. A transaction
+// that needs a different ceiling says so with BoundStatement, which overrides
+// it for that transaction alone.
+const StatementCeiling = 30 * time.Second
+
+// IdleTransactionCeiling is how long a transaction may sit OPEN with no
+// statement running before Postgres ends the session holding it.
+//
+// It is the other half of StatementCeiling and not a duplicate of it: a
+// statement timeout bounds a query that runs too long and says nothing about a
+// transaction that stopped issuing them. Given this product's write shape —
+// domain row, audit row and outbox row in one transaction, with only Go code
+// composing the next statement in between — a gap of a minute is not a slow
+// transaction. It is an abandoned one, and the connection under it will not
+// come back on its own.
+const IdleTransactionCeiling = time.Minute


### PR DESCRIPTION
Closes #5424.

`PoolConfig` sized the pool and turned JIT off, and said nothing about how long
one connection could be held. `http.Server`'s `WriteTimeout` ends the *response*
without cancelling the handler, so a query that had stopped making progress kept
its slot in a pool of 16 until somebody noticed — and the routes that cost the
most slots per request (`/v1/worklist/exceptions` at 54 transactions) are exactly
the ones a person is waiting on.

Two ceilings now ride every connection this package opens:

- **`StatementCeiling` = 30s** — how long any one statement may run when nothing
  tighter was asked for.
- **`IdleTransactionCeiling` = 60s** — how long a transaction may sit open with
  no statement running. The other half, not a duplicate: a statement timeout says
  nothing about a transaction that stopped issuing them, and given the write
  shape (domain row + audit row + outbox row, with only Go composing the next
  statement between) a gap of a minute is not slow, it is abandoned.

They live beside `CallerPredicateBudget`, which is the tighter 5s ceiling the
caller-written predicates already take, so the two are read together.

### Why 30 seconds

Not picked round. The slowest budget this product publishes is 300 ms (`PERF-7`,
context-graph assembly) and the slowest measured p95 is 76 ms (`PERF-3`, search);
`CallerPredicateBudget` gives the one deliberately-unbounded query shape 5s. Thirty
seconds is two orders of magnitude above the first and six times the second, so it
cannot cut a statement that is merely large — only one that is not going to finish.
A ceiling tight enough to argue about would have to be argued about per query.

#5424 asked whether the `x-waits-on-model` routes need a longer one, since they are
slow by contract. They do not: their slowness is the model call, and no path in the
tree holds a transaction across one — `signalextract.go`, `ai/callstore.go` and
`ai/railstart.go` all open their transactions either side of it. Their SQL is
ordinary-length context assembly.

### The roles that run DDL lift both

`WithoutRequestCeilings` puts `0` — which Postgres reads as no bound — on the two
pools that run schema changes rather than serve requests: the migrator's River lane
(`jobs.Migrate` plus the `river_job` index) and the API's custom-field schema pool.
An index build on a populated table is not request-shaped, and one cut half way
leaves the schema short of head with nothing in the failure to say that a timeout
rather than the DDL ended it. The advisory lock those paths queue on is a running
statement too, so the ceiling would end the *wait* as readily as the work.

Core migrations were never at risk — `cmd/migrate` runs them on a bare
`pgx.Connect`, not through this pool.

`withPoolMaxConns` moves into the package as `WithDSNParam` and gains its second
caller, so the two DSN spellings are worked out once rather than beside each pool
that needs a parameter.

### What holds it

- `TestEveryCeilingAPoolSetsIsOneTheSchemaRolesCanLift` derives its subject from
  `PoolConfig` rather than listing it: anything named `*_timeout` that a pool sets
  and the lift misses fails here rather than as a half-built index on somebody's
  installation.
- `TestAStatementPastTheCeilingIsEnded` proves the *kill*, not the setting — a
  runtime parameter that never reaches Postgres reads exactly like one that did.
  Against a shortened ceiling, because proving it at thirty seconds costs thirty
  seconds to learn the same thing.
- `TestATransactionsOwnBudgetOutranksThePoolsCeiling` — the pool's ceiling is a
  floor under queries nobody thought about, never a cap on the ones somebody did.
- The unit tests are mutation-verified: dropping the parameter, dropping the
  DSN-wins rule, and writing seconds where Postgres reads milliseconds each turn
  one of them red.

### Not in this change

- **The request deadline** — #5424's own point 3, which it called "the part needing
  a decision rather than a value". Filed as #5442 with the analysis: the seam
  already exists (`extendDeadlineForModelRoutes` decides per route), and the tree
  already has the idiom for work that must outlive a request (`context.WithoutCancel`
  plus its own budget). What is undecided is whether every `/v1` handler is expected
  to have used it.
- **`lock_timeout`** — deliberately not set. A blocked lock wait is part of the
  statement, so `StatementCeiling` already bounds it; the migrations that need a
  shorter one set `SET LOCAL lock_timeout` and a gate holds them to it.
- The 33–54 transactions per worklist-family read (#4912).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC
