### PR TITLE
fix(migrations): one decision per review foreign key, not two

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -183,8 +183,6 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"record_assignment.project_id":         "gated: the same pair in ensureParentReadable and ensureParentWritable, on project",
 	"contract.company_id":                  "gated: auth.EnsureLinkTarget in createContractTx (H1) — the counterparty is client-supplied, so naming it is a read of it",
 	"project_health_assessment.project_id": "gated: auth.Require plus auth.HoldWritableLive on the project in RecordHealth and CorrectHealth, and auth.Require plus auth.EnsureVisible in ListHealth — the project comes from the ROUTE and every path probes it before a row is written or served",
-	"activity_review_response.deal_id":     "gated: auth.EnsureLinkTarget, through the note. WriteOutcomeReviewTx writes the review's note FIRST, with the deal as its activity link, so the deal a caller names is probed by insertActivityLinks before this row's INSERT runs — the review cannot reach the table under a deal the caller could not have linked a note to",
-	"activity_review_response.activity_id": "server-derived: the note this same transaction just wrote (LogActivityTx), never a caller's id. A review IS that note, and the row points back at it so the frozen answers and the prose stay one record",
 	// The deal and project links carry a SECOND obligation the sibling columns
 	// above do not, and it is the reason this table's gate is not just a copy.
 	// A contract's row visibility is INHERITED from its deal (falling back to


### PR DESCRIPTION
**main does not build.** `rowScopedFKDecisions` in `backend/migrations/schema_fitness_integration_test.go` carries `activity_review_response.activity_id` and `.deal_id` twice, and Go rejects a duplicate key in a map literal:

```
migrations/schema_fitness_integration_test.go:511:2: duplicate key "activity_review_response.activity_id" in map literal
migrations/schema_fitness_integration_test.go:512:2: duplicate key "activity_review_response.deal_id" in map literal (typecheck)
```

`backend/migrations` fails typecheck, and every lane that compiles it goes with it.

## How it got here

Two changes classified the same pair against a base that did not yet hold the other — #5446 landed first, #5444 (mine) minutes later — and each was green on its own branch. Neither review could have seen it. The general answer is the merge queue (#1130); this is the repair.

I searched the open PRs before writing it and found no fix already up.

## Which pair stays

#5446's. It is the fuller of the two, and it sits in the block whose comment explains why this table's two columns are decided on different grounds — which is the reason they are separate entries at all. Mine said the same things more briefly and from two tables away, so removing them costs nothing the file was carrying.