### PR TITLE
claim: main-red — two billing-contact indexes that were already there

### DIFF
--- a/backend/internal/compose/integration/company360/company360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/company360/company360_querycount_integration_test.go
@@ -217,7 +217,13 @@ func TestCompany360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// the attachment count above and for the same reason. Flat in the size of
 	// the account — twenty emails and two cost the one statement — which is
 	// the property this budget protects rather than the absolute number.
-	const budget = 46
+	// 47 since a company says who receives its invoices (#5452): one read of
+	// the account's billing contacts, joined to the contacts it names so the
+	// panel has their titles and addresses without asking per row. Flat in the
+	// size of the account like every section above — an account naming three
+	// billing contacts costs the same one statement as one naming none, which
+	// is what the shape half of this test above has just confirmed.
+	const budget = 47
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}

--- a/backend/migrations/core/1789230000_the_billing_contact_company_index_was_already_there.down.sql
+++ b/backend/migrations/core/1789230000_the_billing_contact_company_index_was_already_there.down.sql
@@ -1,0 +1,9 @@
+SET LOCAL lock_timeout = '3s';
+
+CREATE INDEX IF NOT EXISTS rel_billing_contact_by_company
+    ON relationship (company_id, role)
+    WHERE kind = 'billing_contact' AND archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS rel_billing_contact_by_contact
+    ON relationship (contact_id)
+    WHERE kind = 'billing_contact' AND archived_at IS NULL;

--- a/backend/migrations/core/1789230000_the_billing_contact_company_index_was_already_there.up.sql
+++ b/backend/migrations/core/1789230000_the_billing_contact_company_index_was_already_there.up.sql
@@ -1,0 +1,31 @@
+-- The billing-contact indexes were already there, under other names.
+--
+-- 1789222000 added three indexes for one kind. Two of them earn nothing, which
+-- a look at the table's existing 32 would have shown before they were written.
+--
+-- rel_billing_contact_by_company is (company_id, role) with a partial
+-- predicate, and uq_rel_billing_contact is (company_id, contact_id, role) with
+-- the same predicate — so the unique index already serves every lookup that
+-- starts from the company.
+--
+-- rel_billing_contact_by_contact is (contact_id), and idx_rel_history_contact
+-- has been plain (contact_id) over EVERY kind since the table was built. A
+-- partial copy of an index that already covers the same column unfiltered adds
+-- nothing a billing read can use.
+--
+-- Both verified on a seeded table rather than an empty one, where the planner
+-- will pick almost anything: with each dropped in turn, the read it was meant
+-- to serve still plans as an index scan, over uq_rel_billing_contact and
+-- idx_rel_history_contact respectively.
+--
+-- Worth removing rather than leaving as harmless spare weight. An empty
+-- `relationship` reached 270336 bytes across 32 indexes, and the test harness
+-- gives an unbaselined table 262144 bytes of slack before it stops DELETEing
+-- and starts TRUNCATEing it on every reset. These two are what crossed it, so
+-- their cost is paid by every integration test in the suite, forever, to answer
+-- queries two older indexes already answer.
+
+SET LOCAL lock_timeout = '3s';
+
+DROP INDEX IF EXISTS rel_billing_contact_by_company;
+DROP INDEX IF EXISTS rel_billing_contact_by_contact;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -5251,8 +5251,6 @@ BEGIN
   END LOOP;
 END;
 
-public.rel_billing_contact_by_company CREATE INDEX rel_billing_contact_by_company ON public.relationship USING btree (company_id, role) WHERE ((kind = 'billing_contact'::text) AND (archived_at IS NULL))
-public.rel_billing_contact_by_contact CREATE INDEX rel_billing_contact_by_contact ON public.relationship USING btree (contact_id) WHERE ((kind = 'billing_contact'::text) AND (archived_at IS NULL))
 public.relationship acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.relationship.archived_at timestamp with time zone gen=- def=-
 public.relationship.captured_by text NOT NULL gen=- def=-


### PR DESCRIPTION
Two integration-lane failures on main, both from #5452, both fixed here.

## The testdb baseline

```
public.relationship occupies 270336 bytes empty, at or past the 262144-byte slack
```

#5452 added three indexes on `relationship` for one kind. Two of them earn nothing, which a look at the table's existing 32 would have shown before they were written.

- `rel_billing_contact_by_company` is `(company_id, role)` partial, and `uq_rel_billing_contact` is `(company_id, contact_id, role)` with the same predicate. The unique index already serves every lookup starting from the company.
- `rel_billing_contact_by_contact` is `(contact_id)`, and `idx_rel_history_contact` has been plain `(contact_id)` over every kind since the table was built.

Both checked on a seeded table rather than an empty one, where the planner will pick almost anything. With each dropped in turn, the read it was meant to serve still plans as an index scan over the older index.

This is worth a migration rather than raising the limit. Past that slack the harness TRUNCATEs the table on every reset instead of DELETEing, so the cost would be paid by every integration test in the suite, forever, to answer queries two older indexes already answer. An empty `relationship` is back to 253952 bytes, where it sat before the slice.

The third index stays: `uq_rel_billing_contact` is the uniqueness rule itself.

## The company 360 budget

```
one 360 issued 47 queries, budget is 46
```

This one is a real query and the budget moves by one. The billing contacts are read once for the account, joined to the contacts they name, so the section costs one statement whether an account names three billing contacts or none.

The test has two halves and only the ceiling failed. Its shape half — twelve contacts must cost the same as one — passed, which is the evidence that the new query is flat rather than per-row.

## Verification

- `make check-backend`, green (backend-only change; no frontend files touched)
- `backend/internal/platform/testdb`: 31 tests, green — the failing baseline included
- `backend/internal/compose/integration/company360`: 131 tests, green — the failing budget included
- `backend/internal/modules/contacts`: 831 tests, green — the shard most exposed to dropping an index
- `backend/internal/compose/integration`: 2254 tests, green
- `git diff --shortstat origin/main`: 4 files, 47 insertions, 3 deletions, every deletion accounted for (two catalog lines and the budget constant)

Found by another session running the full lane by hand. Neither failure is reachable by `make check-backend`, which is the third instance of that gap today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes two redundant billing-contact indexes and raises the company 360 query budget. The dropped indexes duplicated existing coverage and pushed the testdb baseline over its size slack; the budget bump accounts for a real read of billing contacts.

**Migration**
- Drops `rel_billing_contact_by_company` and `rel_billing_contact_by_contact`; both are already covered by `uq_rel_billing_contact` and `idx_rel_history_contact`.

<sup>Written for commit 29f6d345f2c5d74aad120feaf2e23ac84d4ff07c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

