### PR TITLE
fix(compose,contacts): two functions back under the 80-line ceiling

### DIFF
--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -32,7 +32,6 @@ import (
 	"github.com/margince/margince/backend/internal/modules/customfields"
 	"github.com/margince/margince/backend/internal/modules/dealrooms"
 	"github.com/margince/margince/backend/internal/modules/deals"
-	"github.com/margince/margince/backend/internal/modules/finance"
 	"github.com/margince/margince/backend/internal/modules/forecasting"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/introductions"
@@ -167,8 +166,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// The warm room ranks its contact edges by the §4 relationship
 		// strength owned by contacts; injected through the adapter below so
 		// signals never imports its sibling.
-		financeHandlers: finance.NewHandlers(InstallationDB(pool), identity.BaseCurrencyOf).
-			WithBillingContacts(financeBillingContacts{contacts: contacts.NewStore(InstallationDB(pool))}),
+		financeHandlers: newFinanceHandlers(pool),
 		// No adapter is registered by default, which is the supported
 		// "no provider connected" configuration (PI-AC-9): every surface
 		// answers honestly and nothing can reach the network. WithProvider

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -34,6 +34,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/contacts"
 	"github.com/margince/margince/backend/internal/modules/customfields"
 	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/modules/finance"
 	"github.com/margince/margince/backend/internal/modules/forecasting"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/integrations"
@@ -69,6 +70,20 @@ func newContactsHandlers(pool *pgxpool.Pool) contactsHandlers {
 		// owns communication_suppression; contacts owns the merge; neither
 		// imports the other, so the edge is injected here.
 		WithStopCarrier(consent.NewStore(InstallationDB(pool)))
+}
+
+// newFinanceHandlers builds the invoicing transport over the two edges it
+// cannot reach for itself: the installation's base currency, and who at the
+// account receives an invoice.
+//
+// The billing-contact edge is an injection rather than an import for the
+// ordinary ADR-0054 reason — contacts owns relationship, finance owns the
+// invoice — and it matters more than usual here: the same read serves the
+// company page's own billing section, so a second one would let the finance
+// card and the account panel disagree about who the recipient is.
+func newFinanceHandlers(pool *pgxpool.Pool) finance.Handlers {
+	return finance.NewHandlers(InstallationDB(pool), identity.BaseCurrencyOf).
+		WithBillingContacts(financeBillingContacts{contacts: contacts.NewStore(InstallationDB(pool))})
 }
 
 // newActivitiesHandlers builds the timeline transport over the sibling

--- a/backend/internal/modules/contacts/relationship.go
+++ b/backend/internal/modules/contacts/relationship.go
@@ -286,34 +286,8 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 		if err != nil {
 			return err
 		}
-		// A kind is only checked on CREATE, and this path names an existing row
-		// — so the exclusion has to be re-stated here or the generic surface
-		// becomes the side door the vocabulary closed.
-		if err := refuseGenericProjectCompany(current.Kind); err != nil {
+		if err := refusePatch(ctx, tx, current, in); err != nil {
 			return err
-		}
-		// Same rule as create: editing an edge is editing its anchor, so it
-		// takes both halves of the anchor's authority — the object grant, and
-		// the row.
-		anchorObject, _ := relationshipAnchor(current.Kind)
-		if err := auth.Require(ctx, anchorObject, principal.ActionUpdate); err != nil {
-			return err
-		}
-		if err := ensureRelationshipAnchorWritable(ctx, tx, current.Kind, current.endpoints()); err != nil {
-			return err
-		}
-		// A patch cannot move an edge's endpoints or its kind, but it CAN move
-		// the role — and for a billing contact the role is what the row means.
-		// Without this, the generic patch surface is the way to turn a stated
-		// capacity into a word the create path refuses. Asked on the PATCHED
-		// value: a patch that leaves role alone keeps whatever already passed.
-		if in.Role != nil {
-			if err := validBillingContactRole(current.Kind, in.Role); err != nil {
-				return err
-			}
-		}
-		if in.IfVersion != nil && *in.IfVersion != current.Version {
-			return apperrors.ErrVersionSkew
 		}
 		// The incumbent is demoted only when the patched row will actually HOLD
 		// the flag, so this statement asks the SAME question as the UPDATE below

--- a/backend/internal/modules/contacts/relationshippatch.go
+++ b/backend/internal/modules/contacts/relationshippatch.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package contacts
+
+// What a patch to a relationship must clear before it lands.
+//
+// Its own file beside relationship.go, which owns the read, the lock and the
+// statement. The refusals are a different subject from the mechanics: they are
+// asked together, about one row, and a reader deciding whether a patch is
+// allowed should meet them as a list rather than interleaved with the
+// transaction that carries them out.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// refusePatch runs the refusals a patch clears once the row is read and locked:
+// what this edge is, who may change it, what the patched value may say, and
+// whether the caller is looking at the version they think they are.
+//
+// Its own function because those are asked TOGETHER and about the same row — a
+// reader answering "may this patch land" should not have to assemble the answer
+// from four places in a transaction that also locks, updates and reads back.
+func refusePatch(ctx context.Context, tx pgx.Tx, current relationshipRow, in UpdateRelationshipInput) error {
+	// A kind is only checked on CREATE, and this path names an existing row
+	// — so the exclusion has to be re-stated here or the generic surface
+	// becomes the side door the vocabulary closed.
+	if err := refuseGenericProjectCompany(current.Kind); err != nil {
+		return err
+	}
+	// Same rule as create: editing an edge is editing its anchor, so it
+	// takes both halves of the anchor's authority — the object grant, and
+	// the row.
+	anchorObject, _ := relationshipAnchor(current.Kind)
+	if err := auth.Require(ctx, anchorObject, principal.ActionUpdate); err != nil {
+		return err
+	}
+	if err := ensureRelationshipAnchorWritable(ctx, tx, current.Kind, current.endpoints()); err != nil {
+		return err
+	}
+	// A patch cannot move an edge's endpoints or its kind, but it CAN move
+	// the role — and for a billing contact the role is what the row means.
+	// Without this, the generic patch surface is the way to turn a stated
+	// capacity into a word the create path refuses. Asked on the PATCHED
+	// value: a patch that leaves role alone keeps whatever already passed.
+	if in.Role != nil {
+		if err := validBillingContactRole(current.Kind, in.Role); err != nil {
+			return err
+		}
+	}
+	if in.IfVersion != nil && *in.IfVersion != current.Version {
+		return apperrors.ErrVersionSkew
+	}
+	return nil
+}


### PR DESCRIPTION
**`make craft-static` fails on main**, and it sweeps the whole tree — so every
branch cut after #5452 fails a gate on code it never touched. That is what makes
this expensive rather than merely untidy: four of my own PRs went red on checks
unrelated to their diffs, and each looked like a defect of its own until chased
back here.

Two MAJORs, both from #5452:

- `newServer` grew two lines for the billing-contact seam and landed at **81**.
- `UpdateRelationship` landed at **85**.

## What changed

**`newFinanceHandlers`** joins the sub-assembly helpers its neighbours already
have in `serverassembly.go` — `newContactsHandlers`, `newActivitiesHandlers`,
`newCollectionsHandlers`, `newConsentHandlers`. The billing-contact injection
gets its reason stated where there is room for it, rather than as a clause
inside a forty-field literal: the same contacts read serves the company page's
own billing section, so a second one would let the finance card and the account
panel disagree about who the recipient is.

**`refusePatch`** is the four refusals a patch to a relationship must clear once
the row is read and locked — what the edge is, who may change it, what the
patched role may say, and whether the caller is looking at the version they
think they are. They are asked together about one row, so a reader deciding
whether a patch is allowed should meet them as a list rather than assemble the
answer from four points inside a transaction that also locks, updates and reads
back.

Its own file, and that is not a stylistic preference: `relationship.go` sits
exactly at the 500-line cap, the extraction put it at **501**, and the gate said
so on the second pass. #5452 had already split the billing vocabulary out of that
same file to clear the same wall.

## Scope note

This branch opened against a third failure too — the company 360 issuing 47
queries against a budget of 46. That landed on main as #5457 while this was in
check. Only the wording of the budget comment differed, so main's stands and
this PR is the two ceilings alone.

## Verification

`make craft-static` is `PASS — 0 blocker, 0 major, 0 minor` across all four
roots (`backend`, `extensions`, `fixtures`, `desktop`), and the contacts
integration package is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC
