### PR TITLE
feat(monitor): the pool says who is WAITING, not only who is busy

### DIFF
--- a/backend/internal/platform/httpserver/metrics.go
+++ b/backend/internal/platform/httpserver/metrics.go
@@ -258,7 +258,7 @@ var poolCounters = []poolCounter{
 	},
 	{
 		"EmptyAcquireCount", "margince_pgxpool_acquire_empty_total",
-		"Acquires that found no free connection and had to wait. Its rate is the waiting line.",
+		"Acquires that found no free connection, waited, and GOT one. Its rate is the waiting line. A caller that gave up while queued is not here — it is in acquire_canceled_total.",
 		countOf((*pgxpool.Stat).EmptyAcquireCount),
 	},
 	{
@@ -268,12 +268,12 @@ var poolCounters = []poolCounter{
 	},
 	{
 		"AcquireDuration", "margince_pgxpool_acquire_seconds_total",
-		"Seconds spent inside acquire since process start, over every acquire.",
+		"Seconds spent inside acquire since process start, over every acquire that SUCCEEDED. A caller that gave up contributes none of its wait.",
 		secondsOf((*pgxpool.Stat).AcquireDuration),
 	},
 	{
 		"EmptyAcquireWaitTime", "margince_pgxpool_acquire_wait_seconds_total",
-		"Seconds spent WAITING for a connection, over the acquires that had to. Over acquire_empty_total, the mean wait of a caller that queued.",
+		"Seconds spent WAITING for a connection, over the acquires that had to and then got one. Over acquire_empty_total, the mean wait of a caller that queued AND WAS SERVED — the ones that gave up are counted nowhere in this series, so read it beside acquire_canceled_total or it reports the queue as shorter than it was.",
 		secondsOf((*pgxpool.Stat).EmptyAcquireWaitTime),
 	},
 	{

--- a/backend/internal/platform/httpserver/metrics.go
+++ b/backend/internal/platform/httpserver/metrics.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -112,7 +113,7 @@ func Metrics(in MetricsInput) http.HandlerFunc {
 
 		writeOutboxBacklog(ctx, out, in.Backlog)
 		writeRelayPublished(out, in.Published)
-		writePoolGauges(out, in.Pool)
+		writePoolMetrics(out, in.Pool)
 
 		if in.Extra != nil && !out.gone() {
 			in.Extra(out)
@@ -182,21 +183,114 @@ func writeRelayPublished(out *exposition, published func() uint64) {
 	out.printf("margince_relay_published_total %d\n", published())
 }
 
-// writePoolGauges renders this process's own connection pool.
+// writePoolMetrics renders this process's own connection pool.
 //
 // Omitted rather than zeroed when no pool was injected: a gauge reporting
 // connections it did not measure reads as an idle pool.
-func writePoolGauges(out *exposition, pool *pgxpool.Pool) {
+//
+// It renders every value pgxpool.Stat computes, and that is the point rather
+// than thoroughness. This section published four numbers for a long time and
+// they were all LEVELS — acquired, idle, total, max — while every value about
+// WAITING was dropped. A saturated pool and a busy one both read "acquired 15
+// of 16", so the board could not tell a queue from a healthy load, and at a
+// five-minute scrape an episode shorter than that was never sampled at all.
+// The waits are counters, so a scrape still integrates the episodes it did not
+// see.
+//
+// Held by: TestEveryPoolStatisticIsExported (backend/internal/platform/httpserver/poolstats_test.go)
+func writePoolMetrics(out *exposition, pool *pgxpool.Pool) {
 	if pool == nil || out.gone() {
 		return
 	}
 	stat := pool.Stat()
 	out.printf("# HELP margince_pgxpool_conns Connection pool state by class.\n")
 	out.printf("# TYPE margince_pgxpool_conns gauge\n")
-	out.printf("margince_pgxpool_conns{state=\"acquired\"} %d\n", stat.AcquiredConns())
-	out.printf("margince_pgxpool_conns{state=\"idle\"} %d\n", stat.IdleConns())
-	out.printf("margince_pgxpool_conns{state=\"total\"} %d\n", stat.TotalConns())
-	out.printf("margince_pgxpool_conns{state=\"max\"} %d\n", stat.MaxConns())
+	for _, level := range poolLevels {
+		out.printf("margince_pgxpool_conns{state=%s} %d\n", Label(level.state), level.read(stat))
+	}
+	for _, counter := range poolCounters {
+		out.printf("# HELP %s %s\n", counter.name, counter.help)
+		out.printf("# TYPE %s counter\n", counter.name)
+		out.printf("%s %s\n", counter.name, counter.render(stat))
+	}
+}
+
+// poolLevel is one state of the connection gauge, and the pgxpool.Stat method
+// that answers it. The method NAME is carried as data rather than only called,
+// because it is what lets the gate ask the pool what it computes instead of
+// keeping a second list of what it ought to.
+type poolLevel struct {
+	stat  string
+	state string
+	read  func(*pgxpool.Stat) int32
+}
+
+var poolLevels = []poolLevel{
+	{"AcquiredConns", "acquired", (*pgxpool.Stat).AcquiredConns},
+	{"IdleConns", "idle", (*pgxpool.Stat).IdleConns},
+	{"ConstructingConns", "constructing", (*pgxpool.Stat).ConstructingConns},
+	{"TotalConns", "total", (*pgxpool.Stat).TotalConns},
+	{"MaxConns", "max", (*pgxpool.Stat).MaxConns},
+}
+
+// poolCounter is one monotonic pool statistic. Durations are rendered in
+// seconds, which is the unit Prometheus expects and not the one pgx answers in.
+type poolCounter struct {
+	stat   string
+	name   string
+	help   string
+	render func(*pgxpool.Stat) string
+}
+
+func countOf(read func(*pgxpool.Stat) int64) func(*pgxpool.Stat) string {
+	return func(s *pgxpool.Stat) string { return strconv.FormatInt(read(s), 10) }
+}
+
+func secondsOf(read func(*pgxpool.Stat) time.Duration) func(*pgxpool.Stat) string {
+	return func(s *pgxpool.Stat) string { return strconv.FormatFloat(read(s).Seconds(), 'f', 6, 64) }
+}
+
+var poolCounters = []poolCounter{
+	{
+		"AcquireCount", "margince_pgxpool_acquire_total",
+		"Connections acquired from the pool since process start.",
+		countOf((*pgxpool.Stat).AcquireCount),
+	},
+	{
+		"EmptyAcquireCount", "margince_pgxpool_acquire_empty_total",
+		"Acquires that found no free connection and had to wait. Its rate is the waiting line.",
+		countOf((*pgxpool.Stat).EmptyAcquireCount),
+	},
+	{
+		"CanceledAcquireCount", "margince_pgxpool_acquire_canceled_total",
+		"Acquires whose caller gave up before a connection came free.",
+		countOf((*pgxpool.Stat).CanceledAcquireCount),
+	},
+	{
+		"AcquireDuration", "margince_pgxpool_acquire_seconds_total",
+		"Seconds spent inside acquire since process start, over every acquire.",
+		secondsOf((*pgxpool.Stat).AcquireDuration),
+	},
+	{
+		"EmptyAcquireWaitTime", "margince_pgxpool_acquire_wait_seconds_total",
+		"Seconds spent WAITING for a connection, over the acquires that had to. Over acquire_empty_total, the mean wait of a caller that queued.",
+		secondsOf((*pgxpool.Stat).EmptyAcquireWaitTime),
+	},
+	{
+		"NewConnsCount", "margince_pgxpool_conns_opened_total",
+		"Connections dialled since process start.",
+		countOf((*pgxpool.Stat).NewConnsCount),
+	},
+	{
+		"MaxLifetimeDestroyCount", "margince_pgxpool_conns_retired_lifetime_total",
+		"Connections closed for reaching pool_max_conn_lifetime.",
+		countOf((*pgxpool.Stat).MaxLifetimeDestroyCount),
+	},
+	{
+		"MaxIdleDestroyCount", "margince_pgxpool_conns_retired_idle_total",
+		"Connections closed for reaching pool_max_conn_idle_time.",
+		countOf((*pgxpool.Stat).MaxIdleDestroyCount),
+	},
 }
 
 // writeOverlayMetrics renders the overlay sync-health section — split

--- a/backend/internal/platform/httpserver/poolstats_integration_test.go
+++ b/backend/internal/platform/httpserver/poolstats_integration_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package httpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/testdb"
+)
+
+// TestEveryDeclaredPoolSeriesReachesTheScrape closes the other half. The census
+// above proves the tables name every statistic; this proves the tables are what
+// the handler renders, so a series can neither be declared and dropped on the
+// way out nor emitted under a name nothing declared.
+//
+// In the integration lane because it holds a pool, and a pool is what
+// check-test-lanes.sh keeps out of the unit one. It needs the database for
+// nothing else: every figure it asserts on is a zero or a count the pool keeps
+// for itself, and no statement is issued.
+func TestEveryDeclaredPoolSeriesReachesTheScrape(t *testing.T) {
+	dsn := os.Getenv("MARGINCE_TEST_DSN")
+	if dsn == "" {
+		t.Fatal("MARGINCE_TEST_DSN is not set — run `make db-up` and try again (integration tests fail loudly, they never skip)")
+	}
+	pool, err := testdb.OwnPool(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("opening a pool to read the exposition off: %v", err)
+	}
+	defer pool.Close()
+
+	rec := httptest.NewRecorder()
+	Metrics(MetricsInput{Pool: pool})(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rec.Body.String()
+
+	for _, level := range poolLevels {
+		if want := `margince_pgxpool_conns{state="` + level.state + `"}`; !strings.Contains(body, want) {
+			t.Errorf("the scrape carries no %s, so %s is declared and never published:\n%s", want, level.stat, body)
+		}
+	}
+	for _, counter := range poolCounters {
+		if !strings.Contains(body, "\n"+counter.name+" ") {
+			t.Errorf("the scrape carries no %s, so %s is declared and never published:\n%s", counter.name, counter.stat, body)
+		}
+		if !strings.Contains(body, "# TYPE "+counter.name+" counter") {
+			t.Errorf("%s is published without the TYPE line that tells Prometheus it is a counter", counter.name)
+		}
+	}
+}

--- a/backend/internal/platform/httpserver/poolstats_test.go
+++ b/backend/internal/platform/httpserver/poolstats_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httpserver
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestEveryPoolStatisticIsExported asks the POOL what it computes rather than
+// keeping a list of what it ought to.
+//
+// This is the defect's own shape. The exposition published four of the values
+// pgxpool.Stat answers and dropped the rest, and nothing failed: a metric that
+// is absent looks exactly like a metric that is zero, and the four that
+// remained were the four that could not show a queue. A list of expected names
+// here would be a second copy of the exporter and would have been written from
+// the same four.
+//
+// A value pgx adds in a later release arrives as an unexported statistic and
+// fails on the upgrade's own pull request, which is the moment somebody is
+// already reading this package.
+func TestEveryPoolStatisticIsExported(t *testing.T) {
+	t.Parallel()
+	exported := map[string]string{}
+	for _, level := range poolLevels {
+		exported[level.stat] = "margince_pgxpool_conns{state=" + level.state + "}"
+	}
+	for _, counter := range poolCounters {
+		if was, dup := exported[counter.stat]; dup {
+			t.Errorf("%s is rendered twice, as %s and as %s", counter.stat, was, counter.name)
+		}
+		exported[counter.stat] = counter.name
+	}
+
+	stat := reflect.TypeOf(&pgxpool.Stat{})
+	var missing []string
+	for i := range stat.NumMethod() {
+		name := stat.Method(i).Name
+		if _, ok := exported[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("pgxpool.Stat computes %d statistic(s) this process never publishes:\n\t%s\n"+
+			"Each is free — the value is already on the stat the exposition holds — and an operator cannot ask for one that was never emitted. Render it beside the others, or say here why the pool's own measurement is not worth a line.",
+			len(missing), strings.Join(missing, "\n\t"))
+	}
+	// The reverse: a name that no longer answers anything renders a metric
+	// nobody can explain, and the compiler cannot see it because the table
+	// carries the method as a string beside the call.
+	for name := range exported {
+		if _, ok := stat.MethodByName(name); !ok {
+			t.Errorf("the exposition names pgxpool.Stat.%s, which the pool no longer computes", name)
+		}
+	}
+	if stat.NumMethod() == 0 {
+		t.Fatal("read no statistic off pgxpool.Stat at all — this type has always had some, so the census read something smaller than it claims")
+	}
+}
+
+// TestThePoolsWaitsAreCountersAndItsLevelsAreGauges pins the split the board
+// depends on. A level answers only for the instant it was scraped, so at a
+// five-minute interval a queue that formed and drained between two scrapes
+// leaves no trace; a counter carries it into the next one regardless. Emitting
+// a wait as a gauge would publish the series and lose exactly the episodes it
+// was added for.
+func TestThePoolsWaitsAreCountersAndItsLevelsAreGauges(t *testing.T) {
+	t.Parallel()
+	// pgx names a running total Count, and an accumulated one Time or
+	// Duration; everything else it answers is a reading of the pool now.
+	for _, level := range poolLevels {
+		for _, monotonic := range []string{"Count", "Time", "Duration"} {
+			if strings.HasSuffix(level.stat, monotonic) {
+				t.Errorf("%s is rendered as a gauge; a statistic that only goes up is a counter, and a scrape that misses its episode must still see it", level.stat)
+			}
+		}
+	}
+	for _, counter := range poolCounters {
+		if strings.HasSuffix(counter.stat, "Conns") {
+			t.Errorf("%s is rendered as a counter; it is a reading of the pool now, and a counter that goes down is one Prometheus reads as a reset", counter.stat)
+		}
+	}
+	for _, counter := range poolCounters {
+		if !strings.HasSuffix(counter.name, "_total") {
+			t.Errorf("%s is a counter named without the _total suffix Prometheus reads it by", counter.name)
+		}
+		if strings.Contains(counter.name, "seconds") && !strings.HasSuffix(counter.name, "_seconds_total") {
+			t.Errorf("%s reports seconds without saying so where the unit is read", counter.name)
+		}
+	}
+}
+
+// TestTheOperatorDocNamesEveryPoolSeries holds the reference to the exporter.
+//
+// The doc is where an operator finds out a series exists, so a family that is
+// emitted and undocumented is one nobody queries, and a family documented and
+// never emitted is a query that returns nothing with no error to explain it.
+// Both are silent, which is why the parity is a test rather than a habit.
+func TestTheOperatorDocNamesEveryPoolSeries(t *testing.T) {
+	t.Parallel()
+	const doc = "../../../../docs/reference/configuration.md"
+	raw, err := os.ReadFile(doc)
+	if err != nil {
+		t.Fatalf("reading the operator reference: %v", err)
+	}
+	text := string(raw)
+
+	for _, name := range append(poolCounterNames(), "margince_pgxpool_conns") {
+		if !strings.Contains(text, name) {
+			t.Errorf("%s is published and %s never names it, so an operator has no way to learn it exists", name, doc)
+		}
+	}
+	for _, level := range poolLevels {
+		if !strings.Contains(text, "`"+level.state+"`") {
+			t.Errorf("the pool publishes state=%q and %s does not list it among the states", level.state, doc)
+		}
+	}
+	// And the other direction, which is the half a hand-written list gets
+	// wrong: a name the doc invented, or one left behind by a rename.
+	for _, documented := range regexp.MustCompile(`margince_pgxpool[a-z_]*`).FindAllString(text, -1) {
+		if documented == "margince_pgxpool_conns" || documented == "margince_pgxpool_" {
+			continue
+		}
+		if !slices.Contains(poolCounterNames(), documented) {
+			t.Errorf("%s documents %s, which nothing publishes", doc, documented)
+		}
+	}
+}
+
+func poolCounterNames() []string {
+	names := make([]string, 0, len(poolCounters))
+	for _, counter := range poolCounters {
+		names = append(names, counter.name)
+	}
+	return names
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -65,7 +65,7 @@ Operational endpoints (served next to `/v1`):
   2s, else 503 naming the unready dependency.
 - `/metrics` — Prometheus text format: the **HTTP section** below,
   `margince_outbox_unpublished`, `margince_relay_published_total`,
-  `margince_pgxpool_conns{state=…}`, the AI router's counters, the overlay
+  the **connection-pool section** below, the AI router's counters, the overlay
   sync-health section, and the **job-runtime section** below. Served openly by
   default, so an annotation-discovered scraper works with no configuration; set
   `--metrics-token` to require a Bearer credential where the port itself is not
@@ -116,6 +116,44 @@ Operational endpoints (served next to `/v1`):
 
   Mind the scrape interval when choosing that window: a rate needs several
   points, so a cluster scraping every 5m wants `[30m]` or wider.
+
+  The connection-pool section reports this process's own pool. It publishes
+  every value pgx computes, and the split between the two kinds is what makes
+  it readable:
+
+  | Family | Type | Labels |
+  |---|---|---|
+  | `margince_pgxpool_conns` | gauge | `state`: `acquired`, `idle`, `constructing`, `total`, `max` |
+  | `margince_pgxpool_acquire_total` | counter | — |
+  | `margince_pgxpool_acquire_empty_total` | counter | — |
+  | `margince_pgxpool_acquire_canceled_total` | counter | — |
+  | `margince_pgxpool_acquire_seconds_total` | counter | — |
+  | `margince_pgxpool_acquire_wait_seconds_total` | counter | — |
+  | `margince_pgxpool_conns_opened_total` | counter | — |
+  | `margince_pgxpool_conns_retired_lifetime_total` | counter | — |
+  | `margince_pgxpool_conns_retired_idle_total` | counter | — |
+
+  **The gauges cannot tell a queue from a busy pool, which is what the counters
+  are for.** `acquired` near `max` is what saturation looks like AND what a
+  healthy peak looks like; the series that separates them is
+  `acquire_empty_total`, an acquire that found nothing free and had to wait.
+  The gauges also only describe the instant they were scraped, so at a 5-minute
+  interval a queue that formed and drained between two scrapes leaves no trace
+  in them at all. The counters carry it into the next scrape regardless.
+
+  The waiting line, and the mean wait of a caller that joined it:
+
+  ```promql
+  rate(margince_pgxpool_acquire_empty_total[30m])
+
+  rate(margince_pgxpool_acquire_wait_seconds_total[30m])
+    / rate(margince_pgxpool_acquire_empty_total[30m])
+  ```
+
+  `acquire_seconds_total` is over EVERY acquire including the ones that waited
+  for nothing, so it measures what acquiring costs on average;
+  `acquire_wait_seconds_total` is over the ones that queued, and is the one that
+  answers how long anybody actually waited.
 - `GET /v1/admin/job-health` — the per-workspace read of the same job
   table, for an admin rather than a scrape. See
   [Reading the job surfaces](#reading-the-job-surfaces).
@@ -428,7 +466,7 @@ re-serves no fleet-wide reading:
 | `go_gc_duration_seconds` | GC pause quantiles — the stop-the-world cost, not merely the cycle count |
 | `process_cpu_seconds_total`, `process_resident_memory_bytes` | this process's CPU and RSS, which cAdvisor can only give per container |
 | `process_start_time_seconds` | uptime, and a crash loop that restarts between scrapes |
-| `margince_pgxpool_conns` | this process's own connection pool, by class |
+| `margince_pgxpool_*` | this process's own connection pool — see the connection-pool section |
 | `margince_relay_published_total` | outbox rows *this* relay has shipped since start |
 | `margince_ai_*` | the AI calls *this* process made — every Router in a binary increments one process-wide collector |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -141,6 +141,16 @@ Operational endpoints (served next to `/v1`):
   interval a queue that formed and drained between two scrapes leaves no trace
   in them at all. The counters carry it into the next scrape regardless.
 
+  **The three wait series count acquires that SUCCEEDED.** pgx increments
+  `EmptyAcquireCount`, `EmptyAcquireWaitTime` and `AcquireDuration` when a
+  caller eventually gets a connection; one that gives up while queued — a
+  cancelled context, a request that went away — lands only in
+  `acquire_canceled_total` and contributes none of its wait. That is the
+  opposite of an academic distinction during the incident these exist for: the
+  callers who gave up are the requests that FAILED, so a mean wait read alone
+  averages over the survivors and reports a shorter queue than the one callers
+  actually stood in. Read the two together.
+
   The waiting line, and the mean wait of a caller that joined it:
 
   ```promql
@@ -150,10 +160,10 @@ Operational endpoints (served next to `/v1`):
     / rate(margince_pgxpool_acquire_empty_total[30m])
   ```
 
-  `acquire_seconds_total` is over EVERY acquire including the ones that waited
-  for nothing, so it measures what acquiring costs on average;
-  `acquire_wait_seconds_total` is over the ones that queued, and is the one that
-  answers how long anybody actually waited.
+  `acquire_seconds_total` is over every SUCCESSFUL acquire including the ones
+  that waited for nothing, so it measures what acquiring costs on average;
+  `acquire_wait_seconds_total` is over the ones that queued and were then
+  served, and is the one that answers how long anybody actually waited.
 - `GET /v1/admin/job-health` — the per-workspace read of the same job
   table, for an admin rather than a scrape. See
   [Reading the job surfaces](#reading-the-job-surfaces).


### PR DESCRIPTION
Closes #5423.

`writePoolGauges` published four numbers about the connection pool. All four were
**levels** — acquired, idle, total, max — and every value `pgxpool.Stat` computes
about **waiting** was dropped on the floor.

The two read identically on a bad day. `acquired=15/16` is what saturation looks
like and what a healthy peak looks like, so the board could not tell a queue from
a busy pool. #5423 demonstrated it: twenty-four concurrent `/v1/worklist` readers
against sixteen slots left at least nine queued, no exported series said nine, and
an unrelated `/v1/me` went from 10 ms p95 to 125 ms with nothing to attribute it to.

## What changed

Every value `pgxpool.Stat` answers is now published — five levels in the existing
`margince_pgxpool_conns{state=…}` family (`constructing` joins the four), and eight
counters:

| series | from |
|---|---|
| `margince_pgxpool_acquire_total` | `AcquireCount` |
| `margince_pgxpool_acquire_empty_total` | `EmptyAcquireCount` — **the waiting line** |
| `margince_pgxpool_acquire_canceled_total` | `CanceledAcquireCount` |
| `margince_pgxpool_acquire_seconds_total` | `AcquireDuration` |
| `margince_pgxpool_acquire_wait_seconds_total` | `EmptyAcquireWaitTime` |
| `margince_pgxpool_conns_opened_total` | `NewConnsCount` |
| `margince_pgxpool_conns_retired_lifetime_total` | `MaxLifetimeDestroyCount` |
| `margince_pgxpool_conns_retired_idle_total` | `MaxIdleDestroyCount` |

**Counters, not gauges**, and that is what makes the fix work at the scrape
interval the board actually has: a level only describes the instant it was
sampled, so at five minutes a queue that formed and drained in between leaves no
trace at all. A counter carries it into the next scrape regardless.

Two deviations from the issue's suggested list, both deliberate:

- It asked for `AcquireDuration` under the name `acquire_wait_seconds_total`. That
  duration is over EVERY acquire including the ones that waited for nothing, so it
  measures what acquiring costs on average. `EmptyAcquireWaitTime` — which the
  issue's nine-value table did not include, this pgx version having thirteen — is
  the time actually spent WAITING. Both ship, under names that say which is which:
  "acquiring costs 3 ms on average" and "whoever queued waited 300 ms" are
  different sentences and only the second is the incident.
- The four the issue did not name (`ConstructingConns`, the two destroy counts,
  and `EmptyAcquireWaitTime`) ship too. They are free — the values are already on
  the `stat` the function holds — and an operator cannot ask for a series that was
  never emitted.

## What holds it

`TestEveryPoolStatisticIsExported` asks the **pool** what it computes, by
reflecting over `pgxpool.Stat`'s method set, rather than keeping a list of what it
ought to. That is the defect's own shape: a metric that is absent looks exactly
like one that is zero, and a hand-written expectation here would have been written
from the same four. It also fails the other way, on a name the tables still
declare that pgx no longer answers. A value pgx adds in a later release fails on
the upgrade's own PR.

The exporter carries each `Stat` method name as data beside the call, which is
what lets the gate share one source with the renderer instead of being a second
copy of it.

Two more: `TestEveryDeclaredPoolSeriesReachesTheScrape` proves the tables are what
the handler actually renders (against an undialled pool — the subject is the
exposition, not the database), and `TestTheOperatorDocNamesEveryPoolSeries` holds
`docs/reference/configuration.md` to the exporter in both directions. All three are
mutation-verified.

## Not in scope

- The dashboard panel the issue asks for. No dashboard lives in this tree.
- The 33–54 transactions per worklist-family read (#4912).
- Nothing bounds how long a request may hold a connection — #5424, in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded `/metrics` output with comprehensive connection-pool gauges and counters, including connection states, acquisition activity, wait times, and connection lifecycle events.

- **Documentation**
  - Added reference documentation describing connection-pool metric families, labels, and interpretation.

- **Tests**
  - Added coverage to verify all connection-pool statistics are exported, correctly typed, and documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->