### PR TITLE
A decision names the rules it was judged under

### DIFF
--- a/backend/gates/messagingruleapplied_test.go
+++ b/backend/gates/messagingruleapplied_test.go
@@ -67,8 +67,10 @@ const (
 // Version is NOT identity, though it reads like it: messaging.Rules says it is
 // "stamped onto every decision taken under it", which is an obligation and a
 // promise to a subject who later asks which rules their message was judged
-// under. Excluding it here was this gate's own first blind spot — the register
-// below carries it instead, which is where an unkept promise belongs.
+// under. Excluding it here was this gate's own first blind spot. The register
+// below carried it until consent.rulesetStamp began writing it onto every
+// staging and transmit row, so it is an applied obligation now and belongs in
+// neither list.
 var rulesIdentityFields = []string{"Jurisdiction"}
 
 // unappliedRules are the obligations the engine does not read yet, each with
@@ -92,10 +94,6 @@ var unappliedRules = gatekit.Waive(map[string]string{
 	"OptOutAcknowledgement": "no acknowledgement is sent. The controller lane is the only " +
 		"one that may write to somebody who has just suppressed themselves, and it " +
 		"registers no template for this",
-	"Version": "no decision records which ruleset judged it. Strictest zeroes the version " +
-		"when it folds two jurisdictions and returns the codes it folded instead, and " +
-		"applicableRules discards that second result — so neither the version nor the " +
-		"codes reach communication_decision, which carries no column for either",
 })
 
 func TestEveryDeclaredMessagingObligationIsAppliedOrRecorded(t *testing.T) {

--- a/backend/gates/piicolumncoverage_test.go
+++ b/backend/gates/piicolumncoverage_test.go
@@ -88,6 +88,13 @@ var erasureColumnBaseline = map[string][]string{
 		// it here would destroy the controller's ability to say which evidence
 		// it relied on for a send it has already made.
 		"evidence",
+		// ISO 3166-1 alpha-2 codes naming which jurisdictions' rules judged the
+		// message — "de", "vn". The installation's own, never the subject's:
+		// applicableRules resolves the country the INSTALLATION declares, and
+		// the recipient's is not read at all. Clearing it would leave a sent
+		// message with no record of the law it was judged under, which is the
+		// accountability half Art. 5(2) requires the erasure to keep.
+		"ruleset_codes",
 	},
 	"activity": {
 		"audience",

--- a/backend/internal/modules/consent/authorizecap.go
+++ b/backend/internal/modules/consent/authorizecap.go
@@ -53,7 +53,7 @@ const capLockNamespace = int64(0x636d7361) << 32 // "cmsa"
 // held, sorted, before the first count, and a per-recipient lock taken inside
 // the decide loop would order them by the caller's To list.
 func (g *Gate) lockCapAddresses(ctx context.Context, tx pgx.Tx, recipients []connector.Recipient) error {
-	rules, applicable, err := g.store.applicableRules(ctx, tx)
+	rules, _, applicable, err := g.store.applicableRules(ctx, tx)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (g *Gate) applyFrequencyCap(ctx context.Context, tx pgx.Tx, d commsauthz.De
 		// rule — stated here because silence would read as an oversight.
 		return d, nil
 	}
-	rules, applicable, err := g.store.applicableRules(ctx, tx)
+	rules, _, applicable, err := g.store.applicableRules(ctx, tx)
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}
@@ -246,14 +246,21 @@ func advertisingMessagesReceived(ctx context.Context, tx pgx.Tx, address string,
 // a jurisdiction's own number and there is no universal one to fall back to.
 // The consent requirement that DOES bind everywhere is enforced by the marketing
 // verdict itself, which runs before this and does not depend on a pack.
-func (s *Store) applicableRules(ctx context.Context, tx pgx.Tx) (messagingrules.Rules, bool, error) {
+// IT RETURNS Applied AS WELL, and stays the ONE door rather than gaining a
+// second beside it. A decision records which jurisdictions judged it, and a
+// separate wider entry point would have left this gate's scan
+// (gates/messagingruleapplied_test.go pins the lookup by name) blind to reads
+// through the other one. Callers that need only the rules discard it.
+func (s *Store) applicableRules(
+	ctx context.Context, tx pgx.Tx,
+) (messagingrules.Rules, messagingrules.Applied, bool, error) {
 	code, err := s.installationCountry(ctx, tx)
 	if err != nil {
-		return messagingrules.Rules{}, false, err
+		return messagingrules.Rules{}, messagingrules.Applied{}, false, err
 	}
 	if code == "" {
-		return messagingrules.Rules{}, false, nil
+		return messagingrules.Rules{}, messagingrules.Applied{}, false, nil
 	}
-	rules, _, found := messagingrules.Strictest(code)
-	return rules, found, nil
+	rules, applied, found := messagingrules.Strictest(code)
+	return rules, applied, found, nil
 }

--- a/backend/internal/modules/consent/authorizestaging.go
+++ b/backend/internal/modules/consent/authorizestaging.go
@@ -83,6 +83,14 @@ func (g *Gate) stageDecisions(ctx context.Context, tx pgx.Tx, deliveryID ids.UUI
 	if err != nil {
 		return commsauthz.DecisionSet{}, err
 	}
+	// WHICH RULES ARE ABOUT TO JUDGE THIS, read here for the same reason the
+	// posture above is: before any decision is taken, so the row records the
+	// ruleset that actually judged it rather than whichever one is live by the
+	// time the rows are written.
+	ruleset, err := g.rulesetStamp(ctx, tx)
+	if err != nil {
+		return commsauthz.DecisionSet{}, err
+	}
 
 	setID := ids.NewV7()
 	set := commsauthz.DecisionSet{}
@@ -112,7 +120,7 @@ func (g *Gate) stageDecisions(ctx context.Context, tx pgx.Tx, deliveryID ids.UUI
 		}
 		directed.instructionID = instruction
 	}
-	if err := g.recordStagingDecisions(ctx, tx, deliveryID, setID, req, set, directedAuthority(directed)); err != nil {
+	if err := g.recordStagingDecisions(ctx, tx, deliveryID, setID, req, set, directedAuthority(directed), ruleset); err != nil {
 		return commsauthz.DecisionSet{}, err
 	}
 	return set, nil
@@ -155,7 +163,7 @@ func refusesAnyRecipient(set commsauthz.DecisionSet) bool {
 // up yet, and every transmit row that follows carries the attempt it belonged
 // to. The fingerprint is of the message as staged, so a later reader can tell
 // whether what went out is what was authorized.
-func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID, setID ids.UUID, req commsauthz.Request, set commsauthz.DecisionSet, instruction ids.UUID) error {
+func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID, setID ids.UUID, req commsauthz.Request, set commsauthz.DecisionSet, instruction ids.UUID, ruleset rulesetStampValue) error {
 	sum := SendingDigest(req.Subject, req.Body, req.HTMLBody)
 	by, err := storekit.CapturedBy(ctx)
 	if err != nil {
@@ -209,14 +217,16 @@ func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID
 			INSERT INTO communication_decision
 			  (delivery_id, attempt, decision_set_id, recipient_address, subject_kind, subject_id,
 			   phase, requested_category, resolved_category, verdict, reason_code, basis, suppression,
-			   content_fingerprint, mode, actor, evidence, execution_authority, instruction_id)
-			VALUES ($1,0,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)
+			   content_fingerprint, mode, actor, evidence, execution_authority, instruction_id,
+			   ruleset_version, ruleset_codes)
+			VALUES ($1,0,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
 			ON CONFLICT (decision_set_id, recipient_address, phase) DO NOTHING`,
 			deliveryID, setID, decisionRecipientKey(d.Recipient),
 			subjectKind, subjectID, string(d.Phase), nullableCategory(d.Requested),
 			string(d.Resolved), string(d.Verdict), d.ReasonCode,
 			nullableBasis(d.Basis), nullableText(d.Suppression),
-			sum[:], string(d.Mode), by, evidence, authority, instructionID)
+			sum[:], string(d.Mode), by, evidence, authority, instructionID,
+			ruleset.Version, ruleset.Codes)
 		if err != nil {
 			return fmt.Errorf("consent: record the staging decision: %w", err)
 		}

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -93,11 +93,25 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 			return err
 		}
 		modeFor := func(c commsauthz.Category) commsauthz.Mode { return ModeFor(modes, c) }
+		// WHICH RULES ARE ABOUT TO JUDGE THIS, read ONCE and before any of them
+		// do, so the row records the ruleset the decisions were actually taken
+		// under.
+		//
+		// Asking again after decideRecipients would let an installation that
+		// changed its declared country mid-transmit record a pack that judged
+		// nothing: the frequency ceiling would have been applied under the old
+		// country while the row named the new one. The reads are separate
+		// unlocked SELECTs under READ COMMITTED, so sharing this transaction
+		// does not make two of them agree — asking once does.
+		stamp, err := g.rulesetStamp(ctx, tx)
+		if err != nil {
+			return err
+		}
 		set, err := g.decideRecipients(ctx, tx, req, legacyAllowed, modeFor)
 		if err != nil {
 			return err
 		}
-		written, err := g.recordDecisions(ctx, tx, req, setID, set)
+		written, err := g.recordDecisions(ctx, tx, req, setID, set, stamp)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/consent/authorizetransmitrecord.go
+++ b/backend/internal/modules/consent/authorizetransmitrecord.go
@@ -28,7 +28,7 @@ import (
 // exists so a later reader can tell whether the message that went is the
 // message that was authorized, and storing the words themselves would make the
 // decision a second copy of the mail.
-func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest, setID ids.UUID, set commsauthz.DecisionSet) ([]commsauthz.Decision, error) {
+func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest, setID ids.UUID, set commsauthz.DecisionSet, ruleset rulesetStampValue) ([]commsauthz.Decision, error) {
 	var written []commsauthz.Decision
 	sum := SendingDigest(req.Subject, req.Body, req.HTMLBody)
 	by, err := storekit.CapturedBy(ctx)
@@ -61,8 +61,8 @@ func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.Tr
 			  (delivery_id, attempt, decision_set_id, recipient_address, subject_kind, subject_id,
 			   phase, resolved_category, verdict, reason_code, basis, suppression,
 			   content_fingerprint, legacy_verdict, mode, actor,
-			   execution_authority, instruction_id)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)
+			   execution_authority, instruction_id, ruleset_version, ruleset_codes)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
 			ON CONFLICT (decision_set_id, recipient_address, phase) DO NOTHING`,
 			req.DeliveryID, req.Attempt, setID, decisionRecipientKey(d.Recipient),
 			subjectKind, subjectID, string(d.Phase), string(d.Resolved), string(d.Verdict),
@@ -71,7 +71,8 @@ func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.Tr
 			// Named on the REFUSED rows only, as at staging: a message allowed
 			// for one recipient and directed for another did not go out on
 			// somebody's decision for both.
-			authorityFor(authority, d.Verdict), instructionFor(instruction, d.Verdict))
+			authorityFor(authority, d.Verdict), instructionFor(instruction, d.Verdict),
+			ruleset.Version, ruleset.Codes)
 		if err != nil {
 			return nil, fmt.Errorf("consent: record the transmit decision: %w", err)
 		}

--- a/backend/internal/modules/consent/authorizewindows.go
+++ b/backend/internal/modules/consent/authorizewindows.go
@@ -68,7 +68,7 @@ type packRules struct {
 // filled in a setting.
 func (s *Store) packRulesFor(ctx context.Context, tx pgx.Tx) (packRules, error) {
 	out := packRules{reply: defaultReplyWindow, dealFollow: defaultDealFollowUpWindow}
-	rules, applicable, err := s.applicableRules(ctx, tx)
+	rules, _, applicable, err := s.applicableRules(ctx, tx)
 	if err != nil {
 		return packRules{}, err
 	}

--- a/backend/internal/modules/consent/disclosurerender.go
+++ b/backend/internal/modules/consent/disclosurerender.go
@@ -85,7 +85,7 @@ func (s *Store) Disclosures(
 func (s *Store) DisclosuresFor(
 	ctx context.Context, tx pgx.Tx, category commsauthz.Category,
 ) ([]DisclosureLine, error) {
-	rules, found, err := s.applicableRules(ctx, tx)
+	rules, _, found, err := s.applicableRules(ctx, tx)
 	if err != nil || !found {
 		return nil, err
 	}

--- a/backend/internal/modules/consent/rulesetstamp.go
+++ b/backend/internal/modules/consent/rulesetstamp.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Naming the rules a decision was judged under, on the decision itself.
+//
+// messaging.Rules has said since it shipped that its Version is "stamped onto
+// every decision taken under it". Nothing stamped it, and
+// gates/messagingruleapplied_test.go carried the gap in its register. This is
+// the reader that closes it.
+//
+// The promise is to a SUBJECT, not to an operator: somebody asking a year later
+// which rules judged their message is owed an answer from the record, and
+// re-deriving it from whatever the packs say today would answer a different
+// question.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// rulesetStamp is what a decision records about the rules that judged it.
+//
+// A VALUE rather than two returns, because the pair travels together from the
+// one lookup to the insert. Splitting them let a caller read the rules a second
+// time between deciding and recording, which is how a row could name a pack
+// that judged nothing.
+type rulesetStampValue struct {
+	// Version is the pack's own, non-nil only when exactly one jurisdiction
+	// applied. A fold carries none.
+	Version *int
+	// Codes are the jurisdictions that contributed, and the answer in both
+	// cases.
+	//
+	// NIL when no country is declared, never an empty slice: pgx writes nil as
+	// NULL, and the CHECK in migration 1789240000 refuses an empty array so
+	// that "no jurisdiction applied" has exactly one spelling in the record.
+	Codes []string
+}
+
+// rulesetStamp answers what to record about the rules that judged this message.
+//
+// TWO ANSWERS, because one cannot carry it. A single jurisdiction's rule set
+// carries its own version. A fold of two carries none — messagingrules.stricter
+// zeroes it deliberately, because stamping a fold with one country's number
+// would misname the rules the decision was actually taken under. The codes
+// answer in both cases, so they are what a reader keys on and the version is the
+// refinement available when exactly one jurisdiction applied.
+//
+// BOTH NULL is a real answer. An installation that declares no country resolves
+// to no rules at all, and that is recorded as absence rather than as zero: a
+// zero version would read as a ruleset that exists and has no version.
+func (g *Gate) rulesetStamp(ctx context.Context, tx pgx.Tx) (rulesetStampValue, error) {
+	rules, applied, found, err := g.store.applicableRules(ctx, tx)
+	if err != nil {
+		return rulesetStampValue{}, err
+	}
+	if !found || len(applied.Codes) == 0 {
+		return rulesetStampValue{}, nil
+	}
+	codes := make([]string, 0, len(applied.Codes))
+	for _, code := range applied.Codes {
+		codes = append(codes, string(code))
+	}
+	// The version travels only with a single jurisdiction, which is the same
+	// condition Applied.Folded reports and the CHECK in migration 1789240000
+	// enforces from the other side.
+	if applied.Folded() {
+		return rulesetStampValue{Codes: codes}, nil
+	}
+	version := rules.Version
+	return rulesetStampValue{Version: &version, Codes: codes}, nil
+}

--- a/backend/internal/modules/consent/rulesetstamp_integration_test.go
+++ b/backend/internal/modules/consent/rulesetstamp_integration_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// Recording which rules judged a decision.
+//
+// messaging.Rules has said since it shipped that its Version is "stamped onto
+// every decision taken under it", and nothing stamped it:
+// gates/messagingruleapplied_test.go carried the gap in its register with the
+// reason that communication_decision had no column for it.
+//
+// The promise is to a SUBJECT. Somebody asking a year later which rules judged
+// their message is owed an answer from the record, and re-deriving it from
+// whatever the packs say today answers a different question — packs change, and
+// that is the whole reason the version exists.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
+)
+
+// inCountry binds the env's gate and store to a pack with the given version.
+func inCountry(t *testing.T, e *resolveEnv, code string, version int) {
+	t.Helper()
+	messagingrules.Register(messagingrules.Rules{
+		Jurisdiction: jurisdiction.Code(code), Version: version,
+	})
+	reader := InstallationCountryFunc(func(context.Context, pgx.Tx) (jurisdiction.Code, error) {
+		return jurisdiction.Code(code), nil
+	})
+	e.gate = e.gate.WithInstallationCountry(reader)
+	e.store = e.store.WithInstallationCountry(reader)
+}
+
+// rulesetOf reads back what a decision recorded about the rules that judged it.
+func rulesetOf(t *testing.T, e *resolveEnv, delivery ids.UUID, phase string) (*int, []string) {
+	t.Helper()
+	var version *int
+	var codes []string
+	if err := e.owner.QueryRow(context.Background(), `
+		SELECT ruleset_version, ruleset_codes
+		  FROM communication_decision
+		 WHERE delivery_id = $1 AND phase = $2
+		 LIMIT 1`, delivery, phase).Scan(&version, &codes); err != nil {
+		t.Fatalf("reading the %s decision: %v", phase, err)
+	}
+	return version, codes
+}
+
+// TestADecisionRecordsTheRulesetThatJudgedIt is the register line this closes.
+//
+// BOTH PHASES, because they answer different questions. The staging row says
+// what was true when the message was composed; the transmit row says what was
+// true when it left, and a delivery can sit queued across a change of either.
+func TestADecisionRecordsTheRulesetThatJudgedIt(t *testing.T) {
+	e := setupResolve(t)
+	inCountry(t, e, "ra", 4)
+	delivery := e.plantDelivery(t)
+
+	stageThenTransmit(t, e, delivery, stagedSubject, stagedBody)
+
+	for _, phase := range []string{"staging", "transmit"} {
+		version, codes := rulesetOf(t, e, delivery, phase)
+		if version == nil || *version != 4 {
+			t.Errorf("the %s decision recorded version %v, want 4 — a subject asking which "+
+				"rules judged their message has only this row to read", phase, version)
+		}
+		if len(codes) != 1 || codes[0] != "ra" {
+			t.Errorf("the %s decision recorded codes %v, want [ra]", phase, codes)
+		}
+	}
+}
+
+// TestAnInstallationDeclaringNoCountryRecordsNoRuleset.
+//
+// NULL is a real answer and not a gap: no country resolves to no rules at all,
+// and a zero version would read as a ruleset that exists and has none. The
+// consent requirement that binds everywhere is enforced by the marketing
+// verdict, which runs before any pack.
+func TestAnInstallationDeclaringNoCountryRecordsNoRuleset(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+
+	stageThenTransmit(t, e, delivery, stagedSubject, stagedBody)
+
+	for _, phase := range []string{"staging", "transmit"} {
+		version, codes := rulesetOf(t, e, delivery, phase)
+		if version != nil {
+			t.Errorf("the %s decision recorded version %d with no jurisdiction declared — "+
+				"that names a ruleset which does not exist", phase, *version)
+		}
+		if len(codes) != 0 {
+			t.Errorf("the %s decision recorded codes %v with no jurisdiction declared", phase, codes)
+		}
+	}
+}
+
+// TestErasureKeepsTheRulesetAndLosesTheSubject.
+//
+// erasure_consent.go already promised this in its own comment — "the verdict,
+// the category, the reason and the ruleset survive as an unattributed statistic
+// about a send that happened" — while no column carried a ruleset. Now one
+// does, so the promise is testable rather than aspirational.
+func TestErasureKeepsTheRulesetAndLosesTheSubject(t *testing.T) {
+	e := setupResolve(t)
+	inCountry(t, e, "rb", 2)
+	delivery := e.plantDelivery(t)
+
+	stageThenTransmit(t, e, delivery, stagedSubject, stagedBody)
+
+	// The erasure write itself, as privacy performs it: the address is
+	// tombstoned and the subject link cut, in place.
+	//
+	// RESTATED, not called. deleteConsentCapabilities is unexported in the
+	// privacy module and this suite is in consent, so what is proven here is
+	// that the two new columns survive THAT shape of update — not that the
+	// production eraser runs it. The statement is copied from
+	// privacy/erasure_consent.go, and gates/piicolumncoverage_test.go is what
+	// fails if a future column escapes the redaction's accounting.
+	if _, err := e.owner.Exec(context.Background(), `
+		UPDATE communication_decision
+		   SET recipient_address = 'erased+' || id || '@example.invalid',
+		       subject_id = NULL, subject_kind = NULL
+		 WHERE delivery_id = $1`, delivery); err != nil {
+		t.Fatalf("erasing the subject: %v", err)
+	}
+
+	version, codes := rulesetOf(t, e, delivery, "transmit")
+	if version == nil || *version != 2 || len(codes) != 1 || codes[0] != "rb" {
+		t.Errorf("erasure destroyed the ruleset: version %v codes %v. The controller must "+
+			"still be able to answer for a message it already sent, which is why the "+
+			"decision survives the subject", version, codes)
+	}
+}
+
+// TestTheRecordedRulesetIsRefusedWhenItNamesNoJurisdiction.
+//
+// array_length answers NULL for an empty array, and a CHECK evaluating to NULL
+// is ACCEPTED. Written as `= 1` alone the constraint admitted a version
+// alongside zero jurisdictions — the exact pair it exists to refuse. The
+// production writer cannot produce that pair, so this asks the database
+// directly rather than through the gate.
+func TestTheRecordedRulesetIsRefusedWhenItNamesNoJurisdiction(t *testing.T) {
+	e := setupResolve(t)
+	inCountry(t, e, "rc", 3)
+	delivery := e.plantDelivery(t)
+	stageThenTransmit(t, e, delivery, stagedSubject, stagedBody)
+
+	for _, bad := range []struct {
+		name    string
+		version any
+		codes   any
+	}{
+		{"a version with no codes at all", 3, []string{}},
+		{"codes recorded as an empty array", nil, []string{}},
+	} {
+		_, err := e.owner.Exec(context.Background(), `
+			UPDATE communication_decision
+			   SET ruleset_version = $2, ruleset_codes = $3
+			 WHERE delivery_id = $1`, delivery, bad.version, bad.codes)
+		if err == nil {
+			t.Errorf("%s was accepted — a decision that recorded no jurisdiction must say "+
+				"so with NULL, so the record has one spelling for it and not two", bad.name)
+		}
+	}
+}
+
+// TestTheRecordedRulesetIsTheOneThatJudgedNotTheOneLiveAtWriteTime.
+//
+// Codex found this: the stamp was read AFTER the decisions were taken, in the
+// function that writes the rows. An installation changing its declared country
+// mid-transmit would have had its frequency ceiling applied under the old pack
+// while the row named the new one — a record saying Vietnam judged a message
+// Germany judged.
+//
+// The country reads are separate unlocked SELECTs under READ COMMITTED, so
+// sharing one transaction does not make two of them agree. Reading once, before
+// any decision, is what does.
+//
+// Mutation: move the rulesetStamp call in stageDecisions back below the decide
+// loop and this fails.
+func TestTheRecordedRulesetIsTheOneThatJudgedNotTheOneLiveAtWriteTime(t *testing.T) {
+	e := setupResolve(t)
+	inCountry(t, e, "rd", 5)
+	delivery := e.plantDelivery(t)
+
+	// The country flips the moment the first decision has been taken, which is
+	// exactly the window the old ordering left open.
+	flipped := false
+	e.gate = e.gate.WithInstallationCountry(
+		InstallationCountryFunc(func(context.Context, pgx.Tx) (jurisdiction.Code, error) {
+			if flipped {
+				return jurisdiction.Code("re"), nil
+			}
+			flipped = true
+			return jurisdiction.Code("rd"), nil
+		}))
+	messagingrules.Register(messagingrules.Rules{
+		Jurisdiction: jurisdiction.Code("re"), Version: 6,
+	})
+
+	stageThenTransmit(t, e, delivery, stagedSubject, stagedBody)
+
+	version, codes := rulesetOf(t, e, delivery, "staging")
+	if version == nil || *version != 5 || len(codes) != 1 || codes[0] != "rd" {
+		t.Errorf("the staging decision recorded version %v codes %v, want 5 and [rd] — "+
+			"the row names a ruleset that judged nothing", version, codes)
+	}
+}

--- a/backend/internal/shared/ports/messagingrules/messagingrules.go
+++ b/backend/internal/shared/ports/messagingrules/messagingrules.go
@@ -123,24 +123,56 @@ func For(code jurisdiction.Code) (Rules, bool) {
 // must treat "no rules at all" as the consent-only floor rather than as
 // permission — Strictest cannot invent an obligation for a country it was
 // never told about.
-func Strictest(codes ...jurisdiction.Code) (Rules, []jurisdiction.Code, bool) {
+//
+// THE APPLIED CODES are the third answer, and they are what a decision records.
+// A fold is no one jurisdiction's rule set, so stricter() clears Jurisdiction
+// and Version rather than misnaming the fold with one country's label — which
+// left a folded decision with nothing to say about the rules it was judged
+// under. The codes that actually contributed answer that, and they are not the
+// codes the caller passed in: an unknown one contributes nothing and must not
+// appear as though it bound the send.
+func Strictest(codes ...jurisdiction.Code) (Rules, Applied, bool) {
 	var out Rules
-	var unknown []jurisdiction.Code
+	var applied Applied
 	found := false
 	for _, code := range codes {
 		r, ok := For(code)
 		if !ok {
-			unknown = append(unknown, code)
+			applied.Unknown = append(applied.Unknown, code)
 			continue
 		}
+		applied.Codes = append(applied.Codes, code)
 		if !found {
 			out, found = r, true
 			continue
 		}
 		out = stricter(out, r)
 	}
-	return out, unknown, found
+	return out, applied, found
 }
+
+// Applied names which jurisdictions a fold actually used.
+//
+// A DECISION RECORDS THIS, because Rules alone cannot say it. A single
+// jurisdiction's rule set carries its own code and version; a fold of two
+// carries neither, by design. Without the codes, a subject asking which rules
+// judged their message would get an answer only for the installations that
+// happen to declare one country.
+type Applied struct {
+	// Codes are the jurisdictions that contributed obligations, in the order
+	// they were asked about. One entry means Rules.Version is meaningful;
+	// more than one means the fold zeroed it and these are the answer.
+	Codes []jurisdiction.Code
+
+	// Unknown are the codes named that no pack declares. They bound nothing —
+	// recorded so an installation naming a country the product does not carry
+	// is visible rather than silently ungoverned.
+	Unknown []jurisdiction.Code
+}
+
+// Folded reports whether more than one jurisdiction contributed, which is
+// exactly when Rules.Version stops meaning anything.
+func (a Applied) Folded() bool { return len(a.Codes) > 1 }
 
 // stricter folds one rule set into another, obligation by obligation.
 func stricter(a, b Rules) Rules {
@@ -149,7 +181,8 @@ func stricter(a, b Rules) Rules {
 	// country's code would misname the rules a decision was taken under.
 	out.Jurisdiction = ""
 	// A version is only meaningful for a single jurisdiction's set; a folded
-	// one carries none, and the decision records the codes it folded instead.
+	// one carries none, and the decision records Applied.Codes instead — which
+	// Strictest returns for exactly this reason.
 	out.Version = 0
 	out.ReplyWindow = shorterWindow(a.ReplyWindow, b.ReplyWindow)
 	out.DealFollowUpWindow = shorterWindow(a.DealFollowUpWindow, b.DealFollowUpWindow)

--- a/backend/internal/shared/ports/messagingrules/messagingrules_test.go
+++ b/backend/internal/shared/ports/messagingrules/messagingrules_test.go
@@ -130,12 +130,16 @@ func TestAFoldedSetClaimsNoSingleJurisdiction(t *testing.T) {
 // Strictest reports that it found nothing rather than returning an empty set
 // that reads as "no obligations".
 func TestAnUnknownJurisdictionIsNotAnAnswer(t *testing.T) {
-	_, unknown, ok := Strictest("zz")
+	_, applied, ok := Strictest("zz")
 	if ok {
 		t.Error("an unknown jurisdiction reported rules — the caller would read the zero set as 'nothing required'")
 	}
-	if len(unknown) != 1 {
-		t.Errorf("unknown codes = %v, want the one that could not be resolved", unknown)
+	if len(applied.Unknown) != 1 {
+		t.Errorf("unknown codes = %v, want the one that could not be resolved", applied.Unknown)
+	}
+	if len(applied.Codes) != 0 {
+		t.Errorf("applied codes = %v; an unknown jurisdiction bound nothing and must not be "+
+			"recorded as though it judged the message", applied.Codes)
 	}
 }
 
@@ -258,16 +262,58 @@ func TestStrictestReportsTheJurisdictionsItCouldNotResolve(t *testing.T) {
 		MarketingExceptions: []MarketingException{{Kind: ExistingCustomer, RequiresSaleEvidence: true}},
 	})
 
-	got, unknown, ok := Strictest("qc", "zz")
+	got, applied, ok := Strictest("qc", "zz")
 	if !ok {
 		t.Fatal("a known jurisdiction reported nothing")
 	}
-	if len(unknown) != 1 || unknown[0] != "zz" {
-		t.Fatalf("unknown = %v, want the code that could not be resolved", unknown)
+	if len(applied.Unknown) != 1 || applied.Unknown[0] != "zz" {
+		t.Fatalf("unknown = %v, want the code that could not be resolved", applied.Unknown)
+	}
+	// The unresolvable code is NOT an applied one. A decision recording it
+	// would name a jurisdiction that bound nothing.
+	if len(applied.Codes) != 1 || applied.Codes[0] != "qc" {
+		t.Fatalf("applied = %v, want only the jurisdiction that contributed", applied.Codes)
+	}
+	if applied.Folded() {
+		t.Error("one contributing jurisdiction reported as a fold — Rules.Version is " +
+			"meaningful here and would be discarded")
 	}
 	// The rules still come back — the caller decides what to do about a partial
 	// answer — but it can no longer mistake one for a complete fold.
 	if len(got.MarketingExceptions) != 1 {
 		t.Error("the resolvable jurisdiction's rules were lost")
+	}
+}
+
+// TestAFoldNamesTheJurisdictionsItUsedBecauseTheVersionCannot.
+//
+// stricter() zeroes Jurisdiction and Version whenever two countries fold: a
+// fold is nobody's rule set, and stamping it with one country's number would
+// misname the rules a decision was taken under. That left a folded decision
+// with nothing to say about what judged it. The applied codes are the answer,
+// and they are the reason Strictest returns them at all.
+func TestAFoldNamesTheJurisdictionsItUsedBecauseTheVersionCannot(t *testing.T) {
+	Register(Rules{Jurisdiction: "fa", Version: 7, ReplyWindow: 30 * 24 * time.Hour})
+	Register(Rules{Jurisdiction: "fb", Version: 9, ReplyWindow: 365 * 24 * time.Hour})
+
+	got, applied, ok := Strictest("fa", "fb")
+	if !ok {
+		t.Fatal("two known jurisdictions reported nothing")
+	}
+	if got.Version != 0 || got.Jurisdiction != "" {
+		t.Errorf("the fold kept version %d and jurisdiction %q — it belongs to neither",
+			got.Version, got.Jurisdiction)
+	}
+	if !applied.Folded() {
+		t.Error("two contributing jurisdictions did not report as a fold")
+	}
+	if len(applied.Codes) != 2 || applied.Codes[0] != "fa" || applied.Codes[1] != "fb" {
+		t.Errorf("applied = %v, want both contributing jurisdictions in the order asked — "+
+			"this is the only record of which rules judged a folded decision", applied.Codes)
+	}
+	// And the fold is still the stricter answer, so the codes are not a
+	// consolation prize for having lost the rules.
+	if got.ReplyWindow != 30*24*time.Hour {
+		t.Errorf("reply window = %s, want the shorter one", got.ReplyWindow)
 	}
 }

--- a/backend/migrations/core/1789240000_a_decision_names_the_rules_it_was_judged_under.down.sql
+++ b/backend/migrations/core/1789240000_a_decision_names_the_rules_it_was_judged_under.down.sql
@@ -1,0 +1,9 @@
+-- The constraint first: dropping a column a CHECK still names fails.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE communication_decision
+  DROP CONSTRAINT IF EXISTS communication_decision_ruleset_shape;
+
+ALTER TABLE communication_decision
+  DROP COLUMN IF EXISTS ruleset_codes,
+  DROP COLUMN IF EXISTS ruleset_version;

--- a/backend/migrations/core/1789240000_a_decision_names_the_rules_it_was_judged_under.up.sql
+++ b/backend/migrations/core/1789240000_a_decision_names_the_rules_it_was_judged_under.up.sql
@@ -1,0 +1,38 @@
+-- A decision names the rules it was judged under.
+--
+-- messaging.Rules has said since it shipped that the version is "stamped onto
+-- every decision taken under it". Nothing stamped it. A subject asking which
+-- rules judged their message could be answered only by re-deriving them from
+-- whatever the code says today, which is the opposite of a record.
+--
+-- TWO COLUMNS, because one cannot answer it. A single jurisdiction's rule set
+-- carries its own version; a fold of two carries none, because
+-- messagingrules.stricter zeroes it rather than misnaming the fold with one
+-- country's number. ruleset_codes answers in both cases, and ruleset_version is
+-- meaningful exactly when one code applied.
+--
+-- NULL on both is a real answer and not a gap: an installation that declares no
+-- country resolves to no rules at all, and the consent requirement that binds
+-- everywhere is enforced by the marketing verdict, which runs before any pack.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE communication_decision
+  ADD COLUMN ruleset_version int,
+  ADD COLUMN ruleset_codes text[];
+
+-- A version without the codes that produced it names nothing, and codes with a
+-- version when more than one applied would claim a fold had a single version.
+--
+-- coalesce, because array_length answers NULL for an EMPTY array rather than 0,
+-- and a CHECK evaluating to NULL is accepted. Written as `= 1` alone, the
+-- constraint would have admitted a version alongside zero jurisdictions — the
+-- exact pair it exists to refuse.
+--
+-- An empty array is also refused outright: a decision that recorded no codes
+-- must say so with NULL, so "no jurisdiction applied" is one answer in the
+-- record instead of two that read the same.
+ALTER TABLE communication_decision
+  ADD CONSTRAINT communication_decision_ruleset_shape CHECK (
+    (ruleset_codes IS NULL OR coalesce(array_length(ruleset_codes, 1), 0) > 0)
+    AND (ruleset_version IS NULL OR coalesce(array_length(ruleset_codes, 1), 0) = 1)
+  );

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1768,6 +1768,7 @@ public.communication_decision.communication_decision_instruction_shape CHECK (((
 public.communication_decision.communication_decision_mode CHECK ((mode = ANY (ARRAY['observe'::text, 'warn'::text, 'enforce'::text])))
 public.communication_decision.communication_decision_phase CHECK ((phase = ANY (ARRAY['staging'::text, 'transmit'::text])))
 public.communication_decision.communication_decision_pkey PRIMARY KEY (id)
+public.communication_decision.communication_decision_ruleset_shape CHECK ((((ruleset_codes IS NULL) OR (COALESCE(array_length(ruleset_codes, 1), 0) > 0)) AND ((ruleset_version IS NULL) OR (COALESCE(array_length(ruleset_codes, 1), 0) = 1))))
 public.communication_decision.communication_decision_subject_kind CHECK (((subject_kind IS NULL) OR (subject_kind = ANY (ARRAY['contact'::text, 'lead'::text]))))
 public.communication_decision.communication_decision_subject_shape CHECK (((subject_kind IS NULL) = (subject_id IS NULL)))
 public.communication_decision.communication_decision_verdict CHECK ((verdict = ANY (ARRAY['allow'::text, 'deny'::text, 'review'::text])))
@@ -1786,6 +1787,8 @@ public.communication_decision.reason_code text NOT NULL gen=- def=-
 public.communication_decision.recipient_address text NOT NULL gen=- def=-
 public.communication_decision.requested_category text gen=- def=-
 public.communication_decision.resolved_category text NOT NULL gen=- def=-
+public.communication_decision.ruleset_codes text[] gen=- def=-
+public.communication_decision.ruleset_version integer gen=- def=-
 public.communication_decision.subject_id uuid gen=- def=-
 public.communication_decision.subject_kind text gen=- def=-
 public.communication_decision.suppression text gen=- def=-

--- a/backend/pkg/extension/messaging/messaging.go
+++ b/backend/pkg/extension/messaging/messaging.go
@@ -47,9 +47,12 @@ type Rules struct {
 	// taken, and those rules change, so the number is meant to be recorded
 	// rather than re-derived from whatever the code says today.
 	//
-	// DECLARED, NOT YET APPLIED: no decision records it. Held by
-	// TestEveryDeclaredMessagingObligationIsAppliedOrRecorded
-	// (backend/gates/messagingruleapplied_test.go), which carries the reason.
+	// APPLIED: consent.rulesetStamp writes it onto every staging and transmit
+	// decision, beside the codes that produced it. A fold of two jurisdictions
+	// carries NO version — Strictest zeroes it rather than misnaming the fold
+	// with one country's number — and the recorded codes are what answers in
+	// that case. Held by TestEveryDeclaredMessagingObligationIsAppliedOrRecorded
+	// (backend/gates/messagingruleapplied_test.go).
 	Version int
 
 	// ReplyWindow is how long an inbound message keeps making a reply a reply


### PR DESCRIPTION
A jurisdiction pack declares a version, and `messaging.Rules` has said since it shipped that the number is "stamped onto every decision taken under it". Nothing stamped it. The register in the messaging-rule gate carried the gap, with the reason: the decision table had no column for it.

The promise is to a subject. Somebody asking a year later which rules judged their message is owed an answer from the record. Re-deriving it from whatever the packs say today answers a different question, because packs change, which is the whole reason a version exists.

## Two columns, because one cannot answer it

A single jurisdiction's rule set carries its own version. A fold of two carries none: the fold deliberately clears the version rather than misnaming itself with one country's number. So the recorded codes are what answers in both cases, and the version is the refinement available when exactly one jurisdiction applied.

Both null is a real answer. An installation that declares no country resolves to no rules at all.

## A correction to what the fold returned

`Strictest` returned the codes it could not resolve, while two comments in the tree claimed a decision records "the codes it folded". Nothing could do that, because no function returned them. It now returns which jurisdictions actually contributed, kept separate from the unresolvable ones. A code no pack declares bound nothing and must not appear as though it judged the message.

## The ruleset is read before any decision is taken

Codex found this on review. The stamp was read in the function that writes the rows, after the decisions were made. An installation changing its declared country mid-send would have had its frequency ceiling applied under the old pack while the row named the new one. The country reads are separate unlocked statements, so sharing a transaction does not make two of them agree. Reading once, up front, is what does.

## One lookup door

Resolution stays a single function rather than gaining a wider sibling. The gate that polices this pins the lookup by name and scans for reads through it, so a second entry point would have made those reads invisible to it.

## Gates

The messaging-rule register entry is removed, which is the point of that register. The new codes column is accounted for in the Art. 17 redaction baseline: it holds the installation's own country codes, never the subject's.

Full backend gate green. Integration lanes green for consent, migrations and compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records which ruleset judged each messaging decision, so a subject asking later which rules judged their message has an answer from the record instead of whatever the packs say today.

**Migration**
- Adds `ruleset_version` and `ruleset_codes` to `communication_decision`, NULL when no country is declared and the version only when one jurisdiction judged.
- Enforces via CHECK that a version never appears without exactly one recorded code, and that "no jurisdiction applied" has one spelling: NULL.
- The new columns hold the installation's declared country codes, never the subject's, and are scoped out of Art. 17 erasure.

**Bug Fixes**
- Reads the ruleset once, before decisions are taken, so the recorded pack is the one that actually judged — a country change mid-send previously named a pack that applied nothing.
- `messagingrules.Strictest` now returns the jurisdictions that contributed instead of the ones it couldn't resolve, so folded decisions have codes to record.

<sup>Written for commit a6bb8fd14702d5d2262a5bbf483db330839c86cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorization decisions now record the ruleset version and jurisdictions used to evaluate each staging and transmission decision.
  * Decisions involving multiple jurisdictions retain all contributing jurisdictions, while single-jurisdiction decisions also record the applicable version.
  * Recorded ruleset details remain available after erasure, preserving the legal basis for past decisions.
* **Data Integrity**
  * Validation prevents incomplete or inconsistent ruleset information from being stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->