### PR TITLE
fix(gates): the lead object's read half has a fitness function

### DIFF
--- a/backend/gates/edgereaders_test.go
+++ b/backend/gates/edgereaders_test.go
@@ -44,55 +44,37 @@ package gates
 
 import (
 	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
 	"path"
-	"path/filepath"
-	"regexp"
-	"slices"
-	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
-// relationshipReadLiteral matches a SQL string literal that reads the
-// relationship table by name.
-//
-// The pattern is gatekit's, and it is shared rather than spelled here because a
-// matcher that stops seeing this tree's SQL finds nothing to object to and reads
-// exactly like a clean tree. Its boundary cases are tested where it lives.
-var relationshipReadLiteral = gatekit.TableReadPattern(edgeTable)
-
-// edgeTable is the table this census is about, named once so the pattern above
-// and the failure messages below cannot disagree about the subject.
+// edgeTable is the table this census is about, named once so the pattern and
+// the failure messages below cannot disagree about the subject.
 const edgeTable = "relationship"
 
-// edgeGateSeeds are the spellings that ARE the edge's read admission, anywhere.
-// Only EdgeReadScope qualifies: it is the one that takes the object gate.
-var edgeGateSeeds = []string{"EdgeReadScope"}
-
-// rowHalfSeeds are the row-scope spellings. They bound WHICH edges, and answer
-// nothing about whether the caller may read edges at all — so on their own they
-// are the INVERTED form of the defect this gate exists to catch, and a compose
-// read taking the conjunction without the gate must not read green.
+// relationshipGate is the subject: the edge table, what counts as its read
+// admission, and the row-scope spellings that satisfy only inside the packages
+// owning the object's own surface.
 //
-// They still satisfy inside the packages that own the object's own surface,
-// where the object gate is asked at the store entry point and these are the
-// clause that entry point composes.
-var rowHalfSeeds = []string{"RelationshipEndpointScope", "EnsureRelationshipVisible"}
-
-// rowHalfOwners are the packages where a row-half spelling alone is enough:
-// contacts owns the relationship surface and gates every store entry point on it,
-// and auth is where the gate itself lives.
-var rowHalfOwners = []string{"internal/modules/contacts", "internal/platform/auth"}
-
-// requireCall matches a call that asks the object gate under any of this
-// tree's spellings — auth.Require, or a package-local wrapper such as
-// contact360's requireRead. Paired with the object name in the same function
-// body, it is the older form of the admission and still counts.
-var requireCall = regexp.MustCompile(`^[Rr]equire[A-Za-z]*$`)
+// EdgeReadScope is the gate seed, because it takes the object gate. The row-half seeds bound WHICH edges and answer nothing
+// about whether the caller may read edges at all — alone they are the INVERTED
+// form of the defect this gate exists to catch, and a compose read taking the
+// conjunction without the gate must not read green. contacts owns the
+// relationship surface and gates every store entry point on it; auth is where
+// the gate itself lives.
+//
+// The literal pattern is gatekit's, shared rather than spelled here because a
+// matcher that stops seeing this tree's SQL finds nothing to object to and
+// reads exactly like a clean tree. Its boundary cases are tested where it lives.
+var relationshipGate = objectGate{
+	object:        edgeTable,
+	literal:       gatekit.TableReadPattern(edgeTable),
+	gateSeeds:     []string{"EdgeReadScope"},
+	rowHalfSeeds:  []string{"RelationshipEndpointScope", "EnsureRelationshipVisible"},
+	rowHalfOwners: []string{"internal/modules/contacts", "internal/platform/auth"},
+}
 
 // predicateEdgeReads: the edge appears only inside a JOIN or EXISTS that
 // selects or routes records the caller is separately gated on, and nothing
@@ -233,18 +215,19 @@ var edgeReaderScope = gatekit.Scope{
 }
 
 func readsRelationshipTable(filePath string, file *ast.File) bool {
-	return gatekit.FileReadsTable(filePath, file, relationshipReadLiteral)
+	return gatekit.FileReadsTable(filePath, file, relationshipGate.literal)
 }
 
 func TestEveryReaderOfTheRelationshipTableCarriesTheEdgeGateOrAVerdict(t *testing.T) {
 	t.Parallel()
 	files := edgeReaderScope.Files(t)
-	gated := gatedFunctionsByPackage(t, files)
+	gated := relationshipGate.gatedFunctionsByPackage(t, files)
+	consts := constantTable{}
 
 	var satisfied int
 	for _, parsed := range files {
 		pkg := path.Dir(parsed.Path)
-		for _, site := range relationshipReadSites(parsed) {
+		for _, site := range relationshipGate.readSites(parsed, consts.of(t, pkg)) {
 			subject := parsed.Path
 			if site.function != "" {
 				subject += ":" + site.function
@@ -255,9 +238,9 @@ func TestEveryReaderOfTheRelationshipTableCarriesTheEdgeGateOrAVerdict(t *testin
 			// per-function precisely to prevent.
 			carriesGate := site.holdsGate || callsAGatedHelper(site.calls, gated[pkg])
 			if site.function == "" {
-				carriesGate = site.holdsGate || fileHoldsAGatedFunction(t, parsed, gated[pkg])
+				carriesGate = site.holdsGate || relationshipGate.fileHoldsAGatedFunction(t, parsed, gated[pkg], consts.of(t, pkg))
 			}
-			verdict := verdictFor(t, subject)
+			verdict := verdictIn(t, subject, edgeVerdicts)
 
 			switch {
 			case carriesGate && verdict != "":
@@ -296,305 +279,14 @@ func TestEveryReaderOfTheRelationshipTableCarriesTheEdgeGateOrAVerdict(t *testin
 	deferredEdgeReads.AssertAllMatched(t)
 }
 
-// verdictFor names the declaration a subject sits in, and refuses one sitting
-// in two: the verdict IS the declaration, so a subject with two of them has no
-// verdict at all.
-func verdictFor(t *testing.T, subject string) string {
-	t.Helper()
-	var found []string
-	for _, set := range []struct {
-		name    string
-		waivers *gatekit.Waivers[string]
-	}{
-		{"predicate", predicateEdgeReads},
-		{"lifecycle", lifecycleEdgeReads},
-		{"ruled", ruledEdgeReads},
-		{"deferred", deferredEdgeReads},
-	} {
-		// A file-keyed verdict answers for every site in the file; a
-		// function-keyed one answers for its own site only. Both are asked,
-		// because a lifecycle FILE and a deferred FUNCTION are both real shapes.
-		if set.waivers.Waived(t, subject) || set.waivers.Waived(t, fileOf(subject)) {
-			found = append(found, set.name)
-		}
-	}
-	if len(found) > 1 {
-		t.Errorf("%s carries %s verdicts at once: which declaration a read sits in IS its verdict, "+
-			"so two of them is none", subject, strings.Join(found, " and "))
-		return ""
-	}
-	if len(found) == 1 {
-		return found[0]
-	}
-	return ""
-}
-
-func fileOf(subject string) string {
-	if idx := strings.LastIndex(subject, ":"); idx >= 0 {
-		return subject[:idx]
-	}
-	return subject
-}
-
-// site is one relationship read: the function that holds it, empty for a
-// package-level SQL fragment, the first line of the SQL for the report, and
-// whether that function's OWN body takes the admission.
-//
-// holdsGate is answered from the declaration itself rather than by looking the
-// function up by name, and that distinction is the whole reason this field
-// exists. *Store and Handlers in one module routinely spell the same method
-// names — contacts has both a Store.RemoveProjectStakeholder and a
-// Handlers.RemoveProjectStakeholder — so a by-name index lets one answer for
-// the other, and which one wins is Go map iteration order. rbacgate_test.go
-// says so in its own header, having been bitten by exactly this. The name index
-// below is still used, but only to reach a gate in a SIBLING function, where a
-// collision can merely be optimistic rather than wrong.
-type site struct {
-	function  string
-	sql       string
-	holdsGate bool
-	// calls is what this declaration calls, so a gate reached through a helper
-	// in a sibling file resolves without consulting this declaration's name.
-	calls map[string]bool
-}
-
-func callsAGatedHelper(calls map[string]bool, gated map[string]bool) bool {
-	for name := range calls {
-		if gated[name] {
-			return true
-		}
-	}
-	return false
-}
-
-func pkgOf(filePath string) string { return path.Dir(filePath) }
-
-func relationshipReadSites(parsed gatekit.ParsedFile) []site {
-	var sites []site
-	for _, decl := range parsed.File.Decls {
-		reads := gatekit.DeclReads(decl, relationshipReadLiteral)
-		if len(reads) == 0 {
-			continue
-		}
-		refs := referencesIn(decl)
-		sites = append(sites, site{
-			function: reads[0].Function, sql: gatekit.FirstLineOf(reads[0].SQL),
-			holdsGate: holdsSeedGate(refs, pkgOf(parsed.Path)), calls: refs.calls,
-		})
-	}
-	return sites
-}
-
-// gatedFunctionsByPackage resolves, per package directory, every function that
-// reaches an edge-gate spelling — directly, or through another function in the
-// same package. Transitive because this tree routinely splits a read across the
-// function holding the SQL and the helper building its predicate (company360's
-// edgeScope, meetingbrief's seatJoinPredicate), and a gate asking only about
-// direct calls would report the reader red while its admission sits in the file
-// next door.
-func gatedFunctionsByPackage(t *testing.T, files []gatekit.ParsedFile) map[string]map[string]bool {
-	t.Helper()
-	// The WHOLE package, not only the files that read the table. The admission
-	// this tree writes routinely lives in a sibling file that holds no SQL of
-	// its own — company360's edgeScope sits in sections.go while the three reads it
-	// gates are in graphreads.go and contacts.go — so a resolution seeded from
-	// the subject files alone reports gated code as ungated, which costs the
-	// gate its credibility faster than a miss does.
-	bodies := map[string]map[string][]references{}
-	for _, parsed := range files {
-		pkg := path.Dir(parsed.Path)
-		if bodies[pkg] != nil {
-			continue
-		}
-		bodies[pkg] = packageFunctionReferences(t, pkg)
-	}
-
-	// A name is gated when ANY declaration spelling it is — a union, never an
-	// overwrite. Optimistic where two receivers share a method name, and
-	// deliberately so: this index only ever answers "is there a gated helper
-	// called X in this package", and the site's own declaration has already
-	// been asked directly, so the optimism cannot excuse an ungated read whose
-	// same-named neighbour happens to be gated.
-	gated := map[string]map[string]bool{}
-	for pkg, funcs := range bodies {
-		gated[pkg] = map[string]bool{}
-		for name, decls := range funcs {
-			for _, refs := range decls {
-				if holdsSeedGate(refs, pkg) {
-					gated[pkg][name] = true
-					break
-				}
-			}
-		}
-		for grew := true; grew; {
-			grew = false
-			for name, decls := range funcs {
-				if gated[pkg][name] {
-					continue
-				}
-				for _, refs := range decls {
-					for callee := range gated[pkg] {
-						if refs.calls[callee] {
-							gated[pkg][name] = true
-							grew = true
-							break
-						}
-					}
-					if gated[pkg][name] {
-						break
-					}
-				}
-			}
-		}
-	}
-	return gated
-}
-
-// holdsSeedGate reports whether a function body IS the admission: one of the
-// platform spellings, or the older object-gate form — a Require-shaped call
-// somewhere in a body that also names the object. The pair is what makes it the
-// edge's gate and not some other object's.
-func holdsSeedGate(refs references, pkg string) bool {
-	for _, seed := range edgeGateSeeds {
-		if refs.calls[seed] {
-			return true
-		}
-	}
-	// The older form: a Require-shaped call taking the object as an ARGUMENT.
-	// Read off the call rather than from the body at large, because a body
-	// holding RequireHuman(ctx) and, separately, an unrelated "relationship"
-	// string — an entity-type constant, a table name in a comment's sibling
-	// literal — would otherwise vouch for itself.
-	if refs.gatesTheEdge {
-		return true
-	}
-	if !slices.Contains(rowHalfOwners, pkg) {
-		return false
-	}
-	for _, seed := range rowHalfSeeds {
-		if refs.calls[seed] {
-			return true
-		}
-	}
-	return false
-}
-
-// references is what a function CALLS and what string literals it holds. Read
-// off the syntax rather than the source text, so a gate spelling cannot be
-// matched inside a comment that merely discusses it — and calls only, because a
-// parameter or local variable that happens to share a gated function's name is
-// not a call to it.
-type references struct {
-	calls    map[string]bool
-	literals map[string]bool
-	// gatesTheEdge records a Require-shaped call that takes "relationship" as
-	// one of its OWN arguments. Kept as a resolved fact rather than as two
-	// facts a reader has to pair up, because pairing them at the body level is
-	// what let RequireHuman(ctx) beside an unrelated "relationship" literal
-	// vouch for a read.
-	gatesTheEdge bool
-}
-
-// packageFunctionReferences parses every non-test source in one package
-// directory and returns what each function mentions.
-//
-// The directory is read and its files parsed one at a time rather than through
-// parser.ParseDir, which is deprecated for a reason that would bite here: it
-// does not consider build tags when grouping files into packages, and several
-// of the directories this walks hold tagged files.
-func packageFunctionReferences(t *testing.T, pkg string) map[string][]references {
-	t.Helper()
-	// The path is relative to the module root, which is this test's working
-	// directory: package gates sits one below it and TestMain chdirs up.
-	dir := filepath.FromSlash(pkg)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("reading %s to resolve its edge gates: %v", pkg, err)
-	}
-	fset := token.NewFileSet()
-	refs := map[string][]references{}
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		file, parseErr := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
-		if parseErr != nil {
-			t.Fatalf("parsing %s/%s to resolve its edge gates: %v", pkg, name, parseErr)
-		}
-		for fn, decls := range functionBodies(gatekit.ParsedFile{File: file}) {
-			refs[fn] = append(refs[fn], decls...)
-		}
-	}
-	return refs
-}
-
-func functionBodies(parsed gatekit.ParsedFile) map[string][]references {
-	bodies := map[string][]references{}
-	for _, decl := range parsed.File.Decls {
-		fn, isFunc := decl.(*ast.FuncDecl)
-		if !isFunc {
-			continue
-		}
-		bodies[fn.Name.Name] = append(bodies[fn.Name.Name], referencesIn(fn))
-	}
-	return bodies
-}
-
-func referencesIn(node ast.Node) references {
-	refs := references{calls: map[string]bool{}, literals: map[string]bool{}}
-	ast.Inspect(node, func(n ast.Node) bool {
-		switch typed := n.(type) {
-		case *ast.CallExpr:
-			if name := calleeName(typed); requireCall.MatchString(name) && namesTheEdge(typed) {
-				refs.gatesTheEdge = true
-			}
-			// calleeName is retentionscope_test.go's, shared rather than
-			// respelled: "the called function's own name, ignoring any
-			// qualifier" is the same question here, and auth.EdgeReadScope and
-			// a local edgeScope both need to resolve to what they call.
-			if name := calleeName(typed); name != "" {
-				refs.calls[name] = true
-			}
-		case *ast.BasicLit:
-			if text, isString := gatekit.LiteralText(typed); isString {
-				refs.literals[text] = true
-			}
-		}
-		return true
-	})
-	return refs
-}
-
-// fileHoldsAGatedFunction answers for a package-level SQL fragment, which has
-// no declaration of its own to ask: the file that declares it is judged as a
-// whole, as restrictedreaders_test.go judges one.
-func fileHoldsAGatedFunction(t *testing.T, parsed gatekit.ParsedFile, gated map[string]bool) bool {
-	t.Helper()
-	for name, decls := range functionBodies(parsed) {
-		if gated[name] {
-			return true
-		}
-		for _, refs := range decls {
-			if holdsSeedGate(refs, pkgOf(parsed.Path)) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// namesTheEdge reports whether a call passes the relationship object as one of
-// its own arguments — auth.Require(ctx, "relationship", …) and contact360's
-// requireRead(ctx, "relationship") alike. Asked of the CALL rather than of the
-// body, so an unrelated "relationship" literal elsewhere in a function cannot
-// pair with an unrelated Require-shaped call to vouch for a read.
-func namesTheEdge(call *ast.CallExpr) bool {
-	for _, arg := range call.Args {
-		text, isString := gatekit.LiteralText(arg)
-		if isString && text == edgeTable {
-			return true
-		}
-	}
-	return false
+// edgeVerdicts are the four declarations, in the order a reader meets them
+// above. Named as one list because "which declaration a read sits in IS its
+// verdict" is only true if every declaration is asked — a set left off this
+// list would silently stop counting as a verdict and start reading as a
+// finding, which is the one direction this census must not fail in.
+var edgeVerdicts = []namedVerdict{
+	{"predicate", predicateEdgeReads},
+	{"lifecycle", lifecycleEdgeReads},
+	{"ruled", ruledEdgeReads},
+	{"deferred", deferredEdgeReads},
 }

--- a/backend/gates/leadreaders_test.go
+++ b/backend/gates/leadreaders_test.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// `lead` is an RBAC object, and until this gate nothing held the object half of
+// that anywhere outside the module that owns it.
+//
+// A lead is somebody who has NOT agreed to be a customer: a form fill, a list
+// purchase, a conference badge scan. The grant exists because a seat with no
+// business in the top of the funnel should not be able to read one — names,
+// addresses, employers and a score saying how promising the company thinks
+// they are.
+//
+// Two gates cover the compose tier and both say in their own words that they do
+// not cover this: rbacgate_test.go judges only exported methods on a module's
+// *Store or *Service, and composerowscope_test.go covers ROW scope and refuses
+// to count object admission as satisfaction. Between them the object half had
+// no fitness function outside internal/modules/contacts.
+//
+// So every read of the lead table either asks the object gate, or says which
+// kind of read it is that does not need to. The shape, the discriminator and
+// the three verdicts are edgereaders_test.go's — this is the second census over
+// objectGate, and the walk is shared rather than copied.
+
+import (
+	"go/ast"
+	"path"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// leadTable is the table this census is about. Both the pattern and the failure
+// messages below read it, so neither can drift from the subject.
+const leadTable = "lead"
+
+// leadGate is the subject. No platform spelling gateSeeds it: unlike the edge,
+// a lead has no bespoke admission helper — `auth.Require(ctx, "lead", …)` IS
+// the object gate, and objectGate reads that off the call.
+//
+// No row-half allowance either, and that is a finding about the tree rather
+// than an omission: contacts asks auth.Require at its lead entry points, so the
+// transitive resolution reaches the object gate itself and never needs the row
+// clause to stand in for it.
+var leadGate = objectGate{
+	object:  leadTable,
+	literal: gatekit.TableReadPattern(leadTable),
+}
+
+// predicateLeadReads: the lead table appears only inside a JOIN or EXISTS that
+// selects or routes records the caller is separately gated on, and nothing
+// about the lead reaches the response. The test that puts a read here rather
+// than in the gated set: removing the lead condition could only WIDEN the
+// result the caller already sees.
+var predicateLeadReads = gatekit.Waive(map[string]string{
+	"internal/modules/activities/responsemetrics.go":                   "the lead arm of \"is this a SALES thread\" in the first-response metrics: `%[3]s` renders workingLeadPredicate — a LIFECYCLE test (new/contacted/engaged, unarchived) and not a row-scope clause — so the arm only decides which inbound activities are counted. What reaches the caller is a count and a median over their own activity scope, never a lead column. Removing the arm would widen the set measured, never narrow it",
+	"internal/modules/activities/waitingsql.go":                        "two arms, both off the GATED link join: the same workingLeadPredicate sales test as responsemetrics.go, and the ownership walk's `LEFT JOIN lead ownerLead`, whose only projection is owner_id into a four-way COALESCE answering who owns a waiting thread. A USER id, not lead content, and only for threads the caller's own activity scope already admits. Removing either arm widens the worklist or leaves a thread unowned; neither narrows what a caller may see",
+	"internal/modules/activities/lasttouch.go":                         "the lead arm of the cold-queue selector, the twin of the stakeholder arm beside it that edgereaders_test.go files the same way: the lead's status and age decide which QUEUE ENTRIES are stale enough to surface, and no lead column reaches the caller. Removing the arm would widen the queue, never narrow it. The cost is that a queue entry's presence weakly reflects that a lead of the caller's is still in the working part of its lifecycle",
+	"internal/modules/consent/gate.go:grantedForLead":                  "the lead arm of the consent question, asked of an address the CALLER ALREADY NAMED as the recipient of a send. One boolean leaves it — is there a granted, DOI-confirmed purpose for this address — consumed inside the engine to authorize or refuse the message. No lead id, name, title or company reaches anyone. Removing the arm would refuse a lawful send rather than widen one, which is the reverse of the usual risk here, and the dispatching worker holds the system principal because no human is present at transmit time",
+	"internal/modules/consent/authorizelead.go:resolveLead":            "names the one live lead behind that same caller-supplied address, so the grant above can be looked up against a subject. TWO live leads answer `found=false` rather than a guess, which is the whole point of the LIMIT 2: a silent pick would attribute one subject's consent to another. The id it resolves is consumed inside the engine; what the caller is told is authorized or not, and why",
+	"internal/modules/consent/withdrawalmint.go:bindWithdrawalSubject": "stamps the subject a one-click unsubscribe link acts for, resolved from the address the send is going TO. A contact wins over a lead, and ambiguity leaves the credential unbound rather than stamping one subject's id on another's opt-out link — the credential still works, because it names the address. Nothing about the lead reaches the recipient or the sender: the token is opaque, and the mint runs on the dispatch path under the system principal",
+})
+
+// lifecycleLeadReads: cascades, merges, lawful-processing sweeps, capture and
+// enrichment resolution, seeders. Each is gated by the WRITE it belongs to, or
+// runs as PrincipalSystem — which auth.Require short-circuits outright
+// (platform/auth/rbac.go), so the gate would admit them anyway and the entry
+// records why asking was never the point.
+var lifecycleLeadReads = gatekit.Waive(map[string]string{
+	"internal/modules/privacy/sar.go:subjectReach":                          "the subject-access export must enumerate every lead that was promoted into this contact, or into a record later merged into them, or the export it produces is incomplete — a lawful-processing defect. It reads ids and nothing else, to reach the lead-keyed proof A6 leaves on the lead rather than on the survivor. Runs as the system principal on a request a human already authorised. The cost is that this path resolves one subject's lead twins with no per-caller gate",
+	"internal/modules/privacy/sarsections.go:sarRecordSections":             "the lead record AS the export: every column of it is what Art. 15 owes the data subject about themselves, so a grant that narrowed it would make the answer wrong rather than safer. Runs as the system principal on a request a human already authorised, and the rows it reads are already bounded to the subject's own lead twins. The cost is unlimited lead reach for the export, bounded by that subject binding",
+	"internal/modules/privacy/sarsections.go:sarProvenanceSections":         "the handoff provenance arm of the same export, reaching the subject's leads through the same promoted_contact_id join for the same reason. The cost is the same",
+	"internal/modules/privacy/erasuretimeline.go:deleteSubjectHandoffs":     "the erasure's handoff arm names sdr_handoff_event and sdr_handoff explicitly rather than leaving them to a cascade, so both this census and the next reader auditing what Art. 17 destroys can see them. The lead subquery only RESOLVES which handoffs belong to the subject, by promotion; no lead column leaves the statement and the statement is a DELETE. Respecting a caller's grants here would under-delete, which is a worse defect than the disclosure this census fixes",
+	"internal/modules/privacy/retention_leadrecord.go:anonymizeLead":        "the retention scrub reads the lead's email FOR UPDATE so a standing objection is detached onto the address it applies to before the UPDATE beside it nulls that address — read after the scrub and the objection is orphaned, and a re-capture from the same address comes back mailable. Runs as the system principal on the retention sweep; the address never leaves the transaction that erases it. The cost is that the sweep reads one lead's address with no per-caller gate, which is the whole of what makes the erasure durable",
+	"internal/modules/privacy/erasure_selectors.go:notTransitivelyHeld":     "the legal-hold exclusion reads lead.legal_hold to REFUSE erasing an activity still held through a lead. Its only effect is to keep a row, never to disclose one: no lead column leaves the predicate and the statement it joins is an erase bound. A selector that could not see a lead would delete a row under hold, which is the failure this arm exists to prevent",
+	"internal/modules/privacy/retentionrestricted.go:notHeldThroughAnyLink": "the same legal-hold exclusion, spelled for the retention selectors: it asks whether a linked lead holds the row and, if so, leaves it alone. Same shape, same cost — a lead it could not see would be a row deleted under hold",
+	"internal/platform/database/storekit/leadidentity.go:liveLeadBy":        "the exclusive-key dedupe probe behind LiveLeadByEmail and LiveLeadByLinkedInURL: it answers whether a live lead already holds this address or profile, so a write can refuse a duplicate rather than mint one. Its predicate is a fixed literal chosen by the two exported wrappers and never caller text. Both callers are writes — contacts' gated lead create and update paths, and capture's lead sink under the system principal — and what leaves is an id that becomes a conflict, never a lead column",
+	"internal/modules/activities/followupownership.go:leadOwner":            "reads the lead's current owner so the follow-up task it owns can be reassigned to match. It is a workflow handler answering lead.updated on the bus, under the principal the workflow runner binds, and the write it leads to is on this module's OWN table. A direct read rather than a call into contacts because a module never imports a sibling",
+	"internal/modules/search/embedgen.go":                                   "the per-entity source text the embedding lane indexes, mirroring each record's search_tsv columns so the vector and lexical lanes agree about one text. It runs on the indexing path under the system principal, and what it produces is a vector on the index row; the SEARCH that later reads that row carries the caller's own scope. A grant asked here would leave a lead unindexed for everyone rather than hidden from one reader",
+	"internal/modules/privacy/retentionselectors.go":                        "the retention selectors themselves, including `lead/unconverted`: they select the IDS a retention rule is due to act on, under the system principal on the sweep's schedule. No lead column reaches any caller — the output is a delete or scrub bound — and a selector that respected a caller's grants would under-delete, which is the defect the sweep exists to prevent",
+})
+
+// calleeGatedLeadReads: a private helper inside the module that OWNS the lead
+// object, whose every caller asks the object gate at the store entry point
+// above it.
+//
+// A verdict of its own rather than folded into lifecycle, which is where
+// edgereaders_test.go puts the same shape. The edge's helpers are cascades and
+// sweeps and the word fits them; the lead surface is mostly one store, and
+// calling a plain single-row read "lifecycle" would empty that word of meaning
+// in the census where it matters most.
+//
+// What each entry has to establish, and what the reason therefore names: EVERY
+// caller of this function asks auth.Require(ctx, "lead", …). One that does not
+// makes the entry false, and the entry is where a reviewer checks it — this
+// census resolves gates FORWARD (a function that reaches a gate) and cannot
+// resolve them caller-ward, because the call graph is by NAME and a gated
+// Store.X would then vouch for an ungated Handlers.X. rbacgate_test.go's header
+// records being bitten by exactly that.
+var calleeGatedLeadReads = gatekit.Waive(map[string]string{
+	"internal/modules/contacts/lead_read.go:readLead":                          "the shared single-row lead read, and the spine every lead surface goes through. Its eight callers are DemoteLead, PromoteLead and its preview, MergeLead, CreateLead/CreateLeadTx, UpdateLead and GetLead — each of which asks auth.Require for the lead object at its own entry, and most of which take a row probe as well. The cost is that the spine trusts its callers rather than re-asking eight times in one transaction",
+	"internal/modules/contacts/demote.go:promotedContactOf":                    "reads which contact a lead was promoted into, so DemoteLead can lock that contact BEFORE the lead — the order MergeContact takes, and taking it in the other order is the whole of a deadlock. Its one caller asks auth.Require(lead, update) and auth.EnsureWritable on the lead before reaching it, which its own doc records as owed one frame earlier precisely because the lock moved one frame earlier. No lead column beyond that pointer leaves the function",
+	"internal/modules/contacts/demote.go:isSharedByOthers":                     "the guard that refuses archiving a promoted contact something else still depends on: it asks whether another lead points at the same contact, and its answer is the refusal. Reached only through unwindContact from DemoteLead, past the lead's own Require and EnsureWritable and the contact's. No lead column reaches the caller, only a boolean, and that boolean only ever KEEPS a record",
+	"internal/modules/contacts/lead.go:replayedLead":                           "the source-key idempotency probe: a create carrying the same source_system/source_id answers the standing lead instead of minting a second. It takes the ROW half itself — auth.VisibleTo on the lead it found, answering ErrConflict rather than the row when the caller may not see it — and its two callers, CreateLead and CreateLeadTx, each ask auth.Require(lead, create) first. The census cannot see VisibleTo because it is not Require-shaped, which is what this entry records",
+	"internal/modules/contacts/leaddedupe.go:fuzzyLead":                        "the near-match scan a lead write owes its review queue: it reads live leads to find the one this write reads like. Reached only through recordLeadNearMatch, from CreateLead, CreateLeadTx and UpdateLead, each of which asks auth.Require for the lead object at its entry. What it produces is a review row inside the caller's own transaction, not a response",
+	"internal/modules/contacts/leadmerge.go:readLeadMergeState":                "one end of a lead merge, passed to mergePair as a function value from mergeLeadTx. Its only caller is MergeLead, which asks auth.Require(lead, update) and then takes the pair lock. The archived branch answers the merge pointer and ErrNotFound, which is what makes a merged-away id resolve to where it went",
+	"internal/modules/contacts/leadrecompute.go:recomputeLeadScoreTx":          "the shared §3 recompute inside an open transaction. Its three callers — RecomputeLeadScore, SetLeadManualSignal and UpdateLead's override-clear path — each ask auth.Require(lead, update) and take their own row probe; the doc on RecomputeLeadScore says why the LIVE probe is at the entry point and not here. Nothing leaves the function but a written score",
+	"internal/modules/contacts/leadscorehistory.go:appendOverrideScoreHistory": "records a Commercial Judgement override as its own point in the score series, reading the previous entry so the machine numbers are carried forward rather than re-derived. Its one caller is UpdateLead, past auth.Require(lead, update) and the lead's own row probe. Its only effect is a history row on the lead the caller just changed",
+	"internal/modules/contacts/leadrouting.go:ownerCapacity":                   "counts each candidate owner's open lead load so routing can place work under the cap. Reached only from RouteLead, which asks auth.Require(lead, update) and holds the routing advisory lock. What it answers is a number per USER and never a lead column — and the eligibility half deliberately says what auth.EnsureAssignee says on the manual path, so the machine cannot place work a human could not have placed",
+	"internal/modules/contacts/leadsla.go:recordFirstResponseTx":               "the one spelling of what counts as a lead's first response, shared by the outbox subscriber and the breach scan so the two cannot disagree about it. It takes the ROW half itself (auth.EnsureWritableLive on the lead) and its named caller RecordLeadFirstResponse asks auth.Require(lead, update); the breach scan reaches it holding the lead row it is about to judge. It reads one timestamp, to refuse moving a stamp already set",
+	"internal/modules/automation/automations_preview.go:leadPreviewDefs":       "the catalog entries whose blast-radius preview ranges over the lead table, including the count of leads created in the window. resolvePreviewRecipe asks auth.Require(ctx, def.table, principal.ActionRead) before running any of them, and def.table is \"lead\" for exactly these — the object arrives as a struct field, which is why no static reader can see the gate from the definition",
+	"internal/modules/contacts/mergeface.go:readLeadFaces":                     "the label and detail line a merge card shows for each side of a pair. Its only caller is DescribeForMerge, which asks auth.Require(entityType, read) — the object name arrives as a parameter, which is why no static reader can see the gate from here — and then narrows the ids through auth.VisibleSubset, so a lead the caller cannot see is absent before this runs",
+})
+
+// ruledLeadReads: a DISCLOSING read the product has ruled needs no lead grant.
+var ruledLeadReads = gatekit.Waive(map[string]string{})
+
+// notTheLeadTable: the read pattern matched SQL's OWN `lead()` window function
+// rather than the table named lead.
+//
+// gatekit.TableReadPattern counts an opening paren as a delimiter on purpose —
+// `FROM rollup($1)` is a read of the rollup, and a census that stopped seeing a
+// relation the day it became set-returning would be under-recognising. That
+// same rule makes `extract(epoch FROM lead(h.changed_at) OVER …)` look like a
+// read, and only for a table whose name is also a SQL keyword.
+//
+// Declared rather than fixed in gatekit: narrowing the shared pattern to refuse
+// `FROM <name>(` would cost every other census the set-returning case, to spare
+// one table one entry. Over-recognition answered by a named declaration is the
+// safe direction; the alternative is a pattern that reads green over a real
+// read somewhere else.
+var notTheLeadTable = gatekit.Waive(map[string]string{
+	"internal/modules/deals/closedatesweep.go:stageVelocityDays": "`extract(epoch FROM lead(h.changed_at) OVER (PARTITION BY h.deal_id ORDER BY h.changed_at, h.id) - h.changed_at)` — the window function that reads the NEXT row's value, measuring how long a deal sat in each stage. The statement never names the lead table",
+})
+
+// deferredLeadReads: a DISCLOSING read that is still ungated, each naming the
+// issue that will close it.
+var deferredLeadReads = gatekit.Waive(map[string]string{
+	"internal/compose/weekly/weeklycounts.go:countWeekLeads": "the week's routed / answered-in-target / breached counts. It takes the ROW half (auth.ScopeClauseFor on lead) and never the object half, so a seat whose role grants no lead read is still answered lead figures for its own rows. Deferred rather than gated because the answer turns on what a weekly review SAYS to such a seat: failing the whole review is fail-closed and breaks a report whose other blocks are fine, and zeroed counts read as failure at work nobody asked of them — which this file's own doc names as the thing it must not print. #5466",
+	"internal/compose/weekly/weeklyscorecard.go:hasLeads":    "whether the rep carried a funnel at all, the presence question the lead block hangs off. Same row-half-only shape and the same open question as countWeekLeads beside it. #5466",
+	"internal/compose/weekly/weeklyscorecard.go:scoreLeads":  "the lead block itself. It already models the absent case — an absent block IS the answer for a rep who carried no leads — so it is the one of the three a refusal could be folded into cleanly; it is deferred with the other two because a review whose block is omitted and whose counts are not would be worse than either. #5466",
+})
+
+var leadVerdicts = []namedVerdict{
+	{"predicate", predicateLeadReads},
+	{"lifecycle", lifecycleLeadReads},
+	{"callee-gated", calleeGatedLeadReads},
+	{"not-the-table", notTheLeadTable},
+	{"ruled", ruledLeadReads},
+	{"deferred", deferredLeadReads},
+}
+
+// wantMinimumGatedLeadSites is the floor below the count of sites that satisfy
+// the gate today. It exists for the reason every floor in this directory does:
+// an extractor that stops recognising SQL finds no sites and reports nothing,
+// which is indistinguishable from a clean tree.
+const wantMinimumGatedLeadSites = 1
+
+var leadReaderScope = gatekit.Scope{
+	Roots:   []string{"internal"},
+	Subject: readsLeadTable,
+	Exempt:  gatekit.Waive(map[string]string{}),
+}
+
+func readsLeadTable(filePath string, file *ast.File) bool {
+	return gatekit.FileReadsTable(filePath, file, leadGate.literal)
+}
+
+func TestEveryReaderOfTheLeadTableCarriesTheObjectGateOrAVerdict(t *testing.T) {
+	t.Parallel()
+	files := leadReaderScope.Files(t)
+	gated := leadGate.gatedFunctionsByPackage(t, files)
+	consts := constantTable{}
+
+	var satisfied int
+	for _, parsed := range files {
+		pkg := path.Dir(parsed.Path)
+		for _, site := range leadGate.readSites(parsed, consts.of(t, pkg)) {
+			subject := parsed.Path
+			if site.function != "" {
+				subject += ":" + site.function
+			}
+			carriesGate := site.holdsGate || callsAGatedHelper(site.calls, gated[pkg])
+			if site.function == "" {
+				carriesGate = site.holdsGate || leadGate.fileHoldsAGatedFunction(t, parsed, gated[pkg], consts.of(t, pkg))
+			}
+			verdict := verdictIn(t, subject, leadVerdicts)
+
+			switch {
+			case carriesGate && verdict != "":
+				t.Errorf("%s carries the lead object gate AND a %s verdict — remove the verdict, it "+
+					"now describes code that is gated", subject, verdict)
+			case carriesGate:
+				satisfied++
+			case verdict == "":
+				t.Errorf("%s reads the lead table without the object gate and without a verdict.\n"+
+					"  Reading a lead discloses somebody who has not agreed to be a customer, "+
+					"which is what the lead grant governs.\n"+
+					"  Either ask auth.Require(ctx, \"lead\", …), or declare the read in "+
+					"predicateLeadReads / lifecycleLeadReads / calleeGatedLeadReads / ruledLeadReads "+
+					"with the reason it "+
+					"needs no gate.\n"+
+					"  Left alone it is indistinguishable from a read nobody considered.\n"+
+					"  The read: %s", subject, site.sql)
+			}
+		}
+	}
+
+	if satisfied < wantMinimumGatedLeadSites {
+		t.Errorf("only %d lead reads satisfy the object gate, want at least %d — a literal extractor "+
+			"that stopped recognising this tree's SQL would report exactly this, and it reads the "+
+			"same as a clean tree", satisfied, wantMinimumGatedLeadSites)
+	}
+	t.Logf("lead reads: %d gated, %d predicate, %d lifecycle, %d callee-gated, %d ruled, %d DEFERRED (still disclosing)",
+		satisfied, len(predicateLeadReads.Subjects()), len(lifecycleLeadReads.Subjects()),
+		len(calleeGatedLeadReads.Subjects()), len(ruledLeadReads.Subjects()), len(deferredLeadReads.Subjects()))
+
+	predicateLeadReads.AssertAllMatched(t)
+	lifecycleLeadReads.AssertAllMatched(t)
+	calleeGatedLeadReads.AssertAllMatched(t)
+	notTheLeadTable.AssertAllMatched(t)
+	ruledLeadReads.AssertAllMatched(t)
+	deferredLeadReads.AssertAllMatched(t)
+}

--- a/backend/gates/listsortvocabulary_test.go
+++ b/backend/gates/listsortvocabulary_test.go
@@ -43,6 +43,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
 // listSurface pairs a screen with the resource it lists.
@@ -161,7 +163,7 @@ func sharedColumnSorts(t *testing.T) map[string]string {
 // package constant to the string it holds.
 func goSortVocabulary(t *testing.T, source, name string) []string {
 	t.Helper()
-	constants := packageStringConstants(t, filepath.Dir(source))
+	constants := gatekit.PackageStringConstants(t, filepath.Dir(source))
 	file, err := parser.ParseFile(token.NewFileSet(), source, nil, 0)
 	if err != nil {
 		t.Fatalf("parsing %s: %v", source, err)
@@ -193,45 +195,6 @@ func goSortVocabulary(t *testing.T, source, name string) []string {
 				out = append(out, value)
 			default:
 				t.Fatalf("%s has a key this gate cannot read (%T)", name, kv.Key)
-			}
-		}
-	}
-	return out
-}
-
-// packageStringConstants reads every string constant one package declares.
-func packageStringConstants(t *testing.T, dir string) map[string]string {
-	t.Helper()
-	sources, err := filepath.Glob(filepath.Join(dir, "*.go"))
-	if err != nil {
-		t.Fatalf("listing %s: %v", dir, err)
-	}
-	out := map[string]string{}
-	for _, source := range sources {
-		if strings.HasSuffix(source, "_test.go") {
-			continue
-		}
-		file, err := parser.ParseFile(token.NewFileSet(), source, nil, 0)
-		if err != nil {
-			t.Fatalf("parsing %s: %v", source, err)
-		}
-		for _, decl := range file.Decls {
-			general, ok := decl.(*ast.GenDecl)
-			if !ok || general.Tok != token.CONST {
-				continue
-			}
-			for _, spec := range general.Specs {
-				value, ok := spec.(*ast.ValueSpec)
-				if !ok || len(value.Names) != 1 || len(value.Values) != 1 {
-					continue
-				}
-				if lit, ok := value.Values[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
-					unquoted, err := strconv.Unquote(lit.Value)
-					if err != nil {
-						t.Fatalf("unquoting %s in %s: %v", lit.Value, source, err)
-					}
-					out[value.Names[0].Name] = unquoted
-				}
 			}
 		}
 	}

--- a/backend/gates/objectgatewalk_test.go
+++ b/backend/gates/objectgatewalk_test.go
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package gates
+
+// The walk behind an object-half census: which functions read a table, and
+// which of them reach that table's object gate.
+//
+// Its own file because two censuses now ask it — the relationship edge and the
+// lead record — and the question is the same one both times: RBAC's object half
+// says whether a caller may read this KIND of record at all, the row half says
+// which ones, and a read that takes only the second is the defect neither
+// composerowscope_test.go nor rbacgate_test.go covers in the compose tier.
+//
+// It is deliberately NOT in gatekit. The shared walk moves there when a third
+// SHAPE needs it; what these two share is one shape used twice, and an
+// abstraction lifted out of the tree before its second real caller is shaped for
+// the cases it happened to see. restrictedreaders_test.go is the structural
+// near-twin that would make three — and it is not refactored here, because
+// refactoring it against a walk built for two is the same mistake one level up.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// objectGate is one census's subject: the table whose reads carry the
+// obligation, and the spellings that discharge it.
+//
+// The object and the table are one field because they are one name in every
+// case this tree has — `relationship` reads are governed by the `relationship`
+// object, `lead` by `lead`. A schema where they diverge would need two, and
+// would need the census to say which of them the failure message is about.
+type objectGate struct {
+	// object is the RBAC object name AND the table name.
+	object string
+	// literal matches a SQL string literal reading the table.
+	literal *regexp.Regexp
+	// gateSeeds are the spellings that ARE the admission, anywhere in the tree.
+	gateSeeds []string
+	// rowHalfSeeds bound WHICH rows and answer nothing about whether the caller
+	// may read this kind of record at all — so alone they are the INVERTED form
+	// of the defect, and they satisfy only inside rowHalfOwners.
+	rowHalfSeeds []string
+	// rowHalfOwners are the packages that ask the object gate at their store
+	// entry points, where a row-half spelling is the clause that entry point
+	// composes rather than a substitute for it.
+	rowHalfOwners []string
+}
+
+// requireCall matches a call that asks the object gate under any of this
+// tree's spellings — auth.Require, or a package-local wrapper such as
+// contact360's requireRead. Paired with the object name in the same CALL, it
+// is the older form of the admission and still counts.
+var requireCall = regexp.MustCompile(`^[Rr]equire[A-Za-z]*$`)
+
+// site is one read: the function that holds it, empty for a package-level SQL
+// fragment, the first line of the SQL for the report, and whether that
+// function's OWN body takes the admission.
+//
+// holdsGate is answered from the declaration itself rather than by looking the
+// function up by name, and that distinction is the whole reason this field
+// exists. *Store and Handlers in one module routinely spell the same method
+// names — contacts has both a Store.RemoveProjectStakeholder and a
+// Handlers.RemoveProjectStakeholder — so a by-name index lets one answer for
+// the other, and which one wins is Go map iteration order. rbacgate_test.go
+// says so in its own header, having been bitten by exactly this. The name index
+// below is still used, but only to reach a gate in a SIBLING function, where a
+// collision can merely be optimistic rather than wrong.
+type site struct {
+	function  string
+	sql       string
+	holdsGate bool
+	// calls is what this declaration calls, so a gate reached through a helper
+	// in a sibling file resolves without consulting this declaration's name.
+	calls map[string]bool
+}
+
+func (g objectGate) readSites(parsed gatekit.ParsedFile, consts map[string]string) []site {
+	var sites []site
+	for _, decl := range parsed.File.Decls {
+		reads := gatekit.DeclReads(decl, g.literal)
+		if len(reads) == 0 {
+			continue
+		}
+		refs := referencesIn(decl, consts)
+		sites = append(sites, site{
+			function: reads[0].Function, sql: gatekit.FirstLineOf(reads[0].SQL),
+			holdsGate: g.holdsSeedGate(refs, pkgOf(parsed.Path)), calls: refs.calls,
+		})
+	}
+	return sites
+}
+
+func callsAGatedHelper(calls map[string]bool, gated map[string]bool) bool {
+	for name := range calls {
+		if gated[name] {
+			return true
+		}
+	}
+	return false
+}
+
+func pkgOf(filePath string) string { return path.Dir(filePath) }
+
+// gatedFunctionsByPackage resolves, per package directory, every function that
+// reaches the object's gate — directly, or through another function in the
+// same package. Transitive because this tree routinely splits a read across the
+// function holding the SQL and the helper building its predicate (company360's
+// edgeScope, meetingbrief's seatJoinPredicate), and a gate asking only about
+// direct calls would report the reader red while its admission sits in the file
+// next door.
+func (g objectGate) gatedFunctionsByPackage(t *testing.T, files []gatekit.ParsedFile) map[string]map[string]bool {
+	t.Helper()
+	// The WHOLE package, not only the files that read the table. The admission
+	// this tree writes routinely lives in a sibling file that holds no SQL of
+	// its own — company360's edgeScope sits in sections.go while the three reads it
+	// gates are in graphreads.go and contacts.go — so a resolution seeded from
+	// the subject files alone reports gated code as ungated, which costs the
+	// gate its credibility faster than a miss does.
+	bodies := map[string]map[string][]references{}
+	for _, parsed := range files {
+		pkg := path.Dir(parsed.Path)
+		if bodies[pkg] != nil {
+			continue
+		}
+		bodies[pkg] = packageFunctionReferences(t, pkg)
+	}
+
+	// A name is gated when ANY declaration spelling it is — a union, never an
+	// overwrite. Optimistic where two receivers share a method name, and
+	// deliberately so: this index only ever answers "is there a gated helper
+	// called X in this package", and the site's own declaration has already
+	// been asked directly, so the optimism cannot excuse an ungated read whose
+	// same-named neighbour happens to be gated.
+	gated := map[string]map[string]bool{}
+	for pkg, funcs := range bodies {
+		gated[pkg] = map[string]bool{}
+		for name, decls := range funcs {
+			for _, refs := range decls {
+				if g.holdsSeedGate(refs, pkg) {
+					gated[pkg][name] = true
+					break
+				}
+			}
+		}
+		for grew := true; grew; {
+			grew = false
+			for name, decls := range funcs {
+				if gated[pkg][name] {
+					continue
+				}
+				for _, refs := range decls {
+					for callee := range gated[pkg] {
+						if refs.calls[callee] {
+							gated[pkg][name] = true
+							grew = true
+							break
+						}
+					}
+					if gated[pkg][name] {
+						break
+					}
+				}
+			}
+		}
+	}
+	return gated
+}
+
+// holdsSeedGate reports whether a function body IS the admission: one of the
+// platform spellings, or the older object-gate form — a Require-shaped call
+// taking the object as an argument.
+func (g objectGate) holdsSeedGate(refs references, pkg string) bool {
+	for _, seed := range g.gateSeeds {
+		if refs.calls[seed] {
+			return true
+		}
+	}
+	// The older form is read off the CALL rather than from the body at large,
+	// because a body holding RequireHuman(ctx) and, separately, an unrelated
+	// object-name string — an entity-type constant, a table name in a comment's
+	// sibling literal — would otherwise vouch for itself.
+	if refs.gatedObjects[g.object] {
+		return true
+	}
+	if !slices.Contains(g.rowHalfOwners, pkg) {
+		return false
+	}
+	for _, seed := range g.rowHalfSeeds {
+		if refs.calls[seed] {
+			return true
+		}
+	}
+	return false
+}
+
+// references is what a function CALLS and what string literals it holds. Read
+// off the syntax rather than the source text, so a gate spelling cannot be
+// matched inside a comment that merely discusses it — and calls only, because a
+// parameter or local variable that happens to share a gated function's name is
+// not a call to it.
+type references struct {
+	calls    map[string]bool
+	literals map[string]bool
+	// gatedObjects are the object names this body passes to a Require-shaped
+	// call. Resolved here rather than left as two facts a reader has to pair
+	// up, because pairing them at the body level is what let RequireHuman(ctx)
+	// beside an unrelated "relationship" literal vouch for a read.
+	//
+	// A set rather than one boolean so ONE walk of a package serves every
+	// census over it: a function gating `deal` and a function gating `lead`
+	// look identical to the parser, and the difference is which name reached
+	// the call.
+	gatedObjects map[string]bool
+}
+
+// packageFunctionReferences parses every non-test source in one package
+// directory and returns what each function mentions.
+//
+// The directory is read and its files parsed one at a time rather than through
+// parser.ParseDir, which is deprecated for a reason that would bite here: it
+// does not consider build tags when grouping files into packages, and several
+// of the directories this walks hold tagged files.
+func packageFunctionReferences(t *testing.T, pkg string) map[string][]references {
+	t.Helper()
+	// The path is relative to the module root, which is this test's working
+	// directory: package gates sits one below it and TestMain chdirs up.
+	dir := filepath.FromSlash(pkg)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s to resolve its object gates: %v", pkg, err)
+	}
+	// The package's own string constants first: contacts writes
+	// auth.Require(ctx, entityLead, …) against `const entityLead = "lead"`, and
+	// a walk reading only literals would report the tree's own owning module as
+	// ungated. Under-recognition reported as a finding against correct code
+	// costs a gate its credibility faster than a miss does.
+	parsedFiles := parsePackage(t, pkg, entries, dir)
+	consts := gatekit.PackageStringConstants(t, dir)
+	refs := map[string][]references{}
+	for _, file := range parsedFiles {
+		for fn, decls := range functionBodies(gatekit.ParsedFile{File: file}, consts) {
+			refs[fn] = append(refs[fn], decls...)
+		}
+	}
+	return refs
+}
+
+func parsePackage(t *testing.T, pkg string, entries []os.DirEntry, dir string) []*ast.File {
+	t.Helper()
+	fset := token.NewFileSet()
+	var out []*ast.File
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parsing %s/%s to resolve its object gates: %v", pkg, name, parseErr)
+		}
+		out = append(out, file)
+	}
+	return out
+}
+
+func functionBodies(parsed gatekit.ParsedFile, consts map[string]string) map[string][]references {
+	bodies := map[string][]references{}
+	for _, decl := range parsed.File.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if !isFunc {
+			continue
+		}
+		bodies[fn.Name.Name] = append(bodies[fn.Name.Name], referencesIn(fn, consts))
+	}
+	return bodies
+}
+
+func referencesIn(node ast.Node, consts map[string]string) references {
+	refs := references{calls: map[string]bool{}, literals: map[string]bool{}, gatedObjects: map[string]bool{}}
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch typed := n.(type) {
+		case *ast.CallExpr:
+			// calleeName is retentionscope_test.go's, shared rather than
+			// respelled: "the called function's own name, ignoring any
+			// qualifier" is the same question here, and auth.EdgeReadScope and
+			// a local edgeScope both need to resolve to what they call.
+			name := calleeName(typed)
+			if requireCall.MatchString(name) {
+				for _, object := range stringArgumentsOf(typed, consts) {
+					refs.gatedObjects[object] = true
+				}
+			}
+			if name != "" {
+				refs.calls[name] = true
+			}
+		case *ast.BasicLit:
+			if text, isString := gatekit.LiteralText(typed); isString {
+				refs.literals[text] = true
+			}
+		}
+		return true
+	})
+	return refs
+}
+
+// stringArgumentsOf is the object names a Require-shaped call could be gating.
+// Every string argument, because the position differs by spelling —
+// auth.Require(ctx, "lead", action) and contact360's requireRead(ctx, "lead")
+// — and a census pinned to one index would silently stop seeing the other.
+func stringArgumentsOf(call *ast.CallExpr, consts map[string]string) []string {
+	var out []string
+	for _, arg := range call.Args {
+		// FoldStrict: an argument this cannot fully resolve is not an object
+		// name, rather than a half-read one. A gate vouching for a read on a
+		// fragment it guessed is worse than one that misses it.
+		if text, isString := gatekit.StringExpr(arg, consts, gatekit.FoldStrict); isString {
+			out = append(out, text)
+		}
+	}
+	return out
+}
+
+// fileHoldsAGatedFunction answers for a package-level SQL fragment, which has
+// no declaration of its own to ask: the file that declares it is judged as a
+// whole, as restrictedreaders_test.go judges one.
+func (g objectGate) fileHoldsAGatedFunction(t *testing.T, parsed gatekit.ParsedFile, gated map[string]bool, consts map[string]string) bool {
+	t.Helper()
+	for name, decls := range functionBodies(parsed, consts) {
+		if gated[name] {
+			return true
+		}
+		for _, refs := range decls {
+			if g.holdsSeedGate(refs, pkgOf(parsed.Path)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// verdictIn names the declaration a subject sits in, and refuses one sitting in
+// two: the verdict IS the declaration, so a subject with two of them has no
+// verdict at all.
+func verdictIn(t *testing.T, subject string, sets []namedVerdict) string {
+	t.Helper()
+	var found []string
+	for _, set := range sets {
+		// A file-keyed verdict answers for every site in the file; a
+		// function-keyed one answers for its own site only. Both are asked,
+		// because a lifecycle FILE and a deferred FUNCTION are both real shapes.
+		if set.waivers.Waived(t, subject) || set.waivers.Waived(t, fileOf(subject)) {
+			found = append(found, set.name)
+		}
+	}
+	if len(found) > 1 {
+		t.Errorf("%s carries %s verdicts at once: which declaration a read sits in IS its verdict, "+
+			"so two of them is none", subject, strings.Join(found, " and "))
+		return ""
+	}
+	if len(found) == 1 {
+		return found[0]
+	}
+	return ""
+}
+
+type namedVerdict struct {
+	name    string
+	waivers *gatekit.Waivers[string]
+}
+
+func fileOf(subject string) string {
+	if idx := strings.LastIndex(subject, ":"); idx >= 0 {
+		return subject[:idx]
+	}
+	return subject
+}
+
+// constantTable memoises one census's per-package string constants. A census
+// asks for a package's table once per file in it, and parsing a package the
+// size of contacts a dozen times is the difference between a gate somebody runs
+// and one they skip.
+//
+// Held by the census rather than at package scope, because two censuses over
+// this walk run t.Parallel() and a shared map between them is a data race.
+type constantTable map[string]map[string]string
+
+func (c constantTable) of(t *testing.T, pkg string) map[string]string {
+	t.Helper()
+	if known, cached := c[pkg]; cached {
+		return known
+	}
+	c[pkg] = gatekit.PackageStringConstants(t, filepath.FromSlash(pkg))
+	return c[pkg]
+}

--- a/backend/internal/modules/contacts/leadsource.go
+++ b/backend/internal/modules/contacts/leadsource.go
@@ -191,20 +191,6 @@ func deriveSourceKey(label string) string {
 	return strings.Trim(key, "_")
 }
 
-// visibleLeadScope renders the lead row-scope clause for the vocabulary
-// rows' lead_count — a count of the leads the CALLER MAY SEE, embedded in
-// the representation the vocabulary writers return. It exists as its own
-// spelling (rather than sharing scopeOrAllRows) so the write-authority gate
-// waives exactly this probe: a future write path reaching the shared helper
-// still fails the gate and states its own reason.
-func visibleLeadScope(ctx context.Context, arg func(any) int) (string, error) {
-	clause, err := auth.ScopeClauseFor(ctx, "lead", "", arg)
-	if err != nil || clause != "" {
-		return clause, err
-	}
-	return scopeAllRows, nil
-}
-
 // leadSourceColumns renders the select list. lead_count carries the caller's
 // row scope — a narrowed actor counts only the leads they may see — and
 // counts a connector family's leads through the family prefix, because the

--- a/backend/internal/modules/contacts/leadvocabularyscope.go
+++ b/backend/internal/modules/contacts/leadvocabularyscope.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package contacts
+
+// What a lead vocabulary row's count may count.
+//
+// Its own file because it is the one place both vocabularies and the
+// discovered-source roll-up go through, and because the question it settles is
+// not the source list's: a `lead_source` row is configuration, and the number
+// beside it is lead data.
+
+import (
+	"context"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// visibleLeadScope renders the lead row-scope clause for the vocabulary
+// rows' lead_count — a count of the leads the CALLER MAY SEE, embedded in
+// the representation the vocabulary writers return. It exists as its own
+// spelling (rather than sharing scopeOrAllRows) so the write-authority gate
+// waives exactly this probe: a future write path reaching the shared helper
+// still fails the gate and states its own reason.
+//
+// BOTH HALVES OF RBAC, and the object half is asked HERE rather than at each
+// vocabulary entry point because this is the one helper every lead count goes
+// through — the two column lists and the discovered-sources roll-up alike.
+//
+// The row half alone was not enough, and the gap was not theoretical: these
+// surfaces are gated on `custom_field`, so a role granted the vocabulary and
+// not leads was answered a count of every lead its row scope reached — which,
+// for an unbounded seat, is all of them — and the discovered-sources list hands
+// back the SOURCE VALUES themselves, which are lead data and not a number. No
+// seeded role has custom_field without lead, so nothing a default installation
+// does changes; what changes is that a custom role cannot be built that reads
+// leads through the settings screen.
+func visibleLeadScope(ctx context.Context, arg func(any) int) (string, error) {
+	if err := auth.Require(ctx, "lead", principal.ActionRead); err != nil {
+		return "", err
+	}
+	clause, err := auth.ScopeClauseFor(ctx, "lead", "", arg)
+	if err != nil || clause != "" {
+		return clause, err
+	}
+	return scopeAllRows, nil
+}

--- a/backend/internal/shared/gatekit/stringexpr.go
+++ b/backend/internal/shared/gatekit/stringexpr.go
@@ -18,8 +18,12 @@ package gatekit
 
 import (
 	"go/ast"
+	"go/parser"
 	"go/token"
+	"path/filepath"
 	"strconv"
+	"strings"
+	"testing"
 )
 
 // StringFold says what a reading does with a part it cannot resolve.
@@ -134,4 +138,61 @@ func concatString(expr *ast.BinaryExpr, consts map[string]string, fold StringFol
 		return "", false
 	}
 	return left + right, true
+}
+
+// PackageStringConstants reads every string constant one package declares, as
+// the table StringExpr folds identifiers against.
+//
+// It lives here rather than in a gate because two censuses in different BUILDS
+// need it: the list-sort parity gate is `//go:build !integration` and the
+// object-half censuses are not, so a copy in either is a copy the other cannot
+// reach. A second reading of "what does this package call that string" is also
+// exactly the drift StringExpr exists to prevent one level down.
+//
+// Non-test sources only, and single-name single-value specs only: a grouped
+// `const ( a, b = …)` or an iota block is not a string table, and guessing at
+// one would fold a name onto a value the package never gave it.
+func PackageStringConstants(t testing.TB, dir string) map[string]string {
+	t.Helper()
+	sources, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("listing %s for its string constants: %v", dir, err)
+	}
+	out := map[string]string{}
+	for _, source := range sources {
+		if strings.HasSuffix(source, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), source, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s for its string constants: %v", source, err)
+		}
+		collectFileStringConstants(t, source, file, out)
+	}
+	return out
+}
+
+func collectFileStringConstants(t testing.TB, source string, file *ast.File, into map[string]string) {
+	t.Helper()
+	for _, decl := range file.Decls {
+		general, isGeneral := decl.(*ast.GenDecl)
+		if !isGeneral || general.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range general.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			if !isValue || len(value.Names) != 1 || len(value.Values) != 1 {
+				continue
+			}
+			lit, isLit := value.Values[0].(*ast.BasicLit)
+			if !isLit || lit.Kind != token.STRING {
+				continue
+			}
+			unquoted, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				t.Fatalf("unquoting %s in %s: %v", lit.Value, source, err)
+			}
+			into[value.Names[0].Name] = unquoted
+		}
+	}
 }

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -131,7 +131,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (146)
+## Census (147)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -206,6 +206,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |
 | `laneinputscope_test.go` | H3 | A path-filtered lane runs on a change to the scripts it EXECUTES. |
 | `leadcontactlockorder_test.go` | H2 | ONE lock order over the lead and the contact it was promoted into. |
+| `leadreaders_test.go` | H2 | `lead` is an RBAC object, and until this gate nothing held the object half of that anywhere outside the module that owns it. |
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
 | `lintbuildtagreach_test.go` | H2 | Every Go file in this repository is compiled by a pass the merge gate runs, analysed by one that lints, and read by both lint configs or neither. |
 | `machineryapplied_test.go` | H2 | Every setting read through an ungated machinery reader — settings.ApplyTx or settings.ApplyManyTx — is declared MachineryApplied. |


### PR DESCRIPTION
`lead` is an RBAC object, and until now nothing held the object half of that anywhere outside the module that owns it. Both gates covering the compose tier say so in their own words — `rbacgate_test.go` judges only exported methods on a module's `*Store`/`*Service`, and `composerowscope_test.go` covers ROW scope and *refuses* to count object admission as satisfaction. Between them a compose read could take the conjunction: the right rows, for a caller with no business reading leads at all.

This is the **first object slice of #1964**, on the shape my sizing comment there suggested — one object per PR, the smallest first, so the discriminator is proven before it meets `person`.

## Three reads were actually ungated

Not a by-product of the census; the reason for it.

The lead-source and lead-disqualify-reason vocabularies are gated on `custom_field`, and each row carries a `lead_count` that took only the row half. So a role granted the vocabulary and not leads was answered a count of every lead its row scope reached — for an unbounded seat, all of them — and `discoveredLeadSources` hands back the **source values themselves**, which are lead data and not a number.

`visibleLeadScope` is the one helper all three go through, and it now asks both halves. No seeded role has `custom_field` without `lead`, so nothing a default installation does changes; what changes is that a custom role cannot be built that reads leads through the settings screen.

## The verdicts

Every remaining site is a per-site judgement, in one of five declarations:

| verdict | n | what it says |
|---|---|---|
| gated | 11 | asks `auth.Require(ctx, "lead", …)`, directly or through a helper in its package |
| predicate | 6 | the lead decides which OTHER records appear, and nothing about it reaches the response |
| lifecycle | 11 | a sweep or a capture path under the system principal, or gated by the write it belongs to |
| callee-gated | 12 | a private helper whose every caller asks the gate at a store entry point |
| not-the-table | 1 | `extract(epoch FROM lead(h.changed_at) OVER …)` — SQL's own window function |
| **deferred** | **3** | still disclosing, and named: #5466 |

`callee-gated` is a verdict of its own rather than folded into `lifecycle`, which is where `edgereaders_test.go` puts the same shape. The edge's helpers are cascades and sweeps and the word fits them; the lead surface is mostly one store, and calling a plain single-row read "lifecycle" would empty that word of meaning in the census where it matters most. Each entry names the callers it establishes — the census resolves gates FORWARD and cannot resolve them caller-ward, because the call graph is by name and a gated `Store.X` would then vouch for an ungated `Handlers.X`.

The three deferred are the weekly review's lead figures. They take the row half and never the object half, and closing that turns on what a weekly review SAYS to a seat with no lead grant — failing the whole review is fail-closed and breaks a report whose other blocks are fine; zeroed counts read as failure at work nobody asked of them, which that file's own doc names as the thing it must not print. Filed as **#5466**, `status: needs-decision`.

## The shared walk

Moved out of `edgereaders_test.go` into `objectgatewalk_test.go`, so the two censuses share it rather than copying it. **Not into `gatekit`**: the issue rules that out until a third SHAPE needs it, and what these two share is one shape used twice — `restrictedreaders_test.go` is the structural near-twin that would make three, and refactoring it against a walk built for two is the same mistake one level up.

The refactor is behaviour-preserving: the relationship census reports the same 40 gated / 24 predicate / 22 lifecycle / 2 ruled / 0 deferred before and after, checked against `origin/main`'s copy.

One real strengthening came with it. The object-gate resolution now folds the package's own string constants — `contacts` writes `auth.Require(ctx, entityLead, …)` against `const entityLead = "lead"`, and a census reading only literals reported the tree's own owning module as ungated. Under-recognition reported as a finding against correct code costs a gate its credibility faster than a miss does. `gatekit` gains `PackageStringConstants` for it, because the two readers of that question sit in different builds (`listsortvocabulary_test.go` is `//go:build !integration`) and a copy in either is one the other cannot reach.

## Mutation-checked

- a new ungated compose read of `lead` → named, with its SQL;
- the vocabulary object gate removed again → all three sites reported;
- a waived read that gains its gate → reported as carrying both;
- the relationship census, after the refactor: an ungated edge read still named.

`make check-backend` and `make craft-static` green.

Part of #1964 — `person`, `deal` and `organization` remain.