### PR TITLE
fix(search,agents): the caller's token is bounded, not the remedy after it

### DIFF
--- a/backend/internal/modules/agents/badargs.go
+++ b/backend/internal/modules/agents/badargs.go
@@ -193,6 +193,10 @@ func (e *BadArgsError) FieldFaults() []apperrors.FieldRefusal {
 
 // boundDetail caps a message at n bytes, cutting on a rune boundary so the
 // result stays valid UTF-8 rather than ending mid-sequence.
+//
+// It is the bound for text this package did not render. echoSafe bounds its own
+// output while writing instead, because a cut measured after escaping cannot
+// know where an escape began.
 func boundDetail(s string, n int) string {
 	if len(s) <= n {
 		return s
@@ -240,22 +244,40 @@ func invalidByteAt(s string, i int) bool {
 // httperr.QuoteCaller bounds a caller's token with `%q` before it ever reaches
 // here, and two spellings of "safe to echo" that disagreed would mean the
 // protection depended on which door the text came through.
+// THE BOUND IS APPLIED WHILE WRITING, not to the finished string, and that is
+// the difference between a cut and a mangled escape. Escaping expands: one
+// escape byte becomes six characters as `\u001b`, so a message legally inside
+// the budget when its producer wrote it crosses the bound here. Cutting the
+// result at a byte position — corrected only to a rune boundary, which every
+// character of an escape already is — lands inside `\u001b` and leaves `\u001`,
+// which reads as a bug in this function rather than as a truncated name.
+//
+// Writing unit by unit against the remaining budget makes that unrepresentable:
+// a unit that does not fit is not written, so the answer ends between escapes
+// or it ends at the end.
 func echoSafe(s string, n int) string {
 	var b strings.Builder
 	b.Grow(len(s))
+	// cut is the longest prefix written so far that still leaves room for the
+	// ellipsis. Tracked rather than subtracted up front, because a message that
+	// fits WHOLE must come back whole: reserving the ellipsis unconditionally
+	// would truncate a remedy of exactly the budget, and explain() sizes its own
+	// arithmetic on that case.
+	cut := 0
 	for i, r := range s {
+		var unit string
 		switch {
 		case r == '\n':
-			b.WriteString(`\n`)
+			unit = `\n`
 		case r == '\r':
-			b.WriteString(`\r`)
+			unit = `\r`
 		case r == '\t':
-			b.WriteString(`\t`)
+			unit = `\t`
 		case r == utf8.RuneError && invalidByteAt(s, i):
 			// A byte that is not UTF-8 at all. Ranging yields RuneError for it,
 			// which IS printable, so writing the rune back would replace the
 			// caller's byte with U+FFFD and report a name they did not send.
-			fmt.Fprintf(&b, `\x%02x`, s[i])
+			unit = fmt.Sprintf(`\x%02x`, s[i])
 		case !unicode.IsPrint(r) && r > 0xFFFF:
 			// An UNPRINTABLE rune above the BMP, and the printability test comes
 			// first for a reason: an emoji and a CJK extension character are
@@ -264,12 +286,19 @@ func echoSafe(s string, n int) string {
 			// `\ue0020` for U+E0020 is not a legal escape anywhere and reads as
 			// `\ue002` followed by a `0` — and U+E0000..U+E007F is the tag block
 			// used to smuggle invisible text.
-			fmt.Fprintf(&b, `\U%08x`, r)
+			unit = fmt.Sprintf(`\U%08x`, r)
 		case !unicode.IsPrint(r):
-			fmt.Fprintf(&b, `\u%04x`, r)
+			unit = fmt.Sprintf(`\u%04x`, r)
 		default:
-			b.WriteRune(r)
+			unit = string(r)
+		}
+		if b.Len()+len(unit) > n {
+			return b.String()[:cut] + "…"
+		}
+		b.WriteString(unit)
+		if b.Len()+len("…") <= n {
+			cut = b.Len()
 		}
 	}
-	return boundDetail(b.String(), n)
+	return b.String()
 }

--- a/backend/internal/modules/agents/tools_badargs_test.go
+++ b/backend/internal/modules/agents/tools_badargs_test.go
@@ -233,3 +233,93 @@ func TestBoundDetailCutsOnARuneBoundary(t *testing.T) {
 		}
 	}
 }
+
+// A cut never lands inside an escape, and a message that FITS comes back whole.
+//
+// echoSafe expands as it escapes: one escape byte becomes six characters, and a
+// tag-block rune becomes ten. So a message legally inside its budget when its
+// producer wrote it crosses the bound here. A cut measured on the FINISHED
+// string lands inside an escape and leaves a dangling backslash, which reads as
+// a bug in the escaper rather than as a truncated name. Writing unit by unit
+// against the remaining budget is what makes that unrepresentable.
+func TestEchoSafeCutsBetweenEscapesAndNeverInsideOne(t *testing.T) {
+	// Every escape WIDTH this function emits, so a cut is tried against each:
+	// two characters for the named ones, four for a raw byte, six for a BMP rune,
+	// ten for an astral one.
+	for _, c := range []struct {
+		name   string
+		source string
+	}{
+		{"newlines", strings.Repeat("\n", 200)},
+		{"raw bytes that are not UTF-8", strings.Repeat("\xff", 200)},
+		{"unprintable BMP runes", strings.Repeat("\v", 200)},
+		{"unprintable astral runes", strings.Repeat("\U000e0020", 200)},
+		{"escapes between printable text", strings.Repeat("ab\vcd", 100)},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			for n := 4; n <= 200; n++ {
+				got := echoSafe(c.source, n)
+				if len(got) > n {
+					t.Fatalf("echoSafe(%d) answered %d bytes: %q", n, len(got), got)
+				}
+				if !utf8.ValidString(got) {
+					t.Fatalf("echoSafe(%d) produced invalid UTF-8: %q", n, got)
+				}
+				// A dangling backslash is what a cut inside an escape looks like,
+				// and it reads as this function being broken rather than as a name
+				// being long.
+				if partialEscapeTail(strings.TrimSuffix(got, "\u2026")) {
+					t.Fatalf("echoSafe(%d) cut inside an escape: %q", n, got)
+				}
+			}
+		})
+	}
+}
+
+// partialEscapeTail reports whether s ends inside one of echoSafe's escapes:
+// an unpaired backslash, or one followed by fewer digits than its form takes.
+func partialEscapeTail(s string) bool {
+	for i := len(s) - 1; i >= 0 && len(s)-i <= 10; i-- {
+		if s[i] != '\\' {
+			continue
+		}
+		// The run of backslashes before this one decides whether it opens an
+		// escape or is itself escaped text.
+		backslashes := 0
+		for j := i; j >= 0 && s[j] == '\\'; j-- {
+			backslashes++
+		}
+		if backslashes%2 == 0 {
+			return false
+		}
+		switch tail := s[i+1:]; {
+		case tail == "":
+			return true
+		case tail[0] == 'n' || tail[0] == 'r' || tail[0] == 't':
+			return false
+		// SHORTER than the form takes, not merely different: an escape may be
+		// followed by ordinary text, and a length test for equality would read
+		// a complete escape with a letter after it as a cut one.
+		case tail[0] == 'x':
+			return len(tail) < 3
+		case tail[0] == 'u':
+			return len(tail) < 5
+		case tail[0] == 'U':
+			return len(tail) < 9
+		}
+		return false
+	}
+	return false
+}
+
+// A message that fits comes back UNCHANGED. explain() sizes its remedy budget
+// on exactly this: a remedy of precisely the bound spends precisely one slot,
+// and reserving room for an ellipsis it does not need would silently drop the
+// last remedy that fits.
+func TestEchoSafeLeavesAMessageThatFitsAlone(t *testing.T) {
+	for _, s := range []string{"", "a", strings.Repeat("x", 300), "\u65e5\u672c\u8a9e"} {
+		if got := echoSafe(s, 300); got != s {
+			t.Errorf("echoSafe(%q) = %q, want it unchanged", s, got)
+		}
+	}
+}

--- a/backend/internal/modules/search/queryrefusal.go
+++ b/backend/internal/modules/search/queryrefusal.go
@@ -19,9 +19,9 @@ import (
 	"errors"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 
+	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
 
@@ -190,10 +190,28 @@ func unknownPlanMember(member string) *PlanRefusal {
 			"; read margince://schema/query for the plan grammar")
 }
 
-// quote renders a caller-supplied token for a message.
+// quote renders a caller-supplied token for a message: escaped, quoted, and
+// BOUNDED.
 //
-// It ESCAPES rather than merely wrapping in quotes. The token is the caller's
-// own text, and a token carrying a quote or a newline concatenated bare would
-// end the quoted run early or split the message across lines — a refusal an
-// agent parses as two, or as one it cannot tell the boundaries of.
-func quote(s string) string { return strconv.Quote(s) }
+// It escapes rather than merely wrapping in quotes. The token is the caller's
+// own text, and one carrying a quote or a newline concatenated bare would end
+// the quoted run early or split the message across lines — a refusal an agent
+// parses as two, or as one it cannot tell the boundaries of.
+//
+// The bound is httperr's, and it is what stops a caller choosing how much of
+// the answer they receive. Every refusal here puts the token first and the
+// remedy after it, and httperr cuts the whole message at MaxFaultText — so an
+// invented field name long enough ate the sentence saying what to do about it,
+// and the operator refusal below, which names the field's whole operator SET,
+// lost the set. The caller kept their own mistake and lost the answer.
+//
+// Bounding the caller's contribution rather than the sentence around it is the
+// rule the rest of this tree already applies (httperr.QuoteCaller's own doc,
+// agents.echoSafe, BadArgsError.Guidance), and TheClosedSetSurvivesAFlood is
+// what holds it here.
+//
+// The few SERVER-side names rendered through this — the plan version, a
+// target, a relation — are bounded too, which is a no-op the census beside it
+// proves rather than assumes: a vocabulary member that did not fit would be
+// quoted back truncated and match nothing in the set printed next to it.
+func quote(s string) string { return httperr.QuoteCaller(s) }

--- a/backend/internal/modules/search/queryrefusalbudget_test.go
+++ b/backend/internal/modules/search/queryrefusalbudget_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// A refusal that names a closed set must be able to DELIVER that set, and a
+// caller must not be able to push it out.
+//
+// Every refusal here puts the caller's own token first and the remedy after it,
+// and httperr cuts the whole message at MaxFaultText before any surface sees
+// it. So an invented field name long enough ate the sentence saying what to do
+// about it, and the operator refusal — which names a field's whole operator set
+// — lost the set. A truncated set is worse than an absent one: it reads as
+// complete, so a caller stops looking for the entry that was removed.
+//
+// compose has this census for its own vocabularies and says in its own header
+// that it cannot reach this package's. This is that obligation, held here.
+//
+// TWO CLAIMS, and the second is the premise of the first:
+//
+//   - a flooded caller token leaves the remedy and the set intact;
+//   - every member of this package's own vocabularies renders WITHIN the caller
+//     bound, so quoting one back is lossless. Without it the first claim would
+//     be bought by truncating the answer instead of the question.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/httperr"
+)
+
+// floodedToken is what a caller sends when the refusal's budget is the thing
+// under attack: far past any bound, so a producer that does not bound its echo
+// leaves nothing for the remedy.
+const floodedToken = 4000
+
+// TestTheRemedySurvivesAFloodedCallerToken drives the real producers and reads
+// the CLASSIFIED fault rather than the raw message.
+//
+// The renderer is not the only ceiling: httperr bounds a module-declared fault
+// at MaxFaultText before any surface is reached, so a test measuring the raw
+// string would see a remedy the caller never gets. Asking httperr.Classify is
+// asking the surface rather than a model of it.
+func TestTheRemedySurvivesAFloodedCallerToken(t *testing.T) {
+	t.Parallel()
+	vocab := TargetVocabulary{
+		Target: "contact",
+		Fields: []Field{newField("full_name", KindText), newField("created_at", KindTimestamp)},
+	}
+	flood := strings.Repeat("k", floodedToken)
+
+	for _, tc := range []struct {
+		name   string
+		clause Predicate
+		remedy string
+		// set is what the refusal must still be able to say, beyond the remedy:
+		// the closed vocabulary a caller acts on. Empty where the refusal names
+		// no set and the remedy IS the whole answer.
+		set []string
+	}{
+		{
+			name:   "an invented field name",
+			clause: Predicate{Field: flood, Op: OpEq, Value: json.RawMessage(`"x"`)},
+			remedy: "read margince://schema/query for the fields available to you",
+		},
+		{
+			name:   "an invented operator on a real field",
+			clause: Predicate{Field: "full_name", Op: flood, Value: json.RawMessage(`"x"`)},
+			remedy: "is not one of them",
+			set:    operatorsByKind[KindText],
+		},
+		{
+			name:   "both halves flooded at once",
+			clause: Predicate{Field: flood, Op: flood, Value: json.RawMessage(`"x"`)},
+			remedy: "read margince://schema/query for the fields available to you",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var plan ValidatedPlan
+			refusals := checkPredicates(vocab, "where", []Predicate{tc.clause}, &plan)
+			if len(refusals) != 1 {
+				t.Fatalf("the flood produced %d refusal(s), want exactly 1: %+v", len(refusals), refusals)
+			}
+			fault, classified := httperr.Classify(&PlanRefusal{Refusals: refusals})
+			if !classified {
+				t.Fatalf("the refusal is outside the taxonomy, so a caller receives an opaque 500: %+v", refusals)
+			}
+			if len(fault.Fields) != 1 {
+				t.Fatalf("the fault carries %d field entries, want 1: %+v", len(fault.Fields), fault.Fields)
+			}
+			message := fault.Fields[0].Message
+			if !strings.Contains(message, tc.remedy) {
+				t.Errorf("the remedy is gone from the refusal — the caller keeps their own mistake and "+
+					"loses the answer.\n  want to contain: %s\n  got (%d bytes): %s",
+					tc.remedy, len(message), message)
+			}
+			for _, member := range tc.set {
+				if !strings.Contains(message, httperr.QuoteCaller(member)) {
+					t.Errorf("%q is missing from the operator set the refusal names — a truncated set "+
+						"reads as complete, so a caller stops looking for what was removed.\n  got "+
+						"(%d bytes): %s", member, len(message), message)
+				}
+			}
+			// The bound is what makes the above possible, so it is asserted
+			// rather than inferred from the two passing: a producer that stopped
+			// bounding would pass the remedy check on a message httperr then
+			// cuts, and the failure would appear one layer away.
+			if len(message) > httperr.MaxFaultText {
+				t.Errorf("the delivered refusal is %d bytes, past httperr's own %d — which means the "+
+					"bound moved rather than that this passed", len(message), httperr.MaxFaultText)
+			}
+			if strings.HasSuffix(message, "…") {
+				t.Errorf("the delivered refusal ends in an ellipsis, so httperr cut it: the caller "+
+					"keeps their own token and loses whatever came after it.\n  got (%d bytes): %s",
+					len(message), message)
+			}
+		})
+	}
+}
+
+// TestEveryVocabularyMemberFitsTheCallerBound is the premise the test above
+// rests on. Quoting is lossless only for a name inside the bound; a member
+// longer than it would be quoted back TRUNCATED and match nothing in the set
+// printed beside it, which is the same defect wearing the server's name instead
+// of the caller's.
+//
+// The operators are derived from the map that defines them rather than listed,
+// so a kind that gains one is covered the day it does.
+func TestEveryVocabularyMemberFitsTheCallerBound(t *testing.T) {
+	t.Parallel()
+	members := []string{PlanVersion}
+	for _, ops := range operatorsByKind {
+		members = append(members, ops...)
+	}
+	for kind := range operatorsByKind {
+		members = append(members, string(kind))
+	}
+	if len(members) < len(operatorsByKind) {
+		t.Fatalf("the census gathered %d member(s) from %d kind(s) — it has stopped reaching this "+
+			"package's vocabularies and would pass over nothing",
+			len(members), len(operatorsByKind))
+	}
+	for _, member := range members {
+		if quoted := httperr.QuoteCaller(member); strings.Contains(quoted, "…") {
+			t.Errorf("%q renders as %s — a server-side name past the caller bound comes back "+
+				"truncated, matching nothing in the set beside it", member, quoted)
+		}
+	}
+}


### PR DESCRIPTION
A query-plan refusal puts the caller's own token first and the remedy after it, and `httperr` cuts the whole message at `MaxFaultText` (300) before any surface sees it. So an invented field name long enough ate the sentence saying what to do about it:

```
the query plan cannot name "<caller token>" on "contact"; read margince://schema/query for
```

...and the operator refusal, which names the field's **whole operator set**, lost the set. The caller kept their own mistake and lost the answer.

## The rule, and where it already lives

Bound the caller's contribution where it enters, not the sentence the server wrote around it. `httperr.QuoteCaller` already spells it, and `BadArgsError.Guidance` already carries the diagnosis in a comment: bounding server-authored guidance together with a caller echo *"made the accepted-field list truncate mid-word on a long unknown key - cutting away the list the message exists to teach, exactly when the caller most needed it."*

search's own `quote` - whose doc already said *"renders a caller-supplied token"* - now calls `QuoteCaller`. That is the whole production change for the live instance.

## The census

A truncated set is worse than an absent one: it reads as complete, so a caller stops looking for the entry that was removed. `compose`'s closed-set refusal budget holds that for compose's vocabularies and says in its own header that it **cannot reach** the ones in `modules/search`. This is that obligation, held here:

- `TestTheRemedySurvivesAFloodedCallerToken` floods the field, the operator, and both at once, and asserts the remedy survives, the operator set survives whole, and the delivered message does not end in an ellipsis. It reads the **classified fault**, not the raw string, because `httperr` bounds a module-declared fault before any surface is reached - a test measuring the raw message would see a remedy the caller never gets.
- `TestEveryVocabularyMemberFitsTheCallerBound` is its premise: quoting is lossless only inside the bound, and a member longer than it would come back truncated and match nothing in the set printed beside it. Derived from the map that defines the operators, so a kind that gains one is covered the day it does.

Mutation-checked: with `quote` unbounded again, all three cases fail with *"the remedy is gone from the refusal"* and *"the delivered refusal ends in an ellipsis, so httperr cut it"* - which is the defect, reproduced.

## The same rule at the outer layer

`agents.echoSafe` escaped and **then** bounded. Escaping expands - one escape byte becomes six characters, a tag-block rune ten - so a message legally inside its budget when its producer wrote it crossed the bound here, and the cut, corrected only to a rune boundary (which every character of an escape already is), could land inside an escape and leave a dangling one. That reads as a bug in the escaper rather than as a truncated name.

It now bounds **while writing**: a unit that does not fit is not written, so the answer ends between escapes or at the end. A message that fits still comes back unchanged - `explain()` sizes its remedy budget on exactly that, and reserving ellipsis room unconditionally would have silently dropped the last remedy that fits.

`TestEchoSafeCutsBetweenEscapesAndNeverInsideOne` tries every bound from 4 to 200 against every escape width the function emits. Mutation-checked by restoring escape-then-bound.

Neither layer was reachable from the other's producers today, which is why the issue's own comment asked for both together: whatever rule is chosen has to be applied at both, or the outer one re-opens the inner.

`make check-backend` and `make craft-static` green.

Closes #1787.
