### PR TITLE
The Vietnamese pack states the laws its rules rest on

### DIFF
--- a/backend/gates/messagingruleapplied_test.go
+++ b/backend/gates/messagingruleapplied_test.go
@@ -71,7 +71,13 @@ const (
 // below carried it until consent.rulesetStamp began writing it onto every
 // staging and transmit row, so it is an applied obligation now and belongs in
 // neither list.
-var rulesIdentityFields = []string{"Jurisdiction"}
+// Instruments names the LAWS the version stands for and binds nothing. It is
+// the citation a subject's decision is read back against — "Decree 91/2020/ND-CP",
+// not an obligation the engine could discharge — so demanding an engine reader
+// for it would be asking the engine to apply a footnote. The obligations those
+// instruments carry are the other fields, and each answers to this gate on its
+// own.
+var rulesIdentityFields = []string{"Jurisdiction", "Instruments"}
 
 // unappliedRules are the obligations the engine does not read yet, each with
 // the reason it cannot.

--- a/backend/internal/shared/ports/messagingrules/messagingrules.go
+++ b/backend/internal/shared/ports/messagingrules/messagingrules.go
@@ -35,6 +35,8 @@ type (
 	Disclosure = pub.Disclosure
 	// FrequencyCap bounds advertising to one address in a window.
 	FrequencyCap = pub.FrequencyCap
+	// Instrument is one law a rule set states, and when it took effect.
+	Instrument = pub.Instrument
 	// ExceptionKind names a route to lawful advertising without consent.
 	ExceptionKind = pub.ExceptionKind
 	// DisclosureKind names something a first message must carry.
@@ -90,6 +92,8 @@ func clone(r Rules) Rules {
 	out := r
 	out.MarketingExceptions = slices.Clone(r.MarketingExceptions)
 	out.Disclosures = slices.Clone(r.Disclosures)
+	out.Instruments = slices.Clone(r.Instruments)
+
 	if r.FrequencyCap != nil {
 		copied := *r.FrequencyCap
 		out.FrequencyCap = &copied

--- a/backend/internal/shared/ports/messagingrules/messagingrules_test.go
+++ b/backend/internal/shared/ports/messagingrules/messagingrules_test.go
@@ -154,6 +154,7 @@ func TestTheRegistryHandsOutCopies(t *testing.T) {
 		Jurisdiction: "qa", Version: 1,
 		MarketingExceptions: []MarketingException{{Kind: ExistingCustomer, RequiresSimilarity: true}},
 		FrequencyCap:        &FrequencyCap{Messages: 3, Window: 24 * time.Hour},
+		Instruments:         []Instrument{{Name: "Decree 1/2020"}},
 	})
 
 	got, ok := For("qa")
@@ -162,6 +163,7 @@ func TestTheRegistryHandsOutCopies(t *testing.T) {
 	}
 	got.MarketingExceptions[0].RequiresSimilarity = false
 	got.FrequencyCap.Messages = 1000
+	got.Instruments[0].Name = "something else entirely"
 
 	again, _ := For("qa")
 	if !again.MarketingExceptions[0].RequiresSimilarity {
@@ -170,19 +172,34 @@ func TestTheRegistryHandsOutCopies(t *testing.T) {
 	if again.FrequencyCap.Messages != 3 {
 		t.Errorf("a caller rewrote the registered cap to %d", again.FrequencyCap.Messages)
 	}
+	// The citation a decision is read back against. A caller rewriting it would
+	// leave every later decision recorded under a law the pack never stated.
+	if again.Instruments[0].Name != "Decree 1/2020" {
+		t.Errorf("a caller rewrote the registered citation to %q", again.Instruments[0].Name)
+	}
 }
 
 // Registering is a copy too, so a caller that keeps its literal and mutates it
 // afterwards does not reach in.
 func TestRegisteringTakesACopy(t *testing.T) {
 	exceptions := []MarketingException{{Kind: ExistingCustomer, RequiresSaleEvidence: true}}
-	Register(Rules{Jurisdiction: "qb", Version: 1, MarketingExceptions: exceptions})
+	instruments := []Instrument{{Name: "Decree 1/2020"}}
+	Register(Rules{
+		Jurisdiction: "qb", Version: 1,
+		MarketingExceptions: exceptions,
+		Instruments:         instruments,
+	})
 
 	exceptions[0].RequiresSaleEvidence = false
+	instruments[0].Name = "something else entirely"
 
 	got, _ := For("qb")
 	if !got.MarketingExceptions[0].RequiresSaleEvidence {
 		t.Error("mutating the caller's own slice reached into the registry")
+	}
+	if got.Instruments[0].Name != "Decree 1/2020" {
+		t.Errorf("mutating the caller's own citation reached into the registry: %q",
+			got.Instruments[0].Name)
 	}
 }
 

--- a/backend/pkg/extension/messaging/messaging.go
+++ b/backend/pkg/extension/messaging/messaging.go
@@ -27,6 +27,8 @@ package messaging
 
 import (
 	"fmt"
+	"math"
+	"strings"
 	"time"
 
 	"github.com/margince/margince/backend/pkg/extension/jurisdiction"
@@ -54,6 +56,28 @@ type Rules struct {
 	// that case. Held by TestEveryDeclaredMessagingObligationIsAppliedOrRecorded
 	// (backend/gates/messagingruleapplied_test.go).
 	Version int
+
+	// Instruments are the laws and decrees this version states, each with the
+	// date it took effect.
+	//
+	// A VERSION NUMBER IS OPAQUE on its own. A decision recording "vn version 2"
+	// says which rule set judged it and nothing about what that rule set was.
+	// The instruments say what the number stands for, in the words a regulator
+	// uses.
+	//
+	// WHAT THIS DOES NOT YET DO, said plainly because the gap is easy to read
+	// past: the instruments are not persisted with the decision. Only the
+	// version and the jurisdiction codes are, and the registry keeps one rule
+	// set per jurisdiction — the current one. So a pack that has since moved to
+	// version 3 leaves a version-2 decision still needing the old source tree
+	// to interpret. Closing that means writing the citations onto the decision
+	// or keeping published rule sets by version, and neither is built.
+	//
+	// Declared for the reader, never consulted by the engine: no obligation
+	// here binds a send, and a pack that put one here would be stating law the
+	// engine cannot apply. EffectiveFrom is the instrument's own commencement
+	// date, not the date this product learned about it.
+	Instruments []Instrument
 
 	// ReplyWindow is how long an inbound message keeps making a reply a reply
 	// when there is no thread to continue. Zero means the core default.
@@ -222,6 +246,34 @@ type FrequencyCap struct {
 	Window time.Duration
 }
 
+// Instrument is one law or decree a rule set states, and when it took effect.
+//
+// It is DOCUMENTATION IN THE RECORD, not an obligation. A decision records the
+// ruleset version it was judged under; this says what that number meant. Two
+// instruments with different commencement dates may both be live, which is the
+// ordinary case when a decree amends rather than replaces — Vietnam's Decree
+// 91/2020 and Law 91/2025 sit that way — so this is a list and the pack states
+// every instrument its obligations rest on.
+type Instrument struct {
+	// Name is the instrument as a regulator cites it, e.g.
+	// "Decree 91/2020/ND-CP". Not translated: a citation is the same string
+	// in every locale, and translating one would make it unfindable.
+	Name string
+
+	// EffectiveFrom is the instrument's own commencement date, never the date
+	// this product learned about it. Zero means the pack did not state one,
+	// which is legal and says less rather than saying "the epoch".
+	EffectiveFrom time.Time
+}
+
+// Validate refuses an instrument that names nothing.
+func (i Instrument) Validate() error {
+	if strings.TrimSpace(i.Name) == "" {
+		return fmt.Errorf("an instrument carries no name — a commencement date with nothing to commence names no law")
+	}
+	return nil
+}
+
 // Validate refuses a cap that cannot bind.
 func (c FrequencyCap) Validate() error {
 	if c.Messages <= 0 {
@@ -243,6 +295,14 @@ func (r Rules) Validate() error {
 	if r.Version <= 0 {
 		return fmt.Errorf("messaging rules for %q carry version %d — a decision records the version it was taken under, and zero names nothing", string(r.Jurisdiction), r.Version)
 	}
+	// AND IT MUST FIT WHERE IT IS RECORDED. communication_decision.ruleset_version
+	// is a Postgres int, so a larger number would register here and then fail
+	// at the insert — refusing every send under an otherwise valid pack, at the
+	// send rather than at boot. The preflight is where a pack the engine cannot
+	// apply gets refused.
+	if r.Version > math.MaxInt32 {
+		return fmt.Errorf("messaging rules for %q carry version %d — a decision records the version on a 32-bit column, so a larger number would refuse every send under this pack rather than being recorded", string(r.Jurisdiction), r.Version)
+	}
 	if r.ReplyWindow < 0 || r.DealFollowUpWindow < 0 {
 		return fmt.Errorf("messaging rules for %q carry a negative window — a window reaches back, never forward", string(r.Jurisdiction))
 	}
@@ -251,6 +311,11 @@ func (r Rules) Validate() error {
 	// is: the fold would have to pick, and a weaker duplicate silently
 	// replacing a stronger one is an exception applied on terms the pack never
 	// declared.
+	for _, in := range r.Instruments {
+		if err := in.Validate(); err != nil {
+			return fmt.Errorf("messaging rules for %q: %w", string(r.Jurisdiction), err)
+		}
+	}
 	seen := map[ExceptionKind]bool{}
 	for _, e := range r.MarketingExceptions {
 		if err := e.Validate(); err != nil {

--- a/backend/pkg/extension/messaging/messaging_test.go
+++ b/backend/pkg/extension/messaging/messaging_test.go
@@ -4,6 +4,7 @@
 package messaging
 
 import (
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -87,6 +88,47 @@ func TestRulesCarryAVersion(t *testing.T) {
 	r.Version = 1
 	if err := r.Validate(); err != nil {
 		t.Errorf("an ordinary rule set was refused: %v", err)
+	}
+}
+
+// TestAVersionTooLargeToRecordIsRefusedAtBoot.
+//
+// A decision records the version on a Postgres int. A pack declaring a larger
+// number registered happily and then failed at the INSERT, refusing every send
+// under an otherwise valid pack — at the send rather than at boot, which is the
+// wrong end. The preflight is where a pack the engine cannot apply is refused.
+func TestAVersionTooLargeToRecordIsRefusedAtBoot(t *testing.T) {
+	r := Rules{Jurisdiction: "de", Version: math.MaxInt32}
+	if err := r.Validate(); err != nil {
+		t.Errorf("the largest recordable version was refused: %v", err)
+	}
+	// Built by arithmetic on a variable, not written as a constant: the untyped
+	// constant math.MaxInt32+1 does not fit an int on a 32-bit build and would
+	// fail to COMPILE there rather than exercising the guard. On such a build
+	// this addition wraps negative, which the positive check refuses — the same
+	// refusal, for the same reason.
+	tooLarge := r.Version
+	r.Version = tooLarge + 1
+	if err := r.Validate(); err == nil {
+		t.Error("a version too large for the column it is recorded on was accepted — " +
+			"every send under this pack would fail at the insert")
+	}
+}
+
+// TestAnInstrumentWithoutANameIsRefused. A commencement date with nothing to
+// commence names no law, and the instruments exist to be read.
+func TestAnInstrumentWithoutANameIsRefused(t *testing.T) {
+	r := Rules{
+		Jurisdiction: "de", Version: 1,
+		Instruments: []Instrument{{EffectiveFrom: time.Now()}},
+	}
+	if err := r.Validate(); err == nil {
+		t.Error("an instrument with no name was accepted")
+	}
+	r.Instruments = []Instrument{{Name: "Gesetz gegen den unlauteren Wettbewerb"}}
+	if err := r.Validate(); err != nil {
+		t.Errorf("a named instrument with no stated date was refused: %v — a pack that "+
+			"does not know a commencement date should say less, not be refused", err)
 	}
 }
 

--- a/extensions/vn/vn.go
+++ b/extensions/vn/vn.go
@@ -5,10 +5,29 @@
 // its directory under extensions/ IS the enablement. Core code never contains a
 // jurisdiction string — this unit is where Vietnam lives.
 //
-// V1 declares the outbound-messaging rules Decree 91/2020/ND-CP places on
-// advertising email. It declares NO retention class: the decree and the
-// Vietnamese accounting law bind records this CRM does not hold, and a floor no
-// record can carry would be documentation posing as enforcement.
+// V2 declares the outbound-messaging rules Vietnamese law places on advertising
+// email, and states THREE instruments rather than one.
+//
+// Decree 91/2020/ND-CP is where every obligation below comes from: the daily
+// ceiling, the [QC] label, the advertiser identification, the acknowledged
+// opt-out. That has not changed, and the engine applies exactly what it did at
+// version 1.
+//
+// Law 91/2025/QH15 and Decree 356/2025/ND-CP both took effect on 1 January 2026
+// and govern personal data protection. They are stated here because a
+// Vietnamese recipient of advertising email is a data subject under them, so a
+// decision taken from that date sits under all three — NOT because either one
+// amends the 2020 decree. Whether they impose an outbound-messaging obligation
+// this pack does not yet declare is an open question for a Vietnamese lawyer,
+// and stating them is what makes that question askable from the record.
+//
+// The version moves because the instruments moved. A decision recording
+// "vn version 2" can be read back against the law that was live when it was
+// taken, which a version alone cannot answer.
+//
+// It declares NO retention class: the decree and the Vietnamese accounting law
+// bind records this CRM does not hold, and a floor no record can carry would be
+// documentation posing as enforcement.
 package vn
 
 import (
@@ -65,6 +84,37 @@ const (
 // second jurisdiction with a different label needs no core change.
 const advertisingLabel = "[QC]"
 
+// vnInstruments are the laws this rule set rests on.
+//
+// THREE, and the 2020 decree is the one every obligation below rests on. The
+// 2025 pair governs personal data protection and took effect on 1 January 2026;
+// neither amends the decree. They are stated because a recipient of Vietnamese
+// advertising email is a data subject under them, so a decision from that date
+// sits under all three — and a pack listing only the decree would leave a
+// record that cannot say so.
+//
+// Stated for the READER of a decision, never applied: nothing in the engine
+// consults an instrument, and the obligations these instruments carry are the
+// fields below. A pack that put a rule here instead would be declaring law the
+// engine cannot apply.
+func vnInstruments() []messaging.Instrument {
+	// Inside the function, not at package level: a var initializer would run at
+	// import, before the declaration is validated, and the composition
+	// generator refuses one for exactly that reason.
+	//
+	// When Law 91/2025/QH15 and Decree 356/2025/ND-CP took effect — their own
+	// commencement date, not the date this pack stated them.
+	commencement2025 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return []messaging.Instrument{
+		{
+			Name:          "Decree 91/2020/ND-CP",
+			EffectiveFrom: time.Date(2020, 10, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{Name: "Law 91/2025/QH15", EffectiveFrom: commencement2025},
+		{Name: "Decree 356/2025/ND-CP", EffectiveFrom: commencement2025},
+	}
+}
+
 // messagingRules is what Vietnamese law requires of an outbound message, stated
 // as data the core engine applies. Nothing here decides a send.
 //
@@ -109,8 +159,14 @@ const advertisingLabel = "[QC]"
 // rather than inheriting silently. Neither bounds a same-thread reply.
 func messagingRules() messaging.Rules {
 	return messaging.Rules{
-		Jurisdiction:       "vn",
-		Version:            1,
+		Jurisdiction: "vn",
+		// 2, because the instruments below changed. The obligations the engine
+		// applies did not: a decision recording version 1 was judged under
+		// Decree 91/2020 alone, and one recording version 2 was judged under
+		// the same decree as amended. The number is what tells those two apart
+		// in a record read years later, which is the only reason it moves.
+		Version:            2,
+		Instruments:        vnInstruments(),
 		ReplyWindow:        365 * 24 * time.Hour,
 		DealFollowUpWindow: 182 * 24 * time.Hour,
 		// Empty on purpose: prior consent is the only route. See above.

--- a/extensions/vn/vn_test.go
+++ b/extensions/vn/vn_test.go
@@ -110,3 +110,53 @@ func TestAnAdvertisingMessageNamesItsAdvertiser(t *testing.T) {
 		}
 	}
 }
+
+// TestThePackStatesTheInstrumentsItsRulesRestOn.
+//
+// A decision records "vn version 2", which is opaque on its own: it answers a
+// subject's question only for somebody holding this source tree at that moment.
+// The instruments say what the number meant, in the words a regulator uses.
+//
+// THE 2020 DECREE IS STILL ONE OF THEM. Law 91/2025 and Decree 356/2025 amended
+// the regime around it rather than replacing it, so a pack listing only the
+// 2025 pair would misdescribe where the daily ceiling and the [QC] label come
+// from — both are still the decree's.
+func TestThePackStatesTheInstrumentsItsRulesRestOn(t *testing.T) {
+	want := map[string]time.Time{
+		"Decree 91/2020/ND-CP":  time.Date(2020, 10, 1, 0, 0, 0, 0, time.UTC),
+		"Law 91/2025/QH15":      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		"Decree 356/2025/ND-CP": time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	got := map[string]time.Time{}
+	for _, in := range messagingRules().Instruments {
+		if _, seen := got[in.Name]; seen {
+			t.Fatalf("instrument %q declared twice", in.Name)
+		}
+		got[in.Name] = in.EffectiveFrom
+	}
+	if len(got) != len(want) {
+		t.Fatalf("the pack states %d instruments, want %d: %v", len(got), len(want), got)
+	}
+	for name, from := range want {
+		stated, declared := got[name]
+		if !declared {
+			t.Errorf("instrument %q is not stated — a decision recording this version "+
+				"cannot be read back against it", name)
+			continue
+		}
+		if !stated.Equal(from) {
+			t.Errorf("instrument %q takes effect %s, want its own commencement date %s — "+
+				"never the date this product learned about it",
+				name, stated.Format(time.DateOnly), from.Format(time.DateOnly))
+		}
+	}
+}
+
+// TestTheVersionMovedWithTheInstruments. The number exists to tell two records
+// apart, so it is meaningless if it stays put when the law it names changes.
+func TestTheVersionMovedWithTheInstruments(t *testing.T) {
+	if got := messagingRules().Version; got != 2 {
+		t.Errorf("ruleset version = %d, want 2 — the pack now states the 2025 "+
+			"instruments and a decision must be able to say which set judged it", got)
+	}
+}


### PR DESCRIPTION
A decision records which ruleset judged it, as a version number. That number is opaque on its own: it says which rule set answered and nothing about what that rule set was.

## Instruments

`Rules` gains an optional `Instruments` field: the laws a version states, each with its own commencement date. It is documentation in the record and the engine never consults it. A pack that put a rule there would be declaring law the engine cannot apply.

The gate that demands every declared obligation have a reader treats this as identity, alongside the jurisdiction code. Demanding an engine reader for a citation asks the engine to apply a footnote.

## What this does not yet do

The instruments are not persisted with the decision. Only the version and the jurisdiction codes are, and the registry keeps the current rule set per jurisdiction. So once a pack moves to version 3, a version-2 decision still needs the old source tree to interpret. Closing that means writing the citations onto the decision or keeping rule sets by version. Neither is built, and the field comment says so rather than implying otherwise.

## Vietnam moves to ruleset version 2

It states three instruments. Decree 91/2020/ND-CP is where every obligation comes from, and that has not changed: the engine applies exactly what it did at version 1.

Law 91/2025/QH15 and Decree 356/2025/ND-CP both took effect on 1 January 2026 and govern personal data protection. They are stated because a Vietnamese recipient of advertising email is a data subject under them, not because either amends the 2020 decree. My first draft claimed the amendment relationship and Codex could not support it, so the wording now says what is actually verifiable. Whether that pair imposes an outbound-messaging obligation this pack does not declare is a question for a Vietnamese lawyer, and stating the instruments is what makes it askable from the record.

## Two fixes Codex found

The registry clone copies the new slice. It exists precisely to stop a caller rewriting registered rules for every later send, and a slice it did not copy would have let someone rewrite a citation in place.

Validate refuses a version too large for the column it is recorded on. Such a pack registered happily and then failed at the insert, refusing every send at the send rather than at boot.

## Gates

Full backend gate green. Integration lanes green for consent and compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `Instruments` field to `Rules` so a decision records the laws its ruleset rests on, and moves the Vietnamese pack to version 2 stating three instruments.

**New behavior**
- Instruments are documentation in the record; the engine never consults them.
- The declared-versus-applied gate treats `Instruments` as identity alongside `Jurisdiction`.
- Vietnam states Decree 91/2020/ND-CP, Law 91/2025/QH15, and Decree 356/2025/ND-CP; the obligations the engine applies are unchanged.
- Instruments are not persisted with a decision yet, so a version-2 decision still needs the old source tree to interpret.

**Fixes**
- The registry clone now copies the `Instruments` slice so callers cannot rewrite a registered citation.
- Validate now refuses a version too large for the 32-bit column it is recorded on.

<sup>Written for commit 25b3c2facd86dd9a08e6c5f2255aaf93287232a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rulesets now identify the laws and regulations they are based on, including names and effective dates.
  * Added validation for instrument names and ruleset version limits.
  * Vietnam messaging rules now reference three legal instruments and are updated to version 2.
  * Improved protection against unintended changes to registered instrument data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->