### PR TITLE
Write down the re-certification sweep

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,7 @@ decision rather than an omission.
 - [flip-an-overlay-to-native.md](how-to/flip-an-overlay-to-native.md) — the one-way overlay→native cutover: preflight, seal, the typed confirmation, and what recovery actually means.
 - [connect-a-cloud-model-provider.md](how-to/connect-a-cloud-model-provider.md) — bind the AI lanes to a BYOK cloud key (Anthropic / OpenAI / Gemini / any OpenAI-compatible vendor).
 - [certify-an-ai-model.md](how-to/certify-an-ai-model.md) — certify a model against a task's fixture corpus and benchmark a candidate swap (`make e2e-ai`).
+- [re-certify-the-whole-corpus.md](how-to/re-certify-the-whole-corpus.md) — the sweep loop after a tree-wide change stales every record: run both preset bindings, tell a moved question from a model regression before calling anything a drop, fix or flag, re-run one task, regenerate both generated pages.
 - [add-an-ai-task.md](how-to/add-an-ai-task.md) — add a new AI task or invocation site: declare it in the contract, wire the lane, register the site, certify it.
 - [write-a-certification-case.md](how-to/write-a-certification-case.md) — bind a site to the production request builder and validator that certify it: the test-first loop, the case interface, the three site kinds, scenario and rubric authoring, scope.
 - [register-a-webhook.md](how-to/register-a-webhook.md) — register an HTTPS endpoint for Standard-Webhooks-signed, retried outbound delivery of contract-generated event payloads (curl or Settings → Integrations), and verify/inspect/replay a delivery.

--- a/docs/how-to/re-certify-the-whole-corpus.md
+++ b/docs/how-to/re-certify-the-whole-corpus.md
@@ -20,8 +20,12 @@ repeat any of that.
 ## 1. Capture the report BEFORE you spend
 
 ```bash
-cd backend && make e2e-ai-report | tee ../.tmp/readiness-before.txt
+mkdir -p .tmp
+(cd backend && make e2e-ai-report) | tee .tmp/readiness-before.txt
 ```
+
+`.tmp/` is gitignored and may not exist yet — this step runs before anything
+else has written there.
 
 This is not bookkeeping. A stale row names **which half of its stamp moved** —
 the case, the prompt this build sends, or the grader — and that is the only
@@ -148,8 +152,12 @@ unactionable artifact the stamps exist to prevent.
 
 ## 5. Re-run only what you changed
 
-A prompt fix moves that task's stamp and nothing else, so the re-run is one task
-on each preset — seconds and cents, not another sweep:
+**Let the report say what to re-run, rather than assuming your fix was
+task-local.** A prompt edit inside one task's builder moves that task's stamp and
+nothing else, and the re-run is then one task on each preset — seconds and cents,
+not another sweep. An edit to something SHARED moves every stamp that reads it,
+which is the same blast radius that put you here in §1. `make e2e-ai-report`
+tells the two apart for free, and it is the only thing that does:
 
 ```bash
 cd backend
@@ -159,6 +167,11 @@ make e2e-ai TASK=<task> ROUTING=config/presets/gemini_cloud.yaml \
 make e2e-ai TASK=<task> ROUTING=config/presets/openrouter_cloud.yaml \
   JUDGE=gemini:gemini-3.5-flash RESUME=
 ```
+
+Run it again afterwards and read the headline: every site current means the fix
+was as local as you thought. Anything still `stale` is a task your change
+reached and this re-run did not — repeat for each, or sweep §2 again if the list
+is long.
 
 `RESUME=` (empty) forces fresh measurement: the point of this run is that the
 prompt changed, and a replayed journal would answer the old one.

--- a/docs/how-to/re-certify-the-whole-corpus.md
+++ b/docs/how-to/re-certify-the-whole-corpus.md
@@ -100,8 +100,8 @@ Re-read the report and compare it with the file from §1.
 
 **A band that dropped under a moved case is a new baseline, not a worse model.**
 This is the single most common misreading, and it is expensive both ways: it
-sends people hunting a regression that does not exist, and it hides the one that
-does. After a tree-wide rename expect nearly every row to sit under a moved
+sends a reader hunting a regression that does not exist, and it hides the one
+that does. After a tree-wide rename expect nearly every row to sit under a moved
 case — at which point the honest summary is *"new baselines"*, and only the rows
 that moved for another reason are worth a second look.
 

--- a/docs/how-to/re-certify-the-whole-corpus.md
+++ b/docs/how-to/re-certify-the-whole-corpus.md
@@ -1,0 +1,197 @@
+# Re-certify the whole corpus
+
+A tree-wide change — a rename that rewrites every fixture, a prompt-builder edit,
+a grader change — stales every certification record at once. The readiness report
+then reads `0 of N shipped sites carry a current record`, and no band on it
+describes a request this build sends.
+
+This page is the loop that clears it: **run** both preset sweeps, **analyse** what
+moved before calling anything a regression, **fix or flag** what the analysis
+finds, **re-run** only what you changed. It assumes
+[certify-an-ai-model.md](certify-an-ai-model.md) for what the lane is, what the
+report's four states mean, and how a verdict is decided — this page does not
+repeat any of that.
+
+> **The sweep is the expensive one.** Two full passes over the corpus is every
+> shipped site times `RUNS` times two bindings, billed to your own BYOK budget.
+> Everything in §2 is free and several of its answers change what you would
+> otherwise pay to re-run, so do not skip ahead to a fix.
+
+## 1. Capture the report BEFORE you spend
+
+```bash
+cd backend && make e2e-ai-report | tee ../.tmp/readiness-before.txt
+```
+
+This is not bookkeeping. A stale row names **which half of its stamp moved** —
+the case, the prompt this build sends, or the grader — and that is the only
+record of it you will have: once the sweep overwrites the records, the old stamps
+are gone and the report can no longer attribute anything.
+
+The three causes want opposite responses, which is why the report separates them:
+
+- **the case** — somebody rewrote the test. A band that moves is measuring a
+  different question, and re-certifying is a matter of course.
+- **the prompt this build sends** — the product changed. The new band describes
+  the NEW prompt; a drop is a consequence of a product change, and somebody
+  should be told which change.
+- **the grader** — the judge's own request moved. A band can move with neither
+  the test nor the product touched. This reads as a model regression and is not
+  one.
+
+Keep the file. §2 reads it.
+
+## 2. Run both preset sweeps
+
+The presets in [`config/presets/`](../../config/presets/README.md) are the two
+bindings worth a sweep: they are named, committed and reusable, so the records
+they produce are comparable with everybody else's.
+
+```bash
+cd backend
+
+# gemini_cloud: every tier on Gemini, one credential.
+make e2e-ai ROUTING=config/presets/gemini_cloud.yaml \
+  JUDGE=openai_compatible:mistralai/mistral-large-2512 \
+  JUDGE_BASE_URL=https://openrouter.ai/api \
+  TRACE="$PWD/../.tmp/aicert/gemini" RESUME="$PWD/../.tmp/aicert/gemini/resume"
+
+# openrouter_cloud: every lane through the broker.
+make e2e-ai ROUTING=config/presets/openrouter_cloud.yaml \
+  JUDGE=gemini:gemini-3.5-flash \
+  TRACE="$PWD/../.tmp/aicert/openrouter" RESUME="$PWD/../.tmp/aicert/openrouter/resume"
+```
+
+`TRACE=`/`RESUME=` must be **absolute**. The default the Makefile computes is,
+and for a reason a relative one silently gets wrong: a Go test runs with its
+working directory set to the package under test, so `../.tmp/…` typed here would
+land under `backend/internal/compose/` rather than beside the repo.
+
+**The judges are crossed on purpose, and a run refuses them uncrossed.**
+`cert_judge` is a task like any other and leads at `premium`, so a judge bound to
+the model that preset puts on its premium rung collides with every premium-led
+candidate. `validateRoutedBindings` checks every task the routing resolves and
+fails **before the first paid call** — caught mid-corpus it would be caught after
+the tasks before it had been billed.
+
+Two further rules the commands above encode:
+
+- **Give each pass its own `TRACE=` and `RESUME=` directory.** They can then run
+  concurrently — the records they write are disjoint, one file per
+  (task, provider, model, env) — and neither replays the other's journal.
+- **`RESUME=` is a six-hour, same-binary cache.** Any Go edit invalidates the
+  whole journal, so finish the analysis and the fix before restarting a cut-short
+  run, or it re-pays for everything.
+
+Two outcomes are expected rather than wrong:
+
+- **`document_extract` writes no `openrouter_cloud` record and that run exits
+  FAIL.** The OpenAI-compatible wire's `input:` vocabulary is text and image
+  only, so the adapter refuses the PDF rather than dropping it. The run's other
+  tasks still write their records. Tracked as a gap, not a regression; the
+  preset's own README states it.
+- **Neither sweep measures the `frontier` rung.** A routed run certifies the
+  LEADING bound rung per task, and no shipped task's ladder leads at frontier —
+  so a preset can bind a frontier model that the sweep never reaches.
+
+## 3. Analyse before you call anything a regression
+
+Re-read the report and compare it with the file from §1.
+
+**A band that dropped under a moved case is a new baseline, not a worse model.**
+This is the single most common misreading, and it is expensive both ways: it
+sends people hunting a regression that does not exist, and it hides the one that
+does. After a tree-wide rename expect nearly every row to sit under a moved
+case — at which point the honest summary is *"new baselines"*, and only the rows
+that moved for another reason are worth a second look.
+
+**Confirm the judge did not change.** A judge swap moves bands on its own and
+reads exactly like model decay. Every record names the grader that scored it, so
+this is checkable rather than assumed:
+
+```bash
+for f in $(git diff --name-only -- backend/internal/compose/aicert/records); do
+  o=$(git show HEAD:$f | jq -r .judge_served_model); n=$(jq -r .judge_served_model "$f")
+  [ "$o" != "$n" ] && echo "JUDGE CHANGED: $f  $o -> $n"
+done
+```
+
+Silence means every band moved for a reason other than its grader, and the
+summary can say so.
+
+**Read the trace for anything still unexplained.** A task failing every run
+identically is deterministic and has a nameable cause; the payload trace holds
+what the model was actually sent and actually answered
+([certify-an-ai-model.md §4](certify-an-ai-model.md#4-see-the-prompts--trace-requestresponse-for-tuning)).
+A worked example, from the sweep this page was written from: `enrich` failed 3/3
+with `no surviving title`, and the trace showed the model extracting the right
+value and filing it under `role` — a key the prompt offered beside `title` with
+nothing to choose between them, and which no column mirrors. The certification
+failure was the visible end of a defect that had been filing job titles where no
+reader looks.
+
+## 4. Fix, or flag
+
+**Fix it in the same change** when the cause is in reach — a prompt that offers
+two words for one thing, a validator disagreeing with its rubric. Hold the fix
+with a test that fails without it: derive what the test expects from the thing
+that owns it rather than writing a second copy, and watch it go red before you
+trust it.
+
+**Open an issue** when the fix needs a product or architecture decision, or lives
+in another module. Label it — one `priority:`, one `area:` — per
+[issue-labels.md](../reference/issue-labels.md).
+
+Either way, **say which rows are new baselines and which are findings** when you
+report the sweep. A list of band changes with no attribution is the same
+unactionable artifact the stamps exist to prevent.
+
+## 5. Re-run only what you changed
+
+A prompt fix moves that task's stamp and nothing else, so the re-run is one task
+on each preset — seconds and cents, not another sweep:
+
+```bash
+cd backend
+make e2e-ai TASK=<task> ROUTING=config/presets/gemini_cloud.yaml \
+  JUDGE=openai_compatible:mistralai/mistral-large-2512 \
+  JUDGE_BASE_URL=https://openrouter.ai/api RESUME=
+make e2e-ai TASK=<task> ROUTING=config/presets/openrouter_cloud.yaml \
+  JUDGE=gemini:gemini-3.5-flash RESUME=
+```
+
+`RESUME=` (empty) forces fresh measurement: the point of this run is that the
+prompt changed, and a replayed journal would answer the old one.
+
+## 6. Regenerate BOTH generated pages
+
+Two committed pages render from what you just changed, each held by its own drift
+gate, and **a prompt change moves both**:
+
+```bash
+cd backend
+go test ./internal/compose/aicert/ -run TestAICertificationPage -update-ai-cert
+go test ./internal/compose/ -run TestTheAIPromptsPageIsCurrent -update-ai-prompts
+```
+
+The second is the one that gets forgotten.
+[ai-certification.md](../reference/ai-certification.md) tracks the *records*, so
+a records-only sweep needs it alone — but
+[ai-prompts.md](../reference/ai-prompts.md) mirrors every instruction this build
+sends a model, so the moment a fix edits a prompt, that page is stale too. Its
+gate lives in the `internal/compose` package rather than in `aicert`, which is
+why running the certification tests alone leaves it green and CI red.
+
+Then run the package whole rather than your own tests by name — `go test
+./internal/compose/ -count=1` — because a drift gate you did not think to name is
+exactly the one that catches this.
+
+## What this loop does not tell you
+
+- **Anything about the `frontier` rung** (§2), or about any binding neither
+  preset names. Records for those come from `MODEL=` runs and stay stale through
+  a sweep; they are not preset bindings and the sweep does not claim them.
+- **Whether a site survives real input.** Every record measures the corpus
+  fixture. A site can be certified at reliability 1.00 and fail on what
+  production hands it — [debug-an-ai-task.md](debug-an-ai-task.md) is that
+  question.


### PR DESCRIPTION
## Why

The sweep in #5461 — two preset passes over the whole corpus, then triage — was run from scratch, and several of its steps are only obvious in hindsight. Two of them were paid for during that PR: one in a wrong conclusion that had to be walked back, one in a red CI check.

`certify-an-ai-model.md` already covers the lane, the report's four states and how a verdict is decided. It sits exactly at its 350-line budget, and this is a different question anyway — that page is *certify a model against a task*, this one is *every record went stale at once, now what*. So it is a new page rather than a section, and it links to that one instead of restating it.

## What the page carries that nothing else does

**Capture the readiness report before you spend.** A stale row names which half of its stamp moved — the case, the prompt this build sends, or the grader. The sweep overwrites those stamps, so after it runs, nothing can attribute a change any more. That report is the only record of *why*, and it is free.

**A band that dropped under a moved case is a new baseline, not a worse model.** The misreading is expensive in both directions: it sends people hunting a regression that does not exist, and it hides the one that does. In #5461 all 53 changed records sat under a moved case, so the honest summary was "new baselines" — and the one genuine defect (`enrich` filing job titles under a key no column mirrors) stood out precisely because it did not fit that shape.

**Why the judges are crossed.** `cert_judge` leads at `premium`, so a judge bound to the model a preset puts on its premium rung collides with every premium-led candidate. `validateRoutedBindings` refuses it before the first paid call. Neither preset can be swept with a judge drawn from its own binding, and the page gives the working pair for each.

**Regenerate both generated pages.** `ai-certification.{md,json}` tracks the records; `ai-prompts.{md,json}` mirrors every instruction the build sends a model, so a prompt fix stales it too. Its gate lives in `internal/compose`, not `aicert`, which is why running the certification tests alone leaves it green and CI red — that is exactly how it failed in #5461.

**`TRACE=`/`RESUME=` must be absolute.** A Go test runs with its working directory set to the package under test, so a relative `../.tmp/…` lands under `backend/internal/compose/` rather than beside the repo. I had written the relative form into the first draft of this page and caught it while checking the commands resolve — which is the kind of error a how-to exists to stop, so it is called out in the page rather than silently fixed.

Also documented as expected-by-design rather than failures: `document_extract` writing no `openrouter_cloud` record (#1425), and neither preset's `frontier` rung being reached, since no shipped task's ladder leads there.

## Checks

`backend/gates` green with `-count=1`, including the docs page-length and reachability gates. Every command in the page was run during #5461 except the two whose paths I corrected, which are checked against how the Makefile computes its own defaults.

`certify-an-ai-model.md` is deliberately untouched: it is at its line budget, and adding a back-link would have meant trimming content I was not otherwise changing. Discovery is via the `docs/README.md` index entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a how-to page documenting the full re-certification sweep loop and links it from the docs index, so a tree-wide change that stales every certification record no longer requires reverse-engineering the process.

- Captures the readiness report before the sweep, since the run overwrites the stamps that attribute a change.
- Runs both preset bindings with crossed judges, and requires absolute `TRACE=`/`RESUME=` paths.
- Distinguishes a moved case from a model regression, with the worked `enrich` example.
- Scopes the re-run by the report, so a task-local fix costs one task per preset rather than a fresh sweep.
- Regenerates both `ai-certification` and `ai-prompts`, since the latter's gate lives in a different package.
- Documents expected behaviors as by-design: `document_extract` and the `frontier` rung.

<sup>Written for commit 8d6d04c79e0461e640235b894b1f3961822e6c3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a guide for re-certifying the full AI model corpus after tree-wide changes.
  - Documented readiness checks, preset sweeps, crossed-judge analysis, regression handling, targeted reruns, and regeneration of certification pages.
  - Added the new guide to the documentation index.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->