### PR TITLE
perf(frontend): the suite builds a cheaper DOM, and the same tests pass

### DIFF
--- a/extensions/openchannel/frontend/screen.test.tsx
+++ b/extensions/openchannel/frontend/screen.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { LocaleProvider } from "@margince/frontend/app";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/coverage-v8": "^4.1.10",
+    "happy-dom": "20.14.0",
     "jsdom": "^30.0.0",
     "node-html-parser": "^9.0.1",
     "openapi-typescript": "^7.13.0",

--- a/frontend/scripts/autocleanup.test.ts
+++ b/frontend/scripts/autocleanup.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // That every case starts on an empty document.
 //

--- a/frontend/scripts/unroutedsession.test.ts
+++ b/frontend/scripts/unroutedsession.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // That a case which leaves `GET /me` unrouted FAILS, rather than warning.
 //

--- a/frontend/src/App.composed.test.tsx
+++ b/frontend/src/App.composed.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/frontend/src/App.extscreen.test.tsx
+++ b/frontend/src/App.extscreen.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/frontend/src/App.hashcredentials.test.tsx
+++ b/frontend/src/App.hashcredentials.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/App.onboardinggate.test.tsx
+++ b/frontend/src/App.onboardinggate.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { StrictMode } from "react";
@@ -125,14 +125,32 @@ function completedWizardFetch(shape: InstallShape) {
  *
  * A `hashchange` listener alone is not enough and stopped seeing anything the
  * moment redirects began replacing the entry rather than assigning to the hash:
- * `history.replaceState` fires no `hashchange`, so a loop would have counted
- * zero moves and passed. What this test is about is how many times the app
- * decides to go somewhere, so it counts the decisions.
+ * `history.replaceState` fires no `hashchange` where the specification is
+ * followed, so a loop would have counted zero moves and passed. What this test
+ * is about is how many times the app decides to go somewhere, so it counts the
+ * decisions.
  */
 function recordHashChanges(): string[] {
   const seen: string[] = [];
   const at = () => window.location.hash;
+  // ONE MOVE IS RECORDED ONCE, whichever channel announces it.
+  //
+  // The two channels overlap, and by how much depends on the environment.
+  // `hashchange` is specified to fire for an ASSIGNMENT to the hash and not for
+  // a history write — jsdom follows that, happy-dom fires it for
+  // pushState and replaceState too. Counting both channels blind therefore
+  // records every redirect twice under one environment and once under the
+  // other, and the count is the whole assertion: one move looks like a loop.
+  //
+  // So a history write claims the hashchange it causes. A SECOND move to the
+  // same address arrives with nothing claimed and is still counted, which is
+  // the recurrence these cases are looking for.
+  let claimed: string | null = null;
   window.addEventListener("hashchange", () => {
+    if (claimed === at()) {
+      claimed = null;
+      return;
+    }
     seen.push(at());
   });
   for (const write of ["pushState", "replaceState"] as const) {
@@ -145,6 +163,7 @@ function recordHashChanges(): string[] {
       // A stamp on the entry the reader is already on names it; it is not a
       // move, and it passes no URL.
       if (args[2] !== undefined && args[2] !== null) {
+        claimed = at();
         seen.push(at());
       }
     });

--- a/frontend/src/App.tabkey.test.tsx
+++ b/frontend/src/App.tabkey.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SLOWEST_MEASURED_TEST_MS } from "../vitest.budget";

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/api/model-inflight.test.tsx
+++ b/frontend/src/api/model-inflight.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, expect, it } from "vitest";
 import {

--- a/frontend/src/app/account.test.tsx
+++ b/frontend/src/app/account.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent, { type UserEvent } from "@testing-library/user-event";

--- a/frontend/src/app/addressstate.test.ts
+++ b/frontend/src/app/addressstate.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { beforeEach, describe, expect, it } from "vitest";
 import { navigateReplacing } from "./router";
 import { replaceParams } from "./urlstate";

--- a/frontend/src/app/agent-edge-gl.test.ts
+++ b/frontend/src/app/agent-edge-gl.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { describe, expect, it } from "vitest";
 import { createEdgeRenderer, type EdgeHues } from "./agent-edge-gl";

--- a/frontend/src/app/agent-edge-loop.test.ts
+++ b/frontend/src/app/agent-edge-loop.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/frontend/src/app/agent-edge-preference.test.tsx
+++ b/frontend/src/app/agent-edge-preference.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
@@ -167,16 +167,27 @@ describe("the margins, and whether this reader wants them", () => {
     // Storage is refused in some embedded contexts. Persisting is the
     // enhancement; a switch that visibly does nothing when pressed is not a
     // degraded feature, it is a broken control.
-    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
-      throw new Error("storage is not available here");
-    });
-    render(<AgentEdge />);
+    const refuses = vi
+      .spyOn(window.localStorage, "setItem")
+      .mockImplementation(() => {
+        throw new Error("storage is not available here");
+      });
+    try {
+      render(<AgentEdge />);
 
-    act(() => setEdgeLightShown(false));
+      act(() => setEdgeLightShown(false));
 
-    expect(edgeLightShown()).toBe(false);
-    expect(margins()).toBeNull();
-    vi.restoreAllMocks();
+      expect(edgeLightShown()).toBe(false);
+      expect(margins()).toBeNull();
+    } finally {
+      // THIS spy, in a finally, rather than vi.restoreAllMocks() after the
+      // assertions. Two reasons, and the second is what broke: restoring
+      // everything from inside one case reaches mocks the case did not install,
+      // and a restore that only runs when the assertions pass leaves a storage
+      // that throws installed for every case after a failure — which is a
+      // cascade of failures naming the wrong tests.
+      refuses.mockRestore();
+    }
   });
 
   // A fresh module is what makes this a claim about BOOT: the store resolves

--- a/frontend/src/app/agent-edge.test.tsx
+++ b/frontend/src/app/agent-edge.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/agentrail-ticker.test.tsx
+++ b/frontend/src/app/agentrail-ticker.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/app/agentrail.capture.test.tsx
+++ b/frontend/src/app/agentrail.capture.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion

--- a/frontend/src/app/agentrail.crossfade.test.tsx
+++ b/frontend/src/app/agentrail.crossfade.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/agentrail.recap.test.tsx
+++ b/frontend/src/app/agentrail.recap.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion

--- a/frontend/src/app/agentrail.scope.test.tsx
+++ b/frontend/src/app/agentrail.scope.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/frontend/src/app/ai-activity.test.tsx
+++ b/frontend/src/app/ai-activity.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/app/capability.test.tsx
+++ b/frontend/src/app/capability.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/app/capture-chip.test.tsx
+++ b/frontend/src/app/capture-chip.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion

--- a/frontend/src/app/economybanner.test.tsx
+++ b/frontend/src/app/economybanner.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/embedreindexbanner.test.tsx
+++ b/frontend/src/app/embedreindexbanner.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";

--- a/frontend/src/app/errorboundary.test.tsx
+++ b/frontend/src/app/errorboundary.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import {
   QueryClient,
   QueryClientProvider,

--- a/frontend/src/app/pageaside.test.tsx
+++ b/frontend/src/app/pageaside.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/palette.test.tsx
+++ b/frontend/src/app/palette.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/frontend/src/app/recordzone.test.tsx
+++ b/frontend/src/app/recordzone.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/scrollmemory.clamp.test.tsx
+++ b/frontend/src/app/scrollmemory.clamp.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { render } from "@testing-library/react";
 import { act, useRef } from "react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/app/scrollmemory.test.tsx
+++ b/frontend/src/app/scrollmemory.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { render } from "@testing-library/react";
 import { act, useRef } from "react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { House } from "lucide-react";

--- a/frontend/src/app/sormodechip.test.tsx
+++ b/frontend/src/app/sormodechip.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";

--- a/frontend/src/app/theme.test.tsx
+++ b/frontend/src/app/theme.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { act, cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/app/topbar.test.tsx
+++ b/frontend/src/app/topbar.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/unsaved.test.tsx
+++ b/frontend/src/app/unsaved.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/viewport.test.ts
+++ b/frontend/src/app/viewport.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PHONE_MAX_WIDTH, usePhoneViewport } from "./viewport";

--- a/frontend/src/design-system/actionrow.render.test.tsx
+++ b/frontend/src/design-system/actionrow.render.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/frontend/src/design-system/aipending.test.tsx
+++ b/frontend/src/design-system/aipending.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/ambient-waves.test.tsx
+++ b/frontend/src/design-system/ambient-waves.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/design-system/atoms.test.tsx
+++ b/frontend/src/design-system/atoms.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/frontend/src/design-system/avatar.test.tsx
+++ b/frontend/src/design-system/avatar.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { Avatar } from "./atoms";

--- a/frontend/src/design-system/breadcrumb.test.tsx
+++ b/frontend/src/design-system/breadcrumb.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/briefitem.test.tsx
+++ b/frontend/src/design-system/briefitem.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/button.test.tsx
+++ b/frontend/src/design-system/button.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/frontend/src/design-system/calendar.test.tsx
+++ b/frontend/src/design-system/calendar.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";

--- a/frontend/src/design-system/callout.test.tsx
+++ b/frontend/src/design-system/callout.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/design-system/choicelist.test.tsx
+++ b/frontend/src/design-system/choicelist.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/combobox.test.tsx
+++ b/frontend/src/design-system/combobox.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/communicationstatus.test.tsx
+++ b/frontend/src/design-system/communicationstatus.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it } from "vitest";

--- a/frontend/src/design-system/companylogo.test.tsx
+++ b/frontend/src/design-system/companylogo.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, expect, it } from "vitest";
 import { CompanyLogo } from "./companylogo";

--- a/frontend/src/design-system/composed.rail.test.tsx
+++ b/frontend/src/design-system/composed.rail.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { viewerZone } from "../format/timezone";

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";

--- a/frontend/src/design-system/composed.thread.test.tsx
+++ b/frontend/src/design-system/composed.thread.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";

--- a/frontend/src/design-system/confirmmodal.test.tsx
+++ b/frontend/src/design-system/confirmmodal.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/design-system/contactlink.test.tsx
+++ b/frontend/src/design-system/contactlink.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/dateinput.test.tsx
+++ b/frontend/src/design-system/dateinput.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/debouncedsearch.test.ts
+++ b/frontend/src/design-system/debouncedsearch.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/decisioncard.test.tsx
+++ b/frontend/src/design-system/decisioncard.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/design-system/decisiondeck.test.tsx
+++ b/frontend/src/design-system/decisiondeck.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/design-system/emaildetail.test.tsx
+++ b/frontend/src/design-system/emaildetail.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // What the email drawer shows about a message beyond its words: the files that
 // came with it, who it was with, what it is filed against, and the verb that

--- a/frontend/src/design-system/emailentry.test.tsx
+++ b/frontend/src/design-system/emailentry.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/design-system/evidencemark.test.tsx
+++ b/frontend/src/design-system/evidencemark.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import {
   cleanup,
   fireEvent,

--- a/frontend/src/design-system/evidencereceipt.test.tsx
+++ b/frontend/src/design-system/evidencereceipt.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { EvidenceReceipt } from "./evidencereceipt";

--- a/frontend/src/design-system/explain.test.tsx
+++ b/frontend/src/design-system/explain.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";

--- a/frontend/src/design-system/field.test.tsx
+++ b/frontend/src/design-system/field.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/design-system/fielddiff.test.tsx
+++ b/frontend/src/design-system/fielddiff.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { LocaleProvider } from "../i18n";

--- a/frontend/src/design-system/filechip.test.tsx
+++ b/frontend/src/design-system/filechip.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { FileChip, previewMediaType } from "./filechip";

--- a/frontend/src/design-system/filedropzone.test.tsx
+++ b/frontend/src/design-system/filedropzone.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/design-system/filepreview.test.tsx
+++ b/frontend/src/design-system/filepreview.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/design-system/hoverintent.test.tsx
+++ b/frontend/src/design-system/hoverintent.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/iconaction.test.tsx
+++ b/frontend/src/design-system/iconaction.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { IconAction } from "./iconaction";

--- a/frontend/src/design-system/inlinechoice.test.tsx
+++ b/frontend/src/design-system/inlinechoice.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import {
   cleanup,
   fireEvent,

--- a/frontend/src/design-system/listtable.alternate-body.test.tsx
+++ b/frontend/src/design-system/listtable.alternate-body.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { LocaleProvider } from "../i18n";

--- a/frontend/src/design-system/listtable.narrowing-reset.test.tsx
+++ b/frontend/src/design-system/listtable.narrowing-reset.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { LocaleProvider } from "../i18n";

--- a/frontend/src/design-system/listtable.test.tsx
+++ b/frontend/src/design-system/listtable.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/frontend/src/design-system/margince-core-engine.test.tsx
+++ b/frontend/src/design-system/margince-core-engine.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/design-system/margince-core-gl.test.ts
+++ b/frontend/src/design-system/margince-core-gl.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { afterEach, describe, expect, it } from "vitest";
 import { readHue } from "./margince-core-gl";

--- a/frontend/src/design-system/margince-core-loop.test.ts
+++ b/frontend/src/design-system/margince-core-loop.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCoreLoop, type Wanted } from "./margince-core-engine";

--- a/frontend/src/design-system/margince-core-palette.test.ts
+++ b/frontend/src/design-system/margince-core-palette.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/frontend/src/design-system/margince-workbench.test.tsx
+++ b/frontend/src/design-system/margince-workbench.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/design-system/modal.test.tsx
+++ b/frontend/src/design-system/modal.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import {
   act,
   cleanup,

--- a/frontend/src/design-system/moneyinput.test.tsx
+++ b/frontend/src/design-system/moneyinput.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import {
   cleanup,
   fireEvent,

--- a/frontend/src/design-system/motion.test.ts
+++ b/frontend/src/design-system/motion.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { INTRO_MS, useDocumentIntro, useTypeStream } from "./motion";

--- a/frontend/src/design-system/pagezones.test.tsx
+++ b/frontend/src/design-system/pagezones.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/panel.test.tsx
+++ b/frontend/src/design-system/panel.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/frontend/src/design-system/passportselect.test.tsx
+++ b/frontend/src/design-system/passportselect.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/design-system/pipelineladder.test.tsx
+++ b/frontend/src/design-system/pipelineladder.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/design-system/popover.test.tsx
+++ b/frontend/src/design-system/popover.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import {
   act,
   cleanup,

--- a/frontend/src/design-system/projectlinks.test.tsx
+++ b/frontend/src/design-system/projectlinks.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/design-system/provider-mark.test.tsx
+++ b/frontend/src/design-system/provider-mark.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { ProviderMark } from "./provider-mark";

--- a/frontend/src/design-system/rbac.test.tsx
+++ b/frontend/src/design-system/rbac.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/design-system/readings.test.tsx
+++ b/frontend/src/design-system/readings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { Globe, MapPin } from "lucide-react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/design-system/recordpicker.test.tsx
+++ b/frontend/src/design-system/recordpicker.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import {
   act,
   cleanup,

--- a/frontend/src/design-system/recordtabs.test.tsx
+++ b/frontend/src/design-system/recordtabs.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { LocaleProvider } from "../i18n";

--- a/frontend/src/design-system/recordtimeline.test.tsx
+++ b/frontend/src/design-system/recordtimeline.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/design-system/relationshipmap.test.tsx
+++ b/frontend/src/design-system/relationshipmap.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/resolvesheet.test.tsx
+++ b/frontend/src/design-system/resolvesheet.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/design-system/richtext.test.tsx
+++ b/frontend/src/design-system/richtext.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/rowtags.test.tsx
+++ b/frontend/src/design-system/rowtags.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/select.test.tsx
+++ b/frontend/src/design-system/select.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/settingrow.test.tsx
+++ b/frontend/src/design-system/settingrow.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/frontend/src/design-system/stack.test.tsx
+++ b/frontend/src/design-system/stack.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // The primitive exists so a unit can space two things without a stylesheet, so
 // what these hold is that the SCALE decides the spacing and the caller only

--- a/frontend/src/design-system/statstrip.test.tsx
+++ b/frontend/src/design-system/statstrip.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/frontend/src/design-system/swiperow.test.tsx
+++ b/frontend/src/design-system/swiperow.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/design-system/switch.test.tsx
+++ b/frontend/src/design-system/switch.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/design-system/toast.test.tsx
+++ b/frontend/src/design-system/toast.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/design-system/tokeninput.test.tsx
+++ b/frontend/src/design-system/tokeninput.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/tooltip.test.tsx
+++ b/frontend/src/design-system/tooltip.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/design-system/trust.test.tsx
+++ b/frontend/src/design-system/trust.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";

--- a/frontend/src/design-system/visibility.test.tsx
+++ b/frontend/src/design-system/visibility.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // One mark for who may read a thing. What these hold is the claim the mark
 // makes to a reader: the word is exact, the look says the SHAPE of the audience

--- a/frontend/src/design-system/waterfall.test.tsx
+++ b/frontend/src/design-system/waterfall.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { Waterfall } from "./waterfall";

--- a/frontend/src/format/now.test.ts
+++ b/frontend/src/format/now.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { translate } from "../i18n";

--- a/frontend/src/i18n/locale-persistence.test.tsx
+++ b/frontend/src/i18n/locale-persistence.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/frontend/src/i18n/plural-hooks.test.tsx
+++ b/frontend/src/i18n/plural-hooks.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/i18n/publiclocale.test.tsx
+++ b/frontend/src/i18n/publiclocale.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { LocaleProvider, useT } from ".";

--- a/frontend/src/mcp-apps/account-brief/main.test.ts
+++ b/frontend/src/mcp-apps/account-brief/main.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { describe, expect, it } from "vitest";
 import { accountBriefFixture } from "./fixture";

--- a/frontend/src/mcp-apps/bridge.test.ts
+++ b/frontend/src/mcp-apps/bridge.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 //
 // A view is a document, not a Node module: this spec drives a real DOM —
 // postMessage, createElement, textContent — so it declares jsdom for itself

--- a/frontend/src/mcp-apps/commitments/main.test.ts
+++ b/frontend/src/mcp-apps/commitments/main.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { describe, expect, it } from "vitest";
 import { commitmentsFixture } from "./fixture";

--- a/frontend/src/mcp-apps/handoff/main.test.ts
+++ b/frontend/src/mcp-apps/handoff/main.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { describe, expect, it } from "vitest";
 import { handoffFixture } from "./fixture";

--- a/frontend/src/mcp-apps/pipeline-review/main.test.ts
+++ b/frontend/src/mcp-apps/pipeline-review/main.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { describe, expect, it } from "vitest";
 import { pipelineReviewFixture } from "./fixture";

--- a/frontend/src/mcp-apps/relationship-map/main.test.ts
+++ b/frontend/src/mcp-apps/relationship-map/main.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { describe, expect, it } from "vitest";
 import { relationshipMapFixture } from "./fixture";

--- a/frontend/src/screens/accountscan.test.tsx
+++ b/frontend/src/screens/accountscan.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/adddocument.test.tsx
+++ b/frontend/src/screens/adddocument.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/ai-health.test.tsx
+++ b/frontend/src/screens/ai-health.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/ai-provider-keys.test.tsx
+++ b/frontend/src/screens/ai-provider-keys.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/ai-rates.test.tsx
+++ b/frontend/src/screens/ai-rates.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/ai-routing.test.tsx
+++ b/frontend/src/screens/ai-routing.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/ai-settings.test.tsx
+++ b/frontend/src/screens/ai-settings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/ai.test.tsx
+++ b/frontend/src/screens/ai.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/aicalls.test.tsx
+++ b/frontend/src/screens/aicalls.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/aiexport.test.tsx
+++ b/frontend/src/screens/aiexport.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";

--- a/frontend/src/screens/aiscope.test.tsx
+++ b/frontend/src/screens/aiscope.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/aiusage.test.tsx
+++ b/frontend/src/screens/aiusage.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/analytics.coverage.test.tsx
+++ b/frontend/src/screens/analytics.coverage.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";

--- a/frontend/src/screens/analytics.forecast.landing.test.tsx
+++ b/frontend/src/screens/analytics.forecast.landing.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/analytics.forecast.subject.test.tsx
+++ b/frontend/src/screens/analytics.forecast.subject.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/analytics.forecast.test.tsx
+++ b/frontend/src/screens/analytics.forecast.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/analytics.scope.test.tsx
+++ b/frontend/src/screens/analytics.scope.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/analytics.share.test.tsx
+++ b/frontend/src/screens/analytics.share.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/approvalrow.render.test.tsx
+++ b/frontend/src/screens/approvalrow.render.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/approvals.queries.test.tsx
+++ b/frontend/src/screens/approvals.queries.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/archive.test.tsx
+++ b/frontend/src/screens/archive.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";

--- a/frontend/src/screens/audienceservice.test.tsx
+++ b/frontend/src/screens/audienceservice.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/audit.test.tsx
+++ b/frontend/src/screens/audit.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";

--- a/frontend/src/screens/auth.test.tsx
+++ b/frontend/src/screens/auth.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { THEME_KEY } from "../app/theme";
 import { resetTheme } from "../app/theme-reset";
 import { LOCALES, LocaleProvider, localeNameKey, translate } from "../i18n";
+import { locationDouble } from "../testing/locationdouble";
 import { AuthScreen, AvailabilityScreen, ProviderButtons } from "./auth";
 
 // The unauthenticated surface (A107/ADR-0061 §12): login is the default —
@@ -96,7 +97,7 @@ async function stubLocationAssign(
   const originalLocation = window.location;
   const assign = vi.fn();
   Object.defineProperty(window, "location", {
-    value: { ...originalLocation, assign },
+    value: locationDouble({ assign }),
     writable: true,
     configurable: true,
   });

--- a/frontend/src/screens/automationdetail.test.tsx
+++ b/frontend/src/screens/automationdetail.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/automations.test.tsx
+++ b/frontend/src/screens/automations.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/autonomy-settings.test.tsx
+++ b/frontend/src/screens/autonomy-settings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/backfill.test.tsx
+++ b/frontend/src/screens/backfill.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/billingcontacts.test.tsx
+++ b/frontend/src/screens/billingcontacts.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import { afterEach, expect, it } from "vitest";
 import { LocaleProvider } from "../i18n";

--- a/frontend/src/screens/blocked-domains.test.tsx
+++ b/frontend/src/screens/blocked-domains.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/brief.decisions.test.tsx
+++ b/frontend/src/screens/brief.decisions.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/brief.dials.test.tsx
+++ b/frontend/src/screens/brief.dials.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/brief.feed.test.tsx
+++ b/frontend/src/screens/brief.feed.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/brief.plan.contract.test.tsx
+++ b/frontend/src/screens/brief.plan.contract.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/brief.plan.test.tsx
+++ b/frontend/src/screens/brief.plan.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { act, cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/brief.rail.test.tsx
+++ b/frontend/src/screens/brief.rail.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/brief.readings.test.tsx
+++ b/frontend/src/screens/brief.readings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/brief.schedule.test.tsx
+++ b/frontend/src/screens/brief.schedule.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { formatTimeOfDay } from "../format/format";

--- a/frontend/src/screens/brief.teamboard.test.tsx
+++ b/frontend/src/screens/brief.teamboard.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/brief.teamweekly.test.tsx
+++ b/frontend/src/screens/brief.teamweekly.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/brief.teamweeklyagenda.test.tsx
+++ b/frontend/src/screens/brief.teamweeklyagenda.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/brief.test.tsx
+++ b/frontend/src/screens/brief.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import {
   cleanup,
   render as rtlRender,

--- a/frontend/src/screens/brief.waterfall.test.tsx
+++ b/frontend/src/screens/brief.waterfall.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/brief.weekly.learnings.test.tsx
+++ b/frontend/src/screens/brief.weekly.learnings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/brief.weekly.scorecard.test.tsx
+++ b/frontend/src/screens/brief.weekly.scorecard.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/brief.weekly.test.tsx
+++ b/frontend/src/screens/brief.weekly.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RecordZoneProvider } from "../app/recordzone";

--- a/frontend/src/screens/briefcoverage.test.tsx
+++ b/frontend/src/screens/briefcoverage.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/briefdelivery.test.tsx
+++ b/frontend/src/screens/briefdelivery.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/buyerroom.test.tsx
+++ b/frontend/src/screens/buyerroom.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/capture-activity.test.tsx
+++ b/frontend/src/screens/capture-activity.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/capture-exclusions.test.tsx
+++ b/frontend/src/screens/capture-exclusions.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/capture-owner-identities.test.tsx
+++ b/frontend/src/screens/capture-owner-identities.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/capture-settings.test.tsx
+++ b/frontend/src/screens/capture-settings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/channelproviders.test.tsx
+++ b/frontend/src/screens/channelproviders.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/common.test.tsx
+++ b/frontend/src/screens/common.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/companies.header.test.tsx
+++ b/frontend/src/screens/companies.header.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/companies.test.tsx
+++ b/frontend/src/screens/companies.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,

--- a/frontend/src/screens/company-ask.test.tsx
+++ b/frontend/src/screens/company-ask.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/company-context.test.tsx
+++ b/frontend/src/screens/company-context.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/company-contract-overview.test.tsx
+++ b/frontend/src/screens/company-contract-overview.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/company/glance.test.tsx
+++ b/frontend/src/screens/company/glance.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/company360-strip.test.tsx
+++ b/frontend/src/screens/company360-strip.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/company360.failure.test.tsx
+++ b/frontend/src/screens/company360.failure.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/company360.money.test.tsx
+++ b/frontend/src/screens/company360.money.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/companycommercial.test.tsx
+++ b/frontend/src/screens/companycommercial.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { describe, expect, it } from "vitest";
 import { leadingDeal, offerAmount } from "./companycommercial";
 

--- a/frontend/src/screens/companycontacts/contacts.test.tsx
+++ b/frontend/src/screens/companycontacts/contacts.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/companycontacts/introrequest.test.tsx
+++ b/frontend/src/screens/companycontacts/introrequest.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/companycontacts/summary.test.tsx
+++ b/frontend/src/screens/companycontacts/summary.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/companycontractpaper.test.tsx
+++ b/frontend/src/screens/companycontractpaper.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/companycontracts.menu.test.tsx
+++ b/frontend/src/screens/companycontracts.menu.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/companydocuments.test.tsx
+++ b/frontend/src/screens/companydocuments.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/companydossier.test.tsx
+++ b/frontend/src/screens/companydossier.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/companyevidence.test.tsx
+++ b/frontend/src/screens/companyevidence.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/companyfacts.test.tsx
+++ b/frontend/src/screens/companyfacts.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/companyfactspanel.test.tsx
+++ b/frontend/src/screens/companyfactspanel.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/companyfinance.test.tsx
+++ b/frontend/src/screens/companyfinance.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/companygrowthfit.test.tsx
+++ b/frontend/src/screens/companygrowthfit.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/companyheader.test.tsx
+++ b/frontend/src/screens/companyheader.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/companyhealth.test.tsx
+++ b/frontend/src/screens/companyhealth.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { describe, expect, it } from "vitest";
 import { worstOf } from "./companylookups";
 

--- a/frontend/src/screens/companymark.test.tsx
+++ b/frontend/src/screens/companymark.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/companyrail.test.tsx
+++ b/frontend/src/screens/companyrail.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/companyraildetails.test.tsx
+++ b/frontend/src/screens/companyraildetails.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/companyrecent.test.tsx
+++ b/frontend/src/screens/companyrecent.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // What the account page's recent-exchange list draws for each kind it holds.
 //

--- a/frontend/src/screens/companyreject.test.tsx
+++ b/frontend/src/screens/companyreject.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";

--- a/frontend/src/screens/companyscan.test.tsx
+++ b/frontend/src/screens/companyscan.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/companysignals.test.tsx
+++ b/frontend/src/screens/companysignals.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";

--- a/frontend/src/screens/companytasks.test.tsx
+++ b/frontend/src/screens/companytasks.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/companytoday.test.tsx
+++ b/frontend/src/screens/companytoday.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/companyvatmark.test.tsx
+++ b/frontend/src/screens/companyvatmark.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/companywork.test.tsx
+++ b/frontend/src/screens/companywork.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/compose-contact-draft.test.tsx
+++ b/frontend/src/screens/compose-contact-draft.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/compose-dead-address.test.tsx
+++ b/frontend/src/screens/compose-dead-address.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/compose-draft-reveal.test.tsx
+++ b/frontend/src/screens/compose-draft-reveal.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render as rtlRender, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/compose-lead-draft.test.tsx
+++ b/frontend/src/screens/compose-lead-draft.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/compose-links.test.tsx
+++ b/frontend/src/screens/compose-links.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/compose-permission.test.tsx
+++ b/frontend/src/screens/compose-permission.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/compose-recipient.test.tsx
+++ b/frontend/src/screens/compose-recipient.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/compose.head.test.tsx
+++ b/frontend/src/screens/compose.head.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/compose.mailbox.test.tsx
+++ b/frontend/src/screens/compose.mailbox.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/compose.scheduled.test.tsx
+++ b/frontend/src/screens/compose.scheduled.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/compose.transport.test.tsx
+++ b/frontend/src/screens/compose.transport.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/composethread.test.tsx
+++ b/frontend/src/screens/composethread.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";

--- a/frontend/src/screens/confirm.test.tsx
+++ b/frontend/src/screens/confirm.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/connect-panels.test.tsx
+++ b/frontend/src/screens/connect-panels.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/connected-agents.test.tsx
+++ b/frontend/src/screens/connected-agents.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/connectors.contexttag.test.tsx
+++ b/frontend/src/screens/connectors.contexttag.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/connectors.notices.test.tsx
+++ b/frontend/src/screens/connectors.notices.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { LocaleProvider } from "../i18n";

--- a/frontend/src/screens/connectors.test.tsx
+++ b/frontend/src/screens/connectors.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -14,6 +14,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
+import { locationDouble } from "../testing/locationdouble";
 import { ConnectorsCard } from "./connectors";
 import { installFetchStub } from "./story-utils";
 
@@ -369,7 +370,7 @@ describe("the connected-inboxes card", () => {
 
   it("reconnect re-mints the consent URL and redirects", async () => {
     const assign = vi.fn();
-    vi.stubGlobal("location", { ...globalThis.location, assign });
+    vi.stubGlobal("location", locationDouble({ assign }));
     const calls = stubApi([gmailStale], {
       connect: { authorize_url: "https://accounts.google/consent" },
     });
@@ -386,7 +387,7 @@ describe("the connected-inboxes card", () => {
   });
 
   it("sends return_to=settings on reconnect so consent lands back on Settings", async () => {
-    vi.stubGlobal("location", { ...globalThis.location, assign: vi.fn() });
+    vi.stubGlobal("location", locationDouble({ assign: vi.fn() }));
     const calls = stubApi([gmailStale], {
       connect: { authorize_url: "https://accounts.google/consent" },
     });
@@ -663,7 +664,7 @@ describe("add a connection", () => {
 
   it("redirects the browser when an OAuth provider is chosen", async () => {
     const assign = vi.fn();
-    vi.stubGlobal("location", { ...globalThis.location, assign });
+    vi.stubGlobal("location", locationDouble({ assign }));
     stubApi([gmailConnected], {
       connect: { authorize_url: "https://accounts.google/cal" },
     });

--- a/frontend/src/screens/consent.test.tsx
+++ b/frontend/src/screens/consent.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/consumer-mail-domains.test.tsx
+++ b/frontend/src/screens/consumer-mail-domains.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/contact360.test.tsx
+++ b/frontend/src/screens/contact360.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";

--- a/frontend/src/screens/contactaccess.test.tsx
+++ b/frontend/src/screens/contactaccess.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/contactcards.brief.test.tsx
+++ b/frontend/src/screens/contactcards.brief.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/contactcards.loops.test.tsx
+++ b/frontend/src/screens/contactcards.loops.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";

--- a/frontend/src/screens/contactcorrections.test.tsx
+++ b/frontend/src/screens/contactcorrections.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/contactdrawers.research.test.tsx
+++ b/frontend/src/screens/contactdrawers.research.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { ContactResearchDrawer } from "./contactdrawers";

--- a/frontend/src/screens/contactfiles.test.tsx
+++ b/frontend/src/screens/contactfiles.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/contactmemory.test.tsx
+++ b/frontend/src/screens/contactmemory.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // What the contact page's memory card draws for each kind it holds.
 //

--- a/frontend/src/screens/contactnetwork-panel.test.tsx
+++ b/frontend/src/screens/contactnetwork-panel.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/contactnetwork/index.test.tsx
+++ b/frontend/src/screens/contactnetwork/index.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/contactpage.editverbs.test.tsx
+++ b/frontend/src/screens/contactpage.editverbs.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/contactpage.test.tsx
+++ b/frontend/src/screens/contactpage.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import {
   cleanup,
   render,

--- a/frontend/src/screens/contactprovider.test.tsx
+++ b/frontend/src/screens/contactprovider.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/contactrail.test.tsx
+++ b/frontend/src/screens/contactrail.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/contactreadings.test.tsx
+++ b/frontend/src/screens/contactreadings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/contactresearch.test.tsx
+++ b/frontend/src/screens/contactresearch.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/contacts.test.tsx
+++ b/frontend/src/screens/contacts.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,

--- a/frontend/src/screens/contacttabs.test.tsx
+++ b/frontend/src/screens/contacttabs.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/contacttoday.test.tsx
+++ b/frontend/src/screens/contacttoday.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/contacttransport.test.tsx
+++ b/frontend/src/screens/contacttransport.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/context.test.tsx
+++ b/frontend/src/screens/context.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/contractform.currency.test.tsx
+++ b/frontend/src/screens/contractform.currency.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/contractformpaper.test.tsx
+++ b/frontend/src/screens/contractformpaper.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/contractlifecycle.test.tsx
+++ b/frontend/src/screens/contractlifecycle.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/screens/corpusask.test.tsx
+++ b/frontend/src/screens/corpusask.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/coverageexplorer.test.tsx
+++ b/frontend/src/screens/coverageexplorer.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/create.test.tsx
+++ b/frontend/src/screens/create.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/customfields.card.test.tsx
+++ b/frontend/src/screens/customfields.card.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/customfields.form.render.test.tsx
+++ b/frontend/src/screens/customfields.form.render.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/customfields.test.tsx
+++ b/frontend/src/screens/customfields.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/deal360/deal360.test.tsx
+++ b/frontend/src/screens/deal360/deal360.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";

--- a/frontend/src/screens/deal360/dealcommercial.test.tsx
+++ b/frontend/src/screens/deal360/dealcommercial.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/deal360/dealcommittee.test.tsx
+++ b/frontend/src/screens/deal360/dealcommittee.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/dealbulk.test.tsx
+++ b/frontend/src/screens/dealbulk.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/dealemail.test.tsx
+++ b/frontend/src/screens/dealemail.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/dealfiles.test.tsx
+++ b/frontend/src/screens/dealfiles.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/dealproject.test.tsx
+++ b/frontend/src/screens/dealproject.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/dealroom.test.tsx
+++ b/frontend/src/screens/dealroom.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/dealroomdocuments.test.tsx
+++ b/frontend/src/screens/dealroomdocuments.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/dealroompage.test.tsx
+++ b/frontend/src/screens/dealroompage.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/dealroomthreads.test.tsx
+++ b/frontend/src/screens/dealroomthreads.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/deals-company.test.tsx
+++ b/frontend/src/screens/deals-company.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/deals-money.test.tsx
+++ b/frontend/src/screens/deals-money.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/deals-views.test.tsx
+++ b/frontend/src/screens/deals-views.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/dealstakeholders.test.tsx
+++ b/frontend/src/screens/dealstakeholders.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/dealstatus.test.tsx
+++ b/frontend/src/screens/dealstatus.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/directsendaction.test.tsx
+++ b/frontend/src/screens/directsendaction.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/directsendmodal.test.tsx
+++ b/frontend/src/screens/directsendmodal.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/documentextraction.test.tsx
+++ b/frontend/src/screens/documentextraction.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/download.test.ts
+++ b/frontend/src/screens/download.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/edit.test.tsx
+++ b/frontend/src/screens/edit.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/emailaccesseditor.test.tsx
+++ b/frontend/src/screens/emailaccesseditor.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // What the drawer says about who reads a message, and what a reader may change.
 //

--- a/frontend/src/screens/emailrecords.test.tsx
+++ b/frontend/src/screens/emailrecords.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // The records a message is filed against, named on the drawer's envelope block.
 //

--- a/frontend/src/screens/emailreply.test.tsx
+++ b/frontend/src/screens/emailreply.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // Whether the drawer offers to answer the message it is showing, and what such
 // a reply would be filed under.

--- a/frontend/src/screens/embedreindex.test.tsx
+++ b/frontend/src/screens/embedreindex.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/screens/entityref.test.tsx
+++ b/frontend/src/screens/entityref.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/evidenceverdict.test.tsx
+++ b/frontend/src/screens/evidenceverdict.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/extension-access.test.tsx
+++ b/frontend/src/screens/extension-access.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/extension-units.test.tsx
+++ b/frontend/src/screens/extension-units.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/filterbuilder.test.tsx
+++ b/frontend/src/screens/filterbuilder.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/filterdata.test.tsx
+++ b/frontend/src/screens/filterdata.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/filterreference.test.ts
+++ b/frontend/src/screens/filterreference.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/filterresults.test.tsx
+++ b/frontend/src/screens/filterresults.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/filters.test.tsx
+++ b/frontend/src/screens/filters.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/held-threads.test.tsx
+++ b/frontend/src/screens/held-threads.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/history.test.tsx
+++ b/frontend/src/screens/history.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/history.timeline.test.tsx
+++ b/frontend/src/screens/history.timeline.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/historyedge.test.tsx
+++ b/frontend/src/screens/historyedge.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/historyentries.test.tsx
+++ b/frontend/src/screens/historyentries.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/historyfielddiff.test.tsx
+++ b/frontend/src/screens/historyfielddiff.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/historyfields.test.tsx
+++ b/frontend/src/screens/historyfields.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";

--- a/frontend/src/screens/historyreversalrow.test.tsx
+++ b/frontend/src/screens/historyreversalrow.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/imap-connect-form.test.tsx
+++ b/frontend/src/screens/imap-connect-form.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/import.contexttag.test.tsx
+++ b/frontend/src/screens/import.contexttag.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/import.test.tsx
+++ b/frontend/src/screens/import.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/installation-settings.test.tsx
+++ b/frontend/src/screens/installation-settings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/installation-setup.test.tsx
+++ b/frontend/src/screens/installation-setup.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/introasks.test.tsx
+++ b/frontend/src/screens/introasks.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/jobhealth.test.tsx
+++ b/frontend/src/screens/jobhealth.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/knowledge.test.tsx
+++ b/frontend/src/screens/knowledge.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/leadbulk.test.tsx
+++ b/frontend/src/screens/leadbulk.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/leadmerged.test.tsx
+++ b/frontend/src/screens/leadmerged.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/leadpresentation.test.tsx
+++ b/frontend/src/screens/leadpresentation.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/leadreadings.test.tsx
+++ b/frontend/src/screens/leadreadings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/leads.rail.test.tsx
+++ b/frontend/src/screens/leads.rail.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,

--- a/frontend/src/screens/leadsignals.test.tsx
+++ b/frontend/src/screens/leadsignals.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/leadvocab.test.tsx
+++ b/frontend/src/screens/leadvocab.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/license.test.tsx
+++ b/frontend/src/screens/license.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/listquery.address.test.tsx
+++ b/frontend/src/screens/listquery.address.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { describe, expect, it } from "vitest";
 import type { UrlParams } from "../app/urlstate";
 import {

--- a/frontend/src/screens/listquery.ownerchips.test.tsx
+++ b/frontend/src/screens/listquery.ownerchips.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,

--- a/frontend/src/screens/liverecord.test.tsx
+++ b/frontend/src/screens/liverecord.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -1,4 +1,14 @@
 /** @vitest-environment jsdom */
+// jsdom, alone in this suite, and for one case: "refuses a future day for a
+// note" asserts that a date past the input's `max` does not submit, which is
+// the BROWSER's range validation and not the app's. happy-dom implements
+// neither half of it — `checkValidity()` answers true and `validity.
+// rangeOverflow` is false for a value years past the max — so under it the form
+// posts and the case fails against an environment rather than against the code.
+//
+// The app's half is asserted either way (`max` is today), and rewriting the
+// case to assert only that would drop the half that catches a form submitting
+// around its own rule. One file on the slower environment is the smaller cost.
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/mail-sharing.test.tsx
+++ b/frontend/src/screens/mail-sharing.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/meetingbrief/drawer.test.tsx
+++ b/frontend/src/screens/meetingbrief/drawer.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/meetingbrief/view.test.tsx
+++ b/frontend/src/screens/meetingbrief/view.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/network.test.tsx
+++ b/frontend/src/screens/network.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/noticecases.test.tsx
+++ b/frontend/src/screens/noticecases.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/oauth-app.test.tsx
+++ b/frontend/src/screens/oauth-app.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/oauthconsent.test.tsx
+++ b/frontend/src/screens/oauthconsent.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -12,6 +12,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
+import { locationDouble } from "../testing/locationdouble";
 import { OAuthConsent } from "./oauthconsent";
 
 // The consent screen is where a human hands an agent their own authority.
@@ -382,10 +383,10 @@ describe("OAuthConsent — re-entering after sign-in", () => {
     globalThis.location.hash = hashWithoutNonce();
     stubSession(true);
     const assigned: string[] = [];
-    vi.stubGlobal("location", {
-      ...globalThis.location,
-      assign: (url: string) => assigned.push(url),
-    });
+    vi.stubGlobal(
+      "location",
+      locationDouble({ assign: (url: string) => assigned.push(url) }),
+    );
     render(<OAuthConsent />);
     await waitFor(() => expect(assigned).toHaveLength(1));
     const reentered = new URLSearchParams(assigned[0].split("?")[1] ?? "");
@@ -401,10 +402,10 @@ describe("OAuthConsent — re-entering after sign-in", () => {
     globalThis.location.hash = hashWithoutNonce();
     stubSession(false);
     const assigned: string[] = [];
-    vi.stubGlobal("location", {
-      ...globalThis.location,
-      assign: (url: string) => assigned.push(url),
-    });
+    vi.stubGlobal(
+      "location",
+      locationDouble({ assign: (url: string) => assigned.push(url) }),
+    );
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });

--- a/frontend/src/screens/offers.test.tsx
+++ b/frontend/src/screens/offers.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/offertemplates.test.tsx
+++ b/frontend/src/screens/offertemplates.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/onboarding-backread.test.tsx
+++ b/frontend/src/screens/onboarding-backread.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/onboarding-build-scene.test.tsx
+++ b/frontend/src/screens/onboarding-build-scene.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { act, cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-company-form.test.tsx
+++ b/frontend/src/screens/onboarding-company-form.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-connect-panels.test.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/onboarding-conversation/basis-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/basis-act.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-conversation/clarify-dismiss.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/clarify-dismiss.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/onboarding-conversation/company-act-deck-typing.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act-deck-typing.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, within } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-conversation/company-act-refusal.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act-refusal.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/onboarding-conversation/company-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-conversation/confirm-card.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/confirm-card.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { readFileSync } from "node:fs";

--- a/frontend/src/screens/onboarding-conversation/connect-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-act.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/onboarding-conversation/entries.test.ts
+++ b/frontend/src/screens/onboarding-conversation/entries.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FINDING_EXPAND_EVENT, jumpToFindings } from "./entries";
 

--- a/frontend/src/screens/onboarding-conversation/invite-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/invite-act.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-conversation/narration.test.ts
+++ b/frontend/src/screens/onboarding-conversation/narration.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../../api/schema";

--- a/frontend/src/screens/onboarding-conversation/next-step-bar.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/next-step-bar.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/onboarding-conversation/onboarding-conversation.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/onboarding-conversation.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/onboarding-conversation/profile-digest.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/profile-digest.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/onboarding-conversation/read-conclusion.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/read-conclusion.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/onboarding-conversation/review-deck.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/review-deck.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/onboarding-conversation/team-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/team-act.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-conversation/thread.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/thread.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-conversation/use-clarify-answers.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/use-clarify-answers.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/onboarding-conversation/use-company-read.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/use-company-read.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/onboarding-conversation/use-linkedin-account.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/use-linkedin-account.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/onboarding-conversation/use-voice-corpus.test.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-corpus.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {

--- a/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { act, cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-evidence.test.tsx
+++ b/frontend/src/screens/onboarding-evidence.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";

--- a/frontend/src/screens/onboarding-facts.test.tsx
+++ b/frontend/src/screens/onboarding-facts.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import {

--- a/frontend/src/screens/onboarding-gate.test.tsx
+++ b/frontend/src/screens/onboarding-gate.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import {

--- a/frontend/src/screens/onboarding-live-panel.test.tsx
+++ b/frontend/src/screens/onboarding-live-panel.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/onboarding.test.tsx
+++ b/frontend/src/screens/onboarding.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/overlay-health.test.tsx
+++ b/frontend/src/screens/overlay-health.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/overlay-usermap.test.tsx
+++ b/frontend/src/screens/overlay-usermap.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/overlay.test.tsx
+++ b/frontend/src/screens/overlay.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/overnight-grant.test.tsx
+++ b/frontend/src/screens/overnight-grant.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/own-domains.test.tsx
+++ b/frontend/src/screens/own-domains.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/partnercommissions.test.tsx
+++ b/frontend/src/screens/partnercommissions.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,

--- a/frontend/src/screens/partnerdeals.test.tsx
+++ b/frontend/src/screens/partnerdeals.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/partners.test.tsx
+++ b/frontend/src/screens/partners.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/passwordcard.test.tsx
+++ b/frontend/src/screens/passwordcard.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/screens/preferences.test.tsx
+++ b/frontend/src/screens/preferences.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/privacy.assignee.test.tsx
+++ b/frontend/src/screens/privacy.assignee.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/privacy.test.tsx
+++ b/frontend/src/screens/privacy.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/products.test.tsx
+++ b/frontend/src/screens/products.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/project360.test.tsx
+++ b/frontend/src/screens/project360.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/projectcommitments.test.tsx
+++ b/frontend/src/screens/projectcommitments.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/projectcompanies.test.tsx
+++ b/frontend/src/screens/projectcompanies.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";

--- a/frontend/src/screens/projectowner.test.tsx
+++ b/frontend/src/screens/projectowner.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/projects.test.tsx
+++ b/frontend/src/screens/projects.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/projectstakeholders.test.tsx
+++ b/frontend/src/screens/projectstakeholders.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/rates.test.tsx
+++ b/frontend/src/screens/rates.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/record360/citationemail.test.tsx
+++ b/frontend/src/screens/record360/citationemail.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/record360/citations.test.tsx
+++ b/frontend/src/screens/record360/citations.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/record360/spine.test.tsx
+++ b/frontend/src/screens/record360/spine.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/record360/timelinethread.test.tsx
+++ b/frontend/src/screens/record360/timelinethread.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/record360/verdict.test.tsx
+++ b/frontend/src/screens/record360/verdict.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/recordchronology.test.tsx
+++ b/frontend/src/screens/recordchronology.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/recordconversations.test.tsx
+++ b/frontend/src/screens/recordconversations.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/recordemail.test.tsx
+++ b/frontend/src/screens/recordemail.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/recordlist.tagscolumn.test.tsx
+++ b/frontend/src/screens/recordlist.tagscolumn.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/releaseskew.test.tsx
+++ b/frontend/src/screens/releaseskew.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/restrictedrecords.test.tsx
+++ b/frontend/src/screens/restrictedrecords.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/retention.test.tsx
+++ b/frontend/src/screens/retention.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/richfields.test.tsx
+++ b/frontend/src/screens/richfields.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/savedviews.test.tsx
+++ b/frontend/src/screens/savedviews.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/scheduledsends.test.tsx
+++ b/frontend/src/screens/scheduledsends.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/search.test.tsx
+++ b/frontend/src/screens/search.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/sendpermission.test.tsx
+++ b/frontend/src/screens/sendpermission.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/settings-agents.test.tsx
+++ b/frontend/src/screens/settings-agents.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/settings-audit.test.tsx
+++ b/frontend/src/screens/settings-audit.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/settings-chrome.test.tsx
+++ b/frontend/src/screens/settings-chrome.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/settings-exitcriteria.test.tsx
+++ b/frontend/src/screens/settings-exitcriteria.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/settings-grants.test.tsx
+++ b/frontend/src/screens/settings-grants.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GrantSpec } from "../app/mefixture";

--- a/frontend/src/screens/settings-integrations.test.tsx
+++ b/frontend/src/screens/settings-integrations.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type GrantSpec, meFixture } from "../app/mefixture";

--- a/frontend/src/screens/settings-maintenance.test.tsx
+++ b/frontend/src/screens/settings-maintenance.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent, { type UserEvent } from "@testing-library/user-event";

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RbacObject } from "../app/capability";

--- a/frontend/src/screens/settings-passports.test.tsx
+++ b/frontend/src/screens/settings-passports.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/settings-pipelines.test.tsx
+++ b/frontend/src/screens/settings-pipelines.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/settings-reach.test.tsx
+++ b/frontend/src/screens/settings-reach.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/settings-routing.test.tsx
+++ b/frontend/src/screens/settings-routing.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { meFixture } from "../app/mefixture";

--- a/frontend/src/screens/settings-stageautomation.test.tsx
+++ b/frontend/src/screens/settings-stageautomation.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { meFixture } from "../app/mefixture";

--- a/frontend/src/screens/settings-stagerules.test.tsx
+++ b/frontend/src/screens/settings-stagerules.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { isValidElement, type ReactNode } from "react";

--- a/frontend/src/screens/settingssearchbox.test.tsx
+++ b/frontend/src/screens/settingssearchbox.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/setupclaim.test.tsx
+++ b/frontend/src/screens/setupclaim.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/share.test.tsx
+++ b/frontend/src/screens/share.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/sign-in-methods.test.tsx
+++ b/frontend/src/screens/sign-in-methods.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/strength.test.tsx
+++ b/frontend/src/screens/strength.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/tagadmin.test.tsx
+++ b/frontend/src/screens/tagadmin.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/tagchips.test.tsx
+++ b/frontend/src/screens/tagchips.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/tagpicker.test.tsx
+++ b/frontend/src/screens/tagpicker.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/tagresult.test.tsx
+++ b/frontend/src/screens/tagresult.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/tagspanel.test.tsx
+++ b/frontend/src/screens/tagspanel.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/taskactions.test.tsx
+++ b/frontend/src/screens/taskactions.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/screens/taskduedate.test.tsx
+++ b/frontend/src/screens/taskduedate.test.tsx
@@ -8,7 +8,7 @@
 // three days overdue snoozes to two days overdue, and a rep who means tomorrow
 // presses it four times.
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/technicalprofile.test.tsx
+++ b/frontend/src/screens/technicalprofile.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 

--- a/frontend/src/screens/telegram-connect-form.test.tsx
+++ b/frontend/src/screens/telegram-connect-form.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/transcriptread.test.tsx
+++ b/frontend/src/screens/transcriptread.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/unsubscribe.test.tsx
+++ b/frontend/src/screens/unsubscribe.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/users-access.test.tsx
+++ b/frontend/src/screens/users-access.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/users-admin.test.tsx
+++ b/frontend/src/screens/users-admin.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/users-password-link.test.tsx
+++ b/frontend/src/screens/users-password-link.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/vcard-import.test.tsx
+++ b/frontend/src/screens/vcard-import.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/screens/voice-candidate.test.tsx
+++ b/frontend/src/screens/voice-candidate.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/screens/voice-corpus-file.test.ts
+++ b/frontend/src/screens/voice-corpus-file.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/frontend/src/screens/voice-corpus-settings.test.tsx
+++ b/frontend/src/screens/voice-corpus-settings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/voice-dna.test.tsx
+++ b/frontend/src/screens/voice-dna.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/voice-insights.test.tsx
+++ b/frontend/src/screens/voice-insights.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { components } from "../api/schema";

--- a/frontend/src/screens/voice-intake-core.test.ts
+++ b/frontend/src/screens/voice-intake-core.test.ts
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import {

--- a/frontend/src/screens/webhooks.test.tsx
+++ b/frontend/src/screens/webhooks.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/working-hours.test.tsx
+++ b/frontend/src/screens/working-hours.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,

--- a/frontend/src/screens/worklist.acknowledge.test.tsx
+++ b/frontend/src/screens/worklist.acknowledge.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.acts.test.tsx
+++ b/frontend/src/screens/worklist.acts.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // One right-aligned row of verbs, with the lane's answer LAST.
 //

--- a/frontend/src/screens/worklist.automationrow.test.tsx
+++ b/frontend/src/screens/worklist.automationrow.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.bands.test.tsx
+++ b/frontend/src/screens/worklist.bands.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { day, renderWorklist, row, stub } from "./worklist.testkit";

--- a/frontend/src/screens/worklist.bounce.test.tsx
+++ b/frontend/src/screens/worklist.bounce.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // A bounced message names a customer who did not receive something.
 //

--- a/frontend/src/screens/worklist.briefverbs.test.tsx
+++ b/frontend/src/screens/worklist.briefverbs.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.coaching.test.tsx
+++ b/frontend/src/screens/worklist.coaching.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.counts.test.tsx
+++ b/frontend/src/screens/worklist.counts.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.detail.test.tsx
+++ b/frontend/src/screens/worklist.detail.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.dismiss.test.tsx
+++ b/frontend/src/screens/worklist.dismiss.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/screens/worklist.email.test.tsx
+++ b/frontend/src/screens/worklist.email.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // What a waiting EMAIL looks like on the queue, and what every other row keeps.
 //

--- a/frontend/src/screens/worklist.exceptions.test.tsx
+++ b/frontend/src/screens/worklist.exceptions.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/screens/worklist.handled.test.tsx
+++ b/frontend/src/screens/worklist.handled.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/screens/worklist.hidden.test.tsx
+++ b/frontend/src/screens/worklist.hidden.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.hiddenowner.test.tsx
+++ b/frontend/src/screens/worklist.hiddenowner.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { day, renderWorklist, stub } from "./worklist.testkit";

--- a/frontend/src/screens/worklist.identity.test.tsx
+++ b/frontend/src/screens/worklist.identity.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/frontend/src/screens/worklist.linkedcaption.test.tsx
+++ b/frontend/src/screens/worklist.linkedcaption.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";

--- a/frontend/src/screens/worklist.manager.test.tsx
+++ b/frontend/src/screens/worklist.manager.test.tsx
@@ -15,7 +15,7 @@
 // reason from the other side: what it OFFERS is a promise about where a press
 // lands, and a choice that leads nowhere draws exactly like one that works.
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.meetingbriefstory.test.tsx
+++ b/frontend/src/screens/worklist.meetingbriefstory.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { composeStories } from "@storybook/react-vite";
 import { cleanup, render, screen } from "@testing-library/react";

--- a/frontend/src/screens/worklist.meetingoutcome.test.tsx
+++ b/frontend/src/screens/worklist.meetingoutcome.test.tsx
@@ -9,7 +9,7 @@
 // since the field existed — so the one moment a human knows how it went was the
 // one moment nothing on screen could be told.
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.move.test.tsx
+++ b/frontend/src/screens/worklist.move.test.tsx
@@ -8,7 +8,7 @@
 // named a problem and the answer travelled in the response unrendered, so a rep
 // was told a deal had gone quiet and left to work out what to do about it.
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.needsprep.test.tsx
+++ b/frontend/src/screens/worklist.needsprep.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/worklist.paging.test.tsx
+++ b/frontend/src/screens/worklist.paging.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.pair.test.tsx
+++ b/frontend/src/screens/worklist.pair.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.pane.test.tsx
+++ b/frontend/src/screens/worklist.pane.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.pin.test.tsx
+++ b/frontend/src/screens/worklist.pin.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // The reader's own override.
 //

--- a/frontend/src/screens/worklist.pinhint.test.tsx
+++ b/frontend/src/screens/worklist.pinhint.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/worklist.promise.test.tsx
+++ b/frontend/src/screens/worklist.promise.test.tsx
@@ -7,7 +7,7 @@
 // existed and every reader filters on `open`. Nothing wrote the other two, so
 // the row named a debt every morning and there was no way to say it was paid.
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.readings.test.tsx
+++ b/frontend/src/screens/worklist.readings.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.reasons.test.tsx
+++ b/frontend/src/screens/worklist.reasons.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.reply.test.tsx
+++ b/frontend/src/screens/worklist.reply.test.tsx
@@ -6,7 +6,7 @@
 // The row a rep meets most often is somebody who wrote and nobody answered, and
 // it used to send them to the record to press Reply there.
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { day, renderWorklist, row, stub } from "./worklist.testkit";

--- a/frontend/src/screens/worklist.review.test.tsx
+++ b/frontend/src/screens/worklist.review.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 // Seller work and judgements are two jobs, drawn apart.
 //

--- a/frontend/src/screens/worklist.row.compact.test.tsx
+++ b/frontend/src/screens/worklist.row.compact.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { cleanup, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.snooze.test.tsx
+++ b/frontend/src/screens/worklist.snooze.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.swipe.test.tsx
+++ b/frontend/src/screens/worklist.swipe.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {

--- a/frontend/src/screens/worklist.systemeyebrow.test.tsx
+++ b/frontend/src/screens/worklist.systemeyebrow.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { en } from "../i18n/en";

--- a/frontend/src/screens/worklist.takeover.test.tsx
+++ b/frontend/src/screens/worklist.takeover.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/screens/worklist.taskdone.test.tsx
+++ b/frontend/src/screens/worklist.taskdone.test.tsx
@@ -8,7 +8,7 @@
 // verb and what happens after it — the write, the confirmation, the undo, and
 // the undo being refused — while the file it left covers what the queue draws.
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.today.test.tsx
+++ b/frontend/src/screens/worklist.today.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/worklist.verdict.test.tsx
+++ b/frontend/src/screens/worklist.verdict.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { day, renderWorklist, row, stub } from "./worklist.testkit";

--- a/frontend/src/screens/worklist.walknotice.test.tsx
+++ b/frontend/src/screens/worklist.walknotice.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/screens/worklist.when.test.tsx
+++ b/frontend/src/screens/worklist.when.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/screens/writeto.test.tsx
+++ b/frontend/src/screens/writeto.test.tsx
@@ -1,4 +1,4 @@
-/** @vitest-environment jsdom */
+/** @vitest-environment happy-dom */
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 

--- a/frontend/src/testing/locationdouble.ts
+++ b/frontend/src/testing/locationdouble.ts
@@ -1,0 +1,59 @@
+// A stand-in for `location` that a suite can watch a navigation through.
+//
+// NAMED MEMBERS, not a spread, and the difference is the whole reason this file
+// exists. A `Location`'s members are accessors on its PROTOTYPE, so
+// `{ ...globalThis.location }` copies whichever of them the environment happens
+// to have put on the instance — under jsdom that was enough to keep `hash`
+// working, under happy-dom it copies nothing, and the router then read
+// `location.hash` as `undefined` and the suite failed inside production code
+// with a TypeError. A double that depends on how an environment implements the
+// thing it doubles is a double that tests the environment.
+//
+// Three suites replace `location` to observe a navigation — the sign-in screen,
+// the connections card and the OAuth consent screen — and each spelled the copy
+// itself. One spelling, so the next one cannot be written the way that broke.
+
+/** The members of `Location` a screen reads, carried by value. */
+export type LocationDouble = Pick<
+  Location,
+  | "hash"
+  | "host"
+  | "hostname"
+  | "href"
+  | "origin"
+  | "pathname"
+  | "port"
+  | "protocol"
+  | "search"
+> & {
+  assign: (url: string) => void;
+  replace?: (url: string) => void;
+  reload?: () => void;
+};
+
+/**
+ * A double of the CURRENT location, with the given members replaced.
+ *
+ * `assign` is required rather than optional: the reason a suite reaches for
+ * this is to watch a navigation, and a double with no way to record one is a
+ * double that silently lets the browser's real `assign` be called — which, in a
+ * test environment, is either a no-op or a cross-origin error, and neither says
+ * what the suite wanted to know.
+ */
+export function locationDouble(
+  over: Partial<LocationDouble> & Pick<LocationDouble, "assign">,
+): LocationDouble {
+  const current = globalThis.location;
+  return {
+    hash: current.hash,
+    host: current.host,
+    hostname: current.hostname,
+    href: current.href,
+    origin: current.origin,
+    pathname: current.pathname,
+    port: current.port,
+    protocol: current.protocol,
+    search: current.search,
+    ...over,
+  };
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -227,6 +227,21 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // The DESKTOP viewport, stated rather than inherited.
+    //
+    // A list header folds its verbs into one overflow menu at or under
+    // NARROW_MAX_WIDTH (1100, app/viewport.ts), and it asks matchMedia. Under
+    // jsdom that question was never really asked: jsdom ships no matchMedia, so
+    // vitest.setup.ts installed a stub answering `matches: false` to everything
+    // — which happens to mean "not narrow", and every suite asserting a primary
+    // action on a list header rested on that accident. happy-dom ships a real
+    // matchMedia over a 1024-wide window, so the same suites saw the narrow
+    // arrangement and could not find a button that was in the overflow.
+    //
+    // 1280 is a desktop, which is the arrangement those suites are about. A
+    // suite testing the folded one sets its own width; what must not happen
+    // again is the width being decided by which environment is installed.
+    environmentOptions: { happyDOM: { width: 1280, height: 900 } },
     // Worker threads rather than child processes. Every test file still gets
     // its own module graph and its own jsdom (isolation is unchanged — the
     // suite has module-level state that a shared graph breaks, measured at 28

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -52,6 +52,12 @@ if (typeof window !== "undefined") {
   // prefers-reduced-motion on first render. Default to "no preference" so the
   // animated path is what the tests exercise; a test that wants the reduced path
   // overrides this per case.
+  //
+  // happy-dom HAS one, so this installs for the jsdom file alone. Its answers
+  // are the same either way — "no preference", and not narrow — which is what
+  // makes the two environments agree about which arrangement a screen is in.
+  // The viewport that decides the second of those is stated in vite.config.ts
+  // rather than inherited from whichever environment is installed.
   if (!window.matchMedia) {
     window.matchMedia = ((query: string) => ({
       matches: false,
@@ -68,7 +74,8 @@ if (typeof window !== "undefined") {
   // jsdom ships no ResizeObserver, and the list table watches its own body so
   // the frozen column's edge shadow follows a resized column. A stub that never
   // fires is the honest stand-in: the component measures once on mount either
-  // way, which is what the tests assert on.
+  // way, which is what the tests assert on. happy-dom has one, so this too
+  // installs for the jsdom file alone.
   if (!window.ResizeObserver) {
     window.ResizeObserver = class {
       observe() {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.11(vitest@4.1.11)
+      happy-dom:
+        specifier: 20.14.0
+        version: 20.14.0
       jsdom:
         specifier: ^30.0.0
         version: 30.0.1
@@ -100,7 +103,7 @@ importers:
         version: 8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0))
+        version: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.14.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0))
 
 packages:
 
@@ -1227,6 +1230,12 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@vitejs/plugin-react@6.1.0':
     resolution: {integrity: sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1372,6 +1381,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -1495,6 +1508,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -1569,6 +1586,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.14.0:
+    resolution: {integrity: sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2284,6 +2305,10 @@ packages:
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -3149,7 +3174,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.14.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0))
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -3220,6 +3245,12 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.2.0
+
   '@vitejs/plugin-react@6.1.0(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -3237,7 +3268,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.14.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -3364,6 +3395,10 @@ snapshots:
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 26.2.0
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -3474,6 +3509,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@7.0.1: {}
+
   entities@8.0.0: {}
 
   es-errors@1.3.0: {}
@@ -3546,6 +3583,19 @@ snapshots:
       path-scurry: 2.0.2
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.14.0:
+    dependencies:
+      '@types/node': 26.2.0
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -4151,7 +4201,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)):
+  vitest@4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.14.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0))
@@ -4176,6 +4226,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      happy-dom: 20.14.0
       jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
@@ -4187,6 +4238,8 @@ snapshots:
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 


### PR DESCRIPTION
The lane's largest single cost was not the tests. Measured on `origin/main`: `environment 266.67s` against `tests 371.03s` cumulative — constructing jsdom 498 times cost most of what the suite spends. This is the swap the ticket's own measurement recommended, with the three causes of its 16 failures **worked** rather than the tests bent around them.

## Before / after, same machine, whole suite

| | jsdom | happy-dom |
|---|---|---|
| `environment` | 266.67 s | **102.65 s** (−61%) |
| `tests` | 371.03 s | 251.97 s (−32%) |
| `import` | 198.94 s | 211.29 s |
| wall clock | 105.60 s | **76.37 s** (−28%) |

**Test Files 679 passed (679) · Tests 9112 passed | 1 expected fail** — identical to the baseline on both counts, which is the half of the ⚠ at the top of the ticket that matters most.

## What the 16 failures turned out to be

None of them needed a test weakened.

**1 — six suites, a button in the overflow menu.** `products`, `offertemplates`, `listquery` and three more asserted a list header's primary action and could not find it. A header folds its verbs into one overflow menu at or under `NARROW_MAX_WIDTH` (1100) and asks `matchMedia`. Under jsdom that question was never really asked: jsdom ships no `matchMedia`, so `vitest.setup.ts` installed a stub answering `matches: false` to everything — which happens to mean "not narrow". Every suite asserting a desktop arrangement was resting on that accident; happy-dom ships a real `matchMedia` over a 1024-wide window and folded them.

Fixed by **stating the viewport** (`environmentOptions.happyDOM: { width: 1280 }`), so which arrangement a screen is in stops depending on which environment is installed. One config line, six suites.

**2 — seven tests, a spread that copied nothing.** `auth`, `connectors` and `oauthconsent` each replaced `location` with `{ ...globalThis.location, assign }`. A `Location`'s members are accessors on its **prototype**, so the spread copies whatever the environment happened to put on the instance — enough under jsdom, nothing under happy-dom, and `router.tsx` then read `location.hash` as `undefined` and the suites failed inside production code with a `TypeError`.

Fixed by one `locationDouble` helper carrying the members **by name**. Three suites spelled this themselves; now none does.

**3 — three tests inheriting a storage that throws.** A case installs `vi.spyOn(window.localStorage, "setItem")` that throws on purpose, and called `vi.restoreAllMocks()` after its assertions. That reaches mocks the case did not install, and it only runs when the assertions pass. Under happy-dom it does not restore a storage spy at all — probed directly, `restoreAllMocks()` leaves the throwing implementation in place where `spy.mockRestore()` removes it. The spy is now restored in a `finally`, by itself.

**4 — one case that asserts the browser, not the app.** "refuses a future day for a note" asserts that a date past the input's `max` does not submit. happy-dom implements neither half: `checkValidity()` answers true and `validity.rangeOverflow` is false for a value years past the max. **That file stays on jsdom and says why.** Rewriting the case to assert only what the app declares would drop the half that catches a form submitting around its own rule — so one file pays the slower environment, deliberately, and the comment tells the next reader.

## Also

`App.onboardinggate`'s hash recorder counted both `hashchange` and the history spies. `hashchange` is specified to fire for an assignment and **not** for a history write — jsdom follows that, happy-dom fires it for `pushState`/`replaceState` too (probed). Counting both channels blind records every redirect twice under one environment and once under the other, and the count *is* the assertion. A history write now claims the `hashchange` it causes; a second move to the same address arrives with nothing claimed and is still counted, which is the recurrence those cases look for.

`jsdom` stays a devDependency for the one file. The two shims in `vitest.setup.ts` are guarded on their own absence, so they install for that file alone now, and their comments say so.

`make check-fe` green, including the composed extension lane.

Closes #1748.
