### PR TITLE
fix(frontend): the writing verb's refusal claim is one a test can fail

### DIFF
--- a/frontend/src/screens/contactactions.tsx
+++ b/frontend/src/screens/contactactions.tsx
@@ -27,16 +27,21 @@ type Contact360 = components["schemas"]["Contact360"];
 // Why the lead verb may not be pressed, in the reader's words, or undefined
 // when it may.
 //
-// TWO facts refuse it and they are never merged into one sentence: consent says
-// we may not write to this contact, reachability says there is nowhere to write
-// to. A rep who is told the wrong one goes looking in the wrong record.
+// ONE fact refuses it: reachability. There is nowhere to write to, so the
+// composer would have nothing to send on and could only fail at the send.
 //
-// Reachability is asked first because it is the unconditional half — with no
-// transport the composer has nothing to send on whatever consent says, and a
-// consent sentence there would describe a decision that is not what stops them.
-// A guard that has not answered yet refuses nothing: the button is disabled
-// without a reason until the verdict is in, because claiming a refusal the
-// server has not made is worse than a control that is briefly quiet.
+// CONSENT IS NOT ASKED HERE, and that is the decision rather than a gap. A
+// consent verdict is reached per PURPOSE, and which purpose applies is a fact
+// about the MESSAGE — which this page does not have. Disabling the verb on one
+// purpose's verdict told a rep with a lawful service message to send that the
+// product would not let them write at all, with no way to see that only
+// marketing was refused. The composer asks, because the composer is where the
+// purpose is chosen.
+//
+// So the two facts never merge into one sentence because only one of them is a
+// sentence here. Held by "opens the composer even where no purpose currently
+// permits writing" (contactpage.test.tsx), which asserts the verb carries no
+// refusal at all for a consent-blocked contact who is reachable.
 function writeRefusal(
   state: Readonly<{ transports: readonly Transport[] }>,
   t: ReturnType<typeof useT>,

--- a/frontend/src/screens/contactpage.test.tsx
+++ b/frontend/src/screens/contactpage.test.tsx
@@ -325,10 +325,11 @@ const mailBlocked: ContactConsentGuardEntry = {
 };
 
 describe("the header's writing verb", () => {
-  // The two sentences a refusal can say. Held as constants because the point of
-  // the last case is that these two are never the same sentence.
+  // The ONE sentence this verb's refusal can say. There is no consent sentence
+  // to hold beside it, and that is the claim rather than an omission: the
+  // composer asks about consent, because consent is answered per PURPOSE and
+  // the purpose is a fact about the message.
   const NO_TRANSPORT = "No address, and no conversation to reply to.";
-  const CONSENT_REFUSED = "No purpose currently permits writing to them.";
 
   it("names mail when an address is the only way to reach them", async () => {
     mount("overview", view, [mailAllowed]);
@@ -398,7 +399,13 @@ describe("the header's writing verb", () => {
     await waitFor(() => {
       expect(lead.disabled).toBe(false);
     });
-    expect(screen.queryByText(CONSENT_REFUSED)).toBeNull();
+    // NO REFUSAL AT ALL, asserted on the control rather than by looking for a
+    // sentence. The sentence this used to look for was withdrawn from the copy
+    // catalogs with the behaviour, so `queryByText` for it could never find
+    // anything and the case passed whatever the button did. What cannot go
+    // vacuous is the button's own state: a refused verb is disabled and points
+    // at its reason, and this one does neither.
+    expect(lead.getAttribute("aria-describedby")).toBeNull();
     // The verb still names the transport it opens.
     expect(lead.querySelector(".lucide-mail")).toBeTruthy();
   });


### PR DESCRIPTION
Most of #1592 had already landed by the time I got here — and it landed **better than the ruling I wrote**, which is worth saying plainly before the diff.

## What was already there

`ContactActions` reads `useTransports(view)` and names the verb from it: mail when an address is the only way, the provider's own name when a chat channel is, and a neutral `Write` with a paper plane when the composer will open a picker or when there is nowhere to write at all. `writeRefusal` disables it when `transportsFor` finds no transport, with its own sentence.

That is the ticket's three options resolved into one shape, and it is more accurate than the neutral-verb-everywhere answer my 2026-09-01 comment chose: naming the transport when there is exactly one is a promise the composer keeps, and going neutral the moment there is a choice is exactly the case my ruling was worried about.

It also answered the consent half **the other way**, and with a better argument than mine. My ruling said "disabled when consent refuses". The code deliberately does not, and its own case says why: *a contact who stopped the newsletter can still be sent their invoice, and which purpose applies is a question about the MESSAGE — which this page does not have.* Disabling the verb on one purpose's verdict tells a rep with a lawful service message that the product will not let them write at all. That is right and my ruling was wrong.

## What was left, and what this fixes

Two claims about that behaviour, neither of them held.

**1 — a doc describing a guard that was removed.** `writeRefusal`'s comment still says TWO facts refuse the verb, consent and reachability, "never merged into one sentence". It renders one. The doc now states what the code does *and why consent is not asked here*, so the next reader does not restore a guard that was taken out on purpose.

**2 — a case that could not fail.** `opens the composer even where no purpose currently permits writing` asserted `queryByText(CONSENT_REFUSED)).toBeNull()`. `CONSENT_REFUSED` is `"No purpose currently permits writing to them."` — a string that exists in **no copy catalog**; it was withdrawn along with the behaviour, and the constant survived only in the test file. So the query could never find anything and the case passed whatever the button did.

It now asserts the control instead: a refused verb is disabled and points at its reason through `aria-describedby`, and this one does neither. That cannot go vacuous, because it reads the button rather than hunting for a sentence.

## Mutation-checked

- Remove the reachability refusal → the two cases that name it fail.
- Refuse on consent as well → **five** cases fail, including `opens the composer even where no purpose currently permits writing`, which previously could not.

`make check-fe` green.

Closes #1592.
