### PR TITLE
The pre-push hook runs the integration lane for a backend-Go push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Diff-scoped code-craftsmanship gate (ADR-0045, `craft static`).
+# The pre-push gates: diff-scoped craftsmanship (ADR-0045, `craft static`), the
+# sub-second whole-tree greps, and — for a push that changes backend Go — the
+# integration lane. Everything but the lane answers in seconds; the lane is the
+# one deliberate exception and the tail of this file says what buys it.
 #
 # Runs the deterministic craftsmanship linter on the Go files that THIS push
 # changes vs origin/main — backend/, extensions/, fixtures/ and desktop/ alike,
@@ -31,6 +34,59 @@ if [[ -n "$(git diff --name-only "$base"...HEAD -- backend/migrations)" ]]; then
 	"$root/scripts/check-migration-versions.sh"
 fi
 
+# The integration lane. It is the ONE expensive thing this hook runs, and it
+# earns that because it is the only lane that sees a whole class of defect:
+# `make check` compiles every integration file into nothing (they carry
+# `//go:build integration`), so a green check says nothing at all about them.
+#
+# It sits HERE, above the Go-file check, for the reason the migration gate
+# above does: that check exits early when a push changes no Go, and a push that
+# adds only a `.sql` migration is exactly a push this lane is for. A migration
+# is the single likeliest thing to redden it.
+#
+# Scoped to backend/ for the reason the craft gate is scoped to a file list — a
+# docs or frontend push must not pay minutes for a lane that cannot fail on it.
+#
+# WHY THIS IS WORTH MINUTES. Three separate defects reached main on 2026-09-12
+# that no other local gate could see: a rule that broke two pre-existing tests,
+# reference rows registered in the harness's preserved-table list but not the
+# product's, and an index addition that pushed an empty table past the slack
+# deciding DELETE vs TRUNCATE. Every one passed `make check-backend`. All three
+# were found by running this lane by hand, twice by accident.
+#
+# NOT the objection the Makefile's check-all comment used to raise about
+# parallel sessions sharing one test template: scripts/lib-testdb.sh derives a
+# template per LINKED worktree (_testdb_worktree_slug), so two worktrees cannot
+# rebuild each other's schema. Two shells in the SAME worktree still share one,
+# and so does the primary checkout — which is why a failure here is worth
+# reading before believing, if somebody else is mid-run beside you.
+lane_paths="$(git diff --name-only --diff-filter=d "$base"...HEAD -- backend \
+	| grep -E '\.(go|sql)$' | grep -v '_gen\.go$' || true)"
+if [[ -n "$lane_paths" ]]; then
+	# A probe, not a run: the lane fails loudly without Postgres rather than
+	# skipping (a skipped security gate looks exactly like a passing one), and
+	# that is right for a deliberate `make test-integration` and wrong here. A
+	# push with the stack down would be blocked on the stack rather than on the
+	# code, and a hook nobody can push past is a hook that gets turned off. So
+	# the absence is reported at the same volume and the push continues.
+	if nc -z localhost 15432 >/dev/null 2>&1; then
+		echo "integration lane: backend changed — running (minutes; the only lane that sees it)…"
+		if ! make -C "$root" -s test-integration; then
+			echo ""
+			echo "The integration lane BLOCKED the push. This lane is the one"
+			echo "\`make check\` cannot reach, so a green check does not clear it."
+			echo "If the failure is somebody else's red on main, claim it per"
+			echo "AGENTS.md rather than pushing past it."
+			exit 1
+		fi
+	else
+		echo "integration lane: SKIPPED — nothing answers on localhost:15432."
+		echo "  This push changed backend Go or SQL, which is what the lane checks."
+		echo "  Start it with \`make db-up\` and push again, or accept that CI is"
+		echo "  the first thing to run these tests."
+	fi
+fi
+
 # Changed-and-still-present Go files, excluding generated code. extensions/,
 # fixtures/ and desktop/ are each their own module and would otherwise escape the
 # bar entirely — a first-party unit ships the same product as backend/, and the
@@ -59,6 +115,7 @@ fi
 # The whole-tree deterministic gates that are cheap enough to run on every
 # push (sub-second greps): catch an RLS-bypassing store statement or a
 # jurisdiction string in core locally, before CI does. The heavier gates
-# (build, lint, tests, drift) stay in `make check` / CI.
+# (build, lint, drift) stay in `make check` / CI.
 "$root/scripts/check-rls-store-path.sh"
 "$root/scripts/check-no-jurisdiction.sh"
+

--- a/Makefile
+++ b/Makefile
@@ -167,11 +167,16 @@ check:
 ## minutes and needs Postgres up, so paying it on a README edit would train
 ## everybody to skip the gate that also holds the security cases.
 ##
-## Not in the pre-push hook either, and the reason is this machine rather than
-## principle: parallel sessions share one test template, so a hook running the
-## lane on every push would have them rebuilding each other's schema mid-run —
-## failures that are schema-shaped and look nothing like their cause. The hook
-## keeps the checks that are fast, need nothing running, and cannot collide.
+## The pre-push hook DOES run the lane, for a push that changes backend Go.
+## It did not until 2026-09-12, and the reason it gave had expired: parallel
+## sessions were said to share one test template, so a hook would have them
+## rebuilding each other's schema mid-run. scripts/lib-testdb.sh has derived a
+## template per linked worktree since 2026-08-24 (_testdb_worktree_slug), which
+## is two weeks before that reasoning was written down.
+##
+## What is still shared: two shells in the SAME worktree, and the primary
+## checkout. The hook skips rather than blocks when nothing answers on the test
+## port, because a push blocked on a stopped stack is a hook that gets disabled.
 check-all:
 	@bash scripts/phase-timer.sh reset
 	@PHASE_TIMER_OWNED=1 $(MAKE) check-backend


### PR DESCRIPTION
`make check` reaches the integration lane not at all: every integration file carries `//go:build integration` (1341 of them), so the lane's packages compile into nothing and a green check says nothing about them. AGENTS.md already tells a contributor to run `make check-all` for a change touching backend Go. Nothing enforced it.

On 2026-09-12 three parallel sessions merged all day on green local gates, and three defects reached main that no other local gate could see:

- a new rule that broke two pre-existing tests,
- reference rows registered in the test harness's preserved-table list but not the product's, so a reset deleted them mid-shard,
- an index addition that pushed an empty table past the slack deciding DELETE vs TRUNCATE.

Each was found afterwards by running the lane by hand, twice by accident.

## What it does

Runs `make test-integration` when a push changes hand-written Go or SQL under `backend/`. A docs or frontend push pays nothing.

It sits **above** the existing `no changed Go files` early return, for the reason the migration-version gate above it does: that check exits early when a push changes no Go, and a push that adds only a `.sql` migration is exactly a push this lane is for. A migration is the single likeliest thing to redden it.

## It skips rather than blocks when Postgres is down

`make test-integration` fails hard without a database on purpose, because a skipped security gate looks exactly like a passing one. That is right for a deliberate run and wrong for a hook: a push with the stack down is blocked on the stack rather than on the code, and a hook nobody can push past is a hook that gets turned off. The absence is reported at the same volume and the push continues.

## The reason it was kept out had expired

The comment above `check-all` said parallel sessions share one test template, so a hook would have them rebuilding each other's schema mid-run. `scripts/lib-testdb.sh` has derived a template per linked worktree since 2026-08-24 (#2549, `_testdb_worktree_slug`) — two weeks before that reasoning was written down in #4678 on 2026-09-07. Two shells in the SAME worktree still share one, and so does the primary checkout; the comment now says that instead.

## Verification

Exercised live rather than argued from source. I pushed a temporary backend Go commit specifically to reach the lane path: the hook ran 52 packages, 6255 tests, 0 skips, and the template was `margince_test_margince_hook_wt` — the per-worktree isolation observed in a real run. The probe commit was then removed.

Also checked by hand, since Codex was unavailable in this environment: `|| true` survives `set -euo pipefail` and yields an empty string rather than aborting; `make -C "$root"` resolves to the linked worktree and not the primary checkout; the root Makefile does delegate `test-integration` to `backend/Makefile`; and every date and PR number above comes from `git log -S`.

`make check-backend` green on the rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the integration lane from the pre-push hook whenever a push changes hand-written backend Go or SQL. `make check` previously compiled every integration test into nothing, so a green check said nothing about them — a gap that let three defects reach main on 2026-09-12.

- The hook probes Postgres with `pg_isready` (not just a TCP port) and skips loudly rather than blocks when it isn't ready, so a stopped stack can't trap a push; a missing `pg_isready` takes the same skip path, since readiness can't be told.
- Docs and frontend pushes don't pay for the lane.
- The old reason for keeping the lane out expired: `scripts/lib-testdb.sh` now derives a test template per linked worktree, so parallel sessions no longer rebuild each other's schema.

<sup>Written for commit fee3f63c2508c1d50d82d18e67fc9d16a466c0a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Pushes involving backend Go or SQL changes now automatically run integration checks when PostgreSQL is available locally.
  - Integration checks are skipped when the required database readiness tool is unavailable or PostgreSQL is not ready.
  - Failed integration checks block the push.

- **Documentation**
  - Updated developer guidance to clarify the integration lane, its triggers, and when checks are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->