### PR TITLE
An unsubscribe stops marketing, and a subject who wants more has a route

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7404,11 +7404,15 @@ paths:
         (source `preference_center`) which the default-deny suppression gate honors on the very next send
         across every path (manual + agent). Idempotent. Only POST acts — a GET/prefetch by a mail scanner
         never unsubscribes anyone (the reason RFC 8058 mandates POST). With `purpose` only that purpose is
-        withdrawn (the one the message was sent under); without it every lane the recipient has not already
-        stopped is — read from their `choice`, not the raw stored state, so direct correspondence running on
-        no-objection is included rather than silently skipped.
+        withdrawn (the one the message was sent under); without it every MARKETING-class purpose is —
+        marketing and phone outreach, read from the live catalog so an operator's own purpose is included.
+        Business correspondence and transactional mail are NOT stopped: nobody subscribed to them, so there
+        is nothing there to unsubscribe from, and a recipient who unsubscribed from a newsletter still gets
+        the replies to their own enquiries and their invoices. A subject who wants ALL contact stopped uses
+        `/public/preferences/{token}/stop` with `stop_all_contact`, which records an Art. 21 objection
+        rather than withdrawing a consent that was never the basis for those messages.
       parameters:
-        - { name: purpose, in: query, required: false, schema: { type: string }, description: The consent purpose key to withdraw. Omit to withdraw every lane the recipient has not already stopped. }
+        - { name: purpose, in: query, required: false, schema: { type: string }, description: The consent purpose key to withdraw. Omit to withdraw every marketing-class purpose. }
       requestBody:
         required: false
         description: |
@@ -7440,6 +7444,67 @@ paths:
                       The purpose keys this call actually CHANGED. Empty on a replay, because the recipient was
                       already unsubscribed — which is how the page tells a first press from a second one instead
                       of showing a fresh confirmation for a no-op.
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
+
+  /public/preferences/{token}/stop:
+    parameters:
+      - { name: token, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [Public]
+      operationId: publicStopContact
+      security: []   # anonymous public page — the token is the capability
+      x-agent-access: human-only
+      summary: Ask us to stop contacting you (anonymous, token-authed, POST-only).
+      description: |
+        The route for a subject who wants MORE stopped than an unsubscribe stops. One-click unsubscribe
+        withdraws the marketing-class purposes, which is what a subscription link offers; this records an
+        Art. 21 objection instead, and the two are different legal acts rather than two sizes of the same
+        one. A withdrawal says the consent is gone. An objection says the processing must stop whether or
+        not consent was ever its basis, which is the only thing that reaches business correspondence.
+
+        `stop_all_marketing` records a marketing objection at the subject's own authority, so no seat can
+        lift it. `stop_all_contact` records a broad subject request, which binds every category except the
+        few that survive an Art. 18 restriction — a privacy notice, a security notice and the
+        acknowledgement of this very request, because a stop that silenced the confirmation that it worked
+        would leave the subject unable to tell whether anything happened.
+
+        Only POST acts, for the reason RFC 8058 gives: a mail scanner following links must not stop
+        somebody's mail. Idempotent — a replay records nothing new and reports the same receipt.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action]
+              properties:
+                action:
+                  type: string
+                  enum: [stop_all_marketing, stop_all_contact]
+                statement:
+                  type: string
+                  maxLength: 500
+                  description: |
+                    The subject's own words, kept verbatim. An objection a controller has to answer for is
+                    weaker evidence when the record holds only our paraphrase of it.
+      responses:
+        '200':
+          description: Recorded (idempotent).
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [recorded, receipt_reference]
+                properties:
+                  recorded:
+                    type: boolean
+                    description: |
+                      False on a replay, because the stop was already standing. The page tells a first press
+                      from a second one by this rather than by showing a fresh confirmation for a no-op.
+                  receipt_reference:
+                    type: string
+                    description: What the subject quotes when asking what happened to their request.
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
 

--- a/backend/gates/doitokenexposure_test.go
+++ b/backend/gates/doitokenexposure_test.go
@@ -121,6 +121,8 @@ var ratifiedDestinations = map[string]string{
 	"stopForCredential": "resolves the token and records the stop it presses, returning nothing about the token itself",
 
 	"oneClickSubject": "resolves the press to the contact it acts for, trying both credential families, and returns that contact and the withdrawal scope — never the token",
+
+	"publicStopSubject": "resolves a stop request to the contact it acts for, trying both credential families, and returns that contact — never the token",
 }
 
 // launderers are the two functions whose OWN BODY this gate does not inspect,

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -594,6 +594,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/projects/{id}/health-assessments/{assessment_id}/corrections": {Op: "correctProjectHealthAssessment", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/public/booking/{host_slug}":                                   {Op: "bookPublicMeeting", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/public/confirm/{token}":                                       {Op: "submitConfirmDetails", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/public/preferences/{token}/stop":                              {Op: "publicStopContact", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/public/preferences/{token}/unsubscribe":                       {Op: "oneClickUnsubscribe", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/public/rooms/exchange":                                        {Op: "exchangeDealRoomCredential", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/public/rooms/link-request":                                    {Op: "requestDealRoomLink", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/integration/publictokencache_integration_test.go
+++ b/backend/internal/compose/integration/publictokencache_integration_test.go
@@ -37,6 +37,7 @@ package integration
 //   COVERS: GET /public/preferences/{token}
 //   COVERS: PUT /public/preferences/{token}
 //   COVERS: POST /public/preferences/{token}/unsubscribe
+//   COVERS: POST /public/preferences/{token}/stop
 //   COVERS: GET /public/confirm/{token}
 //   COVERS: POST /public/confirm/{token}
 
@@ -168,6 +169,21 @@ func TestEveryPreferenceAnswerIsUncacheable(t *testing.T) {
 		},
 		{"an empty token", "GET", "/v1/public/preferences/", nil},
 		{"a GET on the one-click verb", "GET", "/v1/public/preferences/" + live + "/unsubscribe", nil},
+		// The stronger stop: an Art. 21 objection rather than a withdrawal. Its
+		// answer names a receipt and whether this press changed anything, both
+		// of which are facts about one subject's request.
+		{
+			"a live token's objection", "POST", "/v1/public/preferences/" + live + "/stop",
+			AnyMap{"action": "stop_all_marketing"},
+		},
+		{
+			"a refused stop", "POST", "/v1/public/preferences/" + live + "/stop",
+			AnyMap{"action": "stop_some_of_it"},
+		},
+		{
+			"an unknown token's stop", "POST", "/v1/public/preferences/pref_does_not_exist/stop",
+			AnyMap{"action": "stop_all_contact"},
+		},
 	})
 	assertClaimed(t, driven, "/public/preferences/")
 

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -2051,6 +2051,10 @@ func (stubs) UpdatePreferences(w nethttp.ResponseWriter, r *nethttp.Request, tok
 	httperr.NotImplemented(w, r, "UpdatePreferences")
 }
 
+func (stubs) PublicStopContact(w nethttp.ResponseWriter, r *nethttp.Request, token string) {
+	httperr.NotImplemented(w, r, "PublicStopContact")
+}
+
 func (stubs) OneClickUnsubscribe(w nethttp.ResponseWriter, r *nethttp.Request, token string, params crmcontracts.OneClickUnsubscribeParams) {
 	httperr.NotImplemented(w, r, "OneClickUnsubscribe")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17482,6 +17482,24 @@ func (e UpdatePreferencesJSONBodyChoicesState) Valid() bool {
 	}
 }
 
+// Defines values for PublicStopContactJSONBodyAction.
+const (
+	PublicStopContactJSONBodyActionStopAllContact   PublicStopContactJSONBodyAction = "stop_all_contact"
+	PublicStopContactJSONBodyActionStopAllMarketing PublicStopContactJSONBodyAction = "stop_all_marketing"
+)
+
+// Valid indicates whether the value is a known member of the PublicStopContactJSONBodyAction enum.
+func (e PublicStopContactJSONBodyAction) Valid() bool {
+	switch e {
+	case PublicStopContactJSONBodyActionStopAllContact:
+		return true
+	case PublicStopContactJSONBodyActionStopAllMarketing:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for OneClickUnsubscribeFormdataBodyListUnsubscribe.
 const (
 	OneClickUnsubscribeFormdataBodyListUnsubscribeOneClick OneClickUnsubscribeFormdataBodyListUnsubscribe = "One-Click"
@@ -43661,6 +43679,18 @@ type UpdatePreferencesJSONBody struct {
 // UpdatePreferencesJSONBodyChoicesState defines parameters for UpdatePreferences.
 type UpdatePreferencesJSONBodyChoicesState string
 
+// PublicStopContactJSONBody defines parameters for PublicStopContact.
+type PublicStopContactJSONBody struct {
+	Action PublicStopContactJSONBodyAction `json:"action"`
+
+	// Statement The subject's own words, kept verbatim. An objection a controller has to answer for is
+	// weaker evidence when the record holds only our paraphrase of it.
+	Statement *string `json:"statement,omitempty"`
+}
+
+// PublicStopContactJSONBodyAction defines parameters for PublicStopContact.
+type PublicStopContactJSONBodyAction string
+
 // OneClickUnsubscribeFormdataBody defines parameters for OneClickUnsubscribe.
 type OneClickUnsubscribeFormdataBody struct {
 	ListUnsubscribe *OneClickUnsubscribeFormdataBodyListUnsubscribe `form:"List-Unsubscribe,omitempty" json:"List-Unsubscribe,omitempty"`
@@ -43668,7 +43698,7 @@ type OneClickUnsubscribeFormdataBody struct {
 
 // OneClickUnsubscribeParams defines parameters for OneClickUnsubscribe.
 type OneClickUnsubscribeParams struct {
-	// Purpose The consent purpose key to withdraw. Omit to withdraw every lane the recipient has not already stopped.
+	// Purpose The consent purpose key to withdraw. Omit to withdraw every marketing-class purpose.
 	Purpose *string `form:"purpose,omitempty" json:"purpose,omitempty"`
 }
 
@@ -45463,6 +45493,9 @@ type SubmitConfirmDetailsJSONRequestBody SubmitConfirmDetailsJSONBody
 
 // UpdatePreferencesJSONRequestBody defines body for UpdatePreferences for application/json ContentType.
 type UpdatePreferencesJSONRequestBody UpdatePreferencesJSONBody
+
+// PublicStopContactJSONRequestBody defines body for PublicStopContact for application/json ContentType.
+type PublicStopContactJSONRequestBody PublicStopContactJSONBody
 
 // OneClickUnsubscribeFormdataRequestBody defines body for OneClickUnsubscribe for application/x-www-form-urlencoded ContentType.
 type OneClickUnsubscribeFormdataRequestBody OneClickUnsubscribeFormdataBody
@@ -56839,6 +56872,9 @@ type ServerInterface interface {
 	// Save per-purpose choices from the preference center (anonymous, token-authed).
 	// (PUT /public/preferences/{token})
 	UpdatePreferences(w http.ResponseWriter, r *http.Request, token string)
+	// Ask us to stop contacting you (anonymous, token-authed, POST-only).
+	// (POST /public/preferences/{token}/stop)
+	PublicStopContact(w http.ResponseWriter, r *http.Request, token string)
 	// RFC 8058 one-click unsubscribe (anonymous, token-authed, POST-only).
 	// (POST /public/preferences/{token}/unsubscribe)
 	OneClickUnsubscribe(w http.ResponseWriter, r *http.Request, token string, params OneClickUnsubscribeParams)
@@ -60313,6 +60349,12 @@ func (_ Unimplemented) GetPreferenceCenter(w http.ResponseWriter, r *http.Reques
 // Save per-purpose choices from the preference center (anonymous, token-authed).
 // (PUT /public/preferences/{token})
 func (_ Unimplemented) UpdatePreferences(w http.ResponseWriter, r *http.Request, token string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Ask us to stop contacting you (anonymous, token-authed, POST-only).
+// (POST /public/preferences/{token}/stop)
+func (_ Unimplemented) PublicStopContact(w http.ResponseWriter, r *http.Request, token string) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -82447,6 +82489,32 @@ func (siw *ServerInterfaceWrapper) UpdatePreferences(w http.ResponseWriter, r *h
 	handler.ServeHTTP(w, r)
 }
 
+// PublicStopContact operation middleware
+func (siw *ServerInterfaceWrapper) PublicStopContact(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "token" -------------
+	var token string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "token", chi.URLParam(r, "token"), &token, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "token", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PublicStopContact(w, r, token)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // OneClickUnsubscribe operation middleware
 func (siw *ServerInterfaceWrapper) OneClickUnsubscribe(w http.ResponseWriter, r *http.Request) {
 
@@ -90411,6 +90479,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Put(options.BaseURL+"/public/preferences/{token}", wrapper.UpdatePreferences)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/public/preferences/{token}/stop", wrapper.PublicStopContact)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/public/preferences/{token}/unsubscribe", wrapper.OneClickUnsubscribe)

--- a/backend/internal/modules/consent/handlers_public.go
+++ b/backend/internal/modules/consent/handlers_public.go
@@ -19,6 +19,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -136,20 +137,22 @@ func (h Handlers) unsubscribe(
 		}
 		return h.store.PublicWithdrawAll(ctx, contactID, []string{named})
 	}
-	if viaCredential {
-		// A withdrawal credential's all_marketing scope stops the MARKETING
-		// classes and nothing else. The legacy sweep below stops everything
-		// except the locked transactional purpose, so a press there also ends
-		// business correspondence — a contact who unsubscribed from a
-		// newsletter stops receiving replies to their own enquiries.
-		//
-		// That is older than this credential and narrowing it changes what
-		// links already sitting in mailboxes do, so it belongs to the slice
-		// that owns the canonical purpose vocabulary. A NEW credential is not
-		// owed the old breadth, and its scope says marketing.
-		return h.store.WithdrawMarketingForCredential(ctx, contactID)
-	}
-	return h.store.PublicWithdrawEverything(ctx, contactID)
+	// BOTH CREDENTIAL FAMILIES STOP THE SAME THING, which is what an
+	// unsubscribe means: the marketing classes and nothing else. No branch on
+	// which link carried the press, because the answer no longer differs.
+	//
+	// It used to. The legacy sweep stopped every purpose except the locked
+	// transactional one, so a press there also ended business correspondence —
+	// a contact who unsubscribed from a newsletter stopped receiving replies to
+	// their own enquiries. Narrowing it changes what links already sitting in
+	// mailboxes do, and that is the point: those links say "unsubscribe", and
+	// stopping somebody's replies was never what they offered.
+	//
+	// A subject who wants everything stopped has a different route, and it is a
+	// different legal act: an Art. 21 objection recorded as a subject_request
+	// suppression, not a withdrawal of a consent that was never the basis for
+	// those messages.
+	return h.store.PublicStopAllMarketing(ctx, contactID)
 }
 
 // oneClickSubject resolves the press to the contact it acts for, accepting a
@@ -332,4 +335,87 @@ func wirePurposeChoices(choices []PurposeChoice) []map[string]any {
 		})
 	}
 	return out
+}
+
+// PublicStopContact implements (POST /public/preferences/{token}/stop): the
+// route for a subject who wants MORE stopped than an unsubscribe stops.
+//
+// A DIFFERENT LEGAL ACT from the unsubscribe beside it, which is why it is a
+// different route. One-click withdraws the marketing-class purposes, which is
+// what a subscription link offers. This records an Art. 21 objection, which
+// says the processing must stop whether or not consent was ever its basis —
+// the only thing that reaches business correspondence.
+func (h Handlers) PublicStopContact(w http.ResponseWriter, r *http.Request, token string) {
+	var body crmcontracts.PublicStopContactJSONRequestBody
+	if !httperr.Decode(w, r, &body) {
+		return
+	}
+	contactID, err := h.publicStopSubject(r.Context(), token)
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	statement := ""
+	if body.Statement != nil {
+		statement = *body.Statement
+	}
+	result, err := h.store.PublicStop(
+		r.Context(), contactID, PublicStopAction(body.Action), statement)
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, map[string]any{
+		"recorded":          result.Recorded,
+		"receipt_reference": result.ReceiptReference,
+	})
+}
+
+// publicStopSubject resolves the press to the contact it acts for, accepting a
+// preference token OR a withdrawal credential.
+//
+// BOTH FAMILIES, for the reason the one-click door gives: the whole point of
+// the credential is that a link in an old message keeps working after the
+// preference token that rode with it has rotated. A subject reaching for the
+// stronger stop is the last one who should be told their link expired.
+//
+// A CREDENTIAL WITH NO CONTACT IS REFUSED here, and that is narrower than the
+// one-click door deliberately. There the lead-only case records an
+// address-scoped stop, which suits a marketing withdrawal. An Art. 21 objection
+// is about one contact's processing and is read by contact, so recording one
+// against an address that belongs to no contact would write a stop nothing
+// evaluates — worse than saying no, because the subject would be told it
+// worked.
+func (h Handlers) publicStopSubject(ctx context.Context, token string) (ids.ContactID, error) {
+	if ref, err := h.store.ResolvePreferenceToken(ctx, token); err == nil {
+		return ref.ContactID, nil
+	}
+	ref, err := h.store.ResolveWithdrawalToken(ctx, token)
+	if err != nil {
+		return ids.ContactID{}, err
+	}
+	if ref.ContactID.IsZero() {
+		return ids.ContactID{}, apperrors.ErrNotFound
+	}
+	// THE CREDENTIAL'S SCOPE BOUNDS WHAT THE PRESS MAY ASK FOR, the same way it
+	// bounds which purpose the one-click door may stop.
+	//
+	// A named_purpose link was minted to stop ONE subscription. NEITHER action
+	// here is that narrow — the smaller one objects to all direct marketing —
+	// so the link authorizes neither, and it is refused rather than widened to
+	// the nearest thing it nearly covers. Honouring stop_all_contact from it
+	// would let a forwarded newsletter link end that contact's invoices and
+	// their replies, at the subject's own authority, which no seat can lift.
+	//
+	// The preference centre is where a subject proves more: its token reads and
+	// writes their whole record, so a press from there carries the authority
+	// this one does not.
+	if ref.Scope == WithdrawalScopeNamedPurpose {
+		return ids.ContactID{}, &ValidationError{
+			Field: "action",
+			Reason: "this link stops one named subscription, and both of these stops are " +
+				"broader than it carries — use the preferences page it links to",
+		}
+	}
+	return ref.ContactID, nil
 }

--- a/backend/internal/modules/consent/preferencesave.go
+++ b/backend/internal/modules/consent/preferencesave.go
@@ -262,8 +262,30 @@ func (s *Store) PublicWithdrawAll(
 	return changed, nil
 }
 
-// PublicWithdrawEverything stops every purpose a recipient can be stopped on,
-// choosing them inside the transaction that stops them.
+// PublicStopAllMarketing stops the MARKETING-CLASS purposes, choosing them
+// inside the transaction that stops them.
+//
+// WHAT AN UNSUBSCRIBE MEANS. The press it answers used to stop every purpose in
+// the catalog except the locked transactional one, which swept business
+// correspondence with it: a contact who unsubscribed from a newsletter stopped
+// receiving the replies to their own enquiries. Nobody opted in to
+// correspondence, so there was nothing there to unsubscribe from — the sweep
+// was withdrawing a consent that was never the basis for those messages.
+//
+// phone_outreach goes with marketing because it is marketing by another
+// channel. The two classes left standing, transactional and
+// business_correspondence, rest on the contract and on the subject's own
+// approach rather than on a subscription.
+//
+// A SUBJECT WHO WANTS EVERYTHING STOPPED still has a route, and it is a
+// different one: the stop-all-contact action records a subject_request
+// suppression, which is an Art. 21 objection rather than a withdrawal of
+// consent. Those are different legal acts and the record now tells them apart.
+//
+// ONE TRANSACTION, selection included, for the reason the sweep it replaces
+// gave: a purpose granted between reading the list and acting on it — a
+// confirmation round-trip landing on the press — would survive a stop that
+// reported itself done.
 //
 // The unnamed press used to read the recipient's purposes first and hand the
 // list to PublicWithdrawAll, which is a selection made in one transaction and
@@ -279,7 +301,7 @@ func (s *Store) PublicWithdrawAll(
 //
 // A grant that commits AFTER this transaction still stands, and should: it
 // post-dates the press rather than being missed by it.
-func (s *Store) PublicWithdrawEverything(
+func (s *Store) PublicStopAllMarketing(
 	ctx context.Context, contactID ids.ContactID,
 ) ([]string, error) {
 	var changed []string
@@ -287,7 +309,7 @@ func (s *Store) PublicWithdrawEverything(
 		if err := lockOneSubjectsConsent(ctx, tx, contactID); err != nil {
 			return err
 		}
-		keys, err := withdrawablePurposeKeysTx(ctx, tx)
+		keys, err := withdrawableMarketingPurposeKeysTx(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -300,12 +322,24 @@ func (s *Store) PublicWithdrawEverything(
 	return changed, nil
 }
 
-// withdrawablePurposeKeysTx reads the live purposes a recipient may be stopped
-// on. The catalog rather than a constant: an operator may define their own
-// purpose, and a press that only knew the seeded ones would leave it running.
-func withdrawablePurposeKeysTx(ctx context.Context, tx pgx.Tx) ([]string, error) {
+// withdrawableMarketingPurposeKeysTx reads the live MARKETING-class purposes an
+// unsubscribe may stop.
+//
+// The catalog rather than a constant: an operator may define their own purpose,
+// and a press that only knew the seeded ones would leave it running. Filtered
+// by CLASS in the query rather than by key, for the same reason — a purpose
+// somebody named "quarterly_update" is marketing if its class says so, and no
+// list of key names would know that.
+//
+// LockedPurpose is still consulted below. It names the transactional purpose,
+// which this query already excludes, and keeping the check means a second
+// locked purpose added later is honoured here without anybody remembering to
+// come back.
+func withdrawableMarketingPurposeKeysTx(ctx context.Context, tx pgx.Tx) ([]string, error) {
 	rows, err := tx.Query(ctx,
-		`SELECT key FROM consent_purpose WHERE archived_at IS NULL ORDER BY key`)
+		`SELECT key FROM consent_purpose
+		  WHERE archived_at IS NULL AND class IN ('marketing', 'phone_outreach')
+		  ORDER BY key`)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/modules/consent/preferenceunsubscribe_integration_test.go
+++ b/backend/internal/modules/consent/preferenceunsubscribe_integration_test.go
@@ -76,11 +76,28 @@ func TestAReplayedUnsubscribeReportsNothingChanged(t *testing.T) {
 	}
 }
 
-// The incident's own case. Direct business correspondence runs on
-// no-objection, so it has no 'granted' row — and an unsubscribe-all that
-// filtered on granted walked straight past the only lane the recipient
-// was actually receiving mail under, while reporting success.
-func TestUnsubscribeAllStopsALiveBusinessCorrespondenceLane(t *testing.T) {
+// TestUnsubscribeAllStopsAMarketingLaneWithNoGrantedRow is the incident's own
+// case, kept and re-aimed.
+//
+// The incident: an unsubscribe-all that filtered on 'granted' walked past a
+// lane with no row at all, while reporting success. No row is exactly the state
+// a contact is in when they have simply been written to, so filtering on their
+// stored state meant the press missed the lane the mail was going out under.
+// The fix was to let the CATALOG decide rather than the recipient's state, and
+// that is what this still guards.
+//
+// WHAT REVERSED, and why it is not a weakening. The original test used
+// business_correspondence as its unrowed lane and asserted the press stopped
+// it. An unsubscribe no longer reaches correspondence: nobody subscribed to it,
+// so there was nothing there to withdraw, and sweeping it meant a contact who
+// unsubscribed from a newsletter stopped receiving the replies to their own
+// enquiries. The scope moved; the defect this test names did not, so it is
+// asked here about a MARKETING lane with no row — which is the same shape of
+// mistake inside the new boundary.
+//
+// A subject who wants correspondence stopped has a route, and it is a different
+// legal act: PublicStop's Art. 21 objection, tested in publicstop_integration_test.go.
+func TestUnsubscribeAllStopsAMarketingLaneWithNoGrantedRow(t *testing.T) {
 	e := setupChannelConsent(t)
 	token := seedPreferenceToken(t, e)
 
@@ -89,6 +106,48 @@ func TestUnsubscribeAllStopsALiveBusinessCorrespondenceLane(t *testing.T) {
 	// default — so the lane this test is about does not otherwise exist,
 	// and a test that read it from the env would be testing a marketing
 	// purpose under a business name.
+	unrowed := ids.From[ids.PurposeKind](ids.NewV7())
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO consent_purpose (id, key, label, requires_double_opt_in, class)
+		 VALUES ($1, 'campaign_blast', 'Campaign blast', false, $2)`,
+		unrowed, ClassMarketing); err != nil {
+		t.Fatalf("seed the campaign purpose: %v", err)
+	}
+	// Nothing is seeded for it on purpose: no row at all is exactly the
+	// state a contact is in when they have simply been written to.
+	if got := consentStateOf(t, e, unrowed); got != "" {
+		t.Fatalf("precondition: campaign_blast = %q, want no row", got)
+	}
+
+	stopped := pressUnsubscribe(t, e, token, nil, "")
+
+	var sawCampaign bool
+	for _, key := range stopped {
+		if key == "campaign_blast" {
+			sawCampaign = true
+		}
+	}
+	if !sawCampaign {
+		t.Errorf("unsubscribe-all reported %v — it must stop the lane the mail was sent "+
+			"under, and a lane with no row is exactly the one a state filter walks past", stopped)
+	}
+	if got := consentStateOf(t, e, unrowed); got != string(StateWithdrawn) {
+		t.Errorf("campaign_blast = %q, want withdrawn", got)
+	}
+}
+
+// TestUnsubscribeAllLeavesBusinessCorrespondenceAlone is the other half, and it
+// is what the press reversing cost and gained.
+//
+// Nobody subscribed to correspondence, so an unsubscribe has nothing there to
+// withdraw. Sweeping it meant a contact who unsubscribed from a newsletter
+// stopped receiving the replies to their own enquiries — recorded, on top of
+// that, as a withdrawal of a consent that was never the basis for those
+// messages.
+func TestUnsubscribeAllLeavesBusinessCorrespondenceAlone(t *testing.T) {
+	e := setupChannelConsent(t)
+	token := seedPreferenceToken(t, e)
+
 	business := ids.From[ids.PurposeKind](ids.NewV7())
 	if _, err := e.owner.Exec(context.Background(),
 		`INSERT INTO consent_purpose (id, key, label, requires_double_opt_in, class)
@@ -96,25 +155,15 @@ func TestUnsubscribeAllStopsALiveBusinessCorrespondenceLane(t *testing.T) {
 		business, ClassBusinessCorrespondence); err != nil {
 		t.Fatalf("seed the business_correspondence purpose: %v", err)
 	}
-	// Nothing is seeded for it on purpose: no row at all is exactly the
-	// state a contact is in when they have simply been written to.
-	if got := consentStateOf(t, e, business); got != "" {
-		t.Fatalf("precondition: business_correspondence = %q, want no row", got)
-	}
 
-	stopped := pressUnsubscribe(t, e, token, nil, "")
-
-	var sawBusiness bool
-	for _, key := range stopped {
+	for _, key := range pressUnsubscribe(t, e, token, nil, "") {
 		if key == "business_correspondence" {
-			sawBusiness = true
+			t.Fatal("unsubscribe-all withdrew business correspondence — the contact who " +
+				"unsubscribed from a newsletter stops receiving replies to their own enquiries")
 		}
 	}
-	if !sawBusiness {
-		t.Errorf("unsubscribe-all reported %v — it must stop the lane the mail was sent under", stopped)
-	}
-	if got := consentStateOf(t, e, business); got != string(StateWithdrawn) {
-		t.Errorf("business_correspondence = %q, want withdrawn", got)
+	if got := consentStateOf(t, e, business); got == string(StateWithdrawn) {
+		t.Error("business correspondence was withdrawn by an unsubscribe")
 	}
 }
 

--- a/backend/internal/modules/consent/publicstop.go
+++ b/backend/internal/modules/consent/publicstop.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The subject's own route to stopping more than an unsubscribe stops.
+//
+// One-click unsubscribe withdraws the marketing-class purposes, which is what a
+// subscription link offers. This is the other act: an Art. 21 objection, which
+// says the processing must stop whether or not consent was ever its basis. That
+// is the only thing that reaches business correspondence, and it is why the two
+// are separate doors rather than two sizes of one.
+//
+// Before this existed the unsubscribe press did both jobs badly: it swept every
+// purpose in the catalog, so it stopped correspondence nobody had subscribed to
+// while recording the act as a withdrawal of a consent that was never the basis
+// for those messages. Narrowing the press without building this would have left
+// a subject with no way to say "stop entirely".
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// PublicStopAction is what the subject asked for.
+type PublicStopAction string
+
+const (
+	// StopAllMarketing objects to direct marketing under Art. 21(2). It leaves
+	// correspondence and invoices running.
+	StopAllMarketing PublicStopAction = "stop_all_marketing"
+	// StopAllContact asks for contact to stop entirely. It binds every category
+	// except the few that survive an Art. 18 restriction.
+	StopAllContact PublicStopAction = "stop_all_contact"
+)
+
+// PublicStopResult is what the page tells the subject.
+type PublicStopResult struct {
+	// Recorded is false on a replay, because the stop was already standing.
+	// The page tells a first press from a second one by this rather than by
+	// showing a fresh confirmation for a no-op.
+	Recorded bool
+	// ReceiptReference is what the subject quotes when asking what happened.
+	ReceiptReference string
+}
+
+// PublicStop records a stop the SUBJECT asked for, on the anonymous preference
+// edge.
+//
+// NO SEAT GATE, and that is the difference from Suppress beside it. That door
+// is for a rep relaying a phone call, so it asks whether the caller may write
+// about this contact. Here the token IS the capability: the middleware resolved
+// it to this contact before the handler ran, and there is no seat to ask about.
+// Asking auth.Require would refuse the subject their own Art. 21 right.
+//
+// LEVEL SUBJECT for both actions, whatever authorityOf would say. The subject
+// is the one pressing, so no seat may lift what they recorded — which is the
+// whole point of an objection the controller has to answer for.
+func (s *Store) PublicStop(
+	ctx context.Context, contactID ids.ContactID, action PublicStopAction, statement string,
+) (PublicStopResult, error) {
+	kind, err := publicStopKind(action)
+	if err != nil {
+		return PublicStopResult{}, err
+	}
+	if err := boundStatement(statement); err != nil {
+		return PublicStopResult{}, err
+	}
+	sub, err := consentSubject(RecordInput{ContactID: contactID})
+	if err != nil {
+		return PublicStopResult{}, err
+	}
+	in := SuppressInput{ContactID: contactID, Kind: kind, Reason: statement}
+
+	var result PublicStopResult
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// THE LOCK FIRST, and it is the same one suppressAdmittedTx takes.
+		//
+		// Taking it there only would let two presses both read "no stop
+		// standing", then queue on the lock and each insert a row, an audit
+		// entry and an event — two records of one request, both reporting
+		// recorded=true. There is no unique index to catch that: the one on
+		// this table covers address-scoped hard bounces.
+		//
+		// Re-entrant, so the write taking it again inside is free.
+		//
+		// THIS ID FIRST, then the survivor below. They are the same key unless
+		// a merge has retired this contact, and when they differ both must be
+		// held: the read below and the write inside would otherwise queue on
+		// different keys and the race would be open again. Original-then-
+		// survivor is the order the merge itself takes them in, so two
+		// transactions cannot take them in opposite orders and deadlock.
+		if err := lockSubjectSuppressions(ctx, tx, sub.id); err != nil {
+			return err
+		}
+		// THE SURVIVOR, asked before the replay check rather than only inside
+		// the write.
+		//
+		// A token minted for a contact keeps working after that contact is
+		// merged away, and suppressAdmittedTx writes onto the survivor because
+		// no reader of communication_suppression walks merged_into_id. Checking
+		// the press against the RETIRED id would find no stop every time and
+		// insert another row on the survivor at every press, so the replay
+		// answer would be wrong for exactly the subject whose record moved.
+		//
+		// The lock inside the write is what makes a merge either committed
+		// before this read or not yet begun; this reads the same pointer that
+		// write will follow.
+		surviving, err := survivingSubject(ctx, tx, sub.id)
+		if err != nil {
+			return err
+		}
+		if surviving != sub.id {
+			if err := lockSubjectSuppressions(ctx, tx, surviving); err != nil {
+				return err
+			}
+			sub.id = surviving
+		}
+
+		standing, err := publicStopStandingTx(ctx, tx, sub, kind)
+		if err != nil {
+			return err
+		}
+		// A REPLAY RECORDS NOTHING NEW. Suppress's own door records both
+		// occasions deliberately, because a rep relaying a second phone call is
+		// a second occasion somebody asked and the reason may differ. A subject
+		// pressing the same link twice is one occasion and a stuck browser, so
+		// this one answers the receipt it already has.
+		if standing {
+			result = PublicStopResult{Recorded: false, ReceiptReference: publicStopReceipt(sub.id, kind)}
+			return nil
+		}
+		if err := s.suppressAdmittedTx(ctx, tx, in, sub, commsauthz.LevelSubject); err != nil {
+			return err
+		}
+		result = PublicStopResult{Recorded: true, ReceiptReference: publicStopReceipt(sub.id, kind)}
+		return nil
+	})
+	if err != nil {
+		return PublicStopResult{}, err
+	}
+	return result, nil
+}
+
+// publicStopKind maps the action to the suppression kind that records it.
+//
+// TOTAL over the declared actions, and an unrecognised one is refused rather
+// than defaulted. Defaulting to the narrower kind would silently under-record a
+// subject who asked for everything to stop; defaulting to the broader one would
+// stop invoices somebody never asked to stop.
+func publicStopKind(action PublicStopAction) (string, error) {
+	switch action {
+	case StopAllMarketing:
+		return commsauthz.ReasonObjection, nil
+	case StopAllContact:
+		return suppressibleKind, nil
+	}
+	return "", &ValidationError{
+		Field:  "action",
+		Reason: "a stop is either stop_all_marketing or stop_all_contact",
+	}
+}
+
+// publicStopStandingTx reports whether this kind of stop already stands for this
+// subject AT THEIR OWN AUTHORITY.
+//
+// THE LEVEL IS PART OF THE QUESTION, and leaving it out was a defect Codex
+// found. A rep relaying a phone call writes a subject_request at LevelUser,
+// which an admin may lift. Asking only "does a subject_request stand" would
+// then answer yes to the subject's own press, record nothing, and hand them a
+// receipt — after which an admin lifts the rep's row and the mail resumes, with
+// the subject's own decision never written down.
+//
+// So a weaker row does not satisfy a stronger press. The subject's row is
+// recorded beside it, and liveSuppression takes the strongest.
+func publicStopStandingTx(ctx context.Context, tx pgx.Tx, sub subject, kind string) (bool, error) {
+	var standing bool
+	err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		  SELECT 1 FROM communication_suppression
+		   WHERE `+sub.column+` = $1 AND kind = $2 AND revoked_at IS NULL
+		     AND decided_by_level = $3)`,
+		sub.id, kind, string(commsauthz.LevelSubject)).Scan(&standing)
+	if err != nil {
+		return false, fmt.Errorf("consent: reading whether this stop already stands: %w", err)
+	}
+	return standing, nil
+}
+
+// publicStopReceipt is what the subject quotes when asking what happened.
+//
+// DERIVED, not stored, and stable across a replay: the same subject and the
+// same kind answer the same reference, so somebody who pressed twice and got
+// two confirmations is not holding two different receipts for one request.
+// It carries no address and nothing a stranger could work backwards from.
+func publicStopReceipt(subjectID ids.UUID, kind string) string {
+	short := subjectID.String()
+	return "STOP-" + kind[:3] + "-" + short[len(short)-12:]
+}
+
+// boundStatement caps the subject's own words.
+//
+// SAME BOUND as boundReason beside it and a different FIELD NAME, which is the
+// whole reason it is not that function. boundReason hard-codes "reason", and
+// this route's body calls the field "statement" — a 422 naming a field the
+// caller never sent cannot be attached to the input that caused it, so the page
+// would show the error nowhere.
+func boundStatement(statement string) error {
+	if n := len([]rune(statement)); n > reasonMax {
+		return &ValidationError{
+			Field: "statement",
+			Reason: fmt.Sprintf("your words are kept at up to %d characters; this is %d",
+				reasonMax, n),
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/consent/publicstop_integration_test.go
+++ b/backend/internal/modules/consent/publicstop_integration_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// The subject's own route to stopping more than an unsubscribe stops.
+//
+// The press used to do both jobs and did them badly: it swept every purpose in
+// the catalog, so it ended business correspondence nobody had subscribed to,
+// and it recorded the act as a WITHDRAWAL of a consent that was never the basis
+// for those messages. Narrowing the press without building this route would
+// have left a subject with no way to say "stop entirely".
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// standingStops reads the live suppression kinds for a subject.
+func standingStops(t *testing.T, e *channelConsentEnv) map[string]string {
+	t.Helper()
+	rows, err := e.owner.Query(context.Background(), `
+		SELECT kind, decided_by_level FROM communication_suppression
+		 WHERE contact_id = $1 AND revoked_at IS NULL`, e.contact)
+	if err != nil {
+		t.Fatalf("reading the standing stops: %v", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var kind, level string
+		if err := rows.Scan(&kind, &level); err != nil {
+			t.Fatalf("scanning a stop: %v", err)
+		}
+		out[kind] = level
+	}
+	return out
+}
+
+// TestStopAllContactRecordsAnObjectionTheSubjectOwns.
+//
+// AT THE SUBJECT'S LEVEL, whatever the caller is. The anonymous preference edge
+// binds a system principal with no grants, so authorityOf would answer
+// LevelUser and any seat could then lift what the subject themselves recorded.
+func TestStopAllContactRecordsAnObjectionTheSubjectOwns(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+
+	got, err := e.store.PublicStop(e.ctx, e.contact, StopAllContact, "Please stop writing to me.")
+	if err != nil {
+		t.Fatalf("the subject's stop failed: %v", err)
+	}
+	if !got.Recorded {
+		t.Error("a first press reported nothing recorded")
+	}
+	if got.ReceiptReference == "" {
+		t.Error("the subject was given no receipt to quote")
+	}
+
+	stops := standingStops(t, e)
+	level, standing := stops["subject_request"]
+	if !standing {
+		t.Fatalf("no subject_request stop stands: %v", stops)
+	}
+	if level != string(commsauthz.LevelSubject) {
+		t.Errorf("the stop was recorded at level %q, want %q — at anything less a seat "+
+			"could lift what the subject themselves asked for",
+			level, commsauthz.LevelSubject)
+	}
+}
+
+// TestStopAllMarketingIsAnObjectionAndNotAWithdrawal.
+//
+// The two are different legal acts. A withdrawal says the consent is gone; an
+// objection says the processing must stop whether or not consent was ever its
+// basis. Recording the second as the first is what the old sweep did.
+func TestStopAllMarketingIsAnObjectionAndNotAWithdrawal(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+
+	if _, err := e.store.PublicStop(e.ctx, e.contact, StopAllMarketing, "No more ads."); err != nil {
+		t.Fatalf("the subject's objection failed: %v", err)
+	}
+
+	stops := standingStops(t, e)
+	if _, standing := stops[commsauthz.ReasonObjection]; !standing {
+		t.Errorf("no marketing objection stands: %v", stops)
+	}
+	if _, standing := stops["subject_request"]; standing {
+		t.Error("an objection to marketing recorded a broad subject request — that binds " +
+			"invoices, which the subject did not ask to stop")
+	}
+}
+
+// TestAReplayRecordsNothingNewAndAnswersTheSameReceipt.
+//
+// A subject pressing the same link twice is one occasion and a stuck browser.
+// The seat door beside this one records both deliberately, because a rep
+// relaying a second phone call IS a second occasion and the reason may differ.
+func TestAReplayRecordsNothingNewAndAnswersTheSameReceipt(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+
+	first, err := e.store.PublicStop(e.ctx, e.contact, StopAllContact, "Stop.")
+	if err != nil {
+		t.Fatalf("the first press failed: %v", err)
+	}
+	second, err := e.store.PublicStop(e.ctx, e.contact, StopAllContact, "Stop.")
+	if err != nil {
+		t.Fatalf("the replay failed: %v", err)
+	}
+	if second.Recorded {
+		t.Error("a replay reported a fresh record — the page would show a new confirmation " +
+			"for a no-op")
+	}
+	if second.ReceiptReference != first.ReceiptReference {
+		t.Errorf("the replay answered receipt %q and the first press %q — the subject who "+
+			"pressed twice holds two references for one request",
+			second.ReceiptReference, first.ReceiptReference)
+	}
+}
+
+// TestAnUnrecognisedActionIsRefusedRatherThanDefaulted.
+//
+// Defaulting to the narrower kind would under-record a subject who asked for
+// everything to stop; defaulting to the broader one would stop invoices nobody
+// asked to stop. Neither is a safe direction, so there is no default.
+func TestAnUnrecognisedActionIsRefusedRatherThanDefaulted(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+
+	if _, err := e.store.PublicStop(e.ctx, e.contact, PublicStopAction("stop_some_of_it"), ""); err == nil {
+		t.Fatal("an unrecognised action was accepted")
+	}
+	if stops := standingStops(t, e); len(stops) != 0 {
+		t.Errorf("a refused action still recorded %v", stops)
+	}
+}
+
+// TestAnUnsubscribeWritesNoStopThatBindsCorrespondence is the exit criterion
+// for narrowing the sweep, asked from the other end.
+//
+// The scope test beside it checks WHICH purposes the press withdrew. This
+// checks what the press left behind in the suppression table, because a
+// withdrawal that wrote a broad stop as a side effect would pass the first test
+// and still end the subject's replies.
+//
+// Mutation: point the one-click handler back at a sweep over every class and
+// this stays green — which is why both tests exist. Write a subject_request
+// from the unsubscribe path and this fails.
+func TestAnUnsubscribeWritesNoStopThatBindsCorrespondence(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO consent_purpose (key, label, class) VALUES ($1, $1, 'marketing')
+		 ON CONFLICT (key) DO UPDATE SET class = EXCLUDED.class`, "newsletter_blast"); err != nil {
+		t.Fatalf("seeding the marketing purpose: %v", err)
+	}
+
+	if _, err := e.store.PublicStopAllMarketing(e.ctx, e.contact); err != nil {
+		t.Fatalf("the unsubscribe failed: %v", err)
+	}
+
+	// An unsubscribe is a WITHDRAWAL of consent. It records no suppression at
+	// all: the subject did not object, they stopped subscribing, and those are
+	// different acts with different reach.
+	if stops := standingStops(t, e); len(stops) != 0 {
+		t.Errorf("an unsubscribe wrote %v. A subject_request there would bind the replies "+
+			"to the subject's own enquiries, which is the defect this slice closes; any "+
+			"stop at all overstates what pressing unsubscribe said", stops)
+	}
+}
+
+// TestARepsWeakerStopDoesNotSwallowTheSubjectsOwn is Codex's finding, and the
+// consequence is that the mail resumes.
+//
+// A rep relaying a phone call writes a subject_request at LevelUser, which an
+// admin may lift. A replay check asking only "does a subject_request stand"
+// answers yes to the subject's own press, records nothing, and hands them a
+// receipt — after which an admin lifts the rep's row and nothing the subject
+// did is on the record.
+func TestARepsWeakerStopDoesNotSwallowTheSubjectsOwn(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+
+	// The rep's row, as the seat door writes it.
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO communication_suppression (contact_id, kind, source, captured_by, decided_by_level)
+		VALUES ($1, 'subject_request', 'test', 'human:rep', $2)`,
+		e.contact, string(commsauthz.LevelUser)); err != nil {
+		t.Fatalf("planting the rep's stop: %v", err)
+	}
+
+	got, err := e.store.PublicStop(e.ctx, e.contact, StopAllContact, "Stop, please.")
+	if err != nil {
+		t.Fatalf("the subject's stop failed: %v", err)
+	}
+	if !got.Recorded {
+		t.Fatal("the subject's press recorded nothing because a rep had already written a " +
+			"weaker row — an admin lifting that row leaves the subject's decision nowhere")
+	}
+	if level := standingStops(t, e)["subject_request"]; level != string(commsauthz.LevelSubject) {
+		t.Errorf("the strongest standing subject_request is at level %q, want %q",
+			level, commsauthz.LevelSubject)
+	}
+}
+
+// pressStop drives the real handler, which is where the credential's scope is
+// enforced. The store method below it trusts its caller.
+func pressStop(t *testing.T, e *channelConsentEnv, token, action string) int {
+	t.Helper()
+	h := NewHandlers(database.BindTo(e.store.db.Pool(), ids.From[ids.WorkspaceKind](e.ws)))
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem,
+		ID:   "system:public_preferences",
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/public/preferences/"+token+"/stop",
+		strings.NewReader(`{"action":"`+action+`"}`)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.PublicStopContact(rec, req, token)
+	return rec.Code
+}
+
+// TestANamedSubscriptionLinkCannotStopEverything is Codex's finding, and it was
+// a privilege escalation of my own making.
+//
+// A named_purpose credential is minted to stop ONE subscription. My first
+// resolver read only the contact off it and threw the scope away, so a
+// forwarded newsletter link could POST stop_all_contact and end that contact's
+// invoices and their replies — at the subject's own authority, which no seat
+// can lift.
+//
+// NEITHER action is refused for being large. Both are refused because neither
+// is as narrow as the link: the smaller one objects to all direct marketing,
+// and the link speaks for one subscription.
+func TestANamedSubscriptionLinkCannotStopEverything(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedMarketingPurpose(t, e)
+	seedSubjectAddress(t, e)
+	address := "subject-" + e.contact.String() + "@example.test"
+
+	named := mintWithdrawal(t, e, WithdrawalMintInput{
+		Address:   address,
+		ContactID: e.contact,
+		Scope:     WithdrawalScopeNamedPurpose,
+		PurposeID: e.newsletter.UUID,
+	})
+	if named == "" {
+		t.Fatal("the mint returned no token")
+	}
+
+	for _, action := range []string{"stop_all_contact", "stop_all_marketing"} {
+		if code := pressStop(t, e, named, action); code == http.StatusOK {
+			t.Errorf("a named-subscription link performed %q — a forwarded newsletter link "+
+				"would end this contact's invoices and their replies", action)
+		}
+	}
+	if stops := standingStops(t, e); len(stops) != 0 {
+		t.Errorf("a refused press still recorded %v", stops)
+	}
+}
+
+// TestAnAllMarketingLinkMayStillObject is the positive control: the refusal
+// above must be about the link's scope and not about the route being broken.
+func TestAnAllMarketingLinkMayStillObject(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedMarketingPurpose(t, e)
+	seedSubjectAddress(t, e)
+	address := "subject-" + e.contact.String() + "@example.test"
+
+	broad := mintWithdrawal(t, e, WithdrawalMintInput{
+		Address:   address,
+		ContactID: e.contact,
+		Scope:     WithdrawalScopeAllMarketing,
+	})
+	if code := pressStop(t, e, broad, "stop_all_marketing"); code != http.StatusOK {
+		t.Fatalf("an all-marketing link was refused its own scope: status %d", code)
+	}
+	if _, standing := standingStops(t, e)[commsauthz.ReasonObjection]; !standing {
+		t.Error("the press recorded no marketing objection")
+	}
+}

--- a/backend/internal/modules/consent/unsubscribeallrace_integration_test.go
+++ b/backend/internal/modules/consent/unsubscribeallrace_integration_test.go
@@ -174,7 +174,7 @@ func waitUntilNBlockedBy(t *testing.T, holder *pgx.Conn, want int) {
 // its row locks in its OWN order: the withdrawal sweeps go by ascending purpose
 // key, a granular save goes withdrawals-first so a refused grant cannot cost
 // the suppression beside it. A save of {grant a, withdraw b} therefore locks b
-// before a while an unsubscribe-everything locks a before b — and two at once
+// before a while an stop-all-marketing locks a before b — and two at once
 // on one contact deadlock. Postgres aborts one, and the reader sees a preference
 // change that failed for no reason they can act on.
 //
@@ -203,7 +203,7 @@ func TestOneContactsConsentWritesDoNotInterleave(t *testing.T) {
 
 	pressed := make(chan error, 1)
 	go func() {
-		_, err := e.store.PublicWithdrawEverything(publicPreferencesCtx(e), e.contact)
+		_, err := e.store.PublicStopAllMarketing(publicPreferencesCtx(e), e.contact)
 		pressed <- err
 	}()
 

--- a/backend/internal/modules/consent/withdrawalcredential_integration_test.go
+++ b/backend/internal/modules/consent/withdrawalcredential_integration_test.go
@@ -403,15 +403,18 @@ func TestTheProductionRotationNamesItsReason(t *testing.T) {
 	}
 }
 
-// AN ALL-MARKETING LINK STOPS MARKETING AND LEAVES CORRESPONDENCE ALONE.
+// AN UNSUBSCRIBE STOPS MARKETING AND LEAVES CORRESPONDENCE ALONE.
 //
-// The legacy one-click sweep stops every purpose in the catalog except the
-// locked transactional one, so a press also ends business correspondence: the
-// contact who unsubscribed from a newsletter stops receiving replies to their
-// own enquiries. Narrowing THAT changes what links already in mailboxes do, so
-// it belongs to the slice owning the purpose vocabulary. A new credential is
-// owed no such breadth, and its scope is called all_marketing.
-func TestAnAllMarketingLinkLeavesBusinessCorrespondenceRunning(t *testing.T) {
+// It used to stop every purpose in the catalog except the locked transactional
+// one, so a press also ended business correspondence: the contact who
+// unsubscribed from a newsletter stopped receiving replies to their own
+// enquiries. Nobody opted in to correspondence, so there was nothing there to
+// unsubscribe from — the sweep withdrew a consent that was never the basis for
+// those messages.
+//
+// Both credential families answer here now, which is why the test calls the
+// writer both routes share rather than a credential-only one.
+func TestAnUnsubscribeLeavesBusinessCorrespondenceRunning(t *testing.T) {
 	e := setupChannelConsent(t)
 	seedSubjectAddress(t, e)
 	for _, p := range []struct{ key, class string }{
@@ -426,15 +429,14 @@ func TestAnAllMarketingLinkLeavesBusinessCorrespondenceRunning(t *testing.T) {
 		}
 	}
 
-	stopped, err := e.store.WithdrawMarketingForCredential(e.ctx, e.contact)
+	stopped, err := e.store.PublicStopAllMarketing(e.ctx, e.contact)
 	if err != nil {
-		t.Fatalf("the credential's press failed: %v", err)
+		t.Fatalf("the press failed: %v", err)
 	}
 
 	for _, want := range []string{"newsletter_blast", "cold_calling"} {
 		if !slices.Contains(stopped, want) {
-			t.Errorf("the press left %q running, and a link that says all_marketing "+
-				"has to stop it", want)
+			t.Errorf("the press left %q running, and an unsubscribe has to stop it", want)
 		}
 	}
 	if slices.Contains(stopped, "business_correspondence") {

--- a/backend/internal/modules/consent/withdrawalpress.go
+++ b/backend/internal/modules/consent/withdrawalpress.go
@@ -144,49 +144,6 @@ func (s *Store) StopForCredential(ctx context.Context, token string) error {
 	})
 }
 
-// WithdrawMarketingForCredential stops the MARKETING-CLASS purposes a contact
-// holds, for a credential whose scope is all_marketing.
-//
-// SCOPED BY CLASS, unlike the legacy one-click sweep beside it, which stops
-// every purpose in the catalog except the locked transactional one — so a
-// press there also withdraws business correspondence, and a contact who
-// unsubscribed from a newsletter stops receiving replies to their own
-// enquiries. That defect is older than this credential and its fix is a slice
-// of its own, because narrowing the LEGACY path changes what an existing link
-// in an existing mailbox does.
-//
-// This credential is new, so nothing depends on it being over-broad, and its
-// scope is called all_marketing. Honouring that literally is the only reading
-// that matches the words: a link minted to stop marketing stops marketing.
-//
-// phone_outreach is marketing by another channel and goes with it. The two
-// classes left standing are transactional and business_correspondence, which
-// are not subscriptions anybody opted into and so not things to unsubscribe
-// from.
-func (s *Store) WithdrawMarketingForCredential(
-	ctx context.Context, contactID ids.ContactID,
-) ([]string, error) {
-	var keys []string
-	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, `
-			SELECT key FROM consent_purpose
-			 WHERE archived_at IS NULL AND class IN ('marketing', 'phone_outreach')
-			 ORDER BY key`)
-		if err != nil {
-			return fmt.Errorf("consent: reading the marketing purposes a link may stop: %w", err)
-		}
-		keys, err = pgx.CollectRows(rows, pgx.RowTo[string])
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(keys) == 0 {
-		return []string{}, nil
-	}
-	return s.PublicWithdrawAll(ctx, contactID, keys)
-}
-
 // WithdrawMarketingNamed stops ONE purpose, and only if it is one an
 // all-marketing link may stop.
 //

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4945,11 +4945,50 @@ export interface paths {
          *     (source `preference_center`) which the default-deny suppression gate honors on the very next send
          *     across every path (manual + agent). Idempotent. Only POST acts — a GET/prefetch by a mail scanner
          *     never unsubscribes anyone (the reason RFC 8058 mandates POST). With `purpose` only that purpose is
-         *     withdrawn (the one the message was sent under); without it every lane the recipient has not already
-         *     stopped is — read from their `choice`, not the raw stored state, so direct correspondence running on
-         *     no-objection is included rather than silently skipped.
+         *     withdrawn (the one the message was sent under); without it every MARKETING-class purpose is —
+         *     marketing and phone outreach, read from the live catalog so an operator's own purpose is included.
+         *     Business correspondence and transactional mail are NOT stopped: nobody subscribed to them, so there
+         *     is nothing there to unsubscribe from, and a recipient who unsubscribed from a newsletter still gets
+         *     the replies to their own enquiries and their invoices. A subject who wants ALL contact stopped uses
+         *     `/public/preferences/{token}/stop` with `stop_all_contact`, which records an Art. 21 objection
+         *     rather than withdrawing a consent that was never the basis for those messages.
          */
         post: operations["oneClickUnsubscribe"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/public/preferences/{token}/stop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Ask us to stop contacting you (anonymous, token-authed, POST-only).
+         * @description The route for a subject who wants MORE stopped than an unsubscribe stops. One-click unsubscribe
+         *     withdraws the marketing-class purposes, which is what a subscription link offers; this records an
+         *     Art. 21 objection instead, and the two are different legal acts rather than two sizes of the same
+         *     one. A withdrawal says the consent is gone. An objection says the processing must stop whether or
+         *     not consent was ever its basis, which is the only thing that reaches business correspondence.
+         *
+         *     `stop_all_marketing` records a marketing objection at the subject's own authority, so no seat can
+         *     lift it. `stop_all_contact` records a broad subject request, which binds every category except the
+         *     few that survive an Art. 18 restriction — a privacy notice, a security notice and the
+         *     acknowledgement of this very request, because a stop that silenced the confirmation that it worked
+         *     would leave the subject unable to tell whether anything happened.
+         *
+         *     Only POST acts, for the reason RFC 8058 gives: a mail scanner following links must not stop
+         *     somebody's mail. Idempotent — a replay records nothing new and reports the same receipt.
+         */
+        post: operations["publicStopContact"];
         delete?: never;
         options?: never;
         head?: never;
@@ -43649,7 +43688,7 @@ export interface operations {
     oneClickUnsubscribe: {
         parameters: {
             query?: {
-                /** @description The consent purpose key to withdraw. Omit to withdraw every lane the recipient has not already stopped. */
+                /** @description The consent purpose key to withdraw. Omit to withdraw every marketing-class purpose. */
                 purpose?: string;
             };
             header?: never;
@@ -43689,6 +43728,50 @@ export interface operations {
                          *     of showing a fresh confirmation for a no-op.
                          */
                         unsubscribed: string[];
+                    };
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    publicStopContact: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    action: "stop_all_marketing" | "stop_all_contact";
+                    /**
+                     * @description The subject's own words, kept verbatim. An objection a controller has to answer for is
+                     *     weaker evidence when the record holds only our paraphrase of it.
+                     */
+                    statement?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Recorded (idempotent). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description False on a replay, because the stop was already standing. The page tells a first press
+                         *     from a second one by this rather than by showing a fresh confirmation for a no-op.
+                         */
+                        recorded: boolean;
+                        /** @description What the subject quotes when asking what happened to their request. */
+                        receipt_reference: string;
                     };
                 };
             };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6393,9 +6393,9 @@ export const de = {
   "prefs.wording.marketing_email":
     "„Schick mir Produkt-Updates und gelegentliche Marketing-E-Mails.“",
   "prefs.wording.events": "„Schick mir Einladungen zu Events und Webinaren.“",
-  "prefs.unsubscribeAll": "Alles abschalten, was ich abschalten kann",
+  "prefs.unsubscribeAll": "Alle Werbung abschalten",
   "prefs.unsubscribeAllHint":
-    "Das schaltet jede Zeile oben aus, die ein anklickbares Kästchen hat. Zeilen mit IMMER AN bleiben an — die brauchst du für Dinge, die du selbst angefordert hast.",
+    "Das schaltet jede Werbe-Zeile oben aus. Antworten auf deine eigenen Anfragen und alles, worum du gebeten hast, kommen weiter — dafür hat dich niemand angemeldet, also gibt es da nichts abzuschalten.",
   "prefs.oneClickDone":
     "Erledigt — du bekommst keine Marketing-E-Mails mehr von uns. Das gilt sofort für jede Kampagne.",
   "prefs.oneClickAlreadyOff": "Nichts zu tun — das war bereits abgeschaltet.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6566,9 +6566,9 @@ export const en = {
   "prefs.wording.marketing_email":
     '"Send me product updates & occasional marketing email."',
   "prefs.wording.events": '"Send me event & webinar invitations."',
-  "prefs.unsubscribeAll": "Stop everything I can switch off",
+  "prefs.unsubscribeAll": "Stop all marketing",
   "prefs.unsubscribeAllHint":
-    "This switches off every row above that has a checkbox you can use. Rows marked ALWAYS ON stay on — you need them for things you asked for.",
+    "This switches off every marketing row above. Replies to your own enquiries, and anything you asked us for, keep coming — nobody subscribed you to those, so there is nothing there to switch off.",
   "prefs.oneClickDone":
     "Done — you're off our marketing email. It takes effect immediately across every campaign.",
   "prefs.oneClickAlreadyOff": "Nothing to do — these were already off.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6322,9 +6322,9 @@ export const vi = {
   "prefs.wording.marketing_email":
     '"Hãy gửi cho tôi tin cập nhật sản phẩm & email tiếp thị thỉnh thoảng."',
   "prefs.wording.events": '"Hãy gửi cho tôi lời mời sự kiện & webinar."',
-  "prefs.unsubscribeAll": "Tắt mọi thứ tôi có thể tắt",
+  "prefs.unsubscribeAll": "Tắt toàn bộ tiếp thị",
   "prefs.unsubscribeAllHint":
-    "Thao tác này tắt mọi hàng phía trên có ô đánh dấu bạn dùng được. Các hàng ghi LUÔN BẬT vẫn bật — bạn cần chúng cho những việc chính bạn đã yêu cầu.",
+    "Thao tác này tắt mọi hàng tiếp thị phía trên. Thư trả lời cho chính câu hỏi của bạn, và những gì bạn đã yêu cầu, vẫn được gửi — không ai đăng ký giúp bạn những mục đó nên không có gì để tắt.",
   "prefs.oneClickDone":
     "Xong — bạn đã ra khỏi danh sách email tiếp thị. Việc này có hiệu lực ngay trên mọi chiến dịch.",
   "prefs.oneClickAlreadyOff": "Không cần làm gì — những mục này vốn đã tắt.",


### PR DESCRIPTION
Pressing unsubscribe stopped every purpose in the catalog except the locked transactional one. That included business correspondence, so a contact who unsubscribed from a newsletter stopped receiving the replies to their own enquiries. Nobody subscribed to correspondence, so the press was recording a withdrawal of a consent that was never the basis for those messages.

## What the press does now

It stops the marketing classes, marketing and phone outreach, read from the live catalog by class rather than by key name so an operator's own purpose is included. Selection and withdrawal stay in one transaction, which is what the sweep it replaces was built for: a purpose granted between reading the list and acting on it would otherwise survive a stop that reported itself done.

Both credential families answer the same way. The branch between them is gone because the answer no longer differs, and the duplicate writer that did the same filter across two transactions is deleted.

## A subject who wants everything stopped

Narrowing the press alone would have taken away their only route, so the stop endpoint lands with it. It records an Art. 21 objection rather than a withdrawal. Those are different legal acts: a withdrawal says the consent is gone, an objection says the processing must stop whether or not consent was ever its basis, and only the second reaches correspondence.

Always at the subject's own authority. The anonymous edge binds a system principal with no grants, so deriving the level from the caller would let any seat lift what the subject themselves recorded.

## Three findings Codex caught, two of them mine to be embarrassed by

A named-subscription link could stop everything. My resolver read the contact off the credential and threw its scope away, so a forwarded newsletter link could end that contact's invoices and their replies, at an authority no seat can lift. Both actions are now refused from such a link, because neither is as narrow as the link itself.

A rep's weaker stop swallowed the subject's own. The replay check asked only whether a stop of that kind stood, not at what authority. A subject pressing after a rep had relayed their call got a receipt and no record, and an admin lifting the rep's row would have resumed the mail.

The preference page still promised to stop everything. Its label and hint are corrected in all three catalogs to say marketing, and to say what keeps coming.

Also fixed: the replay check read the pre-merge contact while the write landed on the survivor, two concurrent presses could both insert, and a too-long statement reported a validation error naming a field the route does not have.

## Tests

The incident test that required the old breadth is re-aimed rather than deleted. Its defect was a state filter walking past a lane with no consent row while reporting success, which is still a defect inside the new boundary, so it is asked about a marketing lane instead. Its complement asserts correspondence survives.

Each security fix has a test that fails when the fix is reverted, and the scope refusal has a positive control so it cannot pass by the route being broken.

Full backend gate green. Frontend gate green. Integration lanes green for consent and compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unsubscribe now stops only marketing-class purposes, so a contact who unsubscribes from a newsletter keeps receiving replies to their own enquiries and invoices. Adds `POST /public/preferences/{token}/stop` as the route for subjects who want all contact stopped, recording an Art. 21 objection at the subject's own authority.

**Bug Fixes**
- Forwarded named-subscription links can no longer request broader stops; both actions are refused because the link only authorizes stopping one purpose.
- The stop endpoint's replay check now requires a standing stop at the subject's own level, so a rep's weaker stop doesn't mask the subject's own request.
- Concurrent presses no longer double-insert, and an oversized statement reports a validation error on the `statement` field.

**New Features**
- `stop_all_marketing` records a marketing objection; `stop_all_contact` records a broad subject request that binds everything except a few required notices.

<sup>Written for commit 52958b8553666facc2561018e38a0d770f76abe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

