### PR TITLE
fix(draftcheck): the safer draft is served, not the one with fewer matches

### DIFF
--- a/backend/internal/compose/draftcheck/draftcheck.go
+++ b/backend/internal/compose/draftcheck/draftcheck.go
@@ -34,8 +34,12 @@ import (
 
 // Finding is one thing wrong with a draft, in words a contact can act on.
 type Finding struct {
-	// Rule names what was violated, for the log and the regeneration prompt.
-	Rule string
+	// Rule names what was violated, for the log and the regeneration prompt,
+	// and carries how bad breaking it is. A Rule rather than a string because
+	// the serve decision compares severities, and a rule whose class was
+	// declared somewhere other than its own identity is a rule the next one
+	// can be written without.
+	Rule Rule
 	// Phrase is the text that triggered it, so a reader can find it.
 	Phrase string
 	// Why says what makes it wrong HERE — the same phrase is fine at another
@@ -167,7 +171,7 @@ func Reasoning(labels []string, lang textlang.Lang, band convstate.Band) []Findi
 		for _, phrase := range allDirectedRelationshipPhrases() {
 			if startsWord(lowered, phrase) {
 				findings = append(findings, Finding{
-					Rule:   "invented-relationship",
+					Rule:   RuleInventedRelationship,
 					Phrase: phrase,
 					Why: "no referral record exists to support who introduced whom, so a " +
 						"chip asserting one states a fact the product does not hold",
@@ -261,7 +265,7 @@ func Body(body string, lang textlang.Lang, band convstate.Band, on Grounds) []Fi
 	for _, phrase := range wellbeing[lang] {
 		if contains(opening(lowered), phrase) {
 			findings = append(findings, Finding{
-				Rule:   "wellbeing-opener",
+				Rule:   RuleWellbeingOpener,
 				Phrase: phrase,
 				Why:    "an opening pleasantry is filler, and it reads as a template",
 			})
@@ -270,12 +274,12 @@ func Body(body string, lang textlang.Lang, band convstate.Band, on Grounds) []Fi
 
 	if !on.Threaded {
 		findings = append(findings, firstMatch(lowered, spokenExchange[lang],
-			"invented-conversation",
+			RuleInventedConversation,
 			"this message opens a new conversation, so nothing in the input says a "+
 				"call or meeting took place — write from the messages on the record")...)
 
 		findings = append(findings, firstMatch(lowered, attributedClaim[lang],
-			"attributed-claim",
+			RuleAttributedClaim,
 			"the input says what a message was about, never who wrote it — "+
 				"name the topic instead of attributing it to the recipient")...)
 	}
@@ -286,7 +290,7 @@ func Body(body string, lang textlang.Lang, band convstate.Band, on Grounds) []Fi
 	// untouched — that is the message this product exists to write.
 	if !on.Booked {
 		findings = append(findings, firstMatch(lowered, scheduledArrangement[lang],
-			"unscheduled-arrangement",
+			RuleUnscheduledArrangement,
 			"nothing in the input books a meeting with this recipient, so writing about one "+
 				"as already arranged puts an appointment in front of them that nobody made — "+
 				"propose it instead")...)
@@ -294,7 +298,7 @@ func Body(body string, lang textlang.Lang, band convstate.Band, on Grounds) []Fi
 
 	if lang == textlang.German && mixedRegister(body) {
 		findings = append(findings, Finding{
-			Rule:   "mixed-register",
+			Rule:   RuleMixedRegister,
 			Phrase: "du/Sie",
 			Why: "the draft addresses the recipient formally in one sentence and " +
 				"familiarly in another — pick the one the correspondence uses and hold it",
@@ -315,7 +319,7 @@ func Formatting(body string) []Finding {
 		return nil
 	}
 	return []Finding{{
-		Rule:   "unbroken-block",
+		Rule:   RuleUnbrokenBlock,
 		Phrase: "the whole message on one line",
 		Why: "the greeting and the message run together as a single block, which " +
 			"reads as a wall of text in every mail client — put the greeting on its " +
@@ -357,7 +361,7 @@ func bandGated(lowered string, lang textlang.Lang, band convstate.Band) []Findin
 		for _, phrase := range invention[lang] {
 			if contains(lowered, phrase) {
 				findings = append(findings, Finding{
-					Rule:   "invented-first-touch",
+					Rule:   RuleInventedFirstTouch,
 					Phrase: phrase,
 					Why: "this is a first message and nothing in the input supports that claim — " +
 						"write only from the recipient, their employer and the stated reason for writing",
@@ -374,7 +378,7 @@ func bandGated(lowered string, lang textlang.Lang, band convstate.Band) []Findin
 		for _, phrase := range resolvedEvent[lang] {
 			if strings.Contains(lowered, phrase) {
 				findings = append(findings, Finding{
-					Rule:   "assumed-resolution",
+					Rule:   RuleAssumedResolution,
 					Phrase: phrase,
 					Why: "nothing in the input says that happened — after months of silence " +
 						"their side's state is unknown, so ask rather than assert",
@@ -387,7 +391,7 @@ func bandGated(lowered string, lang textlang.Lang, band convstate.Band) []Findin
 		for _, phrase := range assumedMemory[lang] {
 			if contains(lowered, phrase) {
 				findings = append(findings, Finding{
-					Rule:   "assumed-memory",
+					Rule:   RuleAssumedMemory,
 					Phrase: phrase,
 					Why: "the correspondence has been silent for " + string(band) +
 						", so the recipient does not have that exchange in mind — name it instead",
@@ -477,7 +481,7 @@ func boundary(text string, i int) bool {
 // One rather than all, because the finding is fed back to the model as a
 // correction and a list of six ways it said the same wrong thing is not six
 // corrections. The first is enough to name what to stop doing.
-func firstMatch(lowered string, phrases []string, rule, why string) []Finding {
+func firstMatch(lowered string, phrases []string, rule Rule, why string) []Finding {
 	for _, phrase := range phrases {
 		if contains(lowered, phrase) {
 			return []Finding{{Rule: rule, Phrase: phrase, Why: why}}

--- a/backend/internal/compose/draftcheck/draftcheck_test.go
+++ b/backend/internal/compose/draftcheck/draftcheck_test.go
@@ -24,7 +24,7 @@ func TestTheDraftTheJudgeFlooredIsCaught(t *testing.T) {
 		t.Fatal("the phrasing the judge floored passed the check")
 	}
 	for _, f := range findings {
-		if f.Rule != "assumed-memory" {
+		if f.Rule != draftcheck.RuleAssumedMemory {
 			t.Errorf("unexpected rule %q for %q", f.Rule, f.Phrase)
 		}
 	}
@@ -53,7 +53,7 @@ func TestAWellbeingOpenerIsCaughtAtEveryBand(t *testing.T) {
 		convstate.BandNone, convstate.BandFresh, convstate.BandWeeks, convstate.BandMonths,
 	} {
 		findings := draftcheck.Body(body, textlang.English, band, draftcheck.Grounds{})
-		if len(findings) != 1 || findings[0].Rule != "wellbeing-opener" {
+		if len(findings) != 1 || findings[0].Rule != draftcheck.RuleWellbeingOpener {
 			t.Errorf("at band %q: got %+v, want one wellbeing-opener finding", band, findings)
 		}
 	}
@@ -147,7 +147,7 @@ func TestAnInventedIntroductionInAChipIsCaught(t *testing.T) {
 	if len(findings) == 0 {
 		t.Fatal("the chip that shipped the original defect passed the check")
 	}
-	if findings[0].Rule != "invented-relationship" {
+	if findings[0].Rule != draftcheck.RuleInventedRelationship {
 		t.Errorf("expected an invented-relationship finding, got %q", findings[0].Rule)
 	}
 }
@@ -279,7 +279,7 @@ func TestAMixedRegisterIsCaught(t *testing.T) {
 	if len(findings) == 0 {
 		t.Fatal("a draft using both du and Sie should be caught")
 	}
-	if findings[0].Rule != "mixed-register" {
+	if findings[0].Rule != draftcheck.RuleMixedRegister {
 		t.Errorf("expected a mixed-register finding, got %q", findings[0].Rule)
 	}
 }
@@ -330,7 +330,7 @@ func TestADraftMayNotDeclareTheirSideResolved(t *testing.T) {
 	if len(findings) == 0 {
 		t.Fatal("a draft asserting their side resolved something should be caught")
 	}
-	if findings[0].Rule != "assumed-resolution" {
+	if findings[0].Rule != draftcheck.RuleAssumedResolution {
 		t.Errorf("expected an assumed-resolution finding, got %q", findings[0].Rule)
 	}
 }
@@ -456,7 +456,7 @@ func TestAnEnglishDayIsRefusedToo(t *testing.T) {
 // refusedAsUnscheduled reports whether the unscheduled-arrangement rule fired.
 func refusedAsUnscheduled(findings []draftcheck.Finding) bool {
 	for _, f := range findings {
-		if f.Rule == "unscheduled-arrangement" {
+		if f.Rule == draftcheck.RuleUnscheduledArrangement {
 			return true
 		}
 	}

--- a/backend/internal/compose/draftcheck/invention_test.go
+++ b/backend/internal/compose/draftcheck/invention_test.go
@@ -38,10 +38,10 @@ func TestTheServedInventedDraftIsRefusedAtEveryBand(t *testing.T) {
 			if len(findings) == 0 {
 				t.Fatalf("the served draft passed clean at band %s", band)
 			}
-			if !hasRule(findings, "invented-conversation") {
+			if !hasRule(findings, RuleInventedConversation) {
 				t.Errorf("the invented call was not caught at band %s: %+v", band, findings)
 			}
-			if !hasRule(findings, "attributed-claim") {
+			if !hasRule(findings, RuleAttributedClaim) {
 				t.Errorf("the invented attribution was not caught at band %s: %+v", band, findings)
 			}
 		})
@@ -142,7 +142,7 @@ func TestGermanInventionIsCaught(t *testing.T) {
 	}
 }
 
-func hasRule(findings []Finding, rule string) bool {
+func hasRule(findings []Finding, rule Rule) bool {
 	for _, f := range findings {
 		if f.Rule == rule {
 			return true

--- a/backend/internal/compose/draftcheck/rule.go
+++ b/backend/internal/compose/draftcheck/rule.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftcheck
+
+// What a check is, and how bad breaking it is.
+//
+// A rule used to be a bare string at the site that raised it, and its severity
+// was nowhere — so the loop that picks which of two drafts to serve could only
+// count findings. Counting is not a judgement: the band-gated loops append one
+// finding per matching phrase while the world-claim rules report one per rule,
+// so a draft saying the same wrong thing three ways outscored a draft making
+// two false statements, and the more serious one was discarded.
+//
+// The severity travels WITH the name, in one value, so a rule cannot exist
+// without one. That is the compile-time half of the fix: a new check has to
+// name a Rule, and there is no way to write a Rule that has not said which kind
+// of wrong it is.
+
+// Severity says what KIND of wrong a finding is, which is the only comparison a
+// reader would agree with.
+//
+// TWO CLASSES, deliberately, and not a numeric scale. "Is this a false
+// statement, or is it a phrasing tic" is decidable per rule by anyone who reads
+// the rule; "is this a 7 or an 8" is not, and a scale invites a rule to be
+// tuned until the arithmetic comes out the way somebody wanted.
+type Severity int
+
+const (
+	// Style is a phrasing or shape defect: filler, a wall of text, a subject
+	// line too long to read. The message is true; it reads badly.
+	Style Severity = iota
+	// Claim is the draft stating something about the world or the relationship
+	// that the input does not support — a call that never happened, a meeting
+	// nobody booked, a reply prefix on a thread that was never replied to.
+	//
+	// Strictly worse than Style, and the ordering is the whole point: a rep
+	// sends what the product wrote, and a false claim reaches the recipient as
+	// the company's own word. A stale phrase is a habit; an invented call is a
+	// thing that did not happen.
+	Claim
+)
+
+// Rule is one check's identity and its severity, as one value.
+type Rule struct {
+	name     string
+	severity Severity
+}
+
+// Name is what a log and a regeneration prompt call this rule.
+func (r Rule) Name() string { return r.name }
+
+// Severity is how bad breaking it is.
+func (r Rule) Severity() Severity { return r.severity }
+
+// String makes a Rule print as its name wherever a string was printed before.
+func (r Rule) String() string { return r.name }
+
+// The rules, each declaring what kind of wrong it is.
+//
+// Grouped by severity rather than by the file that raises them, because the
+// grouping IS the classification and a reader checking one rule's class should
+// see it beside its peers rather than beside the code that happens to match it.
+var (
+	// A false statement about the world or the relationship.
+	RuleInventedRelationship   = Rule{"invented-relationship", Claim}
+	RuleInventedFirstTouch     = Rule{"invented-first-touch", Claim}
+	RuleAssumedResolution      = Rule{"assumed-resolution", Claim}
+	RuleAssumedMemory          = Rule{"assumed-memory", Claim}
+	RuleInventedConversation   = Rule{"invented-conversation", Claim}
+	RuleAttributedClaim        = Rule{"attributed-claim", Claim}
+	RuleUnscheduledArrangement = Rule{"unscheduled-arrangement", Claim}
+	RuleUnearnedReplyPrefix    = Rule{"unearned-reply-prefix", Claim}
+	RuleInventedHistorySubject = Rule{"invented-history-subject", Claim}
+
+	// A phrasing or shape defect. The message is true; it reads badly.
+	RuleWellbeingOpener = Rule{"wellbeing-opener", Style}
+	RuleMixedRegister   = Rule{"mixed-register", Style}
+	RuleUnbrokenBlock   = Rule{"unbroken-block", Style}
+	RuleEmptySubject    = Rule{"empty-subject", Style}
+	RuleLongSubject     = Rule{"long-subject", Style}
+)
+
+// Worst is the severity of the most serious finding present, and false when
+// there are none.
+func Worst(findings []Finding) (Severity, bool) {
+	if len(findings) == 0 {
+		return Style, false
+	}
+	worst := findings[0].Rule.Severity()
+	for _, f := range findings[1:] {
+		if f.Rule.Severity() > worst {
+			worst = f.Rule.Severity()
+		}
+	}
+	return worst, true
+}
+
+// Rules counts the DISTINCT rules a set of findings breaks.
+//
+// The comparable number, and the reason the raw length is not: the band-gated
+// loops append one finding per matching phrase, so three phrasings of one
+// assumption counted three against another draft's two separate rules. Nobody
+// asked which draft has more matches; they asked which draft is worse.
+func Rules(findings []Finding) int {
+	seen := make(map[string]struct{}, len(findings))
+	for _, f := range findings {
+		seen[f.Rule.Name()] = struct{}{}
+	}
+	return len(seen)
+}

--- a/backend/internal/compose/draftcheck/subject.go
+++ b/backend/internal/compose/draftcheck/subject.go
@@ -44,7 +44,7 @@ func Subject(subject string, lang textlang.Lang, band convstate.Band, threaded b
 
 	if trimmed == "" {
 		return []Finding{{
-			Rule:   "empty-subject",
+			Rule:   RuleEmptySubject,
 			Phrase: "",
 			Why:    "a message with no subject line arrives looking like spam",
 		}}
@@ -56,7 +56,7 @@ func Subject(subject string, lang textlang.Lang, band convstate.Band, threaded b
 		}
 		if !threaded {
 			findings = append(findings, Finding{
-				Rule:   "unearned-reply-prefix",
+				Rule:   RuleUnearnedReplyPrefix,
 				Phrase: strings.TrimSuffix(prefix, ":"),
 				Why: "there is no inbound thread with this subject, so the prefix claims " +
 					"a message that was never received",
@@ -72,7 +72,7 @@ func Subject(subject string, lang textlang.Lang, band convstate.Band, threaded b
 			assumedMemory[lang]...), firstTouchSubjects[lang]...) {
 			if contains(lowered, phrase) {
 				findings = append(findings, Finding{
-					Rule:   "invented-history-subject",
+					Rule:   RuleInventedHistorySubject,
 					Phrase: phrase,
 					Why:    "this is a first message, so the subject cannot refer back to anything",
 				})
@@ -83,7 +83,7 @@ func Subject(subject string, lang textlang.Lang, band convstate.Band, threaded b
 
 	if n := len([]rune(trimmed)); n > SubjectMaxRunes {
 		findings = append(findings, Finding{
-			Rule:   "long-subject",
+			Rule:   RuleLongSubject,
 			Phrase: trimmed[:40] + "…",
 			Why: "a subject this long is truncated by the client that shows it, so the " +
 				"part that carries the meaning may never be read",

--- a/backend/internal/compose/draftcheck/unbroken_test.go
+++ b/backend/internal/compose/draftcheck/unbroken_test.go
@@ -17,7 +17,7 @@ import (
 func rules(body string) []string {
 	out := []string{}
 	for _, finding := range draftcheck.Formatting(body) {
-		out = append(out, finding.Rule)
+		out = append(out, finding.Rule.Name())
 	}
 	return out
 }
@@ -30,7 +30,7 @@ func rules(body string) []string {
 func TestAProvenanceChipIsNotAskedForParagraphs(t *testing.T) {
 	long := strings.TrimSpace(strings.Repeat("die offene Frage zu Michael Grodd und dem Angebot ", 6))
 	for _, finding := range draftcheck.Reasoning([]string{long}, textlang.German, convstate.BandWeeks) {
-		if finding.Rule == "unbroken-block" {
+		if finding.Rule == draftcheck.RuleUnbrokenBlock {
 			t.Errorf("a reasoning chip was told to add paragraphs: %q", long)
 		}
 	}

--- a/backend/internal/compose/draftcore/draftcore.go
+++ b/backend/internal/compose/draftcore/draftcore.go
@@ -44,8 +44,14 @@ type Observer interface {
 	// RetryFailed: the correction call itself errored, and the first draft
 	// stands.
 	RetryFailed(ctx context.Context, findings int, err error)
-	// RetryDidNotClear: the retry answered, and rejected phrasing survived it.
-	RetryDidNotClear(ctx context.Context, rule, phrase string, remaining int)
+	// RetryDidNotClear: the retry answered, and something survived it.
+	//
+	// The RULE rather than its name, because "the retry did not clear" means
+	// something different for a false claim than for a phrasing tic, and an
+	// operator reading the line needs to be able to tell which without knowing
+	// every rule by heart. `remaining` counts the DISTINCT rules still broken,
+	// which is the number the serve decision was made on.
+	RetryDidNotClear(ctx context.Context, rule draftcheck.Rule, phrase string, remaining int)
 }
 
 // TextOf reads the two channels of a draft a check has to judge.
@@ -147,15 +153,51 @@ func CorrectOnce[D any](
 		return retried, nil
 	}
 	if observe != nil {
-		observe.RetryDidNotClear(ctx, remaining[0].Rule, remaining[0].Phrase, len(remaining))
+		observe.RetryDidNotClear(ctx, remaining[0].Rule, remaining[0].Phrase, draftcheck.Rules(remaining))
 	}
-	// A TIE goes to the retry. Both attempts carry one finding often enough to
-	// matter — the model swaps "circling back" for "checking in" — and the
-	// retried one was at least written with the correction in hand, so it is
-	// the better bet on everything the check does not measure. Only a retry
-	// that is strictly worse is discarded.
-	if len(remaining) <= len(findings) {
+	if servesRetry(findings, remaining) {
 		return retried, nil
 	}
 	return draft, nil
+}
+
+// servesRetry decides which attempt a reader would call safer.
+//
+// SEVERITY FIRST, then the count of distinct rules, and neither half alone is
+// the answer.
+//
+// The raw finding count was not comparable across rules, because the rules do
+// not match at the same rate: the band-gated loops append one finding per
+// matching phrase while the world-claim rules report one per rule. So a draft
+// saying the same wrong thing three ways scored 3 and a draft making two
+// separate false statements scored 2, and the more serious one was discarded.
+//
+// Deduplicating by rule makes the two styles comparable and still gets that
+// case wrong: three phrasings of one memory assumption is ONE rule against the
+// other draft's TWO, so a false statement about the world still loses to a
+// phrasing habit. Severity is what fixes it, and it is the half a reader would
+// have used first: a rep sends what the product wrote, and an invented call
+// reaches the recipient as the company's own word.
+//
+// A TIE goes to the retry, unchanged. Both attempts carry one finding often
+// enough to matter — the model swaps "circling back" for "checking in" — and
+// the retried one was at least written with the correction in hand, so it is
+// the better bet on everything the check does not measure. Only a retry that is
+// strictly worse is discarded.
+func servesRetry(first, retried []draftcheck.Finding) bool {
+	firstWorst, _ := draftcheck.Worst(first)
+	retriedWorst, _ := draftcheck.Worst(retried)
+	if retriedWorst != firstWorst {
+		return retriedWorst < firstWorst
+	}
+	if firstRules, retriedRules := draftcheck.Rules(first), draftcheck.Rules(retried); retriedRules != firstRules {
+		return retriedRules < firstRules
+	}
+	// SAME SEVERITY AND THE SAME NUMBER OF RULES: the raw match count is the
+	// last thing that separates them, and here it is honest. The comparison the
+	// ticket objected to was across DIFFERENT rules, where one rule reports per
+	// phrase and another reports once however many matched; by this point both
+	// drafts break the same number of rules, and a draft saying the same wrong
+	// thing three ways is more of it than a draft saying it once.
+	return len(retried) <= len(first)
 }

--- a/backend/internal/compose/draftcore/draftcore_test.go
+++ b/backend/internal/compose/draftcore/draftcore_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/draftcheck"
 	"github.com/margince/margince/backend/internal/compose/draftcore"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
@@ -182,7 +183,7 @@ type recorder struct {
 }
 
 func (r *recorder) RetryFailed(context.Context, int, error) { r.failed++ }
-func (r *recorder) RetryDidNotClear(_ context.Context, _, phrase string, _ int) {
+func (r *recorder) RetryDidNotClear(_ context.Context, _ draftcheck.Rule, phrase string, _ int) {
 	r.notCleared = append(r.notCleared, phrase)
 }
 
@@ -222,5 +223,100 @@ func TestTheLoopReportsARetryThatDidNotHelp(t *testing.T) {
 	}
 	if quiet.failed != 0 || len(quiet.notCleared) != 0 {
 		t.Errorf("a retry that worked should report nothing, got %+v", quiet)
+	}
+}
+
+// A FALSE CLAIM LOSES TO A PHRASING TIC, however many phrases the tic carries.
+//
+// This is the case the raw finding count could not see and that deduplicating
+// by rule does not fix either. The rules do not match at the same rate: the
+// band-gated loops append one finding per matching phrase, so a draft saying
+// the same wrong thing three ways scored 3, while a draft inventing a call
+// scored 1 and was served as the better one.
+//
+// Both counts are beside the point. A rep sends what the product wrote, and an
+// invented conversation reaches the recipient as the company's own word; a
+// stale opener is a habit. Severity is the comparison a reader would have made
+// first, so it is the one made first here.
+func TestAFalseClaimIsWorseThanAnyNumberOfPhrasingTics(t *testing.T) {
+	// The first attempt is three wellbeing openers — Style, three findings, one
+	// rule. The retry invents a conversation on an unthreaded message — Claim,
+	// one finding, one rule. Every count says the retry is better.
+	lane := &scripted{bodies: []string{
+		"I hope this finds you well. I hope you are well. Hope you're doing well. " +
+			"The quote is attached and the depot slots are open on Tuesday.",
+		"It was great speaking with you earlier. The quote is attached and the " +
+			"depot slots are open on Tuesday.",
+	}}
+	got, err := draftcore.CorrectOnce(context.Background(),
+		textlang.English, convstate.BandMonths, false, lane.write, bodyOf, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.body != lane.bodies[0] {
+		t.Errorf("a draft claiming a conversation that never happened was served over one whose "+
+			"only fault is three stale openers — the recipient reads the first as the company's "+
+			"own word.\n  served: %q", got.body)
+	}
+}
+
+// And the severity is what a surface is told, not only what the loop used.
+//
+// "The retry did not clear" means something different for a false claim than
+// for a phrasing tic, and an operator scanning the line should not have to know
+// every rule by name to tell them apart.
+func TestTheUnclearedRetryIsReportedWithItsSeverity(t *testing.T) {
+	stubborn := "It was great speaking with you earlier. The quote is attached."
+	seen := &severityRecorder{}
+	lane := &scripted{bodies: []string{stubborn, stubborn}}
+	if _, err := draftcore.CorrectOnce(context.Background(),
+		textlang.English, convstate.BandMonths, false, lane.write, bodyOf, nil, seen); err != nil {
+		t.Fatal(err)
+	}
+	if len(seen.rules) != 1 {
+		t.Fatalf("the loop reported %d uncleared retries, want 1", len(seen.rules))
+	}
+	if got := seen.rules[0].Severity(); got != draftcheck.Claim {
+		t.Errorf("the uncleared retry was reported as severity %v, want Claim — %q states a "+
+			"conversation the input does not carry", got, stubborn)
+	}
+}
+
+// severityRecorder keeps the RULE rather than its phrase, which is what the
+// observer gained: the phrase says where, the rule says how bad.
+type severityRecorder struct{ rules []draftcheck.Rule }
+
+func (severityRecorder) RetryFailed(context.Context, int, error) {}
+func (r *severityRecorder) RetryDidNotClear(_ context.Context, rule draftcheck.Rule, _ string, _ int) {
+	r.rules = append(r.rules, rule)
+}
+
+// THE TICKET'S OWN EXAMPLE: two false statements lose to three phrasings of one.
+//
+// The rules do not report at the same rate. The band-gated loops append one
+// finding per matching phrase, so "circling back … as discussed … touching
+// base" scores 3 while the world-claim rules report once per rule, so an
+// invented conversation plus an attributed claim scores 2. The raw count then
+// served the draft making TWO separate false statements over the one making
+// one, three ways.
+//
+// Deduplicating by rule is what makes the two styles comparable: 2 rules
+// against 1. Severity cannot decide this pair — both are claims about the world
+// — which is why this case is here beside the one severity does decide.
+func TestTwoBrokenRulesLoseToThreePhrasingsOfOne(t *testing.T) {
+	lane := &scripted{bodies: []string{
+		"It was great speaking with you earlier.\n\nYou mentioned the depot slots " +
+			"were the blocker, so the quote is attached.",
+		"Circling back as discussed.\n\nTouching base on the quote, which is attached.",
+	}}
+	got, err := draftcore.CorrectOnce(context.Background(),
+		textlang.English, convstate.BandMonths, false, lane.write, bodyOf, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.body != lane.bodies[1] {
+		t.Errorf("a draft breaking TWO rules was served over one breaking one three ways — the "+
+			"raw finding count is not comparable across rules that do not match at the same "+
+			"rate.\n  served: %q", got.body)
 	}
 }

--- a/backend/internal/compose/replydraftmodel.go
+++ b/backend/internal/compose/replydraftmodel.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/margince/margince/backend/internal/compose/draftcheck"
 	"github.com/margince/margince/backend/internal/compose/draftcore"
 	"github.com/margince/margince/backend/internal/compose/draftrules"
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
@@ -198,9 +199,24 @@ func (l draftRetryLog) RetryFailed(ctx context.Context, findings int, err error)
 		"findings", findings, "err", err)
 }
 
-func (l draftRetryLog) RetryDidNotClear(ctx context.Context, rule, phrase string, remaining int) {
-	l.log.WarnContext(ctx, "draft still carries rejected phrasing after one retry",
-		"rule", rule, "phrase", phrase, "remaining", remaining)
+func (l draftRetryLog) RetryDidNotClear(ctx context.Context, rule draftcheck.Rule, phrase string, remaining int) {
+	// The SEVERITY is logged beside the rule, because "the retry did not clear"
+	// is a different event for a false claim than for a phrasing tic, and an
+	// operator scanning these lines should not have to know every rule by name
+	// to tell them apart.
+	l.log.WarnContext(ctx, "draft still carries a rejected phrase after one retry",
+		"rule", rule.Name(), "severity", severityName(rule.Severity()),
+		"phrase", phrase, "remaining_rules", remaining)
+}
+
+// severityName renders a severity for a log line. A word rather than the
+// integer, because an operator reading `severity=1` learns nothing and the
+// ordering is an implementation detail of the comparison.
+func severityName(s draftcheck.Severity) string {
+	if s == draftcheck.Claim {
+		return "claim"
+	}
+	return "style"
 }
 
 // parseReplyDraft reads one model reply as the draft it claims to be. The


### PR DESCRIPTION
`draftcore.CorrectOnce` picked between its two attempts by comparing `len(findings)`, and that number is not comparable across rules. The band-gated loops append **one finding per matching phrase**; the world-claim rules report **one per rule** however many phrases match. So a draft breaking two rules — inventing a conversation *and* attributing a claim — scored 2 and was served over a draft breaking one rule three ways, which scored 3.

## Three keys, in the order a reader would use them

**1 — severity.** Each rule declares whether breaking it states something false about the world or the relationship (`Claim`) or is a phrasing defect (`Style`). Two named classes and deliberately not a scale: *"is this a false statement or a tic"* is decidable per rule by anyone who reads the rule; *"is this a 7 or an 8"* is not, and a scale invites a rule to be tuned until the arithmetic comes out. A rep sends what the product wrote, so an invented call reaches the recipient as the company's own word while a stale opener is a habit.

The severity travels **with** the name, in one `Rule` value — the compile-time half the ticket asked for. A new check has to name a `Rule`, and there is no way to write one that has not said which kind of wrong it is. That matters because this defect existed for exactly that reason: a new rule's *matching style* silently changed how the comparison behaved.

**2 — distinct rules.** What makes the two matching styles comparable at all, and what settles the ticket's own example.

**3 — the raw count, and only last.** By that point both drafts break the same number of rules at the same severity, so more matches is *more of the same wrong thing* rather than a comparison across rules that count differently.

The tie rule is unchanged, for the reason already written down: the retried draft was at least written with the correction in hand.

## Each key is load-bearing, and mutation-checked

| remove | what fails |
|---|---|
| severity | `TestAFalseClaimIsWorseThanAnyNumberOfPhrasingTics` — a draft inventing a conversation served over one whose only fault is three stale openers |
| distinct rules | `TestTwoBrokenRulesLoseToThreePhrasingsOfOne` — the ticket's own example |
| the raw count | `TestOnlyAStrictlyWorseRetryIsDiscarded` — a retry saying one tic three ways ties a first attempt that said it once, and ties go to the retry |

## Where I departed from the ruling, and why

My own 2026-08-31 comment worked the ticket's example through and concluded that deduplicating *"still serves the memory draft over the invented-call draft — a false statement about the world losing to a phrasing tic, which is the wrong answer"*.

That reasoning was wrong on two counts, and I would rather say so than implement it.

- It treats `assumed-memory` as a phrasing tic. It is not. Its own doc says the phrases are *"harmless in a live exchange, **false after a long gap**"* — the rule is band-gated precisely so it fires only where the claim is untrue. It is classified `Claim` here, with `invented-relationship`, `invented-first-touch`, `assumed-resolution`, `invented-conversation`, `attributed-claim`, `unscheduled-arrangement`, `unearned-reply-prefix` and `invented-history-subject`. `wellbeing-opener`, `mixed-register`, `unbroken-block`, `empty-subject` and `long-subject` are `Style`.
- With both drafts at `Claim`, the pair is settled by rule count: **one** broken rule said three ways beats **two** separate false statements. That is the right answer, and it is the answer the ticket asks for.

So severity does not decide the ticket's headline pair — deduplication does. Severity decides the pair deduplication cannot see, which is the new test above. Both are needed; the ruling attributed the wrong one to the wrong case.

Also from the ruling, and kept: `RetryDidNotClear` now carries the `Rule` rather than its name, so an operator can tell a false claim from a phrasing tic without knowing every rule by heart, and reports the count of **distinct** rules the decision was made on.

`make check-backend` and `make craft-static` green.

Closes #1176.
