### PR TITLE
fix(tests): a fixture that needs this session's seat stops picking one

### DIFF
--- a/backend/gates/seatfixturepick_test.go
+++ b/backend/gates/seatfixturepick_test.go
@@ -57,17 +57,27 @@ var picksOneSeat = regexp.MustCompile(`(?is)\bfrom\s+app_user\b.*\blimit\s+1\b`)
 // carrying one is answering a question its caller already settled.
 //
 // TWO SHAPES, because the tree names a seat two ways. A bound id or email is a
-// caller naming the row. A correlated predicate — `a.captured_by = 'human:' ||
-// u.id::text` inside a LATERAL — names it from the row being joined, which
-// decides the pick exactly as a bind would; the `LIMIT 1` there bounds a
-// union's classes rather than choosing between seats.
+// caller naming the row. A correlated COMPARISON against the joined row —
+// `a.captured_by = 'human:' || u.id::text` inside a LATERAL, and the LIKE form
+// beside it — names it from the row being joined, which decides the pick
+// exactly as a bind would; the `LIMIT 1` there bounds a union's classes rather
+// than choosing between seats.
+//
+// The comparison is matched and not the expression: `u.id::text` alone appears
+// in a PROJECTION too, and `SELECT u.id::text FROM app_user u LIMIT 1` is this
+// defect wearing the shape that excuses it. The operator and the prefix are
+// left open — `=` or `LIKE`, any literal — because what makes it a pin is being
+// compared to a column of the other row, not which prefix the tree happens to
+// use today.
 //
 // `id <> $1` is deliberately NOT one of them. It says which seat the pick is
 // not, and leaves the ordering to choose among the rest — which is this defect
 // with one row excluded from it. A statement meaning "the colleague" says so in
 // a waiver, because "any of the others" is a claim about the fixture and not
 // about the SQL.
-var pinsTheRow = regexp.MustCompile(`(?is)\b(id|email)\s*=\s*\$\d|\bu\.id::text\b`)
+var pinsTheRow = regexp.MustCompile(
+	`(?is)\b(id|email)\s*=\s*\$\d` +
+		`|\b[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*\s*(=|like)\s*'[^']*'\s*\|\|\s*u\.id::text\b`)
 
 // seatPickWaivers ratifies a single-row pick that is NOT resolving the session's
 // own seat. Each says which seat it means instead.

--- a/backend/gates/seatfixturepick_test.go
+++ b/backend/gates/seatfixturepick_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H1
+
+package gates
+
+// A fixture that needs THIS SESSION'S seat does not pick one out of app_user.
+//
+// `SELECT id FROM app_user WHERE is_agent = false ORDER BY created_at LIMIT 1`
+// names the seat a scenario signed in as only while the installation holds
+// exactly one contact. Rows inserted in one transaction share `now()`, so with a
+// second contact the tie-break is whatever the plan returns — and the pick
+// silently becomes somebody else.
+//
+// It fails in the worst direction available, which is why this is a gate and
+// not a preference. demoteToRep demoted a seat the session was not using, the
+// session stayed admin, and a test asserting an admin-only route answers 403
+// got a 200 — reported as a permission defect in the route, in a full parallel
+// lane, green in isolation and green on the next run. The same pick then turned
+// up twice more: staging an approval inbox on behalf of an arbitrary seat, and
+// recording a directed-send decision as one.
+//
+// Three copies of one mistake is what makes it a rule rather than three fixes.
+//
+// WHAT COUNTS AS PINNED. A statement that names the row — `WHERE id = $1`,
+// `WHERE email = $1` — is answering a question the caller already settled, and
+// is not this defect. So is one with no `LIMIT`: reading every seat is a
+// different question from picking one. What is refused is a statement that
+// takes ONE row out of app_user on an ordering that does not decide which.
+//
+// THE FIX IS `sessionUserID`, in compose/integration: it reads the signed-in
+// seat from `GET /v1/me`, which is the same resolution the handlers take. A
+// fixture deriving production's answer for itself is free to derive a different
+// one, and here "different" means acting as a stranger.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// picksOneSeat matches a read of app_user bounded to a single row.
+//
+// `(?s)` so the pattern spans the newlines a formatted statement carries, and
+// the LIMIT is looked for anywhere after the table because a real statement puts
+// a WHERE, an ORDER BY or a join between them.
+var picksOneSeat = regexp.MustCompile(`(?is)\bfrom\s+app_user\b.*\blimit\s+1\b`)
+
+// pinsTheRow matches the predicates that decide WHICH seat, so a statement
+// carrying one is answering a question its caller already settled.
+//
+// TWO SHAPES, because the tree names a seat two ways. A bound id or email is a
+// caller naming the row. A correlated predicate — `a.captured_by = 'human:' ||
+// u.id::text` inside a LATERAL — names it from the row being joined, which
+// decides the pick exactly as a bind would; the `LIMIT 1` there bounds a
+// union's classes rather than choosing between seats.
+//
+// `id <> $1` is deliberately NOT one of them. It says which seat the pick is
+// not, and leaves the ordering to choose among the rest — which is this defect
+// with one row excluded from it. A statement meaning "the colleague" says so in
+// a waiver, because "any of the others" is a claim about the fixture and not
+// about the SQL.
+var pinsTheRow = regexp.MustCompile(`(?is)\b(id|email)\s*=\s*\$\d|\bu\.id::text\b`)
+
+// seatPickWaivers ratifies a single-row pick that is NOT resolving the session's
+// own seat. Each says which seat it means instead.
+var seatPickWaivers = gatekit.Waive(map[string]string{
+	"internal/compose/installation.go":                                   "seedBookingPage runs inside the INSTALLATION seed, where exactly one non-agent seat exists — the bootstrap admin it is provisioning the page for. Its own comment already names the hazard this gate is about (\"first by created_at is heap order between two rows written in one transaction\"); what makes it safe is that there is no second row yet, not the ordering",
+	"internal/modules/privacy/sarmergelineage_integration_test.go":       "seedRefusalAgainst needs A user to hang a transmit-refusal decision off, and the decision is about the SUBJECT rather than about whoever recorded it — the fixture asserts what the subject-access export reaches, and the recorder never appears in it. Any seat will do, and no seat is the session's",
+	"internal/compose/integration/fieldhistory_http_integration_test.go": "seedHumanFieldHistoryRow wants a REAL seat rather than a particular one, which its own comment states: the name resolution joins app_user on the `human:` || id key, so a made-up id would exercise the join against a shape no write produces. Which real seat is immaterial — the assertion is that a name resolves at all",
+	"internal/compose/captureofflinedemo.go":                             "the colleague to CC in the offline capture demo, and its own comment says what it wants: \"any other seat will do — the point is that a thread sometimes has a third party, not which one\". It is a development seeder, and `id <> $1` bounds the pick away from the session's own seat — which says which seat it is NOT, and is why this is a ratification rather than a pattern",
+})
+
+// wantSeatPickFloor is what the walk judged when this gate landed. A pattern
+// that stops matching app_user finds nothing to object to and reads exactly
+// like a clean tree.
+const wantSeatPickFloor = 20
+
+func TestNoFixturePicksASeatAnOrderingDoesNotDecide(t *testing.T) {
+	t.Parallel()
+	defer seatPickWaivers.AssertAllMatched(t)
+
+	fset := token.NewFileSet()
+	judged := 0
+	for _, path := range handWrittenGoSources(t) {
+		slash := filepath.ToSlash(path)
+		// This file plants the defect below as the gate's own evidence.
+		if filepath.Base(path) == "seatfixturepick_test.go" {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		for _, sql := range appUserSQL(file) {
+			if !strings.Contains(strings.ToLower(sql), "app_user") {
+				continue
+			}
+			judged++
+			if !picksOneSeat.MatchString(sql) || pinsTheRow.MatchString(sql) {
+				continue
+			}
+			if seatPickWaivers.Waived(t, slash) {
+				continue
+			}
+			t.Errorf("%s takes ONE row out of app_user on an ordering that does not decide which:\n\t%s\n\n"+
+				"Rows inserted in one transaction share now(), so a second contact makes this pick "+
+				"arbitrary — and a fixture acting as a stranger fails as a defect in whatever it was "+
+				"asserting about. Read the signed-in seat instead (sessionUserID, compose/integration), "+
+				"or pin the row by id or email.",
+				slash, gatekit.FirstLineOf(sql))
+		}
+	}
+	if judged < wantSeatPickFloor {
+		t.Errorf("the walk judged %d app_user statement(s) and judged at least %d when this gate "+
+			"landed — it has stopped recognising this tree's SQL, which reads the same as a clean tree",
+			judged, wantSeatPickFloor)
+	}
+}
+
+// appUserSQL collects the flattened SQL literals in one file that name app_user.
+func appUserSQL(file *ast.File) []string {
+	var out []string
+	for _, text := range gatekit.SQLStatementsOf(file) {
+		if strings.Contains(strings.ToLower(text), "app_user") {
+			out = append(out, text)
+		}
+	}
+	return out
+}

--- a/backend/internal/compose/integration/approval_bundle_http_integration_test.go
+++ b/backend/internal/compose/integration/approval_bundle_http_integration_test.go
@@ -68,11 +68,15 @@ func stageBundleRows(t *testing.T, e *apptest.AppEnv, companyID string, kinds ..
 	t.Helper()
 	ctx := context.Background()
 	bundle, readID := ids.NewV7(), ids.NewV7()
-	var adminID string
-	if err := e.Owner.QueryRow(ctx,
-		`SELECT id FROM app_user WHERE is_agent = false ORDER BY created_at LIMIT 1`).Scan(&adminID); err != nil {
-		t.Fatalf("admin lookup: %v", err)
-	}
+	// THIS SESSION'S seat, read from the app rather than picked out of app_user.
+	// The pick here used to be `is_agent = false ORDER BY created_at LIMIT 1`,
+	// which names the session's seat only while the installation holds exactly
+	// one contact: rows inserted in one transaction share now(), so a second
+	// contact makes it arbitrary. These rows are what the session then decides,
+	// so an arbitrary seat stages an inbox belonging to somebody else and the
+	// suite asserts against a bundle its caller never proposed. Same defect as
+	// demoteToRep's, same fix — #1180, #1074.
+	adminID := sessionUserID(t, e)
 	for i, kind := range kinds {
 		payload := siteReadPayload(kind, companyID, readID.String(), fmt.Sprintf("contact%d", i))
 		if _, err := e.Owner.Exec(ctx, `

--- a/backend/internal/compose/integration/directedsend_integration_test.go
+++ b/backend/internal/compose/integration/directedsend_integration_test.go
@@ -442,13 +442,19 @@ func TestADecisionPastItsWindowSaysSoRatherThanLoopingTheCaller(t *testing.T) {
 	// A decision is recorded against this review and then left to go stale.
 	// Written directly because the route records and sends in one action, and
 	// what is under test is the door's answer once the window has closed.
+	// Directed by THIS SESSION'S seat, read from the app. The subselect here
+	// used to be `FROM app_user u WHERE NOT u.is_agent LIMIT 1`, which is the
+	// session's seat only while the installation holds exactly one contact —
+	// and what is under test is whether the door refuses a decision that has
+	// gone stale, which is a question about the caller's own decision. Same
+	// defect as demoteToRep's, same fix — #1180, #1074.
 	if _, err := c.Owner.Exec(context.Background(), `
 		INSERT INTO communication_instruction
 		  (review_id, directed_by, reason_code, explanation, warning_version,
 		   acknowledged_at, facts_as_of, valid_until)
-		SELECT $1, u.id, 'contractual_necessity', 'decided a while ago', 'override-v1',
-		       now() - interval '2 days', now() - interval '2 days', now() - interval '1 day'
-		  FROM app_user u WHERE NOT u.is_agent LIMIT 1`, review); err != nil {
+		VALUES ($1, $2, 'contractual_necessity', 'decided a while ago', 'override-v1',
+		        now() - interval '2 days', now() - interval '2 days', now() - interval '1 day')`,
+		review, sessionUserID(t, c.AppEnv)); err != nil {
 		t.Fatalf("recording the stale decision: %v", err)
 	}
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -338,7 +338,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 | `writeliveness_test.go` | H2 | The LIVENESS obligation as a fitness function: a write that targets one standing row of a table which can be archived either REFUSES an archived row, DECLARES that it deliberately reaches one, or is ratified with a reason. |
 
-## Prohibition (58)
+## Prohibition (59)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -388,6 +388,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebookdirection_test.go` | H1 | The reference direction is one-way: AGENTS.md links down into docs/, and nothing under docs/ links back up to a rulebook. |
 | `rulebooktally_test.go` | H1 | A rulebook must not spell out a tally of anything the tree can be asked for. |
 | `runtimeddlwholerow_test.go` | H1 | A table an administrator can ALTER at runtime is never read whole-row. |
+| `seatfixturepick_test.go` | H1 | A fixture that needs THIS SESSION'S seat does not pick one out of app\_user. |
 | `seenaddressrule_test.go` | H2 | SPDX-License-Identifier: BUSL-1.1 SPDX-FileCopyrightText: 2026 Gradion |
 | `subjectphotobytes_test.go` | H2 | A subject's photo may not be STORED until erasure can destroy the bytes. |
 | `technicaldomain_test.go` | H2 | The technical lookup reads the domain the RECORD holds, and nothing else. |


### PR DESCRIPTION
#4957 fixed `demoteToRep`, and **the same pick survived in two more fixtures**.

```sql
SELECT id FROM app_user WHERE is_agent = false ORDER BY created_at LIMIT 1
```

That names the seat a scenario signed in as only while the installation holds exactly one contact. Rows inserted in one transaction share `now()`, so with a second contact the tie-break is whatever the plan returns — and the pick silently becomes somebody else.

## The two survivors

- **`approval_bundle_http_integration_test.go`** — `stageBundleRows` uses it as `proposed_by` and `on_behalf_of`, and the suite then *decides those rows as the session*. An arbitrary seat stages an inbox belonging to somebody else, and the assertion is about a bundle its caller never proposed.
- **`directedsend_integration_test.go`** — records a stale `directed_by` decision. What is under test is whether the door refuses a decision that has **gone stale**, which is a question about the caller's own decision.

Both now read the signed-in seat through `sessionUserID`, which resolves it the way the handlers do — `GET /v1/me`, inside the request's own transaction. A fixture deriving production's answer for itself is free to derive a different one, and here "different" means acting as a stranger.

## And a gate, because three copies is a rule

`TestNoFixturePicksASeatAnOrderingDoesNotDecide` refuses any statement that takes **one** row out of `app_user` on an ordering that does not decide which, unless it either names the row or is ratified with the seat it means instead.

**What counts as naming it:** a bound `id`/`email`, or a correlated predicate inside a `LATERAL` (`a.captured_by = 'human:' || u.id::text`) — that decides the pick exactly as a bind would, and the `LIMIT 1` there bounds a union's classes rather than choosing between seats.

**`id <> $1` deliberately does not count.** It says which seat the pick is *not* and leaves the ordering to choose among the rest — this defect with one row excluded from it.

The walk found seven sites. Two were the defect (fixed above); one was a false positive the `LATERAL` shape now covers; four are ratified, each saying why any seat will do:

| site | why any seat |
|---|---|
| `captureofflinedemo.go` | a colleague to CC — *"the point is that a thread sometimes has a third party, not which one"* |
| `fieldhistory_http_integration_test.go` | wants a **real** seat so a `human:` join resolves; which one is immaterial |
| `sarmergelineage_integration_test.go` | a recorder for a refusal decision that is about the **subject**, and never appears in the export |
| `installation.go` | the installation seed, where only the bootstrap admin exists — its own comment already names this exact hazard |

A fifth waiver means writing down that any seat will do, which is the moment an author would notice it will not.

Mutation-checked: restoring the old pick in `approval_bundle_http` is named by the gate, with its SQL.

`make check-backend` and `make craft-static` green; both affected integration suites pass.

Closes #1074.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected approval and communication test fixtures to consistently use the active session user when multiple contacts are present.
  * Prevented test data from selecting an arbitrary contact based on creation order.

* **Tests**
  * Added automated coverage to detect ambiguous single-row seat selections in SQL fixtures.

* **Documentation**
  * Updated the gate inventory to include the new fixture validation check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->