### PR TITLE
fix(brief): the changed-since count is taken where the filter is

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -45529,8 +45529,31 @@ components:
         reason: a source read to its work bound makes every figure here a FLOOR rather
         than a total, and a strip stating "3 buyers waiting" over a scan that stopped
         early tells a rep the opposite of the truth.
-      required: [revenue_at_risk_minor, buyer_replies, prospecting, review, more_available]
+      required: [revenue_at_risk_minor, buyer_replies, prospecting, review, changed_since_brief, more_available]
       properties:
+        changed_since_brief:
+          type: integer
+          minimum: 0
+          description: |
+            How many of the rows this page is answerable for report something the overnight
+            run did not see, counted over the same set the four figures above describe —
+            after the scope narrowing, BEFORE the category filter, the fold and the page cut.
+
+            The set is the point. A client counting the flag over the rows it received
+            counts one PAGE of an unfiltered read, while `?filter=changed_since_brief`
+            opens every row past that cut — so the number and the door it labels disagree
+            by however many ranked below position 25, and only ever in the direction that
+            makes a busy morning look quiet.
+
+            It runs the SAME predicate the filter runs, including the exclusion of rows a
+            decisions-drawing surface already answers: a row on screen as a card is not
+            also news. Two spellings of that rule is the defect one layer down, which is
+            why this is counted where the filter lives rather than beside it.
+
+            Zero is a real answer and means the night saw everything. A day with no
+            overnight run leaves every row's `changed_since_brief` absent, so this counts
+            zero for the same reason — and a client must read the flags, not this figure,
+            to tell "nothing changed" from "there was no night".
         revenue_at_risk_minor:
           type: [integer, 'null']
           format: int64

--- a/backend/internal/compose/attention/linkedfilter_test.go
+++ b/backend/internal/compose/attention/linkedfilter_test.go
@@ -11,6 +11,7 @@ package attention
 // answer, and each test states the wrong number it stops.
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -616,4 +617,74 @@ func rankedIDs(rows []ranked) []string {
 		out = append(out, row.item.Id)
 	}
 	return out
+}
+
+// TestTheChangedCountMatchesWhatTheLaneOpens is the defect #5362 reported,
+// stated as the property that makes it impossible.
+//
+// The strip's number and the door beside it are one question asked twice, and
+// they used to be answered in two places: the browser tallied the flag over the
+// rows it received — one page of an unfiltered read — while the link opened
+// every row this filter admits. The gap was whatever ranked past the cut, and it
+// only ever ran one way: a busy morning read as a quiet one.
+//
+// So the count is taken where the filter lives, over `considered`, and this
+// holds the two to each other. The set here is deliberately larger than any
+// page: the point is that the figure does not stop at one.
+func TestTheChangedCountMatchesWhatTheLaneOpens(t *testing.T) {
+	t.Parallel()
+
+	cutoff := rankInstant.Add(-time.Hour)
+	fresh := cutoff.Add(time.Minute)
+	stale := cutoff.Add(-time.Minute)
+	var lanes []crmcontracts.AttentionItem
+	for at := range 40 {
+		when := stale
+		if at%2 == 0 {
+			when = fresh
+		}
+		lanes = append(lanes,
+			item(strconv.Itoa(at), "deal_at_risk", withOccurred(when)))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: lane(lanes...)}
+
+	considered := markChangedSinceBrief(classifyDay(day, rankInstant, dayMoney{}), cutoff)
+	readings := readingsOf(considered, nil, nil)
+	opened := keepFiltered(considered, filterChangedSinceBrief)
+
+	if got, want := int(readings.ChangedSinceBrief), len(opened); got != want {
+		t.Fatalf("the strip says %d and its own lane opens %d — the number and the door it labels are one question", got, want)
+	}
+	// And the figure reaches past a page, which is the half a count taken from
+	// the drawn rows could never satisfy.
+	if readings.ChangedSinceBrief != 20 {
+		t.Fatalf("counted %d of 20 fresh rows — a figure that stops at the page is the defect this replaced",
+			readings.ChangedSinceBrief)
+	}
+}
+
+// TestTheChangedCountLeavesOutWhatTheDeckAlreadyDrew keeps the count on the
+// filter's own rule rather than a second reading of it. A row already on screen
+// as a card is not also news, and a count that forgot the exclusion would
+// overstate the door by exactly the decisions the deck is drawing.
+func TestTheChangedCountLeavesOutWhatTheDeckAlreadyDrew(t *testing.T) {
+	t.Parallel()
+
+	cutoff := rankInstant.Add(-time.Hour)
+	fresh := cutoff.Add(time.Minute)
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{
+			item("decision", "approval", withKind("send_email"), withOccurred(fresh)),
+		},
+		AtRisk: lane(item("risk", "deal_at_risk", withOccurred(fresh))),
+	}
+
+	considered := markChangedSinceBrief(classifyDay(day, rankInstant, dayMoney{}), cutoff)
+	readings := readingsOf(considered, nil, nil)
+
+	if readings.ChangedSinceBrief != 1 {
+		t.Fatalf("counted %d, want 1 — the approval is already a card and the strip does not name it twice",
+			readings.ChangedSinceBrief)
+	}
 }

--- a/backend/internal/compose/attention/readings.go
+++ b/backend/internal/compose/attention/readings.go
@@ -67,6 +67,20 @@ func readingsOf(
 	// the deal, and it is the only field the two lanes' rows share.
 	countedDeals := map[openapi_types.UUID]bool{}
 	for _, row := range considered {
+		// The freshness figure, and it is counted HERE rather than in the
+		// browser for the reason the set makes obvious: a client counts the
+		// flag over the rows it received, which is one page of an unfiltered
+		// read, while the door beside the number opens every row past that cut.
+		// The two then disagree by whatever ranked below the page, and only ever
+		// in the direction that makes a busy morning look quiet.
+		//
+		// keepsRow, not a second spelling of its rule. The filter already
+		// excludes a row a decisions-drawing surface answers — a card on screen
+		// is not also news — and that exclusion is exactly the kind of detail a
+		// reimplementation here would drop.
+		if keepsRow(row, filterChangedSinceBrief) {
+			out.ChangedSinceBrief++
+		}
 		switch row.item.Category {
 		case crmcontracts.WorklistItemCategoryCustomerWaiting:
 			out.BuyerReplies++

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -39458,6 +39458,27 @@ type WorklistReadings struct {
 	// BuyerReplies How many customers have written and are waiting on an answer.
 	BuyerReplies int `json:"buyer_replies"`
 
+	// ChangedSinceBrief How many of the rows this page is answerable for report something the overnight
+	// run did not see, counted over the same set the four figures above describe —
+	// after the scope narrowing, BEFORE the category filter, the fold and the page cut.
+	//
+	// The set is the point. A client counting the flag over the rows it received
+	// counts one PAGE of an unfiltered read, while `?filter=changed_since_brief`
+	// opens every row past that cut — so the number and the door it labels disagree
+	// by however many ranked below position 25, and only ever in the direction that
+	// makes a busy morning look quiet.
+	//
+	// It runs the SAME predicate the filter runs, including the exclusion of rows a
+	// decisions-drawing surface already answers: a row on screen as a card is not
+	// also news. Two spellings of that rule is the defect one layer down, which is
+	// why this is counted where the filter lives rather than beside it.
+	//
+	// Zero is a real answer and means the night saw everything. A day with no
+	// overnight run leaves every row's `changed_since_brief` absent, so this counts
+	// zero for the same reason — and a client must read the flags, not this figure,
+	// to tell "nothing changed" from "there was no night".
+	ChangedSinceBrief int `json:"changed_since_brief"`
+
 	// MoreAvailable True when any source behind any figure here was read to its work bound, so
 	// every number above is a floor. Set once for the strip rather than per reading:
 	// the four are read as one row, and a reader who cannot trust one of them cannot

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -34548,6 +34548,28 @@ export interface components {
          */
         WorklistReadings: {
             /**
+             * @description How many of the rows this page is answerable for report something the overnight
+             *     run did not see, counted over the same set the four figures above describe —
+             *     after the scope narrowing, BEFORE the category filter, the fold and the page cut.
+             *
+             *     The set is the point. A client counting the flag over the rows it received
+             *     counts one PAGE of an unfiltered read, while `?filter=changed_since_brief`
+             *     opens every row past that cut — so the number and the door it labels disagree
+             *     by however many ranked below position 25, and only ever in the direction that
+             *     makes a busy morning look quiet.
+             *
+             *     It runs the SAME predicate the filter runs, including the exclusion of rows a
+             *     decisions-drawing surface already answers: a row on screen as a card is not
+             *     also news. Two spellings of that rule is the defect one layer down, which is
+             *     why this is counted where the filter lives rather than beside it.
+             *
+             *     Zero is a real answer and means the night saw everything. A day with no
+             *     overnight run leaves every row's `changed_since_brief` absent, so this counts
+             *     zero for the same reason — and a client must read the flags, not this figure,
+             *     to tell "nothing changed" from "there was no night".
+             */
+            changed_since_brief: number;
+            /**
              * Format: int64
              * @description What the drifting deals are worth, summed over the deals this read PRICED, in
              *     the currency `revenue_currency` names.

--- a/frontend/src/screens/brief.changed.test.ts
+++ b/frontend/src/screens/brief.changed.test.ts
@@ -1,92 +1,66 @@
 import { describe, expect, it } from "vitest";
 import { changedSinceBrief } from "./brief.changed";
-import type { Worklist, WorklistItem } from "./worklist.queries";
+import type { Worklist } from "./worklist.queries";
 
 // What has happened since the night looked.
 //
-// The cases are all about the difference between three states the wire keeps
-// apart and a careless client would not: changed, not changed, and no run to
-// compare against. The helper is pure, so they are asked of it directly — the
-// count is rendered by the Today panel's own head, and a render test here would
-// be asserting that panel's copy from the wrong file.
+// THREE OF THESE CASES USED TO LIVE HERE AND NOW LIVE IN GO, and that is the
+// change rather than a loss of coverage: which rows count as new, whether an
+// absent flag means "unchanged" or "there was no night", and whether a row the
+// Decisions deck already draws is also news — the browser answered all three by
+// walking the queue it received, which is one page of an unfiltered read. It now
+// reads a figure taken over every candidate weighed, so those rules are asserted
+// where they are decided (attention/linkedfilter_test.go:
+// TestTheChangedCountMatchesWhatTheLaneOpens and its sibling).
+//
+// What is left is what this function still decides: read the figure, stay quiet
+// when there is nothing to say, and point at the same lane the figure was taken
+// over.
 
-function item(over: Partial<WorklistItem> = {}): WorklistItem {
+function day(changed?: number): Worklist {
   return {
-    id: "i1",
-    source: "waiting_customer",
-    category: "customer_waiting",
-    title: "Aster Handel",
-    because: [],
-    actions: ["open"],
-    ...over,
-  } as unknown as WorklistItem;
-}
-
-function day(queue: WorklistItem[]): Worklist {
-  return { queue, as_of: "2026-09-03T06:42:00Z" } as unknown as Worklist;
+    queue: [],
+    as_of: "2026-09-03T06:42:00Z",
+    readings:
+      changed === undefined ? undefined : { changed_since_brief: changed },
+  } as unknown as Worklist;
 }
 
 describe("changedSinceBrief", () => {
-  it("counts the rows the server marked as new, and only those", () => {
-    const changed = changedSinceBrief(
-      day([
-        item({ id: "a", changed_since_brief: true }),
-        item({ id: "b", changed_since_brief: true }),
-        item({ id: "c", changed_since_brief: false }),
-      ]),
-    );
-
-    expect(changed?.count).toBe(2);
+  it("reports the server's own count", () => {
+    expect(changedSinceBrief(day(7))?.count).toBe(7);
   });
 
-  // ABSENT IS NOT FALSE. A row carries no flag at all when there was no run to
-  // compare against, and a morning with no night is not a morning where nothing
-  // changed. Counting an absent flag as "unchanged" is harmless; counting it as
-  // changed would report movement nobody observed.
-  it("ignores a row the night never saw, and a row it saw standing still", () => {
-    expect(
-      changedSinceBrief(
-        day([item({ id: "a" }), item({ id: "b", changed_since_brief: false })]),
-      ),
-    ).toBeUndefined();
+  // The number the strip prints is NOT the number of rows this page holds. A
+  // reader's first page carries twenty-five, and the figure is taken over every
+  // candidate the read weighed — so a morning with more news than fits still
+  // says how much there is.
+  it("reports a count larger than any page it could have drawn", () => {
+    expect(changedSinceBrief(day(40))?.count).toBe(40);
   });
 
-  // The DECK above answers approvals, and it draws them as cards at the same
-  // moment. Counting them here reported the same work twice on one page — which
-  // is why this reads `waitingRows` rather than the raw queue.
-  it("leaves out the approvals the decisions deck already answers", () => {
-    const changed = changedSinceBrief(
-      day([
-        item({ id: "a", source: "approval", changed_since_brief: true }),
-        item({ id: "b", changed_since_brief: true }),
-      ]),
-    );
-
-    expect(changed?.count).toBe(1);
-  });
-
-  // Nothing moved, so there is nothing to say. A head that reported "0 changed"
+  // Nothing moved, so there is nothing to say. A head reporting "0 changed"
   // every morning would teach a reader to stop reading it.
   it("says nothing at all on a morning where nothing moved", () => {
-    expect(changedSinceBrief(day([]))).toBeUndefined();
+    expect(changedSinceBrief(day(0))).toBeUndefined();
   });
 
-  // A payload with no queue at all answers nothing rather than throwing: a page
-  // that throws is a worse answer than one that draws nothing.
-  it("answers nothing rather than throwing on a payload with no queue", () => {
+  // A payload with no readings answers nothing rather than throwing, and the
+  // same for no payload at all: a page that throws is a worse answer than one
+  // that draws nothing.
+  it("answers nothing rather than throwing on a payload it cannot read", () => {
+    expect(changedSinceBrief(day())).toBeUndefined();
     expect(changedSinceBrief({} as unknown as Worklist)).toBeUndefined();
     expect(changedSinceBrief(undefined)).toBeUndefined();
   });
 
-  // The door carries the SAME narrowing the count was taken over. A bare
+  // The door carries the SAME narrowing the figure was taken over. A bare
   // `#/worklist` named three rows and opened a queue of forty, so the count and
-  // its door shared nothing at all — which is the whole reason the server grew
-  // this filter.
+  // its door shared nothing at all — which is why the server grew this filter,
+  // and why the count is now taken by running it.
   it("points at exactly the rows it counted", () => {
-    const changed = changedSinceBrief(
-      day([item({ id: "a", changed_since_brief: true })]),
+    expect(changedSinceBrief(day(1))?.href).toBe(
+      "#/worklist?filter=changed_since_brief",
     );
-
-    expect(changed?.href).toBe("#/worklist?filter=changed_since_brief");
   });
 });

--- a/frontend/src/screens/brief.changed.ts
+++ b/frontend/src/screens/brief.changed.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { waitingRows } from "./brief.sentence";
 import { worklistLaneHref } from "./worklist.header";
 import type { Worklist } from "./worklist.queries";
 
@@ -48,14 +47,17 @@ import type { Worklist } from "./worklist.queries";
 export function changedSinceBrief(
   day: Worklist | undefined,
 ): Readonly<{ count: number; href: string }> | undefined {
-  // waitingRows, not the raw queue: it drops the approvals the Decisions deck
-  // already answers, and it is the ONE spelling of "what this page is
-  // answerable for". Counting `day.queue` here reported a decision the deck was
-  // drawing as a card at the same moment. It also answers [] for a payload with
-  // no queue, so it is the null guard too.
-  const count = waitingRows(day).filter(
-    (item) => item.changed_since_brief === true,
-  ).length;
+  // THE SERVER'S COUNT, not a tally of the rows this page received.
+  //
+  // Counting here read one page of an unfiltered worklist — twenty-five rows —
+  // while the door below opens every row the same freshness test admits. The
+  // two then disagreed by whatever ranked past the cut, and only ever in the
+  // direction that makes a busy morning look quiet: a strip saying five over a
+  // list of seven. The figure is taken over every candidate the read weighed,
+  // before the fold and before the page, and it runs the same predicate the
+  // filter runs — including dropping the rows the Decisions deck already draws
+  // as cards, which this file used to spell for itself through waitingRows.
+  const count = day?.readings?.changed_since_brief ?? 0;
   if (count === 0) {
     return undefined;
   }

--- a/frontend/src/screens/brief.feed.stories.tsx
+++ b/frontend/src/screens/brief.feed.stories.tsx
@@ -59,6 +59,7 @@ function day(queue: FeedItem[], urgent: number): Worklist {
     reach: [],
     counts: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: null,
       buyer_replies: 1,
       prospecting: 1,

--- a/frontend/src/screens/brief.fixtures.ts
+++ b/frontend/src/screens/brief.fixtures.ts
@@ -752,6 +752,7 @@ export function readingsDay(
     reach: [],
     counts,
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: null,
       buyer_replies: 3,
       prospecting: 2,

--- a/frontend/src/screens/worklist.acknowledge.test.tsx
+++ b/frontend/src/screens/worklist.acknowledge.test.tsx
@@ -53,6 +53,7 @@ function day(queue: WorklistItem[]): Worklist {
     },
     sources_unavailable: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: null,
       buyer_replies: 0,
       prospecting: 0,

--- a/frontend/src/screens/worklist.counts.test.tsx
+++ b/frontend/src/screens/worklist.counts.test.tsx
@@ -54,6 +54,7 @@ function day(counts: WorklistCount[], shown = 1): Worklist {
     summary: { urgent: 0, due: 0, lower_priority: 0, total: shown },
     sources_unavailable: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: null,
       buyer_replies: 0,
       prospecting: 0,

--- a/frontend/src/screens/worklist.detail.test.tsx
+++ b/frontend/src/screens/worklist.detail.test.tsx
@@ -53,6 +53,7 @@ function day(queue: WorklistItem[]): Worklist {
     },
     sources_unavailable: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: null,
       buyer_replies: 0,
       prospecting: 0,

--- a/frontend/src/screens/worklist.header.stories.tsx
+++ b/frontend/src/screens/worklist.header.stories.tsx
@@ -50,6 +50,7 @@ function day(scopes: readonly WorklistScope[]): Worklist {
     reach: [],
     counts: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: 0,
       revenue_currency: "EUR",
       buyer_replies: 0,

--- a/frontend/src/screens/worklist.readings.stories.tsx
+++ b/frontend/src/screens/worklist.readings.stories.tsx
@@ -35,6 +35,7 @@ function day(readings: Partial<Readings> = {}): Worklist {
     reach: [],
     counts: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: 384_500_00,
       revenue_currency: "EUR",
       buyer_replies: 14,

--- a/frontend/src/screens/worklist.readings.test.tsx
+++ b/frontend/src/screens/worklist.readings.test.tsx
@@ -27,6 +27,7 @@ function day(readings: Partial<WorklistReadingsData> = {}): Worklist {
     reach: [],
     counts: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: null,
       buyer_replies: 0,
       prospecting: 0,

--- a/frontend/src/screens/worklist.reasons.test.tsx
+++ b/frontend/src/screens/worklist.reasons.test.tsx
@@ -47,6 +47,7 @@ function day(queue: WorklistItem[]): Worklist {
     },
     sources_unavailable: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: null,
       buyer_replies: 0,
       prospecting: 0,

--- a/frontend/src/screens/worklist.stories.tsx
+++ b/frontend/src/screens/worklist.stories.tsx
@@ -73,6 +73,7 @@ export const AFullDay: Story = {
       reach: [],
       // A full day: money drifting, buyers waiting, a decision pile.
       readings: {
+        changed_since_brief: 0,
         revenue_at_risk_minor: 384_500_00,
         revenue_currency: "EUR",
         buyer_replies: 14,
@@ -203,6 +204,7 @@ export const WorkDueLater: Story = {
       sources_unavailable: [],
       reach: [],
       readings: {
+        changed_since_brief: 0,
         revenue_at_risk_minor: 0,
         revenue_currency: "EUR",
         buyer_replies: 0,
@@ -294,6 +296,7 @@ export const NothingWaiting: Story = {
       reach: [],
       // Nothing waiting: every figure honestly zero, and the money priced.
       readings: {
+        changed_since_brief: 0,
         revenue_at_risk_minor: 0,
         revenue_currency: "EUR",
         buyer_replies: 0,
@@ -327,6 +330,7 @@ export const PartlyUnread: Story = {
       reach: [],
       // Partly unread: the figures are floors, so the strip says so.
       readings: {
+        changed_since_brief: 0,
         revenue_at_risk_minor: 42_000_00,
         revenue_currency: "EUR",
         buyer_replies: 2,
@@ -364,6 +368,7 @@ export const ALeadsDay: Story = {
       reach: [],
       // A leads day: prospecting carries it, and nothing at risk could be priced.
       readings: {
+        changed_since_brief: 0,
         revenue_at_risk_minor: null,
         buyer_replies: 1,
         prospecting: 9,
@@ -412,6 +417,7 @@ export const ATeamBiggerThanTheBoardCanCount: Story = {
         reach: [],
         // A team bigger than the board can count: every figure a floor.
         readings: {
+          changed_since_brief: 0,
           revenue_at_risk_minor: 1_250_000_00,
           revenue_currency: "EUR",
           buyer_replies: 61,
@@ -453,6 +459,7 @@ export const WhatWentWrong: Story = {
       sources_unavailable: [],
       reach: [],
       readings: {
+        changed_since_brief: 0,
         revenue_at_risk_minor: 0,
         revenue_currency: "EUR",
         buyer_replies: 0,

--- a/frontend/src/screens/worklist.testkit.tsx
+++ b/frontend/src/screens/worklist.testkit.tsx
@@ -165,6 +165,7 @@ export function day(over: Partial<Worklist> = {}): Worklist {
     reach: [],
     counts: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: null,
       buyer_replies: 0,
       prospecting: 0,

--- a/frontend/src/screens/worklist.when.test.tsx
+++ b/frontend/src/screens/worklist.when.test.tsx
@@ -60,6 +60,7 @@ function day(queue: WorklistItem[]): Worklist {
     },
     sources_unavailable: [],
     readings: {
+      changed_since_brief: 0,
       revenue_at_risk_minor: null,
       buyer_replies: 0,
       prospecting: 0,


### PR DESCRIPTION
Closes #5362.

`brief.tsx` caps the worklist read at its first page, by an invariant its own
comment states:

> Brief reads the day's FIGURES — coverage, readings, scope options — and never
> its rows, so the first page is the whole of what it needs.

`ChangedSinceBrief`, added two days later, is handed that same object and walks
`day.queue` — a **row** list — counting how many carry `changed_since_brief`. The
invariant the first commit stated is not one the second commit's component holds
to.

So the strip counted one page of an unfiltered read while the link beside it
opened every row the same freshness test admits. Measured live in the issue: a
strip of 5 over a list of 7, the two missing rows being hygiene batches ranked
below position 25. It can only ever UNDERcount, and a busier seat makes the gap
wider.

## Why this is the same defect as #5101, one layer down

#5101 fixed the half where the count and the link used two different FILTERS.
This is the count running out of ROWS to count from while the link it labels
keeps counting. A reader cannot tell the two apart on screen — both read as "the
number under Open the worklist does not match what opens".

## The fix

The figure rides `WorklistReadings`, which already describes exactly the right
set and says so for the four figures beside it: *after the scope narrowing,
BEFORE the category filter, the fold and the page cut*. That is the only set for
which the number is stable, and it is the set `?filter=changed_since_brief`
narrows from.

It is counted by **calling `keepsRow(row, filterChangedSinceBrief)`**, not by
restating the rule. That matters more than it looks: the filter already excludes
rows a decisions-drawing surface answers — a card on screen is not also news —
and `page.go` documents that its predicate is deliberately matched to the
browser's own spelling in `brief.sentence.ts`. Two sides of one rule were already
the design; what had drifted was the SET each ran over, so the fix is to run the
one predicate over the right set rather than to add a third spelling.

`TestTheChangedCountMatchesWhatTheLaneOpens` holds the count and the lane to each
other over 40 rows — deliberately more than any page — and
`TestTheChangedCountLeavesOutWhatTheDeckAlreadyDrew` pins the exclusion. Both
mutation-verified: replacing the `keepsRow` call with a bare flag test turns the
second red.

## Three cases moved from the browser to Go

`brief.changed.test.ts` used to assert which rows count as new, whether an absent
flag means "unchanged" or "there was no night", and whether a card is also news.
The browser no longer decides any of those, so they are asserted where they are
decided. The test file says so rather than leaving the next reader to think
coverage was dropped; what is left is what the function still decides — read the
figure, stay quiet at zero, point at the same lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpMjrHVzZBkJGovR4wN8JC
