### PR TITLE
A composed message is checked against what its jurisdiction requires

### DIFF
--- a/backend/gates/messagingruleapplied_test.go
+++ b/backend/gates/messagingruleapplied_test.go
@@ -93,10 +93,6 @@ var rulesIdentityFields = []string{"Jurisdiction", "Instruments"}
 // struct no longer declares, because the arm below asks Waived only about a
 // field it has already found unapplied.
 var unappliedRules = gatekit.Waive(map[string]string{
-	"SubjectPrefix": "nothing prepends it. A send composes its own subject — " +
-		"activities.SendEmailInput.Subject is caller-supplied text — and no step " +
-		"between that and the provider consults the applicable rules, so an " +
-		"advertising message leaves unmarked whatever a pack declares",
 	"OptOutAcknowledgement": "no acknowledgement is sent. The controller lane is the only " +
 		"one that may write to somebody who has just suppressed themselves, and it " +
 		"registers no template for this",

--- a/backend/gates/requirementseam_test.go
+++ b/backend/gates/requirementseam_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H1
+
+package gates
+
+// The two halves of the requirement seam describe the same thing.
+//
+// consent owns the jurisdiction packs and answers what a composed message still
+// owes; comms holds the message on its way to the provider and parks it on a
+// finding. They are siblings and neither may import the other, so each declares
+// its own RequirementFinding and the composition root converts between them.
+//
+// A drift here is quieter than most. The adapter names the fields it copies, so
+// a field added on one side keeps compiling and is simply dropped — and what is
+// dropped is the description of an obligation a message failed to meet, so the
+// delivery still parks and the operator reading it is told less about why than
+// the checker knew.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTheRequirementFindingAgreesAcrossTheSeam holds the claim in
+// consent/requirements.go's RequirementFinding doc comment.
+func TestTheRequirementFindingAgreesAcrossTheSeam(t *testing.T) {
+	t.Parallel()
+	owner := structFields(t,
+		filepath.Join(repoRoot, "backend", "internal", "modules", "consent", "requirements.go"),
+		"RequirementFinding")
+	mirror := structFields(t,
+		filepath.Join(repoRoot, "backend", "internal", "modules", "comms", "manifest.go"),
+		"RequirementFinding")
+
+	if strings.Join(owner, ",") != strings.Join(mirror, ",") {
+		t.Errorf("consent's RequirementFinding carries %v and comms' carries %v.\n\n"+
+			"The compose adapter copies field by field and keeps compiling when one side "+
+			"grows, so a field added on the consent side is computed, dropped at the seam, "+
+			"and missing from the reason an operator reads on the parked delivery.",
+			owner, mirror)
+	}
+}

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -391,7 +391,12 @@ func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPa
 		// options rather than the constant, so the two cannot be changed
 		// apart: there is exactly one place the ladder length is declared.
 		sendInsertOpts().MaxAttempts,
-	), relay, vault)}
+		// What the jurisdiction demands of the composed message, checked on the
+		// bytes about to leave rather than on the code that should have put
+		// them there. Injected here for the reason the consent gate is: this is
+		// the one construction every send goes through, so no surface can end
+		// up with a dispatcher that checks nothing and looks green doing it.
+	).WithRequirementChecker(requirementCheckerFor(pool)), relay, vault)}
 }
 
 // controllerLaneOn gives the dispatcher the transport for the installation's own

--- a/backend/internal/compose/requirementcheck.go
+++ b/backend/internal/compose/requirementcheck.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The send path's requirement edge, bound to the consent module.
+//
+// comms hands a message to a provider and must not know what a jurisdiction
+// pack is; consent owns the packs and what the engine resolved each delivery to
+// be. Neither imports the other, so the edge is injected here like every other
+// cross-module edge.
+//
+// This is the caller gates/messagingruleapplied_test.go named as missing for
+// SubjectPrefix: the label was declared, fixed by decree, and nothing between a
+// composed subject and the provider ever looked at it.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/modules/identity"
+)
+
+type requirementAdapter struct {
+	store *consent.Store
+}
+
+// CheckMessage answers one finding per requirement the message does not meet.
+//
+// The message crosses the seam as data and the delivery id as a string, so the
+// interface comms declares carries no type whose meaning consent owns.
+func (a requirementAdapter) CheckMessage(
+	ctx context.Context, m comms.FinalMessage,
+) ([]comms.RequirementFinding, error) {
+	owed, err := a.store.CheckMessage(ctx, m.DeliveryID, m.DecisionSetID, m.Subject)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]comms.RequirementFinding, 0, len(owed))
+	for _, f := range owed {
+		out = append(out, comms.RequirementFinding{Requirement: f.Requirement, Detail: f.Detail})
+	}
+	return out, nil
+}
+
+// requirementCheckerFor builds the checker the send worker holds.
+//
+// WITH THE INSTALLATION COUNTRY, which is what selects the pack. A store
+// without it resolves no jurisdiction and answers no findings, so the gate
+// would pass every message and read exactly like a green one — the failure this
+// whole check exists to end, reintroduced by a missing seam.
+func requirementCheckerFor(pool *pgxpool.Pool) requirementAdapter {
+	return requirementAdapter{store: consent.NewStore(InstallationDB(pool)).
+		WithInstallationCountry(consent.InstallationCountryFunc(identity.CountryOf))}
+}

--- a/backend/internal/modules/comms/dispatcher.go
+++ b/backend/internal/modules/comms/dispatcher.go
@@ -7,12 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
-	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
-	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
 // Outcome is what one dispatch attempt concluded. It is the caller's whole
@@ -60,6 +57,10 @@ type Dispatcher struct {
 	// deployment fact and waiting does not change it.
 	relay    ControllerRelay
 	payloads PayloadVault
+	// requirements checks the composed message against what its jurisdiction
+	// demands. Nil on an installation that declares no country, and on every
+	// test store that has no opinion about compliance packs.
+	requirements RequirementChecker
 }
 
 // defaultMaxAttempts bounds a dispatcher whose ladder length was not
@@ -258,6 +259,13 @@ func (d *Dispatcher) dispatchLoaded(ctx context.Context, del Delivery) (Outcome,
 		}
 	}
 
+	// Gate: what the jurisdiction requires of the composed message, asked last
+	// and of the bytes about to leave. gateRequirements says why, including why
+	// its error is checked alongside its outcome.
+	if outcome, wait, err := d.gateRequirements(ctx, del, ticket); outcome != outcomeUndecided || err != nil {
+		return outcome, wait, err
+	}
+
 	// Policies postpone; they never refuse. They run after both gates, so a
 	// delivery that may never go is refused rather than paced.
 	if profile.paced {
@@ -300,201 +308,4 @@ func (d *Dispatcher) pace(ctx context.Context, del Delivery) (Outcome, time.Dura
 		return d.postpone(ctx, del.ID, "waiting: "+policy.Name(), wait)
 	}
 	return outcomeUndecided, 0, nil
-}
-
-// transmit hands the message to the provider and records what came back. The
-// seam already carries the shape-specific half (sendseam.go), so what follows is
-// the same for a mail message and a channel one.
-func (d *Dispatcher) transmit(ctx context.Context, del Delivery, seam sendSeam, ticket commsauthz.TransmitTicket) (Outcome, time.Duration, error) {
-	// The last thing checked before the wire, and the reason the ticket is
-	// threaded down here rather than trusted from three frames up: a send that
-	// reaches a provider without a decision recorded for THIS delivery and THIS
-	// attempt is a send nobody can account for afterwards. A stale attempt is
-	// as bad as none — it belongs to a try whose world may already have moved.
-	if !ticket.Current(del.ID, del.Attempts) {
-		return d.park(ctx, del.ID, "no current authorization decision covers this attempt")
-	}
-	// The attachment BYTES, resolved before the marker below and not inside the
-	// provider call.
-	//
-	// The ordering is the whole point. A seam that cannot detect a prior send
-	// commits an in-flight marker and then treats any later attempt as "the
-	// outcome was never learned", so a fault BETWEEN the marker and the wire —
-	// an unreadable object, a store that would not answer, a file set too large
-	// to carry — would park a message that never left with a reason telling the
-	// rep it may have arrived and discouraging a resend. Read first, and such a
-	// fault is what it is: nothing transmitted, and the ladder may try again.
-	//
-	// They are still not on the delivery row: a message on a retry ladder would
-	// otherwise hold every attachment it might ever send in the database,
-	// duplicated per delivery, for as long as the maximum age allows.
-	files, err := d.attachedFiles(ctx, del)
-	if err != nil {
-		return d.retry(ctx, del.ID, fmt.Errorf("comms: reading this message's files before transmitting: %w", err))
-	}
-	// At-most-once, for the seams that need it: a transmission whose outcome was
-	// never learned is never attempted a second time.
-	if outcome, wait, err := d.guardAtMostOnce(ctx, del, seam); outcome != outcomeUndecided {
-		return outcome, wait, err
-	}
-	receipt, err := seam.transmit(ctx, files)
-	if err != nil {
-		return d.classifySendFailure(ctx, del, err)
-	}
-
-	if err := d.store.RecordSent(ctx, del.ID, receipt); err != nil {
-		if errors.Is(err, ErrTerminal) {
-			// A newer attempt already closed this row against its own
-			// receipt; overwriting it would replace a real one.
-			return OutcomeSkipped, 0, nil
-		}
-		if !seam.detectsPriorSend {
-			return d.parkTransmitted(ctx, del, receipt, err)
-		}
-		// Mail goes back on the ladder: the next attempt's prior-send lookup
-		// finds the message at the provider and answers from it rather than
-		// transmitting a second copy, so the receipt is recorded late instead of
-		// lost.
-		return OutcomeRetry, 0, fmt.Errorf("comms: recording the send receipt: %w", err)
-	}
-
-	// The one-time link has now been sent and must stop being live.
-	d.retireLink(ctx, del)
-
-	// Metering follows the DURABLE record, not the provider call, because the
-	// send call is not the countable event: a receipt that failed to record
-	// comes back on the ladder, and Send answers a retry from Gmail's
-	// prior-send lookup rather than transmitting again. Metering at the call
-	// would count that one message twice. RecordSent is guarded on
-	// status = 'pending' and reports ErrTerminal otherwise, so exactly one
-	// attempt per delivery ever reaches this line — which is what makes
-	// "metered" mean "one message, once".
-	//
-	// Policies are told here rather than at Wait for the same reason in the
-	// other direction: a limiter counting checks instead of sends paces
-	// nothing.
-	//
-	// Metered only for a sender the policies actually pace. A controller row is
-	// not paced, and its user id is the zero value, so recording it would fill
-	// one bucket forever under a key naming nobody — harmless until somebody
-	// turns pacing on for this sender and finds it already throttled by years
-	// of accumulated slots.
-	if profileFor(del).paced {
-		for _, policy := range d.policies {
-			if recorder, meters := policy.(SendRecorder); meters {
-				recorder.Recorded(del)
-			}
-		}
-	}
-	return OutcomeSent, 0, nil
-}
-
-// receiptUnrecordedReason is what a delivery the provider ACCEPTED records when
-// its receipt could not be written. It is the opposite fact to
-// unknownOutcomeReason and must never be confused with it: nothing here is
-// uncertain — the message went — so the sentence tells the operator the one
-// thing they must not do about it.
-const receiptUnrecordedReason = "the provider accepted this message and its receipt could not be recorded: " +
-	"it WAS sent, and the provider's own message id is kept on this delivery. " +
-	"Do not send it again — the recipient already has it"
-
-// parkTransmitted closes a delivery whose message is already with the provider
-// and whose receipt this attempt could not write.
-//
-// It exists for the seams whose retries cannot detect a prior send. For those,
-// returning the attempt to the ladder is not a delay but a LOSS: the next
-// attempt reads the in-flight marker, learns nothing about what happened, and
-// parks the delivery as an outcome nobody knows — a message the customer is
-// holding, durably recorded as never sent. Parking here instead states what is
-// definitely true and keeps the provider's message id, which after a failed
-// receipt is the only handle left on that message.
-func (d *Dispatcher) parkTransmitted(ctx context.Context, del Delivery, receipt connector.SendReceipt, cause error) (Outcome, time.Duration, error) {
-	if err := d.store.ParkTransmitted(ctx, del.ID, receiptUnrecordedReason, receipt.ProviderMessageID); err != nil {
-		if errors.Is(err, ErrTerminal) {
-			return OutcomeSkipped, 0, nil
-		}
-		// Nothing durable records this send now. The row stays pending with its
-		// marker standing, so the next attempt parks on the uncertainty rather
-		// than messaging the customer twice, and both causes reach the job log.
-		return OutcomeRetry, 0, errors.Join(cause, err)
-	}
-	// The cause goes to the LOG rather than back to the caller. The delivery is
-	// terminal — a returned error would fail a job whose work is done and put a
-	// closed row back on the ladder — and the reason column may not carry a
-	// database fault's own text (faultReason), so this is where an operator's
-	// diagnosis lives.
-	slog.ErrorContext(ctx, "comms: a transmitted message's receipt could not be recorded; the delivery is parked against it",
-		"err", cause, "delivery_id", del.ID, "provider_message_id", receipt.ProviderMessageID)
-	return OutcomeParked, 0, nil
-}
-
-// classifySendFailure turns a provider failure into a disposition using only
-// the shared sentinel vocabulary, so the provider's own text stops at the
-// connector boundary.
-//
-// A permanent rejection is recognized only where the SEAM can prove it:
-// ErrRecipientUnreachable is reported by a provider that answers a refused
-// recipient differently from a refused credential, and it parks at once. The
-// Gmail connector cannot — it maps every non-throttled, non-2xx response to
-// ErrUnreachable, so a refused mail recipient is indistinguishable from an
-// outage there and still burns the whole retry ladder before its job exhausts
-// and the delivery parks.
-func (d *Dispatcher) classifySendFailure(ctx context.Context, del Delivery, err error) (Outcome, time.Duration, error) {
-	if errors.Is(err, connector.ErrSendOutcomeUnknown) {
-		// NEVER retried, and no shape test is needed to decide that: only a seam
-		// that cannot discover a prior send reports this class, and one that can
-		// is obliged to go and find out instead. The in-flight marker
-		// deliberately STAYS — it is the durable record that a message may
-		// already be with the customer, and the park reason is the only honest
-		// thing to tell the operator reading the row.
-		return d.park(ctx, del.ID, unknownOutcomeReason)
-	}
-	// Everything below is a DEFINITE answer from the provider, which proves
-	// nothing was transmitted — so the in-flight marker is retracted before the
-	// delivery goes back on the ladder. It is a no-op for a seam that never set
-	// one, which is what keeps this a single rule rather than a second branch on
-	// provider class.
-	if clearErr := d.store.ClearInFlight(ctx, del.ID); clearErr != nil && !errors.Is(clearErr, ErrTerminal) {
-		// The marker is still standing, so the next attempt will park rather
-		// than re-send. Both causes go back for the job log, and the delivery
-		// errs toward an unsent message — the direction this whole path is built
-		// to err in.
-		return d.retry(ctx, del.ID, errors.Join(err, clearErr))
-	}
-	if errors.Is(err, connector.ErrAuthRejected) {
-		return d.park(ctx, del.ID, "the provider rejected the credential this delivery transmits through; reconnect it to resume sending")
-	}
-	// Checked alongside the credential class, not after the ladder: the two are
-	// the pair an operator most easily confuses, and the whole value of telling
-	// them apart is that each row says which one it was.
-	if errors.Is(err, connector.ErrRecipientUnreachable) {
-		return d.park(ctx, del.ID, unreachableRecipientReason)
-	}
-	// The adapter refused the file set itself. This is a DECISION rather than a
-	// provider condition, so it cannot come out differently on a later attempt:
-	// left on the ladder it would re-read every file from the blobstore once per
-	// rung and then park under "the retry ladder is exhausted", which names no
-	// cause at all. The carriage gate catches this case earlier from the
-	// capability a connector DECLARES; this is the connector refusing what its
-	// own send path cannot honour, which is the half no gate above it can see.
-	if errors.Is(err, connector.ErrFilesNotCarried) {
-		// The cause is LOGGED rather than dropped. filesNotCarriedReason cannot
-		// carry it — a park reason is read by the contact who wrote the message,
-		// and the refusals below the gate name a file, a byte count and a bound
-		// that were built for an operator — but those are the only statement of
-		// WHICH file and WHICH limit ended this delivery. Parking returns nil, so
-		// without this line the job succeeds and the sentence disappears.
-		slog.ErrorContext(ctx, "comms: the channel refused the files this message was staged with; the delivery is parked",
-			"delivery_id", del.ID, "provider", del.Provider, "err", err)
-		return d.park(ctx, del.ID, filesNotCarriedReason)
-	}
-	// Honour the provider's own interval when it named one: it knows when it
-	// will accept the next message, and guessing shorter earns another
-	// throttle. A rate limit with no stated interval leaves nothing to
-	// honour, so it falls through to the retry ladder rather than asking the
-	// caller to re-run immediately against a provider already throttling us.
-	if limited, throttled := errors.AsType[*connector.RateLimitedError](err); throttled && limited.RetryAfter > 0 {
-		return d.throttled(ctx, del, limited.RetryAfter)
-	}
-	return d.retry(ctx, del.ID, err)
 }

--- a/backend/internal/modules/comms/manifest.go
+++ b/backend/internal/modules/comms/manifest.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package comms
+
+// Checking a composed message against what its jurisdiction requires, at the
+// last point it exists as it will be sent.
+//
+// THE LAST POINT IS THE ONLY HONEST ONE. Every obligation the packs declare is
+// rendered somewhere earlier — a disclosure in the body, an unsubscribe header,
+// a subject prefix — and each of those steps can be skipped, short-circuited or
+// simply never reached by a path that composes its own message. A check here
+// asks the question of the bytes about to leave rather than of the code that
+// was supposed to produce them.
+//
+// A MISSING REQUIREMENT IS A FINDING, not a silent omission and not a refusal.
+// gates/messagingruleapplied_test.go has carried "nothing prepends it" about
+// the Vietnamese [QC] label since the pack shipped: an advertising message left
+// unmarked whatever the decree said, and nothing anywhere reported it. That is
+// what this closes.
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// RequirementChecker answers what a message of this category still owes.
+//
+// Declared HERE by the consumer and implemented by consent, injected in
+// compose/ like every other cross-module edge: comms hands a message to a
+// provider and must not know what a jurisdiction pack is.
+//
+// A nil checker finds nothing, which is what every send did before this
+// existed. The dozen test stores and the channel seam keep working without
+// being taught about compliance packs.
+type RequirementChecker interface {
+	// CheckMessage answers one finding per requirement this message does not
+	// meet. An empty answer means it meets them all.
+	CheckMessage(ctx context.Context, m FinalMessage) ([]RequirementFinding, error)
+}
+
+// FinalMessage is the message as the provider will receive it.
+//
+// The fields a requirement can be about, and no more: a checker that could read
+// the recipient list would be a jurisdiction pack reading addresses.
+type FinalMessage struct {
+	// DeliveryID is which send this is, so a finding can name it.
+	DeliveryID string
+	// DecisionSetID names the ONE set of decisions this send was authorized
+	// on, which is what the requirement is judged against.
+	//
+	// Without it the checker would read the delivery's decisions by id alone,
+	// and a delivery can hold several sets: a paced message redispatched after
+	// its circumstances changed writes a fresh set beside the old one. Picking
+	// among them would judge the message by a category it no longer has.
+	DecisionSetID string
+	// Subject is the line as composed, which is where a pack's prefix belongs.
+	Subject string
+	// Body and HTMLBody are the two alternatives. A requirement met in one and
+	// not the other is met for whichever readers happen to fall back, which is
+	// not a standard anybody writes down.
+	Body     string
+	HTMLBody string
+	// ListUnsubscribe is the header, empty when the message carries none.
+	ListUnsubscribe string
+}
+
+// RequirementFinding is one requirement a message does not meet.
+type RequirementFinding struct {
+	// Requirement names what is missing, in the vocabulary the packs use.
+	Requirement string
+	// Detail says what was expected, for whoever reads the record.
+	Detail string
+}
+
+// String renders a finding for a log line or an error.
+func (f RequirementFinding) String() string {
+	if f.Detail == "" {
+		return f.Requirement
+	}
+	return f.Requirement + ": " + f.Detail
+}
+
+// WithRequirementChecker wires what a jurisdiction demands of a composed
+// message.
+//
+// An OPTION for the reason the controller relay is one: an installation that
+// declares no country has no requirements to check, and a deployment should not
+// have to name a nil to say so. Every test store that has no opinion about
+// compliance packs keeps working unchanged.
+func (d *Dispatcher) WithRequirementChecker(c RequirementChecker) *Dispatcher {
+	d.requirements = c
+	return d
+}
+
+// requirementsOf asks the checker, and answers nothing when none is wired.
+func (d *Dispatcher) requirementsOf(
+	ctx context.Context, del Delivery, setID string,
+) ([]RequirementFinding, error) {
+	if d.requirements == nil {
+		return nil, nil
+	}
+	return d.requirements.CheckMessage(ctx, FinalMessage{
+		DeliveryID:      del.ID.String(),
+		DecisionSetID:   setID,
+		Subject:         del.Subject,
+		Body:            del.Body,
+		HTMLBody:        del.HTMLBody,
+		ListUnsubscribe: del.ListUnsubscribe,
+	})
+}
+
+// describeFindings renders findings for the record, in a stable order.
+func describeFindings(findings []RequirementFinding) string {
+	parts := make([]string, 0, len(findings))
+	for _, f := range findings {
+		parts = append(parts, f.String())
+	}
+	return strings.Join(parts, "; ")
+}
+
+// gateRequirements refuses a message that does not meet what its jurisdiction
+// requires.
+//
+// PARKED, NOT RETRIED. A missing subject prefix or an absent opt-out header is
+// a property of the composed message, and the next attempt composes the same
+// bytes from the same row: retrying would burn the ladder and park anyway,
+// having sent nothing and said nothing useful in between. The park message
+// names the requirement, which is the finding this gate exists to produce.
+//
+// NOT A REFUSAL OF THE SUBJECT'S RIGHTS, which is why it is not a consent
+// verdict. Consent answers whether we may write to this contact; this answers
+// whether what we composed is lawful to send at all. A message failing here
+// would be unlawful to send to anybody.
+//
+// IT RUNS LAST of the refusals, on the bytes about to leave, because every
+// earlier step is one that was supposed to put something in them — and the
+// point is to ask the message rather than the code that should have produced
+// it.
+//
+// AN ERROR HERE IS NOT A PASS, and the caller checks it alongside the outcome.
+// Failing to ASK — an unreachable settings table, packs that cannot be resolved
+// — leaves this undecided, and sending on that would be sending on a check
+// nobody performed. That is the one direction this gate must never default to.
+func (d *Dispatcher) gateRequirements(
+	ctx context.Context, del Delivery, ticket commsauthz.TransmitTicket,
+) (Outcome, time.Duration, error) {
+	// MAIL ONLY, and this is not a convenience. Every requirement the packs
+	// declare today is about a mail message's parts — a subject line, a footer,
+	// an unsubscribe header. A channel delivery has no subject at all: staging
+	// writes NULL and the provider's message carries no such field, so asking
+	// the check about one would hand it an empty string, find the label
+	// missing, and park every channel message on an obligation it has no way
+	// to meet and was never under.
+	//
+	// A pack that one day declares a channel obligation needs a channel-shaped
+	// FinalMessage and its own arm here, which is a change somebody makes
+	// deliberately rather than one this gate makes by accident.
+	if del.IsChannel() {
+		return outcomeUndecided, 0, nil
+	}
+	findings, err := d.requirementsOf(ctx, del, ticket.DecisionSetID.String())
+	if err != nil {
+		return outcomeUndecided, 0, err
+	}
+	if len(findings) == 0 {
+		return outcomeUndecided, 0, nil
+	}
+	return d.park(ctx, del.ID, "this message does not carry what its jurisdiction requires ("+
+		describeFindings(findings)+")")
+}

--- a/backend/internal/modules/comms/manifest_test.go
+++ b/backend/internal/modules/comms/manifest_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package comms
+
+// The requirement gate, asked of the message on its way to the provider.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubRequirements answers a fixed set and records what it was asked about.
+type stubRequirements struct {
+	findings []RequirementFinding
+	err      error
+	asked    []FinalMessage
+}
+
+func (s *stubRequirements) CheckMessage(
+	_ context.Context, m FinalMessage,
+) ([]RequirementFinding, error) {
+	s.asked = append(s.asked, m)
+	return s.findings, s.err
+}
+
+// dispatcherWithRequirements is the unit harness the file beside this uses,
+// plus the checker under test.
+func dispatcherWithRequirements(
+	store *fakeStore, sender *fakeSender, c RequirementChecker,
+) *Dispatcher {
+	return NewDispatcher(store, fakeResolver{sender: sender, granted: []string{sendScope}},
+		liveSeat(), nil, &stubConsent{}, nil, func() time.Time { return testNow },
+		time.Hour, 5).WithRequirementChecker(c)
+}
+
+// TestAMessageMissingARequirementParksAndNamesIt.
+//
+// PARKED, NOT RETRIED. The next attempt composes the same bytes from the same
+// row, so retrying would burn the ladder and park anyway, having sent nothing
+// and said nothing useful in between.
+func TestAMessageMissingARequirementParksAndNamesIt(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	d := dispatcherWithRequirements(store, sender, &stubRequirements{
+		findings: []RequirementFinding{{
+			Requirement: "subject_prefix",
+			Detail:      `an advertising subject carries "[QC]" in vn`,
+		}},
+	})
+
+	got, err := dispatch(context.Background(), d, store.delivery.ID)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if got != OutcomeParked {
+		t.Errorf("outcome = %v, want parked — a message missing what its jurisdiction "+
+			"requires must not reach a provider", got)
+	}
+	if sender.calls != 0 {
+		t.Errorf("the provider was called %d times for a message that owes a requirement",
+			sender.calls)
+	}
+	if !strings.Contains(store.parked, "subject_prefix") {
+		t.Errorf("the parked reason is %q and names no requirement — an operator reading it "+
+			"cannot tell what is missing", store.parked)
+	}
+}
+
+// TestAMessageMeetingEveryRequirementStillSends is the positive control: the
+// park above must be about the finding, not about the gate refusing everything.
+func TestAMessageMeetingEveryRequirementStillSends(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	d := dispatcherWithRequirements(store, sender, &stubRequirements{})
+
+	got, err := dispatch(context.Background(), d, store.delivery.ID)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if got != OutcomeSent || sender.calls != 1 {
+		t.Errorf("outcome=%v calls=%d, want sent/1", got, sender.calls)
+	}
+}
+
+// TestNoCheckerWiredSendsExactlyAsBefore. Every test store and the channel seam
+// have no opinion about compliance packs, and a nil checker must leave them
+// working rather than parking their mail.
+func TestNoCheckerWiredSendsExactlyAsBefore(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	d := dispatcherWithRequirements(store, sender, nil)
+
+	got, err := dispatch(context.Background(), d, store.delivery.ID)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if got != OutcomeSent || sender.calls != 1 {
+		t.Errorf("outcome=%v calls=%d, want sent/1 — a dispatcher with no checker must "+
+			"behave as it did before this gate existed", got, sender.calls)
+	}
+}
+
+// TestTheCheckerSeesTheMessageAsTheProviderWould.
+//
+// Both body alternatives travel, because a requirement met in one and not the
+// other is met for whichever readers happen to fall back — which is not a
+// standard anybody writes down.
+func TestTheCheckerSeesTheMessageAsTheProviderWould(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	stub := &stubRequirements{}
+	d := dispatcherWithRequirements(store, sender, stub)
+
+	if _, err := dispatch(context.Background(), d, store.delivery.ID); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(stub.asked) != 1 {
+		t.Fatalf("the checker was asked %d times, want once", len(stub.asked))
+	}
+	asked := stub.asked[0]
+	if asked.Subject != store.delivery.Subject {
+		t.Errorf("subject asked = %q, want %q", asked.Subject, store.delivery.Subject)
+	}
+	if asked.Body != store.delivery.Body {
+		t.Errorf("body asked = %q, want the composed body", asked.Body)
+	}
+	if asked.DeliveryID != store.delivery.ID.String() {
+		t.Errorf("delivery asked = %q, want %q — a finding that cannot name its delivery "+
+			"is unactionable", asked.DeliveryID, store.delivery.ID)
+	}
+}
+
+// TestACheckerThatCannotAnswerDoesNotSend.
+//
+// A failed check is not a passed one. Treating an error as "nothing owed" would
+// send the message the gate could not vouch for, which is the direction that
+// must never be the quiet default.
+func TestACheckerThatCannotAnswerDoesNotSend(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	d := dispatcherWithRequirements(store, sender, &stubRequirements{
+		err: errors.New("the settings table is unreachable"),
+	})
+
+	if _, err := dispatch(context.Background(), d, store.delivery.ID); err == nil {
+		t.Fatal("a checker that could not answer reported no error, so the send proceeded " +
+			"on a check nobody performed")
+	}
+	if sender.calls != 0 {
+		t.Errorf("the provider was called %d times despite an unanswerable check", sender.calls)
+	}
+}
+
+// TestAChannelMessageIsNotAskedForASubjectPrefix is Codex's finding, and it
+// would have parked every channel message on a Vietnamese installation.
+//
+// A channel delivery has no subject: staging writes NULL and the provider's own
+// message carries no such field. Asking the check about one hands it an empty
+// string, finds the label missing, and parks a message that has no way to carry
+// a label and was never under an obligation to.
+func TestAChannelMessageIsNotAskedForASubjectPrefix(t *testing.T) {
+	channel := &stubMessageSender{}
+	store := &fakeStore{delivery: channelDelivery()}
+	stub := &stubRequirements{
+		findings: []RequirementFinding{{Requirement: "subject_prefix"}},
+	}
+	d := newTestDispatcher(store, fakeResolver{channel: channel},
+		&stubConsent{}).WithRequirementChecker(stub)
+
+	got, err := dispatch(context.Background(), d, store.delivery.ID)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if got == OutcomeParked {
+		t.Errorf("a channel message was parked for a subject it cannot carry: %q", store.parked)
+	}
+	if channel.calls != 1 {
+		t.Errorf("the provider was called %d time(s), want 1", channel.calls)
+	}
+	if len(stub.asked) != 0 {
+		t.Errorf("the checker was asked about a channel message %d times — it has no subject "+
+			"to judge and the empty string is not one", len(stub.asked))
+	}
+}

--- a/backend/internal/modules/comms/transmit.go
+++ b/backend/internal/modules/comms/transmit.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package comms
+
+// Handing the message to the provider, and reading what came back.
+//
+// Split from dispatcher.go, which decides WHETHER a delivery goes: the gates,
+// the pacing and the ladder. This is what happens once that is settled, and the
+// two halves change for different reasons — a new refusal is a gate, a new
+// provider failure mode is here.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// transmit hands the message to the provider and records what came back. The
+// seam already carries the shape-specific half (sendseam.go), so what follows is
+// the same for a mail message and a channel one.
+func (d *Dispatcher) transmit(ctx context.Context, del Delivery, seam sendSeam, ticket commsauthz.TransmitTicket) (Outcome, time.Duration, error) {
+	// The last thing checked before the wire, and the reason the ticket is
+	// threaded down here rather than trusted from three frames up: a send that
+	// reaches a provider without a decision recorded for THIS delivery and THIS
+	// attempt is a send nobody can account for afterwards. A stale attempt is
+	// as bad as none — it belongs to a try whose world may already have moved.
+	if !ticket.Current(del.ID, del.Attempts) {
+		return d.park(ctx, del.ID, "no current authorization decision covers this attempt")
+	}
+	// The attachment BYTES, resolved before the marker below and not inside the
+	// provider call.
+	//
+	// The ordering is the whole point. A seam that cannot detect a prior send
+	// commits an in-flight marker and then treats any later attempt as "the
+	// outcome was never learned", so a fault BETWEEN the marker and the wire —
+	// an unreadable object, a store that would not answer, a file set too large
+	// to carry — would park a message that never left with a reason telling the
+	// rep it may have arrived and discouraging a resend. Read first, and such a
+	// fault is what it is: nothing transmitted, and the ladder may try again.
+	//
+	// They are still not on the delivery row: a message on a retry ladder would
+	// otherwise hold every attachment it might ever send in the database,
+	// duplicated per delivery, for as long as the maximum age allows.
+	files, err := d.attachedFiles(ctx, del)
+	if err != nil {
+		return d.retry(ctx, del.ID, fmt.Errorf("comms: reading this message's files before transmitting: %w", err))
+	}
+	// At-most-once, for the seams that need it: a transmission whose outcome was
+	// never learned is never attempted a second time.
+	if outcome, wait, err := d.guardAtMostOnce(ctx, del, seam); outcome != outcomeUndecided {
+		return outcome, wait, err
+	}
+	receipt, err := seam.transmit(ctx, files)
+	if err != nil {
+		return d.classifySendFailure(ctx, del, err)
+	}
+
+	if err := d.store.RecordSent(ctx, del.ID, receipt); err != nil {
+		if errors.Is(err, ErrTerminal) {
+			// A newer attempt already closed this row against its own
+			// receipt; overwriting it would replace a real one.
+			return OutcomeSkipped, 0, nil
+		}
+		if !seam.detectsPriorSend {
+			return d.parkTransmitted(ctx, del, receipt, err)
+		}
+		// Mail goes back on the ladder: the next attempt's prior-send lookup
+		// finds the message at the provider and answers from it rather than
+		// transmitting a second copy, so the receipt is recorded late instead of
+		// lost.
+		return OutcomeRetry, 0, fmt.Errorf("comms: recording the send receipt: %w", err)
+	}
+
+	// The one-time link has now been sent and must stop being live.
+	d.retireLink(ctx, del)
+
+	// Metering follows the DURABLE record, not the provider call, because the
+	// send call is not the countable event: a receipt that failed to record
+	// comes back on the ladder, and Send answers a retry from Gmail's
+	// prior-send lookup rather than transmitting again. Metering at the call
+	// would count that one message twice. RecordSent is guarded on
+	// status = 'pending' and reports ErrTerminal otherwise, so exactly one
+	// attempt per delivery ever reaches this line — which is what makes
+	// "metered" mean "one message, once".
+	//
+	// Policies are told here rather than at Wait for the same reason in the
+	// other direction: a limiter counting checks instead of sends paces
+	// nothing.
+	//
+	// Metered only for a sender the policies actually pace. A controller row is
+	// not paced, and its user id is the zero value, so recording it would fill
+	// one bucket forever under a key naming nobody — harmless until somebody
+	// turns pacing on for this sender and finds it already throttled by years
+	// of accumulated slots.
+	if profileFor(del).paced {
+		for _, policy := range d.policies {
+			if recorder, meters := policy.(SendRecorder); meters {
+				recorder.Recorded(del)
+			}
+		}
+	}
+	return OutcomeSent, 0, nil
+}
+
+// receiptUnrecordedReason is what a delivery the provider ACCEPTED records when
+// its receipt could not be written. It is the opposite fact to
+// unknownOutcomeReason and must never be confused with it: nothing here is
+// uncertain — the message went — so the sentence tells the operator the one
+// thing they must not do about it.
+const receiptUnrecordedReason = "the provider accepted this message and its receipt could not be recorded: " +
+	"it WAS sent, and the provider's own message id is kept on this delivery. " +
+	"Do not send it again — the recipient already has it"
+
+// parkTransmitted closes a delivery whose message is already with the provider
+// and whose receipt this attempt could not write.
+//
+// It exists for the seams whose retries cannot detect a prior send. For those,
+// returning the attempt to the ladder is not a delay but a LOSS: the next
+// attempt reads the in-flight marker, learns nothing about what happened, and
+// parks the delivery as an outcome nobody knows — a message the customer is
+// holding, durably recorded as never sent. Parking here instead states what is
+// definitely true and keeps the provider's message id, which after a failed
+// receipt is the only handle left on that message.
+func (d *Dispatcher) parkTransmitted(ctx context.Context, del Delivery, receipt connector.SendReceipt, cause error) (Outcome, time.Duration, error) {
+	if err := d.store.ParkTransmitted(ctx, del.ID, receiptUnrecordedReason, receipt.ProviderMessageID); err != nil {
+		if errors.Is(err, ErrTerminal) {
+			return OutcomeSkipped, 0, nil
+		}
+		// Nothing durable records this send now. The row stays pending with its
+		// marker standing, so the next attempt parks on the uncertainty rather
+		// than messaging the customer twice, and both causes reach the job log.
+		return OutcomeRetry, 0, errors.Join(cause, err)
+	}
+	// The cause goes to the LOG rather than back to the caller. The delivery is
+	// terminal — a returned error would fail a job whose work is done and put a
+	// closed row back on the ladder — and the reason column may not carry a
+	// database fault's own text (faultReason), so this is where an operator's
+	// diagnosis lives.
+	slog.ErrorContext(ctx, "comms: a transmitted message's receipt could not be recorded; the delivery is parked against it",
+		"err", cause, "delivery_id", del.ID, "provider_message_id", receipt.ProviderMessageID)
+	return OutcomeParked, 0, nil
+}
+
+// classifySendFailure turns a provider failure into a disposition using only
+// the shared sentinel vocabulary, so the provider's own text stops at the
+// connector boundary.
+//
+// A permanent rejection is recognized only where the SEAM can prove it:
+// ErrRecipientUnreachable is reported by a provider that answers a refused
+// recipient differently from a refused credential, and it parks at once. The
+// Gmail connector cannot — it maps every non-throttled, non-2xx response to
+// ErrUnreachable, so a refused mail recipient is indistinguishable from an
+// outage there and still burns the whole retry ladder before its job exhausts
+// and the delivery parks.
+func (d *Dispatcher) classifySendFailure(ctx context.Context, del Delivery, err error) (Outcome, time.Duration, error) {
+	if errors.Is(err, connector.ErrSendOutcomeUnknown) {
+		// NEVER retried, and no shape test is needed to decide that: only a seam
+		// that cannot discover a prior send reports this class, and one that can
+		// is obliged to go and find out instead. The in-flight marker
+		// deliberately STAYS — it is the durable record that a message may
+		// already be with the customer, and the park reason is the only honest
+		// thing to tell the operator reading the row.
+		return d.park(ctx, del.ID, unknownOutcomeReason)
+	}
+	// Everything below is a DEFINITE answer from the provider, which proves
+	// nothing was transmitted — so the in-flight marker is retracted before the
+	// delivery goes back on the ladder. It is a no-op for a seam that never set
+	// one, which is what keeps this a single rule rather than a second branch on
+	// provider class.
+	if clearErr := d.store.ClearInFlight(ctx, del.ID); clearErr != nil && !errors.Is(clearErr, ErrTerminal) {
+		// The marker is still standing, so the next attempt will park rather
+		// than re-send. Both causes go back for the job log, and the delivery
+		// errs toward an unsent message — the direction this whole path is built
+		// to err in.
+		return d.retry(ctx, del.ID, errors.Join(err, clearErr))
+	}
+	if errors.Is(err, connector.ErrAuthRejected) {
+		return d.park(ctx, del.ID, "the provider rejected the credential this delivery transmits through; reconnect it to resume sending")
+	}
+	// Checked alongside the credential class, not after the ladder: the two are
+	// the pair an operator most easily confuses, and the whole value of telling
+	// them apart is that each row says which one it was.
+	if errors.Is(err, connector.ErrRecipientUnreachable) {
+		return d.park(ctx, del.ID, unreachableRecipientReason)
+	}
+	// The adapter refused the file set itself. This is a DECISION rather than a
+	// provider condition, so it cannot come out differently on a later attempt:
+	// left on the ladder it would re-read every file from the blobstore once per
+	// rung and then park under "the retry ladder is exhausted", which names no
+	// cause at all. The carriage gate catches this case earlier from the
+	// capability a connector DECLARES; this is the connector refusing what its
+	// own send path cannot honour, which is the half no gate above it can see.
+	if errors.Is(err, connector.ErrFilesNotCarried) {
+		// The cause is LOGGED rather than dropped. filesNotCarriedReason cannot
+		// carry it — a park reason is read by the contact who wrote the message,
+		// and the refusals below the gate name a file, a byte count and a bound
+		// that were built for an operator — but those are the only statement of
+		// WHICH file and WHICH limit ended this delivery. Parking returns nil, so
+		// without this line the job succeeds and the sentence disappears.
+		slog.ErrorContext(ctx, "comms: the channel refused the files this message was staged with; the delivery is parked",
+			"delivery_id", del.ID, "provider", del.Provider, "err", err)
+		return d.park(ctx, del.ID, filesNotCarriedReason)
+	}
+	// Honour the provider's own interval when it named one: it knows when it
+	// will accept the next message, and guessing shorter earns another
+	// throttle. A rate limit with no stated interval leaves nothing to
+	// honour, so it falls through to the retry ladder rather than asking the
+	// caller to re-run immediately against a provider already throttling us.
+	if limited, throttled := errors.AsType[*connector.RateLimitedError](err); throttled && limited.RetryAfter > 0 {
+		return d.throttled(ctx, del, limited.RetryAfter)
+	}
+	return d.retry(ctx, del.ID, err)
+}

--- a/backend/internal/modules/consent/authorizecaplock_integration_test.go
+++ b/backend/internal/modules/consent/authorizecaplock_integration_test.go
@@ -101,15 +101,27 @@ var capJurisdictions = struct {
 	next int
 }{}
 
+// testJurisdictionSlots is how many codes the minter can hand out: q…a through
+// q…z, minus the letters before "a" — the whole "q" prefix.
+//
+// WIDENED from the QM-QZ fourteen when the requirement tests began drawing from
+// the same counter and the two together came within two of exhausting it. ISO
+// 3166 reserves every QM-QZ code and assigns no other "q" code except QA
+// (Qatar), which this skips: a test jurisdiction that collided with a real one
+// would read as a pack for a country the product actually serves.
+const testJurisdictionSlots = 25
+
 func testJurisdiction(t *testing.T) jurisdiction.Code {
 	t.Helper()
 	capJurisdictions.mu.Lock()
 	defer capJurisdictions.mu.Unlock()
-	if capJurisdictions.next >= 14 {
-		t.Fatalf("this package has taken all %d test jurisdictions in the QM-QZ range — widen the "+
-			"range rather than reusing one, which panics the registry for every test after it", 14)
+	if capJurisdictions.next >= testJurisdictionSlots {
+		t.Fatalf("this package has taken all %d test jurisdictions in the q… range — widen the "+
+			"range rather than reusing one, which panics the registry for every test after it",
+			testJurisdictionSlots)
 	}
-	code := jurisdiction.Code("q" + string(rune('m'+capJurisdictions.next)))
+	// 'b' onward, skipping QA: Qatar is the one assigned "q" code.
+	code := jurisdiction.Code("q" + string(rune('b'+capJurisdictions.next)))
 	capJurisdictions.next++
 	return code
 }

--- a/backend/internal/modules/consent/requirements.go
+++ b/backend/internal/modules/consent/requirements.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What a jurisdiction requires of a composed message, checked against the
+// message itself.
+//
+// gates/messagingruleapplied_test.go has carried "nothing prepends it" about
+// SubjectPrefix since the Vietnamese pack shipped: the decree fixes a [QC]
+// label for advertising mail, the pack declares it, and no step between a
+// composed subject and the provider ever consulted the rules. An advertising
+// message left unmarked and nothing reported it.
+//
+// THIS ASKS THE MESSAGE, not the code that produced it. Every obligation is
+// rendered somewhere earlier, and every one of those steps can be skipped by a
+// path that composes its own body — which three of them do, recorded in that
+// same gate's register. A check on the finished bytes is the one that cannot be
+// walked past.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// The requirement names, in the vocabulary a reader of a parked delivery sees.
+const (
+	// RequirementSubjectPrefix is a pack's advertising label, which the
+	// Vietnamese decree fixes as "[QC]".
+	RequirementSubjectPrefix = "subject_prefix"
+)
+
+// CheckMessage answers one finding per requirement this message does not meet.
+//
+// AN EMPTY ANSWER IS THE ORDINARY ONE. A message under no applicable pack, or
+// one that is not advertising, owes nothing here — and that is reported as
+// nothing owed rather than as nothing checked, which are the same value and
+// different facts. The caller parks on a finding, so answering findings for a
+// message that owes none would refuse lawful mail.
+func (s *Store) CheckMessage(
+	ctx context.Context, deliveryID, decisionSetID, subject string,
+) ([]RequirementFinding, error) {
+	// GATED, on the object the delivery belongs to.
+	//
+	// The send worker runs as a system principal and passes, so this costs the
+	// only production caller nothing. What it closes is a probe: the answer
+	// varies with what the engine decided about a delivery, so an ungated
+	// exported method would let anybody holding a delivery id learn whether it
+	// was judged as advertising by watching a finding appear and disappear.
+	//
+	// `activity` at READ rather than a settings grant, and the difference
+	// matters. Gating on installation_settings would be the mistake the
+	// disclosure readers beside this one argue against: a rep holds contact and
+	// activity grants and no settings grant, so it would refuse the check for
+	// exactly the seats that compose the mail. This asks whether the caller may
+	// read the timeline the delivery hangs off, which every legitimate one can.
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	var findings []RequirementFinding
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		rules, _, applicable, err := s.applicableRules(ctx, tx)
+		if err != nil || !applicable {
+			return err
+		}
+		advertising, found, err := everyRecipientIsAdvertisedToTx(ctx, tx, deliveryID, decisionSetID)
+		if err != nil || !found {
+			// NO DECISION, NO FINDING. A delivery the engine never judged is
+			// one this check knows nothing about, and inventing a requirement
+			// for it would park mail on an absence of evidence rather than on
+			// evidence of absence.
+			return err
+		}
+		if !advertising {
+			return nil
+		}
+		// THE PREFIX IS READ HERE, off the rule set this lookup answered, rather
+		// than inside the helper below taking it as a parameter.
+		//
+		// gates/messagingruleapplied_test.go scans for reads of a rule field on
+		// a local bound from applicableRules, which is how it can tell an
+		// applied obligation from a declared one. A helper reading the field
+		// from its argument satisfies a human reader and not that scan, so the
+		// register would still call this obligation unapplied while it was
+		// being applied — which is the failure the register exists to prevent,
+		// running backwards.
+		findings = append(findings, subjectPrefixFindings(rules.SubjectPrefix,
+			string(rules.Jurisdiction), subject)...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return findings, nil
+}
+
+// RequirementFinding is one requirement a message does not meet. It mirrors
+// comms.RequirementFinding across the module boundary: consent may not import
+// comms, and the composition root adapts between them.
+//
+// Held by: TestTheRequirementFindingAgreesAcrossTheSeam
+// (backend/gates/requirementseam_test.go)
+type RequirementFinding struct {
+	// Requirement names what is missing, in the vocabulary the packs use.
+	Requirement string
+	// Detail says what was expected, for whoever reads the record.
+	Detail string
+}
+
+// subjectPrefixFindings reports an advertising message whose subject does not
+// carry the label its pack fixes.
+//
+// ADVERTISING ONLY. The packs declare the prefix as a marking on advertising,
+// and putting it on an invoice would tell a recipient their payment reminder is
+// an advertisement — a false statement made to satisfy a check, which is worse
+// than the omission it would be fixing.
+//
+// The comparison is case-insensitive on a trimmed subject. A composer that
+// wrote "[qc]" met the decree's purpose, and refusing over the case of a label
+// would park lawful mail on a typographic reading nobody argues for.
+func subjectPrefixFindings(declared, jurisdiction, subject string) []RequirementFinding {
+	prefix := strings.TrimSpace(declared)
+	if prefix == "" {
+		return nil
+	}
+	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(subject)), strings.ToUpper(prefix)) {
+		return nil
+	}
+	return []RequirementFinding{{
+		Requirement: RequirementSubjectPrefix,
+		Detail: fmt.Sprintf("an advertising subject carries %q in %s, and this one begins %q",
+			prefix, jurisdiction, firstRunes(subject, 24)),
+	}}
+}
+
+// everyRecipientIsAdvertisedToTx reports whether this send is advertising to
+// ALL of its recipients, within the one decision set it was authorized on.
+//
+// BOUND TO THE SET, never to the delivery id alone. A delivery can hold several
+// sets: a paced message redispatched after its circumstances changed writes a
+// fresh one beside the old, and reading by delivery would judge the message by
+// a category it no longer has. The set the ticket names is the decision this
+// send is going out on.
+//
+// EVERY recipient, because a subject line is one line for all of them. A
+// message read as an active-deal follow-up for one addressee and as marketing
+// for another is advertising to the second, and adding the label would mark it
+// for both while leaving it off would leave the second unmarked. This answers
+// the first case as "not advertising" deliberately: the mixed send is a
+// composition the product should not make, and refusing it HERE would park mail
+// on a label that cannot be right for everyone rather than on the mixing.
+//
+// A category the engine resolved CONSERVATIVELY is still that category — the
+// engine says what the message is, and second-guessing it here would be a
+// second answer to the question it already answered.
+func everyRecipientIsAdvertisedToTx(
+	ctx context.Context, tx pgx.Tx, deliveryID, decisionSetID string,
+) (bool, bool, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT DISTINCT resolved_category FROM communication_decision
+		 WHERE delivery_id = $1 AND decision_set_id = $2`, deliveryID, decisionSetID)
+	if err != nil {
+		return false, false, fmt.Errorf(
+			"consent: reading what this delivery was judged to be: %w", err)
+	}
+	categories, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		return false, false, fmt.Errorf(
+			"consent: reading what this delivery was judged to be: %w", err)
+	}
+	if len(categories) == 0 {
+		return false, false, nil
+	}
+	for _, c := range categories {
+		if commsauthz.Category(c) != commsauthz.CategoryMarketing {
+			return false, true, nil
+		}
+	}
+	return true, true, nil
+}
+
+// firstRunes bounds what a finding quotes back.
+//
+// A finding is written into a parked delivery's reason, which an operator
+// reads. Quoting a whole subject line would put the message's own words into a
+// field meant to say what is wrong with it.
+func firstRunes(s string, n int) string {
+	r := []rune(strings.TrimSpace(s))
+	if len(r) <= n {
+		return string(r)
+	}
+	return string(r[:n]) + "…"
+}

--- a/backend/internal/modules/consent/requirements_integration_test.go
+++ b/backend/internal/modules/consent/requirements_integration_test.go
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// Checking a composed message against what its jurisdiction requires.
+//
+// gates/messagingruleapplied_test.go carried "nothing prepends it" about
+// SubjectPrefix since the Vietnamese pack shipped: Decree 91/2020 fixes a [QC]
+// label for advertising mail, the pack declares it, and no step between a
+// composed subject and the provider ever consulted the rules. An advertising
+// message left unmarked and nothing reported it.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
+)
+
+// labelledIn binds the store to a pack fixing an advertising label.
+// composerCtx is a seat that may read the timeline a delivery hangs off, which
+// is what CheckMessage asks for.
+//
+// A REAL GRANT rather than a system principal, because the gate is what these
+// tests would otherwise not exercise: an ungated check would let anybody
+// holding a delivery id learn whether it was judged as advertising by watching
+// a finding appear and disappear.
+func composerCtx(e *channelConsentEnv) context.Context {
+	actor, _ := principal.Actor(e.ctx)
+	actor.Permissions.Objects = map[string]principal.ObjectGrant{
+		"activity": {Read: true},
+	}
+	return principal.WithActor(e.ctx, actor)
+}
+
+// THE CODE IS MINTED, never written down. testJurisdiction (authorizecaplock)
+// hands out the qm-qz range from a shared counter, and this package's cap tests
+// draw from the same one — so a literal here takes a code that helper will hand
+// to somebody else, and Register panics for every test after it. The failure
+// passes alone and fails in the suite, which is the worst shape to diagnose.
+//
+// The label is the decree's own, which is why it is a constant rather than a
+// parameter: a test that could choose it would be testing string comparison,
+// and what these tests are about is that the pack's label reaches the check.
+func labelledIn(t *testing.T, e *channelConsentEnv) *Store {
+	t.Helper()
+	code := testJurisdiction(t)
+	messagingrules.Register(messagingrules.Rules{
+		Jurisdiction: code, Version: 1, SubjectPrefix: "[QC]",
+	})
+	return e.store.WithInstallationCountry(
+		InstallationCountryFunc(func(context.Context, pgx.Tx) (jurisdiction.Code, error) {
+			return code, nil
+		}))
+}
+
+// judgedAs plants a delivery the engine resolved to these categories, one
+// decision row per recipient, and answers the delivery and its decision set.
+//
+// THE SET is what a requirement is judged against: a delivery can hold several,
+// and reading by delivery alone would judge a message by a category it no
+// longer has.
+func judgedAs(
+	t *testing.T, e *channelConsentEnv, categories ...commsauthz.Category,
+) (string, string) {
+	t.Helper()
+	activity := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO activity (id, kind, direction, source, occurred_at, captured_by)
+		VALUES ($1, 'email', 'outbound', 'manual', now(), 'human:x')`, activity); err != nil {
+		t.Fatalf("planting the activity the delivery hangs off: %v", err)
+	}
+	delivery := ids.NewV7()
+	// The mail shape the table's own CHECK demands: a message id, an envelope
+	// and a subject. A channel delivery is the other arm and carries none of
+	// them, which is not what a subject-prefix requirement is about.
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO comms_outbound (id, activity_id, user_id, provider, message_id, recipients, cc,
+		                            subject, references_chain, body, status, sender_kind,
+		                            consent_purpose)
+		VALUES ($1, $2, $3, 'test', $4, '["someone@corp.test"]'::jsonb, '[]'::jsonb,
+		        'planted', '[]'::jsonb, 'body', 'pending', 'user', 'newsletter')`,
+		delivery, activity, e.user, "<"+delivery.String()+"@test>"); err != nil {
+		t.Fatalf("planting the delivery: %v", err)
+	}
+	setID := ids.NewV7()
+	for i, category := range categories {
+		if _, err := e.owner.Exec(context.Background(), `
+			INSERT INTO communication_decision
+			  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+			   resolved_category, verdict, reason_code, mode, actor)
+			VALUES ($1, 0, $2, $3, 'staging', $4, 'allow', '', 'enforce', 'test')`,
+			delivery, setID, fmt.Sprintf("someone%d@corp.test", i),
+			string(category)); err != nil {
+			t.Fatalf("planting the decision: %v", err)
+		}
+	}
+	return delivery.String(), setID.String()
+}
+
+// TestAnAdvertisingSubjectWithoutItsLabelIsAFinding is the register line this
+// closes.
+func TestAnAdvertisingSubjectWithoutItsLabelIsAFinding(t *testing.T) {
+	e := setupChannelConsent(t)
+	store := labelledIn(t, e)
+	delivery, set := judgedAs(t, e, commsauthz.CategoryMarketing)
+
+	findings, err := store.CheckMessage(composerCtx(e), delivery, set, "Half price this week")
+	if err != nil {
+		t.Fatalf("checking the message: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Requirement != RequirementSubjectPrefix {
+		t.Fatalf("findings = %+v, want one subject_prefix — an advertising message went out "+
+			"unmarked and nothing reported it, which is the defect this closes", findings)
+	}
+	if findings[0].Detail == "" {
+		t.Error("the finding says nothing about what was expected")
+	}
+}
+
+// TestALabelledAdvertisingSubjectIsNoFinding is the positive control: the
+// finding above must be about the missing label and not about the check
+// refusing everything.
+func TestALabelledAdvertisingSubjectIsNoFinding(t *testing.T) {
+	e := setupChannelConsent(t)
+	store := labelledIn(t, e)
+	delivery, set := judgedAs(t, e, commsauthz.CategoryMarketing)
+
+	for _, subject := range []string{
+		"[QC] Half price this week",
+		"[qc] half price",
+		"  [QC] leading space",
+	} {
+		findings, err := store.CheckMessage(composerCtx(e), delivery, set, subject)
+		if err != nil {
+			t.Fatalf("checking %q: %v", subject, err)
+		}
+		if len(findings) != 0 {
+			t.Errorf("%q was reported as %+v — a message carrying the label was refused, and "+
+				"a case difference is not what the decree is about", subject, findings)
+		}
+	}
+}
+
+// TestAnInvoiceNeverCarriesTheAdvertisingLabel.
+//
+// Putting it there would tell a recipient their payment reminder is an
+// advertisement: a false statement made to satisfy a check, which is worse than
+// the omission it would be fixing.
+func TestAnInvoiceNeverCarriesTheAdvertisingLabel(t *testing.T) {
+	e := setupChannelConsent(t)
+	store := labelledIn(t, e)
+	delivery, set := judgedAs(t, e, commsauthz.CategoryInvoiceOrPayment)
+
+	findings, err := store.CheckMessage(composerCtx(e), delivery, set, "Your April invoice")
+	if err != nil {
+		t.Fatalf("checking the invoice: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("an invoice was told to carry an advertising label: %+v", findings)
+	}
+}
+
+// TestAnInstallationUnderNoPackOwesNothing. Nothing owed and nothing checked
+// are the same value and different facts; the caller parks on a finding, so
+// answering one here would refuse lawful mail.
+func TestAnInstallationUnderNoPackOwesNothing(t *testing.T) {
+	e := setupChannelConsent(t)
+	delivery, set := judgedAs(t, e, commsauthz.CategoryMarketing)
+
+	findings, err := e.store.CheckMessage(composerCtx(e), delivery, set, "Half price this week")
+	if err != nil {
+		t.Fatalf("checking with no country declared: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("an installation declaring no country was told it owes %+v", findings)
+	}
+}
+
+// TestADeliveryTheEngineNeverJudgedOwesNothing. Parking mail on an absence of
+// evidence rather than on evidence of absence would refuse deliveries this
+// check knows nothing about.
+func TestADeliveryTheEngineNeverJudgedOwesNothing(t *testing.T) {
+	e := setupChannelConsent(t)
+	store := labelledIn(t, e)
+
+	findings, err := store.CheckMessage(composerCtx(e), ids.NewV7().String(), ids.NewV7().String(), "Half price this week")
+	if err != nil {
+		t.Fatalf("checking an unjudged delivery: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a delivery with no decision was told it owes %+v", findings)
+	}
+}
+
+// TestAMessageAdvertisingToOnlySomeRecipientsIsNotLabelled is Codex's finding.
+//
+// A subject line is ONE line for everybody it reaches. A send read as an
+// active-deal follow-up for one addressee and as marketing for another would be
+// labelled for both or for neither, and neither answer is right — so the
+// requirement does not fire, and the composition that produced the mix is the
+// thing to fix rather than the label.
+//
+// The alternative, firing on any marketing recipient, parks the message on a
+// label that cannot be correct for everyone.
+func TestAMessageAdvertisingToOnlySomeRecipientsIsNotLabelled(t *testing.T) {
+	e := setupChannelConsent(t)
+	store := labelledIn(t, e)
+	delivery, set := judgedAs(t, e,
+		commsauthz.CategoryMarketing, commsauthz.CategoryActiveDealFollowup)
+
+	findings, err := store.CheckMessage(composerCtx(e), delivery, set, "How did the trial go?")
+	if err != nil {
+		t.Fatalf("checking the mixed send: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a send that is advertising to only some of its recipients was told to "+
+			"carry an advertising label: %+v — the same subject line reaches the addressee "+
+			"it is not advertising to", findings)
+	}
+}
+
+// TestAStaleDecisionSetDoesNotJudgeThisSend.
+//
+// A delivery can hold several decision sets: a paced message redispatched after
+// its circumstances changed writes a fresh one beside the old. Reading by
+// delivery id alone picked among them, so a send authorized as marketing could
+// be judged by an earlier non-marketing row and go out unlabelled.
+func TestAStaleDecisionSetDoesNotJudgeThisSend(t *testing.T) {
+	e := setupChannelConsent(t)
+	store := labelledIn(t, e)
+	delivery, stale := judgedAs(t, e, commsauthz.CategoryActiveDealFollowup)
+
+	// The set this send is actually going out on, written beside the old one
+	// exactly as a redispatch does.
+	live := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO communication_decision
+		  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+		   resolved_category, verdict, reason_code, mode, actor)
+		VALUES ($1, 0, $2, 'someone@corp.test', 'staging', 'marketing', 'allow', '', 'enforce', 'test')`,
+		delivery, live); err != nil {
+		t.Fatalf("planting the live decision: %v", err)
+	}
+
+	findings, err := store.CheckMessage(composerCtx(e), delivery, live.String(), "Half price this week")
+	if err != nil {
+		t.Fatalf("checking the redispatched send: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %+v, want one: the live set says marketing, and an earlier set "+
+			"on the same delivery must not answer for it", findings)
+	}
+
+	// And the stale set still answers for itself, which is what proves the
+	// binding is to the set rather than to whichever row sorts first.
+	stale2, err := store.CheckMessage(composerCtx(e), delivery, stale, "Half price this week")
+	if err != nil {
+		t.Fatalf("checking against the stale set: %v", err)
+	}
+	if len(stale2) != 0 {
+		t.Errorf("the stale set reported %+v, want none", stale2)
+	}
+}
+
+// TestACallerWhoCannotReadTheTimelineLearnsNothing.
+//
+// The answer varies with what the engine decided about a delivery, so an
+// ungated exported method would let anybody holding a delivery id learn whether
+// it was judged as advertising by watching a finding appear and disappear. The
+// send worker is a system principal and passes; a seat without the grant does
+// not.
+func TestACallerWhoCannotReadTheTimelineLearnsNothing(t *testing.T) {
+	e := setupChannelConsent(t)
+	store := labelledIn(t, e)
+	delivery, set := judgedAs(t, e, commsauthz.CategoryMarketing)
+
+	actor, _ := principal.Actor(e.ctx)
+	actor.Permissions.Objects = map[string]principal.ObjectGrant{}
+	stranger := principal.WithActor(e.ctx, actor)
+
+	if _, err := store.CheckMessage(stranger, delivery, set, "Half price this week"); err == nil {
+		t.Fatal("a caller with no activity grant was told what this delivery was judged as")
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (111)
+## Parity (112)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -118,6 +118,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rbacvocabulary_test.go` | H3 | The RBAC vocabulary is DECLARED in the contract and restated in Go, and the two must not drift. |
 | `redmainclaim_test.go` | H2 | Every `claim:` label the prose tells a session to search for is one `.github/labels.yml` declares. |
 | `reopenconditionparity_test.go` | H3 | What a snooze may wait for is spelled in four places, and all four must agree. |
+| `requirementseam_test.go` | H1 | The two halves of the requirement seam describe the same thing. |
 | `rowscopetables_test.go` | H2 | WHICH table a row-scope call bounds, and which column names a reference to one. |
 | `runneractivityparity_test.go` | H3 | The runner's own status vocabulary must be TOTAL over the column it reads. |
 | `seedemploymentpredicate_test.go` | H2 | The dev seeder and the boot proof ask "is this contact currently employed?" the way the PRODUCT asks it, and they ask it in the same words. |


### PR DESCRIPTION
A jurisdiction pack declares a subject prefix. Vietnam's Decree 91/2020 fixes "[QC]" as the label an advertising email must carry, and the register in the messaging-rule gate said what happened to it: nothing prepended it. A send composes its own subject, no step between that and the provider consulted the rules, and an advertising message left unmarked with nothing reporting it.

## Where the check runs

At the last point the message exists as it will be sent. That is the only honest place. Every obligation is rendered somewhere earlier, and every one of those steps can be skipped by a path that composes its own body. Three of them do, recorded in that same register. Asking the finished bytes is the question that cannot be walked past.

A finding parks the delivery and names the requirement. Retrying would compose the same bytes from the same row, burn the ladder and park anyway.

## Four findings from Codex, three of which would have shipped

A channel message would have been parked forever. Channel deliveries have no subject: staging writes null and the provider's message has no such field. The check would have been handed an empty string, found the label missing, and parked every Vietnamese channel message on an obligation it had no way to meet. The gate is now mail only.

A stale decision could judge the send. I read the category by delivery id, and a delivery holds several decision sets once a paced message is redispatched. The check is now bound to the set the ticket names, which is the decision this send is actually going out on.

A mixed send would have been mislabelled. A subject line is one line for everyone it reaches, so a message read as marketing for one addressee and as a deal follow-up for another cannot be labelled correctly either way. The requirement fires only when the whole set is advertising.

The fourth was my reasoning rather than my code. I argued the check should be ungated because the send worker holds no grant. That is false: the RBAC helper admits system principals, so a gate costs the worker nothing. It is now gated on activity read, which closes a probe that let anyone holding a delivery id learn whether it was judged as advertising. The exception I had written into the ungated register is gone.

## One my own test caught

My first version returned only on an outcome, so a checker that could not answer left the gate undecided and the message went out on a check nobody performed.

## Two things worth knowing

The dispatcher was at the 500-line cap, so the transmit half moved to its own file. The two change for different reasons: a new refusal is a gate, a new provider failure mode is transmit. Codex verified the move is behaviour-free.

I hardcoded test jurisdiction codes inside a range a shared minter owns, which passed alone and failed in the suite. The tests now draw from that minter, and its range is widened since two files share it.

Full backend gate green. Integration lanes green for consent, comms and compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checks a composed message against what its jurisdiction requires before it reaches the provider, so advertising email missing a required label (Vietnam's `[QC]` prefix) is now parked with a reason naming the requirement instead of going out unmarked with nothing reported.

**New Features**
- The gate runs on the final message bytes, so no composition path can skip it; a missing requirement parks the delivery rather than retrying.
- Mail only: channel messages have no subject and are never asked about a subject label.
- Fires only when every recipient was judged as advertising; a mixed send cannot be labelled correctly for everyone.
- Judged against the decision set the current send is authorized on, not an older set a redispatch left behind.
- The check is gated on activity read, so a caller holding only a delivery id cannot learn whether a delivery was judged as advertising.
- An error answering the check blocks the send; failing to ask must not read as passing.

**Refactors**
- `dispatcher.go` was at the 500-line cap, so the transmit half moved to `transmit.go` unchanged.

<sup>Written for commit a8d0a87b2ff92e3f044799705dfffed4d7ed917f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added jurisdiction-based compliance checks for outgoing email.
  - Messages missing required subject information are held instead of sent, with the reason provided.
  - Messages that meet applicable requirements continue to send normally.
  - Compliance checks account for the installation’s jurisdiction and message content.

- **Bug Fixes**
  - Prevented messages from being sent when compliance checks cannot be completed safely.
  - Channel messages remain unaffected by email-specific subject requirements.

- **Documentation**
  - Updated the gate inventory to include the new compliance validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->