### PR TITLE
fix(agents): one pin rule for both doors, and a refusal that cannot burn an approval

### DIFF
--- a/backend/internal/compose/agentgateauto.go
+++ b/backend/internal/compose/agentgateauto.go
@@ -16,7 +16,9 @@ package compose
 // against the other.
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -142,14 +144,29 @@ func runAutoExecuted(w http.ResponseWriter, r *http.Request, next http.Handler, 
 func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tokenRedemption, redeemed bool) bool {
 	admitted, gateRead := auth.AutoExecutePin(r.Context())
 	if redemption.pinned {
-		if gateRead && redemption.pin != admitted {
-			httperr.Write(w, r, fmt.Errorf(
-				"the approval released this record at version %d and the tier gate read it at %d — it moved "+
-					"between the two, so neither is the version that was judged; re-read it and retry: %w",
-				redemption.pin, admitted, apperrors.ErrVersionSkew))
+		// NO REFUSAL, though the two can disagree, and the order of events is
+		// why. The redemption commits before this runs, so by the time a
+		// disagreement could be noticed the human's single-use approval is
+		// already spent — and refusing destroys it on a call that never ran and
+		// can never be redeemed again. This branch used to refuse, eighteen
+		// lines above the branch that states the opposite rule for an approval
+		// carrying no pin of its own.
+		//
+		// Forwarding the released pin is no weaker: the store re-checks it
+		// inside the transaction that mutates and refuses there, without
+		// consuming anything. What is not done is staying silent about it.
+		pin, err := auth.ResolveWritePin(auth.WritePinInputs{
+			ReleasedPin:   &redemption.pin,
+			Admitted:      admitted,
+			GateRead:      gateRead,
+			ApprovalSpent: true,
+		})
+		if err != nil {
+			httperr.Write(w, r, err)
 			return false
 		}
-		r.Header.Set(ifMatchHeader, strconv.FormatInt(redemption.pin, 10))
+		reportPinDisagreement(r.Context(), pin, admitted)
+		r.Header.Set(ifMatchHeader, strconv.FormatInt(pin.Version, 10))
 		return true
 	}
 	if !gateRead {
@@ -202,4 +219,30 @@ func pinAutoExecutedWrite(w http.ResponseWriter, r *http.Request, redemption tok
 // had stopped being covered.
 func reachesTheHumanOwnedSplit(pol agentPolicy) bool {
 	return pol.Tool == toolUpdateRecord && !actionShapedUpdateOps[pol.Op]
+}
+
+// reportPinDisagreement leaves the witness for a condition the system believes
+// cannot happen: the approval released this record at one version and the tier
+// gate read it at another.
+//
+// Unreachable through the real stager — a pin is taken server-side only for a
+// concrete, version-checkable target, versions are monotonic, the gate's read
+// precedes the redemption's so admitted ≤ current = released, and a row that
+// genuinely moved fails the redemption's own target re-check first. An
+// unreachable case that quietly becomes reachable is the failure mode with no
+// witness, and this path no longer refuses, so a log line is the only thing
+// that would say it happened.
+//
+// If it ever fires, the fix is to move the comparison BEFORE the redemption
+// commits: a genuine disagreement could then refuse without destroying
+// anything. That is not done now because it reorders the redemption path on
+// both doors for a case nothing can reach.
+func reportPinDisagreement(ctx context.Context, pin auth.WritePin, admitted int64) {
+	if !pin.DisagreedWithAdmitted {
+		return
+	}
+	slog.Default().WarnContext(ctx,
+		"an agent write was pinned at a version the tier gate did not read",
+		"pinned", pin.Version, "admitted", admitted, "source", pin.Source,
+		"approval_spent", true)
 }

--- a/backend/internal/compose/agentgateredeem_test.go
+++ b/backend/internal/compose/agentgateredeem_test.go
@@ -18,8 +18,10 @@ package compose
 // claims.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -204,30 +206,54 @@ func TestAReleasedRetryTakesTheServersPinOverTheCallersIfMatch(t *testing.T) {
 	}
 }
 
-// The released pin and the pin the tier gate read disagreeing is a DEFENSIVE
-// assertion, not a case this door meets.
+// The released pin and the pin the tier gate read disagreeing is REPORTED, and
+// the write goes through on the released one.
 //
 // Through the real stager it is unreachable: approvals pins server-side only for
 // a concrete, version-checkable target, versions are monotonic, and the gate's
 // read precedes the redemption's — so admitted ≤ current = released, and a row
 // that really moved fails validateRedemptionTarget inside the redemption first.
 // This reaches the branch only because countingRedeemer answers a pin without
-// the target re-check production performs. Whether refusing is even the right
-// answer for a disagreement both doors could only discover after the approval is
-// consumed is margince/margince#1069; what this pins meanwhile is that
-// the branch is live and fails closed rather than picking a version.
-func TestADisagreementBetweenTheTwoServerPinsFailsClosed(t *testing.T) {
+// the target re-check production performs, which is why the case is stated here
+// rather than driven through the engine: a fixture that supplies its own version
+// of production proves nothing about production, and saying so is better than a
+// double pretending otherwise.
+//
+// It used to fail closed. That was settled the other way (#1069) on the order of
+// events: consumePresentedToken has already spent the approval by the time this
+// runs, so a 409 destroys a human's one-shot yes on a call that never ran and
+// can never be redeemed again — the agent is told to re-read and retry with
+// nothing left to retry with. The file argued against itself, eighteen lines
+// below, where an approval carrying no pin says "the approval is already spent,
+// so a refusal here would destroy it".
+//
+// Forwarding concedes nothing: the store re-checks the pin inside the
+// transaction that mutates and refuses there, without consuming anything. What
+// is not conceded is silence — an unreachable case that quietly becomes
+// reachable is the failure mode with no witness.
+func TestADisagreementBetweenTheTwoServerPinsIsForwardedAndReported(t *testing.T) {
+	var logged bytes.Buffer
+	restore := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(restore) })
+
 	// versionedDeal reports 12 to the tier gate; the approval was granted at 9.
 	staging := &countingRedeemer{pin: 9, pinned: true}
 
 	saw, status := autoExecutedMove(t, staging, ids.New[ids.ApprovalKind]().String(), "")
 
-	if status != http.StatusConflict {
-		t.Errorf("status = %d, want 409 — picking either version would run the write against a state "+
-			"nothing authorized", status)
+	if status != http.StatusOK || !saw.ran {
+		t.Fatalf("the released retry answered %d and ran=%v — refusing it burns the approval it just "+
+			"consumed on a call that never happened", status, saw.ran)
 	}
-	if saw.ran {
-		t.Errorf("the handler ran with If-Match %q despite the two pins naming different records", saw.ifMatch)
+	if saw.ifMatch != "9" {
+		t.Errorf("forwarded If-Match = %q, want \"9\" — the store re-checks the APPROVED version inside "+
+			"the transaction that mutates, which is where a genuine disagreement refuses without "+
+			"destroying anything", saw.ifMatch)
+	}
+	if line := logged.String(); !strings.Contains(line, "did not read") {
+		t.Errorf("the disagreement was not recorded anywhere: a case the system believes cannot happen "+
+			"and no longer refuses has nothing else to say it happened.\n  logged: %q", line)
 	}
 }
 

--- a/backend/internal/modules/agents/approvals.go
+++ b/backend/internal/modules/agents/approvals.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
@@ -192,21 +193,50 @@ func ApprovalRedeemed(ctx context.Context) bool {
 //nolint:nilnil // no pin IS an answer here: a write with nothing to condition it on is the ordinary case for a static tier and an unapproved call, and a sentinel for it would make every call site branch on a condition none of them act on
 func pinForWrite(ctx context.Context, callerPin *int64) (*int64, error) {
 	admitted, gateRead := auth.AutoExecutePin(ctx)
-	if callerPin != nil {
-		if gateRead && *callerPin != admitted {
-			return nil, fmt.Errorf(
-				"if_version %d is not the version this record was read at (%d) — re-read it and retry: %w",
-				*callerPin, admitted, apperrors.ErrVersionSkew)
-		}
-		return callerPin, nil
-	}
+	var releasedPin *int64
 	if released, pinned := ctx.Value(releasedPinKey{}).(int64); pinned {
-		return &released, nil
+		releasedPin = &released
 	}
-	if gateRead {
-		return &admitted, nil
+	pin, err := auth.ResolveWritePin(auth.WritePinInputs{
+		CallerPin:     callerPin,
+		ReleasedPin:   releasedPin,
+		Admitted:      admitted,
+		GateRead:      gateRead,
+		ApprovalSpent: ApprovalRedeemed(ctx),
+	})
+	if err != nil {
+		return nil, err
 	}
-	return nil, nil
+	reportWritePinDisagreement(ctx, pin, admitted)
+	if pin.Source == auth.PinNone {
+		return nil, nil
+	}
+	version := pin.Version
+	return &version, nil
+}
+
+// reportWritePinDisagreement leaves the witness for a condition the system
+// believes cannot happen.
+//
+// Unreachable through the real stager — a pin is taken server-side only for a
+// concrete, version-checkable target, versions are monotonic, and the gate's
+// read precedes the redemption's — and an unreachable case that quietly becomes
+// reachable is the failure mode with no witness. The write is not refused (the
+// approval is already spent by the time this runs), so a log line is the only
+// thing that would say it happened.
+//
+// slog.Default() because this sits below every seam that carries a logger:
+// pinForWrite is reached from eight tool handlers and takes a context alone,
+// and threading a logger through all eight to reach a branch nothing can enter
+// would be a worse trade than the package default compose already installs.
+func reportWritePinDisagreement(ctx context.Context, pin auth.WritePin, admitted int64) {
+	if !pin.DisagreedWithAdmitted {
+		return
+	}
+	slog.Default().WarnContext(ctx,
+		"an agent write was pinned at a version the tier gate did not read",
+		"pinned", pin.Version, "admitted", admitted, "source", pin.Source,
+		"approval_spent", ApprovalRedeemed(ctx))
 }
 
 // archiveAt performs one archive conditioned on the version the caller's

--- a/backend/internal/platform/auth/writepin.go
+++ b/backend/internal/platform/auth/writepin.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+)
+
+// Which version an agent's write is conditioned on, decided once for both doors.
+//
+// Three places can establish one — the caller's own pin, the pin a redeemed
+// approval was granted against, and the pin the gate read when it admitted the
+// call at the auto-execute tier — and the precedence between them is the same
+// rule whichever transport the call arrived on. It lived as two spellings, in
+// modules/agents and in compose, and the two came to disagree about the case
+// below. One spelling is the fix for that, and the reason this is in platform:
+// it is the only package both doors already reach.
+
+// PinSource names which of the three established the version, for a caller that
+// has to say so in a log line or a refusal.
+type PinSource int
+
+const (
+	// PinNone means nothing conditioned this write. The ordinary case for a
+	// static tier on an unapproved call, and an answer rather than an absence.
+	PinNone PinSource = iota
+	// PinCaller means the caller supplied it. It is bound into the diff_hash a
+	// redemption verified, which is what ties it to the record a human judged.
+	PinCaller
+	// PinReleased means the approval this call redeemed was granted against it.
+	PinReleased
+	// PinAdmitted means the gate read it to resolve a dynamic tier.
+	PinAdmitted
+)
+
+// WritePin is the resolved precondition, and where it came from.
+type WritePin struct {
+	// Version is the version to condition the write on; meaningful only when
+	// Source is not PinNone.
+	Version int64
+	Source  PinSource
+	// DisagreedWithAdmitted marks a pin that does not match the version the
+	// gate read — the case both doors can only discover AFTER the approval is
+	// spent, whether the pin came from the redemption or from the caller.
+	//
+	// REPORTED, NEVER REFUSED, and the order of events is the whole reason. On
+	// both doors the redemption commits before this rule runs, so by the time
+	// either could notice, the human's single-use approval is already gone —
+	// and a refusal there destroys it on a call that never ran and can never be
+	// redeemed again. The agent is told to re-read and retry with nothing left
+	// to retry with. Forwarding the released pin is no weaker: the store
+	// re-checks it inside the transaction that mutates, and refuses there
+	// unless the row is at the version the approval was granted against.
+	//
+	// It is not swallowed either. Through the real stager this is unreachable —
+	// a pin is taken server-side only for a concrete, version-checkable target,
+	// versions are monotonic, the gate's read precedes the redemption's so
+	// admitted ≤ current = released, and a row that genuinely moved fails the
+	// redemption's own target re-check first. A condition the system believes
+	// cannot happen is exactly the one that needs a witness when it does, which
+	// is what this field is for.
+	//
+	// If it ever fires, the fix is to move this comparison BEFORE the
+	// redemption commits: a genuine disagreement could then refuse without
+	// destroying anything. That is not done now because it reorders the
+	// redemption path on both doors for a case nothing can reach.
+	DisagreedWithAdmitted bool
+}
+
+// WritePinInputs is the state one write's precondition is resolved from.
+//
+// A struct rather than five parameters, and not only for the two booleans a
+// positional call would leave a reader decoding: the three pins and the two
+// conditions are ONE state, and a caller assembling it names each half at the
+// site where it knows what it means.
+type WritePinInputs struct {
+	// CallerPin is the version the caller conditioned its own call on, nil when
+	// it named none.
+	CallerPin *int64
+	// ReleasedPin is the version a redeemed approval was granted against, nil
+	// when the call redeemed none or the approval carried no pin.
+	ReleasedPin *int64
+	// Admitted is the version the gate read to resolve a dynamic tier, and is
+	// meaningful only when GateRead is true.
+	Admitted int64
+	// GateRead says whether the gate resolved this call's tier by reading a
+	// record at all. False for a static tier, a tier raised to confirm-first,
+	// and a human principal.
+	GateRead bool
+	// ApprovalSpent says whether a human's single-use approval has ALREADY been
+	// consumed for this call. It is what turns a refusal into a loss.
+	ApprovalSpent bool
+}
+
+// ResolveWritePin applies the precedence: the caller's pin, then the released
+// one, then the admitted one.
+//
+// THE CALLER'S PIN WINS when it supplied one, and is CHECKED against the gate's
+// read rather than trusted. The caller controls this argument, so a version the
+// gate never saw is a version nothing proved — and a caller naming the version
+// a racing close will PRODUCE would walk straight through the guard, because
+// the store's compare then passes on precisely the record the tier decision does
+// not describe. That disagreement answers skew, and a caller holding a stale
+// version learns it is stale and can retry.
+//
+// UNLESS AN APPROVAL HAS ALREADY BEEN SPENT ON IT, which is the same rule the
+// released-versus-admitted case below turns on and the reason they are decided
+// together. Both doors commit the redemption BEFORE this runs, so a refusal
+// here destroys a human's single-use yes on a call that never ran — and the
+// agent is told to re-read and retry with nothing left to retry with. The skew
+// is still not swallowed: the pin is forwarded and the store re-checks it
+// inside the transaction that mutates, which refuses there without consuming
+// anything, and the disagreement is reported.
+//
+// THE RELEASED PIN COMES NEXT. Redemption commits its own transaction and the
+// handler then opens a fresh one, so the check inside the redemption proves the
+// row was at the approved version when the approval was consumed — not that it
+// still is when the effect lands, and the agent controls both sides of that
+// window. Carrying the pin into the write moves the compare inside the
+// transaction that actually mutates.
+//
+// THE ADMITTED PIN closes the same window where there is no approval to carry
+// one. A dynamic tier is resolved by READING the record, and that read commits
+// before the write just as a redemption does; without it a close landing in the
+// window reopens a won deal one tier down.
+func ResolveWritePin(in WritePinInputs) (WritePin, error) {
+	callerPin, releasedPin, admitted := in.CallerPin, in.ReleasedPin, in.Admitted
+	if callerPin != nil {
+		disagrees := in.GateRead && *callerPin != admitted
+		if disagrees && !in.ApprovalSpent {
+			return WritePin{}, fmt.Errorf(
+				"version %d is not the version this record was read at (%d) — re-read it and retry: %w",
+				*callerPin, admitted, apperrors.ErrVersionSkew)
+		}
+		return WritePin{
+			Version: *callerPin, Source: PinCaller,
+			DisagreedWithAdmitted: disagrees,
+		}, nil
+	}
+	if releasedPin != nil {
+		return WritePin{
+			Version:               *releasedPin,
+			Source:                PinReleased,
+			DisagreedWithAdmitted: in.GateRead && *releasedPin != admitted,
+		}, nil
+	}
+	if in.GateRead {
+		return WritePin{Version: admitted, Source: PinAdmitted}, nil
+	}
+	return WritePin{Source: PinNone}, nil
+}

--- a/backend/internal/platform/auth/writepin_test.go
+++ b/backend/internal/platform/auth/writepin_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth_test
+
+// The precedence, and the one rule that overrides it.
+//
+// This is the PRODUCTION resolver, not a model of it: both doors call exactly
+// this function, which is the point of it existing. The disagreement cases it
+// decides are unreachable through the real stager — a pin is taken server-side
+// only for a concrete, version-checkable target, versions are monotonic, and
+// the gate's read precedes the redemption's — so they are stated here rather
+// than driven through an engine that cannot produce them. A fixture that
+// supplied its own redemption would prove something about the fixture.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+)
+
+func pin(v int64) *int64 { return &v }
+
+func TestTheWritePinPrecedenceIsCallerThenReleasedThenAdmitted(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		caller     *int64
+		released   *int64
+		admitted   int64
+		gateRead   bool
+		wantSource auth.PinSource
+		wantPin    int64
+	}{
+		{"the caller's own pin wins", pin(7), pin(9), 7, true, auth.PinCaller, 7},
+		{"the released pin comes next", nil, pin(9), 9, true, auth.PinReleased, 9},
+		{"the admitted pin is the last resort", nil, nil, 9, true, auth.PinAdmitted, 9},
+		{"nothing read a version, nothing pins the write", nil, nil, 0, false, auth.PinNone, 0},
+		{"a caller pin with no gate read is taken as given", pin(7), nil, 0, false, auth.PinCaller, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := auth.ResolveWritePin(auth.WritePinInputs{
+				CallerPin: tc.caller, ReleasedPin: tc.released,
+				Admitted: tc.admitted, GateRead: tc.gateRead,
+			})
+			if err != nil {
+				t.Fatalf("resolving: %v", err)
+			}
+			if got.Source != tc.wantSource {
+				t.Errorf("source = %v, want %v", got.Source, tc.wantSource)
+			}
+			if got.Source != auth.PinNone && got.Version != tc.wantPin {
+				t.Errorf("version = %d, want %d", got.Version, tc.wantPin)
+			}
+		})
+	}
+}
+
+// A caller naming a version the gate never saw is refused — while refusing is
+// still free.
+//
+// The caller controls that argument, so a version nothing proved would walk
+// through the store's compare on precisely the record the tier decision does
+// not describe: a caller naming the version a racing close will PRODUCE.
+func TestACallerPinTheGateDidNotReadIsSkew(t *testing.T) {
+	t.Parallel()
+	_, err := auth.ResolveWritePin(auth.WritePinInputs{CallerPin: pin(7), Admitted: 9, GateRead: true})
+	if !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("a caller pin of 7 against an admitted 9 answered %v, want version skew", err)
+	}
+}
+
+// AND NOT ONCE AN APPROVAL HAS BEEN SPENT ON IT, whichever pin disagrees.
+//
+// Both doors commit the redemption before this runs, so a refusal here destroys
+// a human's single-use yes on a call that never ran and can never be redeemed
+// again — the agent is told to re-read and retry with nothing left to retry
+// with. The skew is not swallowed: the pin is forwarded, the store re-checks it
+// inside the transaction that mutates and refuses there without consuming
+// anything, and the disagreement is reported.
+func TestNoDisagreementRefusesOnceTheApprovalIsSpent(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		caller   *int64
+		released *int64
+		wantPin  int64
+	}{
+		{"the caller's pin disagrees", pin(7), nil, 7},
+		{"the released pin disagrees", nil, pin(7), 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := auth.ResolveWritePin(auth.WritePinInputs{
+				CallerPin: tc.caller, ReleasedPin: tc.released,
+				Admitted: 9, GateRead: true, ApprovalSpent: true,
+			})
+			if err != nil {
+				t.Fatalf("a disagreement refused a call whose approval was already spent: %v", err)
+			}
+			if got.Version != tc.wantPin {
+				t.Errorf("version = %d, want %d — the pin is forwarded for the store to adjudicate",
+					got.Version, tc.wantPin)
+			}
+			if !got.DisagreedWithAdmitted {
+				t.Error("the disagreement was not reported, so a case the system believes cannot " +
+					"happen and no longer refuses has nothing to say it happened")
+			}
+		})
+	}
+}
+
+// A pin that AGREES with the gate's read reports nothing. The witness exists for
+// the impossible case, and a warning on every ordinary write would bury it.
+func TestAnAgreeingPinReportsNothing(t *testing.T) {
+	t.Parallel()
+	for _, released := range []*int64{pin(9), nil} {
+		got, err := auth.ResolveWritePin(auth.WritePinInputs{ReleasedPin: released, Admitted: 9, GateRead: true, ApprovalSpent: true})
+		if err != nil {
+			t.Fatalf("resolving: %v", err)
+		}
+		if got.DisagreedWithAdmitted {
+			t.Errorf("a pin of 9 against an admitted 9 was reported as a disagreement (released=%v)", released)
+		}
+	}
+}


### PR DESCRIPTION
An agent write can be conditioned on a version established in three places — the caller's own pin, the pin a redeemed approval was granted against, and the pin the gate read when it admitted the call. The two doors had **two spellings** of the precedence between them, and they came to disagree about the case neither can reach.

## The file already argued against itself

REST refused when the released pin and the admitted pin named different versions. **Eighteen lines below**, `agentgateauto.go` states the opposite rule for an approval that carried no pin of its own:

> *"the approval is already spent, so a refusal here would destroy it."*

Both branches run **after** the redemption commits. So the refusal burns a human's single-use yes on a call that never ran and can never be redeemed again — and the agent is told to "re-read it and retry" with nothing left to retry with.

A refusal that consumes the thing it refuses is worse than the permissive answer, and forwarding concedes nothing: the store re-checks the pin inside the transaction that mutates and refuses **there**, without consuming anything.

## Where I went past the ruling, and why

The 2026-08-31 decision enumerated the released-versus-admitted branch. The same argument reaches a branch it did not: **MCP refuses a CALLER pin the gate did not read**, on the same path, after the same redemption. That is the identical loss for the identical reason.

So the rule is stated once and applied to both: *a disagreement refuses while refusing is free, and never once an approval has been spent on it.* Fixing the invariant rather than the call site is the tree's own rule, and leaving the caller branch would have left the defect intact one argument over.

## One spelling

`auth.ResolveWritePin` — in `platform/auth`, the one package both doors already reach. It takes the three pins and the two conditions as a named `WritePinInputs` and answers the precedence. Two spellings of one rule is how this arose.

## Neither door stays silent

A pin that disagrees with the gate's read is a condition the system believes cannot happen: a pin is taken server-side only for a concrete, version-checkable target, versions are monotonic, the gate's read precedes the redemption's so `admitted ≤ current = released`, and a row that genuinely moved fails the redemption's own target re-check first.

An unreachable case that quietly becomes reachable is **the failure mode with no witness** — and this path no longer refuses, so a log line is the only thing that would say it happened. The fix if it ever fires (move the comparison before the redemption commits, where a genuine disagreement could refuse without destroying anything) is written down beside it, so the next person does not re-derive it.

## The test, and what it deliberately does not do

The precedence is tested against the **production resolver**, which is what both doors call. The disagreement cases are stated there rather than driven through the engine, because the engine cannot produce them — and per `AGENTS.md`, a fixture that supplies its own redemption proves something about the fixture. The REST suite's existing case is rewritten from "fails closed" to the decided behaviour, and now also asserts the disagreement reaches the log.

Mutation-checked three ways: removing the spent-approval exemption, silencing the released disagreement, and inverting the precedence each fail a named case.

`make check-backend` and `make craft-static` green.

Closes #1069.
