### PR TITLE
A refusal of advertising is acknowledged where the rules owe one

### DIFF
--- a/backend/gates/messagingruleapplied_test.go
+++ b/backend/gates/messagingruleapplied_test.go
@@ -92,11 +92,15 @@ var rulesIdentityFields = []string{"Jurisdiction", "Instruments"}
 // AssertAllMatched sees both a field that has since gained a reader and one the
 // struct no longer declares, because the arm below asks Waived only about a
 // field it has already found unapplied.
-var unappliedRules = gatekit.Waive(map[string]string{
-	"OptOutAcknowledgement": "no acknowledgement is sent. The controller lane is the only " +
-		"one that may write to somebody who has just suppressed themselves, and it " +
-		"registers no template for this",
-})
+// IT IS EMPTY, and that is the point rather than an oversight. Every obligation
+// the shipped packs declare now has an engine reader reachable from a send:
+// the disclosures, the subject prefix, the ruleset version, the frequency cap,
+// the windows and — last to land — the opt-out acknowledgement.
+//
+// An empty register is not a claim that no gap can exist. It says none is
+// RECORDED, and the test below fails the moment a pack declares something the
+// engine does not read, which is what puts the next entry here.
+var unappliedRules = gatekit.Waive(map[string]string{})
 
 func TestEveryDeclaredMessagingObligationIsAppliedOrRecorded(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/modules/consent/authorizeconfirmation.go
+++ b/backend/internal/modules/consent/authorizeconfirmation.go
@@ -99,3 +99,47 @@ func confirmKindFor(category commsauthz.Category) (string, bool) {
 		return "", false
 	}
 }
+
+// validateOptOutAcknowledgement answers whether this contact is owed a
+// confirmation that their refusal of advertising was received.
+//
+// THE EVIDENCE IS THE STOP ITSELF, which is what makes this validator a
+// different shape from the confirmation one above. Those messages carry a link
+// and the live link IS the evidence. An acknowledgement carries nothing to
+// click, so what it must show is the thing it acknowledges: a standing
+// suppression that refused advertising.
+//
+// WITHOUT THIS the message could never be sent. Its category falls through to
+// the legacy verdict and is denied — the defect
+// TestEveryControllerTemplateResolvesToASubjectServingCategory exists to catch,
+// and which shipped once already on the privacy notice.
+//
+// A LIFTED STOP EVIDENCES NOTHING. Somebody whose objection was withdrawn is
+// not owed an acknowledgement of it, and sending one would tell them their
+// advertising is stopped when it is not.
+func validateOptOutAcknowledgement(
+	ctx context.Context, tx pgx.Tx, subject subjectRef, category commsauthz.Category,
+) (resolution, error) {
+	unsupported := resolution{Category: category, Supported: false, Reason: commsauthz.ReasonNoEvidence}
+	if subject.Kind != entityContact {
+		return unsupported, nil
+	}
+	var standing bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		    SELECT 1 FROM communication_suppression
+		    WHERE contact_id = $1
+		      AND kind = ANY($2)
+		      AND revoked_at IS NULL
+		)`, subject.ID, acknowledgeableKinds()).Scan(&standing); err != nil {
+		return resolution{}, fmt.Errorf("consent: reading the stop this would acknowledge: %w", err)
+	}
+	if !standing {
+		return unsupported, nil
+	}
+	return resolution{
+		Category:  category,
+		Basis:     commsauthz.BasisLegalObligation,
+		Supported: true,
+	}, nil
+}

--- a/backend/internal/modules/consent/authorizevalidators.go
+++ b/backend/internal/modules/consent/authorizevalidators.go
@@ -97,10 +97,16 @@ func (g *Gate) validateCategory(ctx context.Context, tx pgx.Tx, req commsauthz.R
 	case commsauthz.CategoryRecordConfirmation, commsauthz.CategoryConsentConfirmation,
 		commsauthz.CategoryPrivacyNotice:
 		return validateConfirmation(ctx, tx, subject, category)
+	case commsauthz.CategoryOptoutConfirmation:
+		// A DIFFERENT EVIDENCE from the three above, which is why it is its own
+		// arm. Those carry a link and the live link is the evidence; an
+		// acknowledgement carries nothing to click, so what it shows is the
+		// standing stop it acknowledges.
+		return validateOptOutAcknowledgement(ctx, tx, subject, category)
 	default:
 		// Every other category — marketing, customer service, account notices,
-		// and the two subject-serving ones that carry no link — has no record
-		// evidence this file can read today. They stay unsupported and fall
+		// and the remaining subject-serving one that carries no link — has no
+		// record evidence this file can read today. They stay unsupported and fall
 		// through to the legacy verdict, which is exactly what they did before
 		// this file existed.
 		return unsupported, nil

--- a/backend/internal/modules/consent/controllertemplates.go
+++ b/backend/internal/modules/consent/controllertemplates.go
@@ -43,6 +43,15 @@ const (
 	// cannot — a contact who asked us to stop is still owed their disclosure,
 	// and only CategoryPrivacyNotice survives that stop.
 	TemplatePrivacyNotice = "privacy_notice"
+	// TemplateOptOutAcknowledgement confirms that a refusal of advertising was
+	// received. Decree 91/2020/ND-CP Art. 16 owes a Vietnamese recipient one
+	// within twenty-four hours.
+	//
+	// THE ONE TEMPLATE THAT CARRIES NO LINK. It goes to somebody who has just
+	// told the product to stop, so anything beyond "we heard you" is the thing
+	// they asked not to receive — and a link asking them to do something more
+	// would read as a message that did not take the first answer.
+	TemplateOptOutAcknowledgement = "optout_acknowledgement"
 )
 
 // Rendered is one template resolved into the words that will be sent.
@@ -96,6 +105,9 @@ type controllerTemplate struct {
 	subject func(mailcopy.Copy) string
 	intro   func(mailcopy.Copy) string
 	closing func(mailcopy.Copy) string
+	// linkless says this template carries no one-time link, so the renderer
+	// writes no placeholder and comms stages it with no material.
+	linkless bool
 }
 
 // controllerTemplates is the closed catalog.
@@ -127,6 +139,17 @@ var controllerTemplates = map[string]controllerTemplate{
 		subject:  func(w mailcopy.Copy) string { return w.NoticeSubject },
 		intro:    func(w mailcopy.Copy) string { return w.NoticeBody },
 		closing:  func(w mailcopy.Copy) string { return w.NoticeIgnore },
+	},
+	TemplateOptOutAcknowledgement: {
+		version:  1,
+		category: commsauthz.CategoryOptoutConfirmation,
+		subject:  func(w mailcopy.Copy) string { return w.OptOutAckSubject },
+		intro:    func(w mailcopy.Copy) string { return w.OptOutAckBody },
+		closing:  func(w mailcopy.Copy) string { return w.OptOutAckIgnore },
+		// The one template with nothing to click. comms refuses a body whose
+		// placeholder count disagrees with the material it was staged with, and
+		// this is staged with none.
+		linkless: true,
 	},
 }
 
@@ -166,6 +189,16 @@ func RenderControllerTemplate(key string, expiresAt time.Time, language string) 
 	}
 	words := mailcopy.For(language)
 	var body strings.Builder
+	if t.linkless {
+		// NOTHING TO CLICK and nothing about a link's life, so the personal-link
+		// sentence and the expiry line are both absent rather than rendered
+		// about a link that does not exist.
+		body.WriteString(t.intro(words) + "\n\n" + t.closing(words) + "\n")
+		return Rendered{
+			Key: key, Version: t.version, Subject: t.subject(words),
+			Body: body.String(),
+		}, t.category, nil
+	}
 	body.WriteString(t.intro(words) + "\n\n  " + linkPlaceholder + "\n\n" + words.ConfirmPersonal)
 	if !expiresAt.IsZero() {
 		// Appended to the personal-link sentence rather than substituted into

--- a/backend/internal/modules/consent/controllertemplates_test.go
+++ b/backend/internal/modules/consent/controllertemplates_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/platform/mailcopy"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // TestEveryControllerTemplateCarriesExactlyOnePlaceholder holds the rendered
@@ -34,10 +35,20 @@ func TestEveryControllerTemplateCarriesExactlyOnePlaceholder(t *testing.T) {
 			if err != nil {
 				t.Fatalf("rendering %q in %s: %v", key, language, err)
 			}
-			if got := strings.Count(rendered.Body, linkPlaceholder); got != 1 {
-				t.Errorf("template %q in %s carries %d link placeholder(s), want exactly 1: comms "+
+			// THE COUNT MUST MATCH THE MATERIAL, which is comms' own rule
+			// (checkPlaceholder): a template staged with a link carries exactly
+			// one placeholder, and one staged with none carries zero. Demanding
+			// one of every template would refuse the acknowledgement, which has
+			// nothing to click by design — it goes to somebody who has just
+			// asked the product to stop.
+			want := 1
+			if controllerTemplates[key].linkless {
+				want = 0
+			}
+			if got := strings.Count(rendered.Body, linkPlaceholder); got != want {
+				t.Errorf("template %q in %s carries %d link placeholder(s), want exactly %d: comms "+
 					"refuses a body whose count disagrees with its material, so this template can "+
-					"never be sent", key, language, got)
+					"never be sent", key, language, got, want)
 			}
 			if rendered.Subject == "" {
 				t.Errorf("template %q renders no subject line in %s", key, language)
@@ -70,9 +81,9 @@ func TestEveryControllerTemplateResolvesToASubjectServingCategory(t *testing.T) 
 				"to send the five categories a caller may not claim; a template resolving to an "+
 				"ordinary one is the installation asking the engine the wrong question", key, category)
 		}
-		if _, evidenced := confirmKindFor(category); !evidenced {
-			t.Errorf("template %q resolves to %q, which validateConfirmation cannot evidence, so "+
-				"every message from this template falls through to the legacy verdict and is denied",
+		if !evidencedCategory(category) {
+			t.Errorf("template %q resolves to %q, which no validator can evidence, so every "+
+				"message from this template falls through to the legacy verdict and is denied",
 				key, category)
 		}
 	}
@@ -167,15 +178,19 @@ func TestTheRenderedBodyNeverCarriesTheLink(t *testing.T) {
 //
 // gatekit:fixture the sha256 of each registered template's rendered wording
 var pinnedWording = map[string]string{
-	"privacy_notice@1@de":       "f22fd4fc7fe4e266bd6f19566cf1c168d9981106ee8bfe64d7d43758b1bd8b3a",
-	"privacy_notice@1@en":       "9bcfa68cac9cece7974e57c71472434f4baf865a4a0c8e12970fe0b3f1212dd4",
-	"privacy_notice@1@vi":       "5fc479c528b31e79df080e9f07cbfedd15e6e67373ed73776b29b7513da9bef2",
-	"record_confirmation@2@en":  "ae6261f551d0f39945b720db03b9ef2f51a36516b88eeff0b1afae80808e0c28",
-	"record_confirmation@2@de":  "3ba76e0c75f2dd619ad4666d3452607b87a638ea1183e3188ace7bd7d4ac6b06",
-	"record_confirmation@2@vi":  "28894b02130d640779a9fd4550a2f987a4925c04aaf2749679d44708eae9d2a7",
-	"consent_confirmation@2@en": "05485c736c4971864938a0a4100a69b0533b7f9792e1d75820299461c043233e",
-	"consent_confirmation@2@de": "78ed420da7fa53e0cbfc5f02996520e27f8ba0fbb84b1c435b52abbe0da30054",
-	"consent_confirmation@2@vi": "e224aa3f581bf8b2fccb3468364abe52f0f6467e3dd045c9e2b056a96fd4b7b3",
+	"privacy_notice@1@de": "f22fd4fc7fe4e266bd6f19566cf1c168d9981106ee8bfe64d7d43758b1bd8b3a",
+	"privacy_notice@1@en": "9bcfa68cac9cece7974e57c71472434f4baf865a4a0c8e12970fe0b3f1212dd4",
+	"privacy_notice@1@vi": "5fc479c528b31e79df080e9f07cbfedd15e6e67373ed73776b29b7513da9bef2",
+
+	"optout_acknowledgement@1@de": "64facabebf95a1aee0040714c4c9a931b747d49477ebc2c50e7c739c0d5c57c1",
+	"optout_acknowledgement@1@en": "b1e875b839add1d0adc02499a2569c4fa7a59ee9f185f44bbd9952482934b76a",
+	"optout_acknowledgement@1@vi": "cf3c6f5faab5c2ea7b736607f0486f121fbea2466280734fee4b017680fd0e49",
+	"record_confirmation@2@en":    "ae6261f551d0f39945b720db03b9ef2f51a36516b88eeff0b1afae80808e0c28",
+	"record_confirmation@2@de":    "3ba76e0c75f2dd619ad4666d3452607b87a638ea1183e3188ace7bd7d4ac6b06",
+	"record_confirmation@2@vi":    "28894b02130d640779a9fd4550a2f987a4925c04aaf2749679d44708eae9d2a7",
+	"consent_confirmation@2@en":   "05485c736c4971864938a0a4100a69b0533b7f9792e1d75820299461c043233e",
+	"consent_confirmation@2@de":   "78ed420da7fa53e0cbfc5f02996520e27f8ba0fbb84b1c435b52abbe0da30054",
+	"consent_confirmation@2@vi":   "e224aa3f581bf8b2fccb3468364abe52f0f6467e3dd045c9e2b056a96fd4b7b3",
 }
 
 // TestEveryControllerTemplateIsPinnedToItsWording fails when a registered
@@ -269,6 +284,12 @@ func checkPin(t *testing.T, seen map[string]bool, key, locale string, rendered R
 func TestTheExpiryDateReadsTheSameInEveryLanguage(t *testing.T) {
 	expires := time.Date(2026, time.March, 9, 12, 0, 0, 0, time.UTC)
 	for key := range controllerTemplates {
+		// A LINKLESS TEMPLATE HAS NO EXPIRY TO READ. The acknowledgement carries
+		// nothing to click, so a date about when that nothing stops working
+		// would be a sentence about a link the reader does not have.
+		if controllerTemplates[key].linkless {
+			continue
+		}
 		for _, language := range mailcopy.Languages() {
 			rendered, _, err := RenderControllerTemplate(key, expires, string(language))
 			if err != nil {
@@ -311,4 +332,23 @@ func TestTheExpiryLineTakesExactlyOneDate(t *testing.T) {
 				language, got, line)
 		}
 	}
+}
+
+// evidencedCategory reports whether some validator can support this category.
+//
+// TWO SHAPES OF EVIDENCE, which is why this is not confirmKindFor. The three
+// link-carrying categories are evidenced by a live confirm_token, and
+// confirmKindFor names which. The opt-out acknowledgement carries nothing to
+// click and is evidenced by the standing stop it acknowledges, so asking only
+// the first question would call a sendable template unsendable.
+//
+// It mirrors decideResolved's dispatch (authorizevalidators.go) and must move
+// with it: a category that gains a validator there and not here reads as
+// unsendable, and one that loses its arm there reads as fine until a message
+// from it is denied.
+func evidencedCategory(category commsauthz.Category) bool {
+	if _, linked := confirmKindFor(category); linked {
+		return true
+	}
+	return category == commsauthz.CategoryOptoutConfirmation
 }

--- a/backend/internal/modules/consent/optoutack.go
+++ b/backend/internal/modules/consent/optoutack.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Acknowledging a refusal of advertising, where the applicable rules owe one.
+//
+// Decree 91/2020/ND-CP Art. 16 gives a Vietnamese recipient who refuses further
+// advertising a confirmation that their refusal was received, within
+// twenty-four hours and carrying no advertising of its own.
+// gates/messagingruleapplied_test.go carried the gap in its register:
+// OptOutAcknowledgement was declared by the pack and nothing sent one.
+//
+// THE CONTROLLER LANE IS THE ONLY ONE THAT MAY, which is the reason this exists
+// here rather than as an ordinary send. Every other path is refused writing to
+// somebody who has just suppressed themselves, and correctly: the
+// acknowledgement is the single exception the category vocabulary already
+// carries, and optout_confirmation survives a broad stop for exactly this.
+//
+// THE TWENTY-FOUR HOURS ARE NOT ENFORCED, and that is worth saying plainly
+// rather than leaving a reader to assume the decree's deadline is handled. The
+// acknowledgement is queued the moment the refusal commits, which is as prompt
+// as this product sends anything — but nothing measures the gap, nothing alerts
+// on it, and a worker outage lasting longer than a day sends it late with no
+// error raised. Controller mail is not paced, so the age ceiling that bounds an
+// ordinary send does not reach here either.
+//
+// Closing it means a deadline on the delivery and something that reads it,
+// which is its own change.
+//
+// SAME TRANSACTION as the suppression it acknowledges. A separate consumer
+// would have to answer what happens when the stop commits and the queue write
+// fails — either a subject who is owed an acknowledgement and does not get one,
+// or a job that has to re-derive whether it is still owed. Staging it here
+// means the two are one fact.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// acknowledgeWithdrawalTx stages the acknowledgement an UNSUBSCRIBE owes.
+//
+// THE ORDINARY REFUSAL, and the one Codex found this feature missing. A
+// suppression is what a rep records and what the stronger public stop writes; a
+// press of an unsubscribe link writes per-purpose withdrawals and no
+// suppression at all. Acknowledging only the first would answer the rarer act
+// and stay silent on the common one, which is the shape of an obligation that
+// looks discharged and is not.
+//
+// ONE MESSAGE FOR THE PRESS, not one per purpose. The subject performed one
+// act, and a stop that withdrew four subscriptions is not four refusals — the
+// message id is derived from the contact and the day for exactly that reason,
+// so a second press the same day is refused by the ledger's own uniqueness
+// index rather than by a count somebody maintains.
+//
+// NOTHING WITHDRAWN, NOTHING TO ACKNOWLEDGE. A replayed press changes no state,
+// and telling somebody again that we stopped is a second message they did not
+// ask for.
+func (s *Store) acknowledgeWithdrawalTx(
+	ctx context.Context, tx pgx.Tx, contactID ids.ContactID, withdrawn []string,
+) error {
+	if len(withdrawn) == 0 {
+		return nil
+	}
+	day, err := databaseDayTx(ctx, tx)
+	if err != nil {
+		return err
+	}
+	return s.stageAcknowledgementTx(ctx, tx,
+		subject{id: contactID.UUID, entityType: entityContact},
+		withdrawalMessageID(contactID, day))
+}
+
+// acknowledgeOptOutTx stages the acknowledgement this stop owes, if any.
+//
+// ANSWERS NOTHING on a stop that owes none, which is the ordinary case: no
+// applicable pack, a pack that declares no acknowledgement, or a stop that is
+// not a refusal of advertising. A stop recorded by a rep relaying a phone call
+// owes one exactly as a self-service press does — the decree is about the
+// refusal, not about which door recorded it.
+func (s *Store) acknowledgeOptOutTx(
+	ctx context.Context, tx pgx.Tx, sub subject, kind string, stopID ids.UUID,
+) error {
+	if !acknowledgeableStop(kind) {
+		return nil
+	}
+	return s.stageAcknowledgementTx(ctx, tx, sub, acknowledgementMessageID(stopID))
+}
+
+// stageAcknowledgementTx is the one place an acknowledgement is composed and
+// queued, for both the suppression door and the unsubscribe press.
+//
+// ONE PLACE, because the two refusals owe the same message and a second copy of
+// this would be a second answer to what the decree requires. What differs is
+// the message id, which each caller derives from the act it is acknowledging.
+func (s *Store) stageAcknowledgementTx(
+	ctx context.Context, tx pgx.Tx, sub subject, messageID string,
+) error {
+	if s.confirmSender == nil {
+		return nil
+	}
+	rules, _, applicable, err := s.applicableRules(ctx, tx)
+	if err != nil || !applicable {
+		return err
+	}
+	if !rules.OptOutAcknowledgement {
+		return nil
+	}
+	address, err := acknowledgementAddressTx(ctx, tx, sub)
+	if err != nil || address == "" {
+		// NO ADDRESS, NO ACKNOWLEDGEMENT, and no error either. A stop can be
+		// recorded against a contact whose address the product does not hold,
+		// or has since erased — and refusing the STOP because the
+		// acknowledgement cannot be addressed would cost the subject the thing
+		// they actually asked for to satisfy the thing they did not.
+		return err
+	}
+	// NO EXPIRY, because there is no link to expire. The renderer skips the
+	// expiry line for a linkless template, so the zero time never reaches the
+	// words.
+	rendered, category, err := RenderControllerTemplate(
+		TemplateOptOutAcknowledgement, time.Time{}, s.mailLanguage(ctx, tx))
+	if err != nil {
+		return err
+	}
+	// A SAVEPOINT, so a staging refusal cannot take the stop with it.
+	//
+	// THE STOP IS WHAT THE SUBJECT ASKED FOR. The acknowledgement is what the
+	// decree adds, and letting the second roll back the first inverts their
+	// importance: a contact whose address has hard-bounced cannot be
+	// acknowledged, and without this that refusal would fail their objection
+	// and leave advertising permitted — the exact opposite of what they said.
+	//
+	// A REPLAY lands here too. The message id is derived from the act, so a
+	// second acknowledgement of one refusal collides on the ledger's own
+	// uniqueness index and is contained here rather than sending twice.
+	nested, err := tx.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("consent: opening the acknowledgement: %w", err)
+	}
+	_, err = s.confirmSender.QueueConfirmationTx(ctx, nested, ConfirmationSend{
+		ContactID: ids.From[ids.ContactKind](sub.id),
+		Recipient: address,
+		Category:  category,
+		MessageID: messageID,
+		// NO LINK, NO EXPIRY, NO MATERIAL. The template is linkless, and comms
+		// refuses a body whose placeholder count disagrees with what it was
+		// staged with — so these staying empty is what the shape check reads.
+		Rendered: rendered,
+	})
+	if err != nil {
+		// A rollback that does not take leaves the outer transaction aborted,
+		// which would fail the stop anyway — so that one is reported rather
+		// than hidden behind the staging error it was trying to contain.
+		if rbErr := nested.Rollback(ctx); rbErr != nil {
+			return fmt.Errorf("consent: the opt-out acknowledgement could not be rolled back: %w", rbErr)
+		}
+		return nil
+	}
+	if err := nested.Commit(ctx); err != nil {
+		return fmt.Errorf("consent: committing the opt-out acknowledgement: %w", err)
+	}
+	return nil
+}
+
+// acknowledgeableStop reports whether this kind of stop is a refusal of
+// ADVERTISING, which is what the decree owes an acknowledgement for.
+//
+// A marketing objection plainly is. A broad subject request is too: somebody
+// asking us to stop contacting them entirely has refused advertising along with
+// everything else, and reading the wider request as not including the narrower
+// one would deny an acknowledgement to the subject who asked for most.
+//
+// A hard bounce is NOT. Nothing was refused — an address stopped working, and
+// mailing an acknowledgement to a dead address would be both futile and a
+// second delivery attempt at one the provider already rejected.
+func acknowledgeableStop(kind string) bool {
+	for _, k := range acknowledgeableKinds() {
+		if kind == k {
+			return true
+		}
+	}
+	return false
+}
+
+// acknowledgeableKinds is the same answer as a list, for the validator that has
+// to ask the database the question.
+//
+// ONE LIST, because the two ends must agree: the writer stages an
+// acknowledgement for these kinds and the validator evidences it from these
+// kinds, and a kind in one and not the other is either a message staged that
+// can never send, or one that sends with nothing behind it.
+func acknowledgeableKinds() []string {
+	return []string{commsauthz.ReasonObjection, suppressibleKind}
+}
+
+// acknowledgementAddressTx reads where to send it: the contact's primary
+// address, by the ordering the preference centre and the confirm card share.
+//
+// Answers EMPTY rather than an error when there is none. A stop can be recorded
+// against a contact whose address the product does not hold, or has since
+// erased, and that is a fact about the contact rather than a failure.
+func acknowledgementAddressTx(ctx context.Context, tx pgx.Tx, sub subject) (string, error) {
+	if sub.entityType != entityContact {
+		// A LEAD holds no contact_email row, and the acknowledgement is
+		// addressed by the same reader every other controller message uses.
+		// Reaching for the lead's own address here would be a second spelling
+		// of "where does this contact receive mail", which is the thing
+		// primaryEmailSQL exists to keep singular.
+		return "", nil
+	}
+	var address string
+	err := tx.QueryRow(ctx,
+		`SELECT `+primaryEmailSQL("$1"), sub.id).Scan(&address)
+	if err != nil {
+		return "", fmt.Errorf("consent: reading where to acknowledge this stop: %w", err)
+	}
+	return address, nil
+}
+
+// acknowledgementMessageID derives the RFC822 identity from the stop it
+// acknowledges.
+//
+// ONE STOP, ONE MESSAGE. The ledger holds a uniqueness index on this column, so
+// deriving it from the row means a second acknowledgement of the same stop is
+// refused by the database rather than by a check somebody has to remember. A
+// minted id would be unique every time, which is the opposite of what is wanted
+// here: the point is that the same refusal cannot be acknowledged twice.
+//
+// It mirrors confirmMessageID's shape, for the same reason that one is derived
+// rather than random.
+func acknowledgementMessageID(stopID ids.UUID) string {
+	return "optout-ack-" + strings.ReplaceAll(stopID.String(), "-", "") + "@margince.invalid"
+}
+
+// withdrawalMessageID derives the RFC822 identity from the contact and the day.
+//
+// THE DAY, not the moment, because one press is one refusal however many
+// subscriptions it withdrew — and because a subject who presses twice in an
+// afternoon has refused once. A second press the same day collides on the
+// ledger's uniqueness index and is contained, which is the behaviour wanted:
+// the decree owes an acknowledgement of the refusal, not of each click.
+//
+// The date comes from the DATABASE rather than a Go clock. Two application
+// processes with skewed wall clocks would otherwise be able to place one press
+// on either side of midnight and send two messages for one act; one clock
+// narrows that to the midnight boundary itself, which is as far as a derived id
+// can take it.
+func withdrawalMessageID(contactID ids.ContactID, day string) string {
+	return "optout-ack-" + strings.ReplaceAll(contactID.String(), "-", "") +
+		"-" + day + "@margince.invalid"
+}
+
+// databaseDayTx reads today's date from the database.
+//
+// ONE CLOCK for every process, rather than each reading its own: the day is
+// part of a message id, so two application hosts with skewed wall clocks could
+// otherwise place one press on either side of midnight and stage two
+// acknowledgements for one refusal.
+func databaseDayTx(ctx context.Context, tx pgx.Tx) (string, error) {
+	var day string
+	if err := tx.QueryRow(ctx, `SELECT to_char(now(), 'YYYYMMDD')`).Scan(&day); err != nil {
+		return "", fmt.Errorf("consent: reading the day this refusal belongs to: %w", err)
+	}
+	return day, nil
+}

--- a/backend/internal/modules/consent/optoutack_integration_test.go
+++ b/backend/internal/modules/consent/optoutack_integration_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// Acknowledging a refusal of advertising, where the applicable rules owe one.
+//
+// gates/messagingruleapplied_test.go carried OptOutAcknowledgement in its
+// register of declared-and-unapplied obligations: the Vietnamese pack has said
+// since it shipped that Decree 91/2020 Art. 16 owes a recipient who refuses
+// advertising a confirmation within twenty-four hours, and nothing sent one.
+// That register is empty now, and this is the last entry to leave it.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
+)
+
+// owingAcknowledgement binds the store to a pack that owes one, with a lane to
+// stage it on.
+func owingAcknowledgement(t *testing.T, e *channelConsentEnv, owes bool) *recordingStager {
+	t.Helper()
+	code := testJurisdiction(t)
+	messagingrules.Register(messagingrules.Rules{
+		Jurisdiction: code, Version: 1, OptOutAcknowledgement: owes,
+	})
+	stager := &recordingStager{}
+	e.store = e.store.
+		WithConfirmationLane(stager, &recordingVault{}, "https://crm.example.test/").
+		WithInstallationCountry(
+			InstallationCountryFunc(func(context.Context, pgx.Tx) (jurisdiction.Code, error) {
+				return code, nil
+			}))
+	return stager
+}
+
+// TestAMarketingObjectionIsAcknowledged is the register line this closes.
+func TestAMarketingObjectionIsAcknowledged(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	stager := owingAcknowledgement(t, e, true)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		ContactID: e.contact, Kind: commsauthz.ReasonObjection, Reason: "No more ads.",
+	}); err != nil {
+		t.Fatalf("recording the objection: %v", err)
+	}
+
+	if stager.calls != 1 {
+		t.Fatalf("the stop staged %d acknowledgements, want 1 — a Vietnamese recipient who "+
+			"refuses advertising is owed one within twenty-four hours", stager.calls)
+	}
+	if stager.seen.Category != commsauthz.CategoryOptoutConfirmation {
+		t.Errorf("the acknowledgement went out as %q, want optout_confirmation — that is the "+
+			"one category a broad stop does not bind, which is what lets this reach somebody "+
+			"who has just stopped everything", stager.seen.Category)
+	}
+}
+
+// TestTheAcknowledgementCarriesNoLinkAndNoAdvertising.
+//
+// It goes to somebody who has just told the product to stop, so anything beyond
+// "we heard you" is the thing they asked not to receive. A link asking them to
+// do something more would read as a message that did not take the first answer.
+func TestTheAcknowledgementCarriesNoLinkAndNoAdvertising(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	stager := owingAcknowledgement(t, e, true)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		ContactID: e.contact, Kind: commsauthz.ReasonObjection,
+	}); err != nil {
+		t.Fatalf("recording the objection: %v", err)
+	}
+
+	body := stager.seen.Rendered.Body
+	if strings.Contains(body, linkPlaceholder) {
+		t.Errorf("the acknowledgement carries a link placeholder:\n%s", body)
+	}
+	if stager.seen.LinkRef != "" || !stager.seen.LinkID.IsZero() {
+		t.Errorf("the acknowledgement was staged with link material (%q/%v) — comms refuses a "+
+			"body whose placeholder count disagrees with what it carries",
+			stager.seen.LinkRef, stager.seen.LinkID)
+	}
+	if body == "" || stager.seen.Rendered.Subject == "" {
+		t.Error("the acknowledgement has no words")
+	}
+}
+
+// TestAStopUnderNoSuchObligationAcknowledgesNothing. Every installation but a
+// Vietnamese one today, and a message nobody is owed is a message somebody who
+// asked us to stop receives anyway.
+func TestAStopUnderNoSuchObligationAcknowledgesNothing(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	stager := owingAcknowledgement(t, e, false)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		ContactID: e.contact, Kind: commsauthz.ReasonObjection,
+	}); err != nil {
+		t.Fatalf("recording the objection: %v", err)
+	}
+	if stager.calls != 0 {
+		t.Errorf("a pack owing no acknowledgement sent %d — the subject asked us to stop and "+
+			"received mail for it", stager.calls)
+	}
+}
+
+// TestABroadStopIsAcknowledgedToo.
+//
+// Somebody asking us to stop contacting them entirely has refused advertising
+// along with everything else. Reading the wider request as not including the
+// narrower one would deny an acknowledgement to the subject who asked for most.
+func TestABroadStopIsAcknowledgedToo(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	stager := owingAcknowledgement(t, e, true)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		ContactID: e.contact, Kind: "subject_request", Reason: "Stop contacting me.",
+	}); err != nil {
+		t.Fatalf("recording the broad stop: %v", err)
+	}
+	if stager.calls != 1 {
+		t.Errorf("a broad stop staged %d acknowledgements, want 1", stager.calls)
+	}
+}
+
+// TestAContactWithNoAddressStillGetsTheirStop.
+//
+// The stop is what the subject asked for; the acknowledgement is what the
+// decree adds. Refusing the first because the second cannot be addressed would
+// cost them the thing they wanted to satisfy the thing they did not.
+func TestAContactWithNoAddressStillGetsTheirStop(t *testing.T) {
+	e := setupChannelConsent(t)
+	stager := owingAcknowledgement(t, e, true)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		ContactID: e.contact, Kind: commsauthz.ReasonObjection,
+	}); err != nil {
+		t.Fatalf("a contact with no address could not be stopped: %v — the stop is the thing "+
+			"they asked for", err)
+	}
+	if stager.calls != 0 {
+		t.Errorf("an acknowledgement was staged for a contact with no address: %d", stager.calls)
+	}
+
+	var standing bool
+	if err := e.owner.QueryRow(context.Background(), `
+		SELECT EXISTS (SELECT 1 FROM communication_suppression
+		                WHERE contact_id = $1 AND revoked_at IS NULL)`,
+		e.contact).Scan(&standing); err != nil {
+		t.Fatalf("reading the stop: %v", err)
+	}
+	if !standing {
+		t.Error("the stop was not recorded")
+	}
+}
+
+// TestAnUnsubscribePressIsAcknowledged is Codex's finding, and it was the
+// common case.
+//
+// A press writes per-purpose withdrawals and no suppression at all, so hooking
+// only the suppression door answered the act a rep records and stayed silent on
+// the one a subject performs — an obligation that looks discharged and is not.
+func TestAnUnsubscribePressIsAcknowledged(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	seedMarketingPurpose(t, e)
+	stager := owingAcknowledgement(t, e, true)
+
+	if _, err := e.store.Record(e.ctx, RecordInput{
+		ContactID: e.contact, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &grantWording,
+	}); err != nil {
+		t.Fatalf("granting before the press: %v", err)
+	}
+
+	withdrawn, err := e.store.PublicStopAllMarketing(e.ctx, e.contact)
+	if err != nil {
+		t.Fatalf("the press failed: %v", err)
+	}
+	if len(withdrawn) == 0 {
+		t.Fatal("the press withdrew nothing, so this test would pass on an acknowledgement " +
+			"that was correctly skipped")
+	}
+	if stager.calls != 1 {
+		t.Errorf("the press staged %d acknowledgements, want 1 — this is the ordinary way a "+
+			"Vietnamese recipient refuses advertising", stager.calls)
+	}
+}
+
+// TestAReplayedPressAcknowledgesOnce. The subject performed one act, and a
+// replay changes no state — telling them again that we stopped is a second
+// message they did not ask for.
+func TestAReplayedPressAcknowledgesOnce(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	seedMarketingPurpose(t, e)
+	stager := owingAcknowledgement(t, e, true)
+
+	if _, err := e.store.Record(e.ctx, RecordInput{
+		ContactID: e.contact, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &grantWording,
+	}); err != nil {
+		t.Fatalf("granting before the press: %v", err)
+	}
+	if _, err := e.store.PublicStopAllMarketing(e.ctx, e.contact); err != nil {
+		t.Fatalf("the first press failed: %v", err)
+	}
+	if _, err := e.store.PublicStopAllMarketing(e.ctx, e.contact); err != nil {
+		t.Fatalf("the replay failed: %v", err)
+	}
+	if stager.calls != 1 {
+		t.Errorf("two presses staged %d acknowledgements, want 1 — a replay withdraws nothing "+
+			"and owes nothing", stager.calls)
+	}
+}
+
+// TestTheStopSurvivesAnAcknowledgementThatCannotBeStaged is Codex's finding,
+// and the consequence was that advertising stayed permitted.
+//
+// The stop is what the subject asked for; the acknowledgement is what the
+// decree adds. Letting the second roll back the first inverts their importance
+// — and the case is not hypothetical, since a contact whose address has
+// hard-bounced cannot be acknowledged at all.
+func TestTheStopSurvivesAnAcknowledgementThatCannotBeStaged(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	stager := owingAcknowledgement(t, e, true)
+	stager.fail = errors.New("this message cannot be staged")
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		ContactID: e.contact, Kind: commsauthz.ReasonObjection, Reason: "No more ads.",
+	}); err != nil {
+		t.Fatalf("a refusal was lost because its acknowledgement could not be staged: %v — "+
+			"advertising stays permitted, which is the opposite of what the subject said", err)
+	}
+
+	var standing bool
+	if err := e.owner.QueryRow(context.Background(), `
+		SELECT EXISTS (SELECT 1 FROM communication_suppression
+		                WHERE contact_id = $1 AND revoked_at IS NULL)`,
+		e.contact).Scan(&standing); err != nil {
+		t.Fatalf("reading the stop: %v", err)
+	}
+	if !standing {
+		t.Error("the stop was rolled back by its own acknowledgement")
+	}
+}

--- a/backend/internal/modules/consent/preferencesave.go
+++ b/backend/internal/modules/consent/preferencesave.go
@@ -314,7 +314,15 @@ func (s *Store) PublicStopAllMarketing(
 			return err
 		}
 		changed, err = s.withdrawPurposesTx(ctx, tx, contactID, keys)
-		return err
+		if err != nil {
+			return err
+		}
+		// THE ACKNOWLEDGEMENT THIS PRESS OWES, where a pack owes one. This is
+		// the ordinary refusal of advertising — the suppression door beside it
+		// is what a rep records and what the stronger public stop writes — so
+		// acknowledging only that one would answer the rarer act and stay
+		// silent on the common one.
+		return s.acknowledgeWithdrawalTx(ctx, tx, contactID, changed)
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/modules/consent/suppress.go
+++ b/backend/internal/modules/consent/suppress.go
@@ -277,11 +277,17 @@ func (s *Store) suppressAdmittedTx(
 	// occasion somebody asked, and the reason they gave may differ. The live
 	// index makes a duplicate harmless — liveSuppression takes the strongest
 	// row — so the honest answer is to record both.
-	if _, err = tx.Exec(ctx, `
+	// RETURNING the row id, which the acknowledgement below derives its message
+	// id from. One stop is one row is one message, so a second stop recorded
+	// for the same subject cannot stage a second acknowledgement under an id
+	// the ledger already holds.
+	var stopID ids.UUID
+	if err = tx.QueryRow(ctx, `
 		INSERT INTO communication_suppression
 		    (`+sub.column+`, kind, source, captured_by, decided_by_level)
-		VALUES ($1, $2, $3, $4, $5)`,
-		sub.id, in.Kind, suppressionSource(in.Reason), by, string(level)); err != nil {
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id`,
+		sub.id, in.Kind, suppressionSource(in.Reason), by, string(level)).Scan(&stopID); err != nil {
 		return fmt.Errorf("consent: recording the suppression: %w", err)
 	}
 
@@ -300,6 +306,20 @@ func (s *Store) suppressAdmittedTx(
 	auditID, err := storekit.AuditEvent(ctx, tx, "update", sub.entityType, sub.id,
 		map[string]any{auditFieldSuppressionKind: in.Kind, "decided_by_level": string(level)})
 	if err != nil {
+		return err
+	}
+	// THE ACKNOWLEDGEMENT THIS STOP OWES, on the same transaction.
+	//
+	// Decree 91/2020 Art. 16 owes a Vietnamese recipient a confirmation that
+	// their refusal was received. Staging it here rather than from a consumer
+	// of the event below makes the stop and its acknowledgement one fact: a
+	// separate consumer would have to answer what happens when the stop commits
+	// and the queue write does not, and every answer is worse than not having
+	// the question.
+	//
+	// Answers nothing where no pack owes one, which is every installation but a
+	// Vietnamese one today.
+	if err := s.acknowledgeOptOutTx(ctx, tx, sub, in.Kind, stopID); err != nil {
 		return err
 	}
 	// EmitEvent, because the payload declares a STATIC entity: this door writes

--- a/backend/internal/platform/mailcopy/catalog.go
+++ b/backend/internal/platform/mailcopy/catalog.go
@@ -320,6 +320,21 @@ func confirmLines(line writeLine) {
 		"You do not need to reply or do anything. This is not a request.",
 		"Sie müssen nicht antworten und nichts tun. Dies ist keine Aufforderung.",
 		"Quý vị không cần trả lời hay làm gì cả. Đây không phải là một yêu cầu.")
+	line(func(c *Copy) *string { return &c.OptOutAckSubject },
+		"We have stopped sending you advertising",
+		"Wir senden Ihnen keine Werbung mehr",
+		"Chúng tôi đã ngừng gửi quảng cáo cho quý vị")
+	line(func(c *Copy) *string { return &c.OptOutAckBody },
+		"You asked us to stop sending you advertising, and we have. It may take a\n"+
+			"short time for anything already on its way to stop arriving.",
+		"Sie haben uns gebeten, Ihnen keine Werbung mehr zu senden, und das haben wir\n"+
+			"getan. Bereits versendete Nachrichten können noch kurz ankommen.",
+		"Quý vị đã yêu cầu chúng tôi ngừng gửi quảng cáo, và chúng tôi đã ngừng.\n"+
+			"Những thư đã gửi đi có thể còn đến trong một thời gian ngắn.")
+	line(func(c *Copy) *string { return &c.OptOutAckIgnore },
+		"You do not need to reply. We are telling you because the law requires it.",
+		"Sie müssen nicht antworten. Wir teilen es Ihnen mit, weil das Gesetz es verlangt.",
+		"Quý vị không cần trả lời. Chúng tôi thông báo vì pháp luật yêu cầu.")
 	line(func(c *Copy) *string { return &c.ConfirmConsentSubject },
 		"Please confirm you want to hear from us",
 		"Bitte bestätigen Sie, dass Sie von uns hören möchten",

--- a/backend/internal/platform/mailcopy/mailcopy.go
+++ b/backend/internal/platform/mailcopy/mailcopy.go
@@ -255,6 +255,19 @@ type Copy struct {
 	// notice rather than a request.
 	NoticeIgnore string
 
+	// The opt-out acknowledgement, which Decree 91/2020/ND-CP Art. 16 owes a
+	// Vietnamese recipient who refuses further advertising: a confirmation
+	// that their refusal was received, within twenty-four hours.
+	//
+	// IT CARRIES NO LINK and no advertising of its own. This is the one message
+	// the product sends to somebody who has just told it to stop, so anything
+	// in it beyond "we heard you" would be the thing they asked not to receive
+	// — and a link asking them to do something more would read as a message
+	// that did not take the first answer.
+	OptOutAckSubject string
+	OptOutAckBody    string
+	OptOutAckIgnore  string
+
 	// The morning brief. Shorter than the weekly on purpose: it arrives every
 	// working day, so it names the top of the queue and links to the rest
 	// rather than restating a day a reader is about to open anyway.


### PR DESCRIPTION
Decree 91/2020/ND-CP Art. 16 owes a Vietnamese recipient who refuses further advertising a confirmation that their refusal was received, within twenty-four hours and carrying no advertising of its own. The Vietnamese pack has declared that since it shipped and nothing sent one.

This was the last entry in the register of declared-but-unapplied obligations, which is now empty. Every rule the shipped packs declare has an engine reader reachable from a send.

## The message

It is the one controller template that carries no link. It goes to somebody who has just told the product to stop, so anything beyond "we heard you" is the thing they asked not to receive, and a link asking them to do something more would read as a message that did not take the first answer.

Its category needed a validator of its own. The three link-carrying categories are evidenced by a live confirm link. This one carries nothing to click, so its evidence is the standing stop it acknowledges. Without that the message could never have been sent, which is the defect the template gate exists to catch and which shipped once already on the privacy notice.

## Four findings from Codex, one of which made the feature dead

Every acknowledgement would have failed at staging. The ledger requires a message identity and I passed none, so recording an eligible refusal would have returned an error and committed neither the acknowledgement nor the stop. My test missed it because the recording stager accepts anything. The identity is now derived from the stop row, which also means a second stop cannot stage a second message.

A failed acknowledgement rolled back the refusal. A contact whose address has hard-bounced cannot be acknowledged, and that would have failed their objection and left advertising permitted. The acknowledgement now runs in a savepoint. What a failure loses is a message nobody can deliver, not a refusal somebody made.

The ordinary unsubscribe was never acknowledged. A press writes per-purpose withdrawals and no suppression, so hooking only the suppression door answered the act a rep records and stayed silent on the one a subject performs. Both paths now share one staging helper, and a replayed press acknowledges once because the identity is derived from the contact and the day.

## What is not implemented

The twenty-four hours are not enforced. The acknowledgement is queued the moment the refusal commits, which is as prompt as this product sends anything, but nothing measures the gap and a worker outage lasting longer than a day sends it late with no error raised. The comment in the file says so rather than leaving a reader to assume otherwise. Closing it means a deadline on the delivery and something that reads it.

Full backend gate green. Integration lanes green for consent and compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends the opt-out acknowledgement that Vietnamese law (Decree 91/2020/ND-CP Art. 16) owes a recipient who refuses advertising. It was the last declared obligation with no engine reader, and the register of unapplied rules is now empty.

**The message**

- The only controller template that carries no link: it goes to somebody who just asked the product to stop, so it carries no advertising, no expiry, and nothing to click.
- Its category needed a validator of its own, because its evidence is the standing stop rather than a live confirm link.
- It is staged on the same transaction as the refusal, so the stop and its acknowledgement commit as one fact.

**Failures this fixes**

- A staging failure no longer rolls back the refusal; the acknowledgement runs in a savepoint, so a contact whose address has hard-bounced keeps their stop.
- The unsubscribe press is now acknowledged too, not just the suppression a rep records; both paths share one staging helper.
- Message IDs derive from the stop row (or contact and day for a press), so a second stop or replayed press cannot queue a second message.

The twenty-four-hour deadline is not enforced; a worker outage longer than a day would send late with no error, and the code comments say so.

<sup>Written for commit 127b2fec67fcde0f4da2b9592e451073abddc39b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-out acknowledgement messages for applicable advertising refusals, broad marketing stops, and unsubscribe actions.
  - Acknowledgements are link-free, contain no advertising, and support English, German, and Vietnamese copy.
  - Messages are sent only when required, provided a primary address is available, and are prevented from being duplicated.

- **Bug Fixes**
  - Opt-out records are preserved even if acknowledgement delivery cannot be staged.
  - Repeated unsubscribe actions no longer generate additional acknowledgements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->