### PR TITLE
fix(compose): a send is refused when the record stopped being ours

### DIFF
--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -59,6 +59,11 @@ type commsAdapter struct {
 	// The activities store excludes participants with a seat; a colleague
 	// without one is only recognisable by domain, and that set is capture's.
 	own *capture.OwnDomainStore
+	// externalSoR answers whether this workspace's records have moved to an
+	// external system of record. See comms_soraut.go: refusing at staging is
+	// not enough on its own, because the mode can flip while an approval waits
+	// in somebody's inbox.
+	externalSoR externalSoR
 }
 
 var _ agents.Comms = commsAdapter{}
@@ -215,6 +220,13 @@ func (c commsAdapter) SendAccountEmail(
 func (c commsAdapter) send(
 	ctx context.Context, origin activities.SendOrigin, in agents.SendEmailArgs,
 ) (agents.SendEmailResult, error) {
+	// FIRST, before the message is composed or a consent decision is recorded:
+	// a record this installation no longer holds is not one to file a send
+	// against, and the staging gate that already said so ran before the
+	// approval waited in somebody's inbox (comms_soraut.go).
+	if err := c.refuseIfHeldElsewhere(ctx, "send mail"); err != nil {
+		return agents.SendEmailResult{}, err
+	}
 	sched, err := agentSchedule(in)
 	if err != nil {
 		return agents.SendEmailResult{}, err
@@ -275,6 +287,9 @@ func agentSchedule(in agents.SendEmailArgs) (*activities.SendSchedule, error) {
 // resolution and the RBAC check cannot differ by transport. The recipient is
 // absent from the arguments by design: the store resolves it from the anchor.
 func (c commsAdapter) SendMessage(ctx context.Context, anchor ids.UUID, in agents.SendMessageArgs) (agents.SendMessageResult, error) {
+	if err := c.refuseIfHeldElsewhere(ctx, "send a message"); err != nil {
+		return agents.SendMessageResult{}, err
+	}
 	input, err := activities.ApplyChannelContext(activities.SendMessageInput{
 		Body:           in.Body,
 		ConsentPurpose: in.ConsentPurpose,
@@ -376,6 +391,9 @@ func (c commsAdapter) Availability(ctx context.Context, host *ids.UUID, from, to
 }
 
 func (c commsAdapter) BookMeeting(ctx context.Context, in agents.BookMeetingArgs) (json.RawMessage, error) {
+	if err := c.refuseIfHeldElsewhere(ctx, "book a meeting"); err != nil {
+		return nil, err
+	}
 	hostID, err := defaultHost(ctx, in.HostUserID)
 	if err != nil {
 		return nil, err

--- a/backend/internal/compose/comms_integration_test.go
+++ b/backend/internal/compose/comms_integration_test.go
@@ -118,6 +118,10 @@ func TestCommsAdapterSharesTheGovernedPaths(t *testing.T) {
 		store:  activities.NewStore(e.DB()),
 		gate:   consent.NewGate(consent.NewStore(InstallationDB(e.Pool))),
 		stager: realDeliveryStager(t, e),
+		// This installation holds its own records, which the send guard asks
+		// before it composes anything (comms_soraut.go). An adapter with no
+		// seam refuses rather than passes, so a suite that sends says so.
+		externalSoR: nativeSoR,
 	}
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 

--- a/backend/internal/compose/comms_soraut.go
+++ b/backend/internal/compose/comms_soraut.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+)
+
+// The second gate on a write whose record is no longer ours to write.
+//
+// Every 🟡 tool that stages already refuses a target held in an external system
+// of record, at STAGING (agents.refuseStagingElsewhere). That is the right
+// place to say it first — it tells an agent immediately, rather than letting a
+// human approve something that will fail — and it is not enough on its own.
+//
+// THE WINDOW IS THE INBOX. Handle is entered after the approval is redeemed and
+// re-reads nothing through the provider, and activating the overlay flips a
+// workspace MODE rather than deleting the native rows — so the store's own
+// existence-and-row-scope probe still answers yes. A staged proposal that waits
+// overnight spans exactly the kind of admin action that moves the system of
+// record, and lands the next morning against a record this installation no
+// longer owns.
+//
+// WHY HERE AND NOT IN THE TOOL. Re-reading every link inside each verb would be
+// N provider round-trips on the approved path, and it would put the
+// system-of-record question in the tool rather than beside the write. This seam
+// is the one place REST, the MCP tools and the automation executors all reach
+// these writes through, and the mode it asks is one cached read for the whole
+// call.
+
+// externalSoR answers whether this workspace's system of record has moved
+// outside the installation. It is the Dispatcher's own cached mode read, passed
+// as a function so this seam has ONE definition of the question rather than a
+// second query beside it.
+type externalSoR func(context.Context) (bool, error)
+
+// refuseIfHeldElsewhere refuses a write whose records this installation no
+// longer holds the authority for.
+//
+// FAIL CLOSED ON A MISSING SEAM, unlike the optional collaborators beside it in
+// commsAdapter. A nil timer means "this surface cannot defer" and a nil
+// calendar means "this deployment reads no diary" — both are honest absences a
+// caller can act on. A nil answer to "may I still write this record" is not an
+// absence; it is the guard not running, and a guard that passes when it cannot
+// ask is the shape of the defect it was added for.
+//
+// The two draft-only adapters that carry no seam (the workflow executors and
+// the reconciler) construct with an empty SendPath and reach no send at all, so
+// this refusal is unreachable from them — but it is the refusal they would get,
+// which is the answer that stays right if one of them ever grows a send.
+func (c commsAdapter) refuseIfHeldElsewhere(ctx context.Context, what string) error {
+	if c.externalSoR == nil {
+		return fmt.Errorf(
+			"this surface cannot tell whether this workspace's records are still held here, so it "+
+				"will not %s against one: %w", what, apperrors.ErrUnsupportedBySoR)
+	}
+	external, err := c.externalSoR(ctx)
+	if err != nil {
+		return fmt.Errorf("compose: reading this workspace's system of record: %w", err)
+	}
+	if !external {
+		return nil
+	}
+	return fmt.Errorf(
+		"this workspace's records are held in an external system of record, so this installation "+
+			"cannot %s against one — the change belongs in the system that owns the record: %w",
+		what, apperrors.ErrUnsupportedBySoR)
+}

--- a/backend/internal/compose/comms_soraut_test.go
+++ b/backend/internal/compose/comms_soraut_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The window the staging gate cannot see.
+//
+// refuseStagingElsewhere refuses a mirror-held target when the approval is
+// STAGED. That is the right first answer and it cannot cover the case this
+// suite is about: Handle is entered after the approval is redeemed and re-reads
+// nothing, and activating the overlay flips a workspace MODE rather than
+// deleting the native rows — so a proposal staged last night against a record
+// this installation owned lands this morning against one it does not.
+//
+// The mode is moved between the two here, which is the only way to be that
+// sequence rather than a description of it.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// movingSoR is the installation's system of record, as a seam a case can flip
+// between the staging and the redemption.
+type movingSoR struct {
+	external bool
+	err      error
+	asked    int
+}
+
+func (m *movingSoR) answer(context.Context) (bool, error) {
+	m.asked++
+	return m.external, m.err
+}
+
+func TestAWriteIsRefusedWhenTheRecordStoppedBeingOursBetweenApprovalAndSend(t *testing.T) {
+	t.Parallel()
+	sor := &movingSoR{external: false}
+	// No store, no stager, no gate: the refusal under test comes FIRST, and a
+	// case that had to wire the send path to observe it would be proving
+	// something about the wiring. A call that got past the guard would panic
+	// here, which is the assertion working the other way.
+	adapter := commsAdapter{externalSoR: sor.answer}
+
+	// The staging moment: the record is ours, and nothing refuses.
+	if err := adapter.refuseIfHeldElsewhere(context.Background(), "send mail"); err != nil {
+		t.Fatalf("a native record was refused while the installation still held it: %v", err)
+	}
+
+	// An administrator activates the overlay while the approval waits.
+	sor.external = true
+
+	for _, tc := range []struct {
+		verb string
+		call func() error
+	}{
+		{"send_email", func() error {
+			_, err := adapter.SendEmail(context.Background(), ids.NewV7(), agents.SendEmailArgs{})
+			return err
+		}},
+		{"send_account_email", func() error {
+			_, err := adapter.SendAccountEmail(context.Background(), nil, agents.SendEmailArgs{})
+			return err
+		}},
+		{"send_message", func() error {
+			_, err := adapter.SendMessage(context.Background(), ids.NewV7(), agents.SendMessageArgs{})
+			return err
+		}},
+		{"book_meeting", func() error {
+			_, err := adapter.BookMeeting(context.Background(), agents.BookMeetingArgs{})
+			return err
+		}},
+	} {
+		t.Run(tc.verb, func(t *testing.T) {
+			err := tc.call()
+			if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+				t.Fatalf("%s ran against a record the installation no longer holds, answering %v — the "+
+					"staging gate refused this at approval time and the mode moved afterwards", tc.verb, err)
+			}
+		})
+	}
+}
+
+// A SURFACE THAT CANNOT ASK REFUSES, rather than passing.
+//
+// The optional collaborators beside it read the other way — a nil timer means
+// "this surface cannot defer", a nil calendar means "this deployment reads no
+// diary" — and both are honest absences a caller can act on. "May I still write
+// this record" has no such reading: a guard that passes when it cannot ask is
+// the defect it was added for.
+func TestASurfaceWithNoSystemOfRecordSeamRefusesRatherThanSends(t *testing.T) {
+	t.Parallel()
+	if err := (commsAdapter{}).refuseIfHeldElsewhere(context.Background(), "send mail"); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("an adapter with no system-of-record seam answered %v, want a refusal — a guard that "+
+			"passes when it cannot ask is not a guard", err)
+	}
+}
+
+// A seam that ERRORS is not a licence either. The mode read can fail — it is a
+// query — and "we could not find out" is the same answer as "we cannot ask".
+func TestAnUnreadableSystemOfRecordRefuses(t *testing.T) {
+	t.Parallel()
+	sor := &movingSoR{err: errors.New("the mode row is unreachable")}
+	err := (commsAdapter{externalSoR: sor.answer}).refuseIfHeldElsewhere(context.Background(), "send mail")
+	if err == nil {
+		t.Fatal("a send ran while the installation's system of record could not be read")
+	}
+}
+
+// And the ordinary case still goes through, asked once.
+func TestANativeWorkspaceIsAskedOnceAndAdmitted(t *testing.T) {
+	t.Parallel()
+	sor := &movingSoR{external: false}
+	if err := (commsAdapter{externalSoR: sor.answer}).refuseIfHeldElsewhere(context.Background(), "send mail"); err != nil {
+		t.Fatalf("a native workspace was refused: %v", err)
+	}
+	if sor.asked != 1 {
+		t.Errorf("the system of record was read %d times for one write, want 1 — the guard is on the "+
+			"approved path and a read per link is what this design exists to avoid", sor.asked)
+	}
+}
+
+// nativeSoR is the answer for a suite whose installation never leaves its own
+// system of record, which is every suite but the one above.
+//
+// Named rather than written as a literal at each call: a case that wired this
+// to answer TRUE by accident would have its sends refused for a reason nowhere
+// near what it was asserting, and a reader would go looking in the send path.
+func nativeSoR(context.Context) (bool, error) { return false, nil }

--- a/backend/internal/compose/dispatcher.go
+++ b/backend/internal/compose/dispatcher.go
@@ -107,6 +107,17 @@ var _ datasource.SystemOfRecordProvider = (*Dispatcher)(nil)
 // e.g. a workflow starter running outside any one tenant's request) has
 // no per-workspace mode to look up either — it honestly answers false
 // (native), the mode every workspace starts in.
+// IsExternalSoR answers whether this workspace's records are held outside the
+// installation, as the externalSoR seam comms.go takes.
+//
+// Exported for that seam alone, and it is the SAME cached read every dispatched
+// verb already makes — the point of passing it rather than letting a caller
+// query the mode itself, which would be a second spelling of the question and
+// free to answer differently.
+func (d *Dispatcher) IsExternalSoR(ctx context.Context) (bool, error) {
+	return d.isOverlay(ctx)
+}
+
 func (d *Dispatcher) isOverlay(ctx context.Context) (bool, error) {
 	wsID, ok := principal.WorkspaceID(ctx)
 	if !ok {

--- a/backend/internal/compose/preference_agent_integration_test.go
+++ b/backend/internal/compose/preference_agent_integration_test.go
@@ -43,7 +43,7 @@ func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	adapter := newCommsAdapter(e.Pool, nil, SendPath{
 		PublicBaseURL: "https://crm.margince.test",
 		Delivery:      realDeliveryStager(t, e),
-	})
+	}, nativeSoR)
 
 	admin := e.Admin()
 	contactID := e.SeedContact(t, "Opt Out Target", &e.Rep1)

--- a/backend/internal/compose/reconcile.go
+++ b/backend/internal/compose/reconcile.go
@@ -301,7 +301,10 @@ func NewFollowUpReconciler(pool *pgxpool.Pool, log *slog.Logger) *deals.FollowUp
 	// through, so an overnight reply and an automation's draft are one drafting
 	// engine. The zero SendPath matches that surface: nothing here sends, the
 	// held-draft release does, through the fully wired path it builds itself.
-	drafter := newCommsAdapter(pool, nil, SendPath{})
+	// No system-of-record seam: this adapter is built for DraftEmail alone and
+	// its empty SendPath reaches no send, so the guard that would need one is
+	// unreachable from here. It refuses rather than passes if that ever changes.
+	drafter := newCommsAdapter(pool, nil, SendPath{}, nil)
 	stager := followUpStager{
 		svc:   approvals.NewService(db),
 		draft: drafter,

--- a/backend/internal/compose/reconcile_integration_test.go
+++ b/backend/internal/compose/reconcile_integration_test.go
@@ -72,7 +72,7 @@ func setupReconcile(t *testing.T) *reconcileEnv {
 	// in production reached it.
 	stager := followUpStager{
 		svc:   e.svc,
-		draft: newCommsAdapter(e.Pool, nil, SendPath{}),
+		draft: newCommsAdapter(e.Pool, nil, SendPath{}, nativeSoR),
 		owner: dealOwnerAuthority{db: e.DB(), users: identity.NewServiceFor(e.DB())},
 	}
 	e.reconciler = deals.NewFollowUpReconciler(e.DB(), stager, quiet)

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -339,7 +339,11 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	agents.RegisterNetworkTools(registry, whoKnowsLister(pool), coverageReader(pool, contacts.NewStore(InstallationDB(pool))),
 		nativeOnlyIntroPath(sorMode, introPathLister(pool)),
 		nativeOnlyAtRisk(sorMode, atRiskLister(pool, contacts.NewStore(InstallationDB(pool)))))
-	agents.RegisterCommsTools(registry, newCommsAdapter(pool, drafter, send), provider)
+	// The seam is the DISPATCHER'S own cached mode read, not a second query
+	// beside it: one definition of "has this workspace's system of record
+	// moved", asked by the tool surface's writes as well as by its reads.
+	agents.RegisterCommsTools(registry,
+		newCommsAdapter(pool, drafter, send, provider.IsExternalSoR), provider)
 	// The location check (🟢), and the verb the probe card hangs off. It reads
 	// no record and takes no seam, so it registers unconditionally.
 	//

--- a/backend/internal/compose/replyaddresscolleague_integration_test.go
+++ b/backend/internal/compose/replyaddresscolleague_integration_test.go
@@ -37,7 +37,7 @@ func seedMeetingWith(t *testing.T, e *integration.Env, address string) ids.UUID 
 func TestAReplyIsNeverAddressedToAColleagueOnTheOwnDomain(t *testing.T) {
 	e := integration.Setup(t)
 	e.WsExec(t, `INSERT INTO workspace_email_domain (domain, source, verified) VALUES ('ourcompany.test', 'admin', true)`)
-	comms := newCommsAdapter(e.Pool, nil, SendPath{})
+	comms := newCommsAdapter(e.Pool, nil, SendPath{}, nativeSoR)
 
 	_, err := comms.ReplyAddress(e.Admin(), seedMeetingWith(t, e, "colleague@ourcompany.test"))
 	var refusal *activities.NoReplyAddressError

--- a/backend/internal/compose/senddeliverability_integration_test.go
+++ b/backend/internal/compose/senddeliverability_integration_test.go
@@ -67,7 +67,7 @@ func TestToolSurfaceSendCarriesTheUnsubscribeSurface(t *testing.T) {
 	adapter := newCommsAdapter(e.Pool, nil, SendPath{
 		PublicBaseURL: toolSurfaceBaseURL,
 		Delivery:      stager,
-	})
+	}, nativeSoR)
 
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 	if _, err := adapter.SendEmail(ctx, anchorID, agents.SendEmailArgs{

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -347,8 +347,11 @@ func sendStore(pool *pgxpool.Pool, send SendPath) *activities.Store {
 // The automation executors pass a zero SendPath, which is a statement rather
 // than an omission: only DraftEmail is reachable through automation.Comms, so
 // that surface has no send to configure.
-func newCommsAdapter(pool *pgxpool.Pool, drafter activities.EmailDrafter, send SendPath) commsAdapter {
+func newCommsAdapter(
+	pool *pgxpool.Pool, drafter activities.EmailDrafter, send SendPath, sor externalSoR,
+) commsAdapter {
 	return commsAdapter{
+		externalSoR:   sor,
 		store:         sendStore(pool, send),
 		gate:          consentGateFor(pool),
 		draft:         drafter,

--- a/backend/internal/compose/workflows.go
+++ b/backend/internal/compose/workflows.go
@@ -67,7 +67,9 @@ func workflowEngineWithDrafter(db *database.DB, drafter activities.EmailDrafter)
 		// configure. What an automation composes waits as a held draft, and
 		// THAT release sends through the fully-wired store the send path builds
 		// (lateApprovalEffects) rather than anything configured here.
-		Comms: newCommsAdapter(db.Pool(), drafter, SendPath{}),
+		// nil system-of-record seam, for reconcile.go's reason: the automation
+		// executors reach DraftEmail alone.
+		Comms: newCommsAdapter(db.Pool(), drafter, SendPath{}, nil),
 		// The notify transport is the durable notice row (noticesseam.go):
 		// recording one is delivering one, so the engine's success record
 		// is finally a true sentence rather than a skipped run.


### PR DESCRIPTION
Every 🟡 tool that stages already refuses a target held in an external system of record — **at staging**. `Handle` is entered after the approval is redeemed and re-reads nothing through the provider, and activating the overlay flips a workspace **mode** rather than deleting the native rows, so the store's own existence-and-row-scope probe still answers yes.

**The window is the inbox.** A proposal staged last night against a record this installation owned lands this morning against one it does not — and `send_email`, `send_account_email`, `send_message` and `book_meeting` carried it out.

## Where the refusal goes, and why not in the tool

`commsAdapter` is the one seam REST, the MCP tools and the automation executors all reach these writes through. One guard there covers every transport and any door added later, costs **one cached mode read for the whole call** rather than a provider round trip per link, and puts *"may I still write this record"* next to the write instead of inside each verb.

The ticket's most literal reading — re-read every link in `Handle` — is the worst trade: N provider reads on the approved path, and the system-of-record question moved into the tool, coupling every future verb to it.

**The staging refusal stays.** Telling an agent immediately beats letting a human approve something that will fail. This is the second gate, not a replacement.

## A missing seam refuses

The optional collaborators beside it read the other way: a nil `timer` means *this surface cannot defer*, a nil `calendars` means *this deployment reads no diary*, and both are honest absences a caller can act on. *"May I still write this record"* has no such reading — **a guard that passes when it cannot ask is the defect it was added for.**

The two draft-only adapters (the workflow executors, the reconciler) carry no seam and reach no send, so the refusal is unreachable from them. It is the answer that stays right if one ever grows one.

The seam itself is the **Dispatcher's own cached mode read**, passed as a function rather than queried again alongside it — a second spelling of "has this workspace's system of record moved" is free to answer differently.

## The test is the sequence, not a description of it

`TestAWriteIsRefusedWhenTheRecordStoppedBeingOursBetweenApprovalAndSend` asks the guard while the record is ours, **moves the mode**, then calls all four verbs and asserts each refuses with `ErrUnsupportedBySoR`. It wires no store, stager or gate deliberately: the refusal comes first, and a call that got past it would panic — which is the assertion working the other way.

Three more cover the properties the design rests on: a surface with no seam refuses, an unreadable mode refuses, and a native workspace is asked **once** (the per-link read this design exists to avoid).

Mutation-checked: removing the guard from `send` fails the two mail verbs, removing it from `BookMeeting` fails that one, and letting a nil seam pass fails the fail-closed case.

## The archive path is not a fifth verb

The ruling asked me to check the arm `overlaywriteshadow.go:161` describes. It is **not** the same defect: `overlayArchive` already dispatches on the mode at write time, so an archive under overlay routes to the mirror rather than writing a native row. The comms verbs did not, which is what this closes. The note about its untested TRUE arm stands on its own terms and is untouched.

`make check-backend`, `make craft-static` and the `compose` integration suite green.

Closes #929.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Communication actions now stop safely when records are managed by an external system of record.
  - Email, messaging, and meeting actions are refused if ownership changes before execution.
  - Actions also refuse to proceed when system-of-record status is unavailable or cannot be verified.
  - Workspaces retaining local record ownership continue to support communication actions normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->