### PR TITLE
fix(compose): the send guard reads the system of record uncached

### DIFF
--- a/backend/internal/compose/comms_soraut.go
+++ b/backend/internal/compose/comms_soraut.go
@@ -29,13 +29,18 @@ import (
 // N provider round-trips on the approved path, and it would put the
 // system-of-record question in the tool rather than beside the write. This seam
 // is the one place REST, the MCP tools and the automation executors all reach
-// these writes through, and the mode it asks is one cached read for the whole
-// call.
+// these writes through, and the mode it asks is one workspace-row read for the
+// whole call.
 
 // externalSoR answers whether this workspace's system of record has moved
-// outside the installation. It is the Dispatcher's own cached mode read, passed
-// as a function so this seam has ONE definition of the question rather than a
-// second query beside it.
+// outside the installation. It is the Dispatcher's own mode read, passed as a
+// function so this seam has ONE definition of the question rather than a second
+// query beside it.
+//
+// It is the UNCACHED read, because this is a mutation boundary: the mode cache
+// is per-process, so a replica that did not commit the flip can answer 'native'
+// for the rest of its TTL, and a send leaving on that answer is not a stale
+// screen the next request corrects.
 type externalSoR func(context.Context) (bool, error)
 
 // refuseIfHeldElsewhere refuses a write whose records this installation no

--- a/backend/internal/compose/dispatcher.go
+++ b/backend/internal/compose/dispatcher.go
@@ -110,12 +110,22 @@ var _ datasource.SystemOfRecordProvider = (*Dispatcher)(nil)
 // IsExternalSoR answers whether this workspace's records are held outside the
 // installation, as the externalSoR seam comms.go takes.
 //
-// Exported for that seam alone, and it is the SAME cached read every dispatched
-// verb already makes — the point of passing it rather than letting a caller
-// query the mode itself, which would be a second spelling of the question and
-// free to answer differently.
+// Exported for that seam alone, so the question has ONE definition rather than
+// a second query beside it that is free to answer differently.
+//
+// UNCACHED, for the reason isOverlayUncached states below and this caller is an
+// instance of: its seam guards MUTATIONS — a send, a message, a booking. The
+// cache is per-process and Invalidate reaches only the process that committed
+// the flip, so a second api replica can hold 'native' for the rest of the TTL
+// after a workspace connects. A cached answer there is not a stale screen the
+// next request corrects; it is a message leaving on the authority of an
+// ownership that has already moved.
+//
+// One workspace-row read per guarded call, which is what the guard's own design
+// argument costs and no more: the alternative it exists to avoid is a provider
+// round trip PER LINK, not a single mode read.
 func (d *Dispatcher) IsExternalSoR(ctx context.Context) (bool, error) {
-	return d.isOverlay(ctx)
+	return d.isOverlayUncached(ctx)
 }
 
 func (d *Dispatcher) isOverlay(ctx context.Context) (bool, error) {

--- a/backend/internal/compose/dispatcherwritemode_test.go
+++ b/backend/internal/compose/dispatcherwritemode_test.go
@@ -159,3 +159,28 @@ func TestDispatcherReadVerbsStillUseTheCachedMode(t *testing.T) {
 		t.Errorf("cached reads re-queried overlay_mode.sor_mode %d time(s); avoiding that on every read is the whole reason the cache exists", *calls)
 	}
 }
+
+// TestTheCommsGuardIgnoresAStaleCachedMode holds the same window shut at the
+// seam comms.go guards its sends behind.
+//
+// IsExternalSoR is not a dispatched verb, so the verb census above cannot see
+// it — but it decides the same question for the same reason: a send, a message
+// and a booking are mutations, and one leaving on a stale 'native' answer is a
+// mail that went out on the authority of an ownership that had already moved.
+// Unlike a routed write, this one is not recoverable afterwards at all.
+func TestTheCommsGuardIgnoresAStaleCachedMode(t *testing.T) {
+	wsID := ids.NewV7()
+	d, calls := cachedModeDispatcher(wsID, modeNative)
+	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+
+	external, err := d.IsExternalSoR(ctx)
+	if err != nil {
+		t.Fatalf("IsExternalSoR: %v", err)
+	}
+	if !external {
+		t.Error("answered native from the stale cache entry; the workspace row says overlay and a send would go out under an ownership that has moved")
+	}
+	if *calls != 1 {
+		t.Errorf("read the workspace row %d times, want exactly 1: the guard must not trust the cache, and must not cost a round trip per call either", *calls)
+	}
+}


### PR DESCRIPTION
Follow-up to the communication system-of-record guard, from a review finding I merged past rather than answered. The finding was right.

## The hole

`IsExternalSoR` is the seam every guarded communication write asks its question through, and it answered from the dispatcher's per-process mode cache. `Invalidate` clears only the cache of the process that committed the flip, so a second api replica keeps answering `native` for the rest of the TTL after a workspace connects to an incumbent — and a send, a message or a booking leaves on that answer.

The window is small and the consequence is not symmetric with the one the guard already handles. A routed write that lands in a native table is wrong but still in the installation; a mail that has left cannot be pulled back.

## The fix

`isOverlayUncached` already spells out the rule this broke, in its own doc: *every mutation boundary* pays one workspace-row read, because a stale answer there is not a stale screen the next request corrects. This guard is a mutation boundary. It now pays the read.

The seam's design argument is unchanged — what it exists to avoid is a provider round trip **per link**, and this is one mode read for the whole call.

## Test

`TestTheCommsGuardIgnoresAStaleCachedMode` seeds the replica's cache with the pre-flip `native` while the workspace row says `overlay`, and asserts both halves: the guard answers `overlay`, and it reads the row exactly once. It sits beside the verb census in `dispatcherwritemode_test.go`, with a note saying why that census cannot see this caller — `IsExternalSoR` is not a dispatched verb.

Mutation-checked: restoring `d.isOverlay(ctx)` fails both assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured message routing decisions use the workspace’s current system-of-record mode, preventing stale cached settings from sending messages through the wrong path.
* **Tests**
  * Added coverage verifying that routing honors the latest workspace configuration and performs the expected single mode check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->