### PR TITLE
fix(privacy): waive the swallowed rollback that turned main red

### DIFF
--- a/backend/internal/modules/privacy/sarrightscases_integration_test.go
+++ b/backend/internal/modules/privacy/sarrightscases_integration_test.go
@@ -214,6 +214,7 @@ func eraseCapabilities(
 		t.Fatalf("opening the erasure: %v", err)
 	}
 	if err := deleteConsentCapabilities(ctx, tx, contact, nil, "test"); err != nil {
+		//craft:ignore swallowed-errors the rollback abandons a transaction the Fatalf below is already failing the test on; its own error cannot change that outcome
 		_ = tx.Rollback(ctx)
 		t.Fatalf("erasing the subject's capabilities: %v", err)
 	}


### PR DESCRIPTION
**main is red** and every open PR fails with it. No open PR was fixing it when I checked, so I took it.

`make craft-static` (whole-tree) blocks on a bare `_ = tx.Rollback(ctx)` in `sarrightscases_integration_test.go`. The pre-push hook and the craftsmanship job both scope to the diff against `origin/main`, so the finding could not appear until the file *was* main — which is why a green PR became a red trunk.

Waived rather than rewritten, in the same shape and voice as the two waivers this tree already ratified for it (`approvals/lockorder_integration_test.go:168`, `approvals/bundle_integration_test.go:455`): the rollback abandons a transaction the `t.Fatalf` on the very next line is already failing the test on, so its own error cannot change the outcome.

One line. `make craft-static` passes clean.
