### PR TITLE
main is red: craftsmanship (swallowed rollback error in privacy SAR test)

### DIFF
--- a/backend/internal/modules/privacy/sarrightscases_integration_test.go
+++ b/backend/internal/modules/privacy/sarrightscases_integration_test.go
@@ -15,6 +15,7 @@ package privacy
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -213,8 +214,17 @@ func eraseCapabilities(
 	if err != nil {
 		t.Fatalf("opening the erasure: %v", err)
 	}
+	// Released here rather than on each failure path, so every exit closes it —
+	// including the t.Fatalf below, which returns through no line of this
+	// function. ErrTxClosed is expected rather than tolerated: whatever failed
+	// may have closed the transaction on its way out, and reporting that as a
+	// second failure would print noise ahead of the cause.
+	t.Cleanup(func() {
+		if err := tx.Rollback(context.Background()); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("releasing the erasure transaction: %v", err)
+		}
+	})
 	if err := deleteConsentCapabilities(ctx, tx, contact, nil, "test"); err != nil {
-		_ = tx.Rollback(ctx)
 		t.Fatalf("erasing the subject's capabilities: %v", err)
 	}
 	if err := tx.Commit(ctx); err != nil {


### PR DESCRIPTION
Claiming:

- `craftsmanship` — `make craft-static`, a required status check that runs whole-tree on the merge commit, so this blocks EVERY open PR.

Cause: `backend/internal/modules/privacy/sarrightscases_integration_test.go:217` — `_ = tx.Rollback(ctx)` blank-assigns a call result, which the gate rates BLOCKER. Landed with #5505.

This is the second craftsmanship red on main today; the first (#5503, mail catalog over the line ceiling) is already merged. Both were invisible to their own PR's CI, which runs the gate on the merge commit before the offending code is on main.

Found from PR #5477. Fix incoming on this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the swallowed rollback error in the privacy SAR integration test that made `make craft-static` red on main and blocked all open PRs. The test now reports a failed rollback instead of blank-assigning it, so the craftsmanship gate passes and a broken rollback won't surface as a defect in whichever test runs next.

- Releases the erasure transaction with `t.Cleanup` after `Begin`, matching the pattern already used at four sites in this package.
- Tolerates `pgx.ErrTxClosed`, since whatever failed may have closed the transaction on its way out.

<sup>Written for commit 96aa483a72a507dbffc0c5e9879fafa2706d54eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/5509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test error reporting by surfacing failures that occur while rolling back a transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->